### PR TITLE
GUI: Support MS Windows 10 dark theme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,12 @@ dependencies {
 
         // Moses MT connector
         implementation 'org.apache.xmlrpc:xmlrpc-client:3.1.3'
+
+        // LookAndFeel
+        implementation 'com.formdev:flatlaf:0.40'
+
+        // Java Native Access(JNA) library
+        implementation 'net.java.dev.jna:jna-platform:5.6.0'
     }
 
     // Test dependencies

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -277,12 +277,6 @@ public final class Main {
             // do nothing
         }
 
-        try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        } catch (Exception e) {
-            // do nothing
-        }
-
         System.setProperty("swing.aatext", "true");
 
         try {

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -49,6 +49,9 @@ import javax.swing.plaf.ColorUIResource;
 import org.omegat.util.OStrings;
 import org.omegat.util.Platform;
 
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.WinReg;
 import com.vlsolutions.swing.docking.AutoHidePolicy;
 import com.vlsolutions.swing.docking.AutoHidePolicy.ExpandMode;
 import com.vlsolutions.swing.docking.DockableContainerFactory;
@@ -78,6 +81,7 @@ public final class UIDesignManager {
      * Initialize docking subsystem.
      */
     public static void initialize() {
+        setDefaultLookAndFeel();
         setDefaultColors();
 
         // Install VLDocking defaults
@@ -367,6 +371,14 @@ public final class UIDesignManager {
                 && System.getProperty("os.version").matches("6\\.[23]|10\\..*");
     }
 
+    // This check if Windows personalize preference is Dark or not.
+    private static boolean isWindowsThemeDark() {
+        return System.getProperty("os.name").startsWith("Windows") &&
+                (0 == Advapi32Util.registryGetIntValue(WinReg.HKEY_CURRENT_USER,
+                        "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                        "AppsUseLightTheme"));
+    }
+
     /**
      * Load icon from classpath.
      *
@@ -468,6 +480,18 @@ public final class UIDesignManager {
                 background.getBlue(),
                 null)[2];
         return background_brightness < foreground_brightness;
+    }
+
+    private static void setDefaultLookAndFeel() {
+        try {
+            if (isWindowsThemeDark()) {
+                UIManager.setLookAndFeel(new FlatDarkLaf());
+            } else {
+                UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            }
+        } catch (Exception e) {
+            // do nothing
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

OmegaT launch its  look and feel in "Light" one, when run on MS Windows 10 and set "Control-Panel" > "Personalize" > "Color" to "Dark" theme.
It is because Oracle/OpenJDK JRE's Windows LAF is hard coded with Light color sets, for example, "TextArea.background" is always "white", and don't respect Operating Systems personalize settings.

This patch try to check registry entry about personalize configuration and change LaF to dark one.

## Related RFE:

 https://sourceforge.net/p/omegat/feature-requests/1513/

## Environment:

Tested on Windows 10 Enterprise Evaluation Build 19041.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>