### PR TITLE
Support offline mode for team projects

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2431,6 +2431,7 @@ TEAM_REMOTE_RETRIEVE_ERROR=Error retrieve {0} as remote project file
 TEAM_REPOSITORIES_DIALOG=Repository Credentials
 TEAM_REBASE_AND_COMMIT=Synchronisation of repositories
 TEAM_OPEN=Opening team project
+TEAM_NETWORK_ERROR=Remote repository network communication error: {0}
 
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options

--- a/src/org/omegat/core/team2/IRemoteRepository2.java
+++ b/src/org/omegat/core/team2/IRemoteRepository2.java
@@ -98,6 +98,7 @@ public interface IRemoteRepository2 {
      */
     @SuppressWarnings("serial")
     class NetworkException extends Exception {
+
         public NetworkException(Throwable ex) {
             super(ex);
         }

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -175,7 +175,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     }
 
     @Override
-    public String getFileVersion(String file) throws Exception {
+    public String getFileVersion(String file) throws IOException {
         File f = new File(localDirectory, file);
         if (!f.exists()) {
             return null;
@@ -183,7 +183,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         return getCurrentVersion();
     }
 
-    protected String getCurrentVersion() throws Exception {
+    protected String getCurrentVersion() throws IOException {
         try (RevWalk walk = new RevWalk(repository)) {
             Ref localBranch = repository.findRef("HEAD");
             RevCommit headCommit = walk.lookupCommit(localBranch.getObjectId());
@@ -204,6 +204,8 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
             git.checkout().setName(version).call();
             git.branchDelete().setForce(true).setBranchNames(LOCAL_BRANCH).call();
             git.checkout().setCreateBranch(true).setName(LOCAL_BRANCH).setStartPoint(version).call();
+        } catch (TransportException e) {
+            throw new NetworkException(e);
         }
     }
 

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -32,6 +32,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.util.Formatter;
@@ -175,16 +177,16 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 conn.setRequestProperty("If-None-Match", etag);
             }
             switch (conn.getResponseCode()) {
-            case HttpURLConnection.HTTP_OK:
-                etag = conn.getHeaderField("ETag");
-                Log.logDebug(LOGGER, "Retrieve " + url + ": 200 with ETag=" + etag);
-                break;
-            case HttpURLConnection.HTTP_NOT_MODIFIED:
-                // not modified - just return
-                Log.logDebug(LOGGER, "Retrieve " + url + ": not modified");
-                return;
-            default:
-                throw new RuntimeException("HTTP response code: " + conn.getResponseCode());
+                case HttpURLConnection.HTTP_OK:
+                    etag = conn.getHeaderField("ETag");
+                    Log.logDebug(LOGGER, "Retrieve " + url + ": 200 with ETag=" + etag);
+                    break;
+                case HttpURLConnection.HTTP_NOT_MODIFIED:
+                    // not modified - just return
+                    Log.logDebug(LOGGER, "Retrieve " + url + ": not modified");
+                    return;
+                default:
+                    throw new RuntimeException("HTTP response code: " + conn.getResponseCode());
             }
 
             // load into .tmp file
@@ -210,6 +212,8 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
             } catch (Exception ex) {
                 // Etags are optionnal, we eat the exception is there is none
             }
+        } catch (UnknownHostException | SocketException e) {
+            throw new NetworkException(e);
         } finally {
             conn.disconnect();
         }

--- a/src/org/omegat/core/team2/impl/SVNRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/SVNRemoteRepository2.java
@@ -67,7 +67,6 @@ public class SVNRemoteRepository2 implements IRemoteRepository2 {
     File baseDirectory;
     SVNClientManager ourClientManager;
     List<File> filesForCommit = new ArrayList<File>();
-    int credentialAskCount;
 
     @Override
     public void init(RepositoryDefinition repo, File dir, ProjectTeamSettings teamSettings) throws Exception {
@@ -122,6 +121,7 @@ public class SVNRemoteRepository2 implements IRemoteRepository2 {
             Log.logInfoRB("SVN_FINISH", "checkout");
         } catch (Exception ex) {
             Log.logErrorRB("SVN_ERROR", "checkout", ex.getMessage());
+            checkNetworkException(ex);
             throw ex;
         }
     }

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -58,6 +58,7 @@ import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
+import org.omegat.core.team2.IRemoteRepository2;
 import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.gui.dialogs.ChooseMedProject;
@@ -488,11 +489,11 @@ public final class ProjectUICommands {
                                     props.setRepositories(repos);      // so we restore the mapping we just lost
                                     needToSaveProperties = true;
                                 }
+                            } catch (IRemoteRepository2.NetworkException e) {
+                                // Do nothing. Network errors are handled in RealProject.
                             } catch (Exception e) {
                                 Log.logErrorRB(e, "TF_PROJECT_PROPERTIES_ERROR");
-                                    Log.log(e);
-                            throw new IOException(OStrings.getString("TF_PROJECT_PROPERTIES_ERROR") + "\n"
-                                            + e.getMessage(), e);
+                                throw e;
                             }
                         }                       
                         // team project - non-exist directories could be created from repo


### PR DESCRIPTION
This pull request (re)implements offline mode for team projects. Right now when a team project is opened or saved OmegaT throws an error to a user instead of handling the situation gracefully.

I didn't remove exception logging because I don't know about project policies on that matter.