### PR TITLE
Fix remote LanguageTool version check

### DIFF
--- a/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
@@ -234,7 +234,7 @@ public class LanguageToolNetworkBridge extends BaseLanguageToolBridge {
         Map<String, Object> response = (Map<String, Object>) JsonParser.parse(json);
         Map<String, String> software = (Map<String, String>) response.get("software");
 
-        if (!software.get("apiVersion").equals(API_VERSION)) {
+        if (!String.valueOf(software.get("apiVersion")).equals(API_VERSION)) {
             Log.logWarningRB("LT_API_VERSION_MISMATCH");
         }
 


### PR DESCRIPTION
LanguageTool 3.8 with OmegaT master returns its API version as integer.