### PR TITLE
Can read SRX format instead of CONF

### DIFF
--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -9,6 +9,7 @@
                2014 Aaron Madlon-Kay, Alex Buloichik
                2015 Aaron Madlon-Kay
                2017 Didier Briel
+               2018 Thomas Cordonnier
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -63,6 +64,7 @@ import gen.core.project.RepositoryDefinition;
  * @author Aaron Madlon-Kay
  * @author Yu Tang
  * @author Alex Buloichik (alex73mail@gmail.com)
+ * @author Thomas Cordonnier
  */
 public class ProjectProperties {
 
@@ -408,7 +410,7 @@ public class ProjectProperties {
      * Loads segmentation.conf if found in the /omegat folder of the project
      */
     public void loadProjectSRX() {
-        this.projectSRX = SRX.loadSRX(new File(getProjectInternal(), SRX.CONF_SENTSEG));
+        this.projectSRX = SRX.loadSRX(new File(getProjectInternal()));
     }
 
     public Filters getProjectFilters() {

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -410,7 +410,7 @@ public class ProjectProperties {
      * Loads segmentation.conf if found in the /omegat folder of the project
      */
     public void loadProjectSRX() {
-        this.projectSRX = SRX.loadSRX(new File(getProjectInternal()));
+        this.projectSRX = SRX.loadFromDir(new File(getProjectInternal()));
     }
 
     public Filters getProjectFilters() {

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -247,7 +247,7 @@ public class RealProject implements IProject {
     public void saveProjectProperties() throws Exception {
         unlockProject();
         try {
-            SRX.saveTo(config.getProjectSRX(), new File(config.getProjectInternal(), SRX.CONF_SENTSEG));
+            SRX.saveTo(config.getProjectSRX(), new File(config.getProjectInternal()));
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -247,7 +247,7 @@ public class RealProject implements IProject {
     public void saveProjectProperties() throws Exception {
         unlockProject();
         try {
-            SRX.saveTo(config.getProjectSRX(), new File(config.getProjectInternal()));
+            SRX.saveToSrx(config.getProjectSRX(), new File(config.getProjectInternal()));
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -139,10 +139,14 @@ public class SRX implements Serializable {
                 gen.core.segmentation.Rule jaxbRule = factory.createRule();
                 lr.getRule().add(jaxbRule);
                 jaxbRule.setBreak(rule.isBreakRule() ? "yes" : "no");
-                jaxbRule.setBeforebreak(factory.createBeforebreak());
-                jaxbRule.getBeforebreak().setContent(rule.getBeforebreak());
-                jaxbRule.setAfterbreak(factory.createAfterbreak());
-                jaxbRule.getAfterbreak().setContent(rule.getAfterbreak());
+                if (rule.getBeforebreak() != null) {
+                    jaxbRule.setBeforebreak(factory.createBeforebreak());
+                    jaxbRule.getBeforebreak().setContent(rule.getBeforebreak());                
+                }
+                if (rule.getAfterbreak() != null) {
+                    jaxbRule.setAfterbreak(factory.createAfterbreak());                
+                    jaxbRule.getAfterbreak().setContent(rule.getAfterbreak());
+                }
             }
         }
 

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -106,9 +106,9 @@ public class SRX implements Serializable {
     /**
      * Saves segmentation rules into specified directory.
      * @param srx OmegaT object to be written; if null, means that we want to delete the file
-     * @param outDir where to put the file. The file name is forced to {@link #SRX_SENTSEG}
+     * @param outDir where to put the file. The file name is forced to {@link #SRX_SENTSEG} and will be in standard SRX format.
      */
-    public static void saveTo(SRX srx, File outDir) throws IOException {
+    public static void saveToSrx(SRX srx, File outDir) throws IOException {
         File outFile = new File (outDir, SRX_SENTSEG);
 
         if (srx == null) {
@@ -117,10 +117,6 @@ public class SRX implements Serializable {
             return;
         }
 
-        saveToSrx(srx, outFile);
-    }
-
-    public static void saveToSrx(SRX srx, File outFile) throws IOException {
         ObjectFactory factory = new ObjectFactory();
         Srx jaxbObject = factory.createSrx();
         jaxbObject.setVersion("2.0");
@@ -182,7 +178,7 @@ public class SRX implements Serializable {
         if (inFile.exists()) {
             SRX srx = loadConfFile(inFile);
             try {
-                saveToSrx(srx, new File(configDir, SRX_SENTSEG));
+                saveToSrx(srx, configDir);
             } catch (Exception o3) {
                 Log.log(o3); // detail why conversion failed, but continue
             }

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -152,7 +152,9 @@ public class SRX implements Serializable {
         try {
             Marshaller m = SRX_JAXB_CONTEXT.createMarshaller();
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            m.marshal(jaxbObject, new FileOutputStream(outFile));
+            try (FileOutputStream fos = new FileOutputStream(outFile)) {
+                m.marshal(jaxbObject, fos);
+            }
         } catch (JAXBException ioe) {
             Log.logErrorRB("CORE_SRX_ERROR_SAVING_SEGMENTATION_CONFIG");
             Log.log(ioe);
@@ -204,9 +206,9 @@ public class SRX implements Serializable {
         SRX res;
         try {
             MyExceptionListener myel = new MyExceptionListener();
-            XMLDecoder xmldec = new XMLDecoder(new FileInputStream(configFile), null, myel);
-            res = (SRX) xmldec.readObject();
-            xmldec.close();
+            try (XMLDecoder xmldec = new XMLDecoder(new FileInputStream(configFile), null, myel)) {
+                res = (SRX) xmldec.readObject();
+            }
 
             if (myel.isExceptionOccured()) {
                 StringBuilder sb = new StringBuilder();

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -126,7 +126,7 @@ public class SRX implements Serializable {
         jaxbObject.setVersion("2.0");
         jaxbObject.setHeader(factory.createHeader());
         jaxbObject.getHeader().setSegmentsubflows(srx.segmentSubflows ? "yes" : "no");
-        jaxbObject.getHeader().setCascade("yes");  // OmegaT rules are always in cascade
+        jaxbObject.getHeader().setCascade(srx.cascade ? "yes" : "no");
         jaxbObject.setBody(factory.createBody());
         jaxbObject.getBody().setMaprules(factory.createMaprules());
         jaxbObject.getBody().setLanguagerules(factory.createLanguagerules());
@@ -267,6 +267,8 @@ public class SRX implements Serializable {
             // set rules only if no errors
             SRX res = new SRX();
             res.setMappingRules(newMap);
+            res.setCascade(! ((data.getHeader() != null) && ("no".equals(data.getHeader().getCascade())))); 	// in OmegaT, defaults to true
+            res.setSegmentSubflows((data.getHeader() != null) && ("yes".equals(data.getHeader().getSegmentsubflows())));	// not really used
             return res;
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -436,9 +438,36 @@ public class SRX implements Serializable {
             MapRule maprule = getMappingRules().get(i);
             if (maprule.getCompiledPattern().matcher(srclang.getLanguage()).matches()) {
                 rules.addAll(maprule.getRules());
+                if (!this.cascade) {
+                    break; // non-cascading means: do not search for other patterns
+                }
             }
         }
         return rules;
+    }
+
+    /**
+     * Holds value of property cascade: true, unless we read an SRX where it was set to false.
+     */
+    private boolean cascade = true;
+
+    /**
+     * Getter for property cascade.
+     *
+     * @return Value of property cascade.
+     */
+    public boolean isCascade() {
+        return this.cascade;
+    }
+
+    /**
+     * Setter for property cascade.
+     *
+     * @param cascade
+     *            New value of property cascade.
+     */
+    public void setCascade(boolean cascade) {
+        this.cascade = cascade;
     }
 
     /**

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -162,7 +162,7 @@ public class SRX implements Serializable {
      * Loads the local segmentation file. Accepts SRX (default) or old CONF format.
      * In case you use conf format, rules about old version remain valid.
      **/
-    public static SRX loadSRX(File configDir) {
+    public static SRX loadFromDir(File configDir) {
         File inFile = null;
         try {
             inFile = new File(configDir, SRX_SENTSEG);

--- a/src/org/omegat/core/segmentation/defaultRules.srx
+++ b/src/org/omegat/core/segmentation/defaultRules.srx
@@ -31,7 +31,7 @@
  Default segmentation rules and exceptions
 -->
 <srx xmlns="http://www.lisa.org/srx20" version="2.0">
-<header></header>
+<header cascade="yes"></header>
   <body>
     <languagerules>
       <!-- CA

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -702,7 +702,7 @@ public final class Preferences {
 
         File srxDir = new File(StaticUtils.getConfigDir());
         try {
-            SRX.saveTo(srx, srxDir);	// save to segmentation.srx in the given directory
+            SRX.saveToSrx(srx, srxDir);	// save to segmentation.srx in the given directory
         } catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -793,7 +793,7 @@ public final class Preferences {
         didInitSegmentation = true;
 
         File srxDir = new File(StaticUtils.getConfigDir());
-        SRX s = SRX.loadSRX(srxDir); // may read SRX or CONF
+        SRX s = SRX.loadFromDir(srxDir); // may read SRX or CONF
         if (s == null) {
             s = SRX.getDefault();
         }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -702,7 +702,7 @@ public final class Preferences {
 
         File srxDir = new File(StaticUtils.getConfigDir());
         try {
-            SRX.saveTo(srx, srxDir);	// defaults to SRX format, but if conf file exists, overwrite it
+            SRX.saveTo(srx, srxDir);	// save to segmentation.srx in the given directory
         } catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -700,9 +700,9 @@ public final class Preferences {
         SRX oldValue = srx;
         srx = newSrx;
 
-        File srxFile = new File(StaticUtils.getConfigDir() + SRX.CONF_SENTSEG);
+        File srxDir = new File(StaticUtils.getConfigDir());
         try {
-            SRX.saveTo(srx, srxFile);
+            SRX.saveTo(srx, srxDir);	// defaults to SRX format, but if conf file exists, overwrite it
         } catch (IOException ex) {
             ex.printStackTrace();
         }
@@ -792,8 +792,8 @@ public final class Preferences {
         }
         didInitSegmentation = true;
 
-        File srxFile = new File(StaticUtils.getConfigDir(), SRX.CONF_SENTSEG);
-        SRX s = SRX.loadSRX(srxFile);
+        File srxDir = new File(StaticUtils.getConfigDir());
+        SRX s = SRX.loadSRX(srxDir); // may read SRX or CONF
         if (s == null) {
             s = SRX.getDefault();
         }


### PR DESCRIPTION
SRX format support

After discussion:
If CONF file is present and SRX absent, convert it. Next time, OmegaT 4 will use the SRX (while CONF is kept for older versions, but not updated anymore)
Rule is valid for global config directory as well as for project-specific segmentation rules. 

Last patch adds support for cascade attribute. This was not needed in the past, since you only used SRX for default rules. But now, if a user copies as segmentation.srx a file coming from another tool, this is required for full compatibility.