### PR TITLE
Bug in the implementation of the filter for the php files of Moodle.

### DIFF
--- a/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -61,7 +61,7 @@ public class MoodlePHPFilter extends AbstractFilter {
 
     public static final String OPTION_REMOVE_STRINGS_UNTRANSLATED = "unremoveStringsUntranslated";
 
-    protected static final Pattern RE_ENTITY = Pattern.compile("\\$string\\['(.+)'] (=) '(.+)';",
+    protected static final Pattern RE_ENTITY = Pattern.compile("\\$string\\['(.+)'\\] (=) '(.+)(';)$",
             Pattern.DOTALL);
 
     protected Map<String, String> align;
@@ -135,9 +135,11 @@ public class MoodlePHPFilter extends AbstractFilter {
                 processBlock(block.toString(), outFile);
                 block.setLength(0);
             }
-            if (!Character.isWhitespace(c)) { // In the regexp, there could be whitespace between " and >
-                previousChar = c;
+            if (c == quotes && previousChar == 92) {
+                previousChar = 0;
             }
+            else
+                previousChar = c;
         }
     }
 

--- a/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -117,7 +117,7 @@ public class MoodlePHPFilter extends AbstractFilter {
 
         StringBuilder block = new StringBuilder();
         boolean isInBlock = false;
-        int quotes = 39;
+        final char quotes = '\'';
         int previousChar = 0;
         int c;
         while ((c = inFile.read()) != -1) {
@@ -135,7 +135,7 @@ public class MoodlePHPFilter extends AbstractFilter {
                 processBlock(block.toString(), outFile);
                 block.setLength(0);
             }
-            if (c == quotes && previousChar == 92) {
+            if (c == quotes && previousChar == '\\') {
                 previousChar = 0;
             }
             else

--- a/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -138,8 +138,9 @@ public class MoodlePHPFilter extends AbstractFilter {
             if (c == quotes && previousChar == '\\') {
                 previousChar = 0;
             }
-            else
+            else {
                 previousChar = c;
+            }
         }
     }
 

--- a/test/data/filters/MoodlePHP/file.php
+++ b/test/data/filters/MoodlePHP/file.php
@@ -18,3 +18,4 @@ $string['cliunknowoption'] = 'Unrecognised options:
   {$a}
 Please use --help option.';
 $string['cannotdeletemodfilter'] = 'You cannot uninstall the \'{$a->filter}\' because it is part of the \'{$a->module}\' module.';
+$string['auth_ldap_attrcreators'] = 'List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \';\'. Usually something like \'cn=teachers,ou=staff,o=myorg\'';

--- a/test/src/org/omegat/filters/MoodlePHPFilterTest.java
+++ b/test/src/org/omegat/filters/MoodlePHPFilterTest.java
@@ -38,10 +38,10 @@ public class MoodlePHPFilterTest extends TestFilterBase {
     public void testParse() throws Exception {
         parse(new MoodlePHPFilter(), "test/data/filters/MoodlePHP/file.php");
     }
-
+    
     @Test
     public void testLoad() throws Exception {
-        String f = "test/data/filters/MoodlePHP/file.php";
+        String f = "test/data/filters/MoodlePHP/file.php"; 
         IProject.FileInfo fi = loadSourceFiles(new MoodlePHPFilter(), f);
 
         checkMultiStart(fi, f);
@@ -51,9 +51,10 @@ public class MoodlePHPFilterTest extends TestFilterBase {
                 "  {$a}\n" +
                 "Please use --help option.", "cliunknowoption", null, null, null, null);
         checkMulti("You cannot uninstall the \\'{$a->filter}\\' because it is part of the \\'{$a->module}\\' module.", "cannotdeletemodfilter", null, null, null, null);
+        checkMulti("List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \\';\\'. Usually something like \\'cn=teachers,ou=staff,o=myorg\\'", "auth_ldap_attrcreators", null, null, null, null);
         checkMultiEnd();
     }
-
+    
     @Test
     public void testTranslate() throws Exception {
         translateText(new MoodlePHPFilter(),
@@ -74,7 +75,7 @@ public class MoodlePHPFilterTest extends TestFilterBase {
     }
 
     public static class AlignResult {
-
+        
         boolean found = false;
     }
 }

--- a/test/src/org/omegat/filters/MoodlePHPFilterTest.java
+++ b/test/src/org/omegat/filters/MoodlePHPFilterTest.java
@@ -38,7 +38,7 @@ public class MoodlePHPFilterTest extends TestFilterBase {
     public void testParse() throws Exception {
         parse(new MoodlePHPFilter(), "test/data/filters/MoodlePHP/file.php");
     }
-    
+
     @Test
     public void testLoad() throws Exception {
         String f = "test/data/filters/MoodlePHP/file.php"; 
@@ -54,7 +54,7 @@ public class MoodlePHPFilterTest extends TestFilterBase {
         checkMulti("List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \\';\\'. Usually something like \\'cn=teachers,ou=staff,o=myorg\\'", "auth_ldap_attrcreators", null, null, null, null);
         checkMultiEnd();
     }
-    
+
     @Test
     public void testTranslate() throws Exception {
         translateText(new MoodlePHPFilter(),


### PR DESCRIPTION
The filter truncates some strings. If the string contain the sequence '; in the inside, it cuts the string in that site. Example:

```php
$string['auth_ldap_attrcreators'] = 'List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \';\'. Usually something like \'cn=teachers,ou=staff,o=myorg\'';
```
In the interface of Omegat shows the next:

> List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \