### PR TITLE
XML 'DOCTYPE' with systemId but not publicId requires 'SYSTEM'

### DIFF
--- a/src/org/omegat/filters3/xml/DTD.java
+++ b/src/org/omegat/filters3/xml/DTD.java
@@ -83,6 +83,10 @@ public class DTD extends XMLPseudoTag {
             res.append("\"" + publicId + "\"");
         }
         if (systemId!=null) {
+	    if (publicId==null) {
+		res.append(" ");
+		res.append("SYSTEM");
+	    }
             res.append(" ");
             res.append("\"" + systemId + "\"");
         }


### PR DESCRIPTION
See https://www.w3.org/TR/xml/#NT-ExternalID