### PR TITLE
Fix NullPointerException in filters dialog

### DIFF
--- a/src/org/omegat/gui/filters2/FiltersCustomizer.java
+++ b/src/org/omegat/gui/filters2/FiltersCustomizer.java
@@ -479,7 +479,7 @@ public class FiltersCustomizer extends JDialog implements ListSelectionListener 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
             Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            if (inUseFilters.contains(value.toString())) {
+            if (value != null && inUseFilters.contains(value.toString())) {
                 component.setFont(component.getFont().deriveFont(Font.BOLD));
             }
             return component;


### PR DESCRIPTION
I'm not sure if this bug is specific to my setup but I noticed it some time ago. NPE happens when I open filters dialog and click on one of the filters.