### PR TITLE
Fix background of dictionary on linux dark mode

### DIFF
--- a/src/org/omegat/util/Platform.java
+++ b/src/org/omegat/util/Platform.java
@@ -86,6 +86,14 @@ public final class Platform {
     }
 
     /**
+     * Returns true if running on Linux
+     */
+    public static boolean isLinux() {
+        OsType os = getOsType();
+        return os == OsType.LINUX32 || os == OsType.LINUX64;
+    }
+
+    /**
      * Returns true if the JVM (NOT the OS) is 64-bit
      */
     public static boolean is64Bit() {

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -477,6 +477,12 @@ public final class UIDesignManager {
         Color hilite;
         if (isDarkTheme()) {
             hilite = UIManager.getColor("TextArea.background").brighter();  // NOI18N
+            // Hack for JDK GTKLookAndFeel bug.
+            // TextPane.background is always white but should be a text_background of GTK.
+            // List.background is as same color as text_background.
+            if (Platform.isLinux()) {
+                UIManager.put("TextPane.background", UIManager.getColor("List.background"));
+            }
         } else {
             Color bg = UIManager.getColor("TextArea.background").darker();  // NOI18N
             hilite = new Color(bg.getRed(), bg.getBlue(), bg.getGreen(), 32);

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -480,7 +480,7 @@ public final class UIDesignManager {
             // Hack for JDK GTKLookAndFeel bug.
             // TextPane.background is always white but should be a text_background of GTK.
             // List.background is as same color as text_background.
-            if (Platform.isLinux()) {
+            if (Platform.isLinux() && Color.WHITE.equals(UIManager.getColor("TextPane.background"))) {
                 UIManager.put("TextPane.background", UIManager.getColor("List.background"));
             }
         } else {


### PR DESCRIPTION
Workaround and hack for GTKLookAndFeel bug that TextPane.background become always white even when dark mode.

ref: https://sourceforge.net/p/omegat/bugs/1013/

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

![omegat-linux-darkmode-hack](https://user-images.githubusercontent.com/123720/92303593-50149f00-efb1-11ea-8014-202ee27acfc9.png)
Linux Mint 20 Dark theme

![omegat-hack-background-light](https://user-images.githubusercontent.com/123720/92303653-08dade00-efb2-11ea-9c84-cdcd84835617.png)
Linux Mint 20 Light theme
