### PR TITLE
StarDict performance improvement by RandomAccessFile

### DIFF
--- a/src/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/org/omegat/core/dictionaries/DictionariesManager.java
@@ -104,8 +104,16 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
     public void stop() {
         monitor.fin();
         synchronized (this) {
-            dictionaries.values().forEach(dic -> dic.dispose());
+            dictionaries.values().forEach(this::closeDict);
             dictionaries.clear();
+        }
+    }
+
+    private void closeDict(IDictionary dict) {
+        try {
+            dict.dispose();
+        } catch (IOException e) {
+            Log.log(e);
         }
     }
 
@@ -114,8 +122,10 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
      */
     public void fileChanged(File file) {
         synchronized (dictionaries) {
-            IDictionary dic = dictionaries.get(file.getPath());
-            if (dic != null) dic.dispose();
+            IDictionary dict = dictionaries.get(file.getPath());
+            if (dict != null) {
+                closeDict(dict);
+            }
             dictionaries.remove(file.getPath());
         }
         if (!file.exists()) {

--- a/src/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/org/omegat/core/dictionaries/DictionariesManager.java
@@ -111,8 +111,8 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
 
     private void closeDict(IDictionary dict) {
         try {
-            dict.dispose();
-        } catch (IOException e) {
+            dict.close();
+        } catch (Exception e) {
             Log.log(e);
         }
     }

--- a/src/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/org/omegat/core/dictionaries/DictionariesManager.java
@@ -104,6 +104,7 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
     public void stop() {
         monitor.fin();
         synchronized (this) {
+            dictionaries.values().forEach(dic -> dic.dispose());
             dictionaries.clear();
         }
     }
@@ -113,6 +114,8 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
      */
     public void fileChanged(File file) {
         synchronized (dictionaries) {
+            IDictionary dic = dictionaries.get(file.getPath());
+            if (dic != null) dic.dispose();
             dictionaries.remove(file.getPath());
         }
         if (!file.exists()) {

--- a/src/org/omegat/core/dictionaries/IDictionary.java
+++ b/src/org/omegat/core/dictionaries/IDictionary.java
@@ -52,7 +52,7 @@ import java.util.List;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Aaron Madlon-Kay
  */
-public interface IDictionary {
+public interface IDictionary extends AutoCloseable {
 
     /**
      * Read article's text.
@@ -83,5 +83,5 @@ public interface IDictionary {
     /**
      * Dispose IDictionary. Default is no action.
      */
-    default void dispose() throws IOException {}
+    default void close() throws IOException {}
 }

--- a/src/org/omegat/core/dictionaries/IDictionary.java
+++ b/src/org/omegat/core/dictionaries/IDictionary.java
@@ -78,4 +78,9 @@ public interface IDictionary {
         // Default implementation for backwards compatibility
         return readArticles(word);
     }
+
+    /**
+     * Dispose IDictionary. Default is no action.
+     */
+    default void dispose() {}
 }

--- a/src/org/omegat/core/dictionaries/IDictionary.java
+++ b/src/org/omegat/core/dictionaries/IDictionary.java
@@ -26,6 +26,7 @@
 
 package org.omegat.core.dictionaries;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -82,5 +83,5 @@ public interface IDictionary {
     /**
      * Dispose IDictionary. Default is no action.
      */
-    default void dispose() {}
+    default void dispose() throws IOException {}
 }

--- a/src/org/omegat/core/dictionaries/StarDict.java
+++ b/src/org/omegat/core/dictionaries/StarDict.java
@@ -159,6 +159,14 @@ public class StarDict implements IDictionaryFactory {
                 throw new FileNotFoundException("No .dict.dz or .dict files were found for " + dictName);
             }
 
+            if (dictType == DictType.DICTFILE) {
+                try {
+                    dictFile = new RandomAccessFile(new File(dataFile), "r");
+                } catch (FileNotFoundException e) {
+                    throw new FileNotFoundException("No .dict files were found for " + dictName);
+                }
+            }
+
             try {
                 data = loadData(getFile(".idx.gz", ".idx").get());
             } catch (NoSuchElementException ex) {
@@ -199,6 +207,17 @@ public class StarDict implements IDictionaryFactory {
             is.close();
             newData.done();
             return newData;
+        }
+
+        @Override
+        public void dispose() {
+            if (dictFile != null) {
+                try {
+                    dictFile.close();
+                } catch (IOException e) {
+                    System.err.println(e.getMessage());
+                }
+            }
         }
 
         @Override
@@ -250,13 +269,6 @@ public class StarDict implements IDictionaryFactory {
          */
         private String readDictArticleText(int start, int len) {
             String result = null;
-            if(dictFile == null){
-                try {
-                    dictFile = new RandomAccessFile(new File(dataFile), "r");
-                } catch (FileNotFoundException e){
-                    System.err.println(e.getMessage());
-                }
-            }
             try {
                 byte[] data = new byte[len];
                 dictFile.seek(start);

--- a/src/org/omegat/core/dictionaries/StarDict.java
+++ b/src/org/omegat/core/dictionaries/StarDict.java
@@ -35,6 +35,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
@@ -110,6 +111,8 @@ public class StarDict implements IDictionaryFactory {
         private final String dataFile;
 
         protected final DictionaryData<Entry> data;
+
+        private RandomAccessFile dictFile;
 
         /**
          * @param ifoFile
@@ -247,16 +250,17 @@ public class StarDict implements IDictionaryFactory {
          */
         private String readDictArticleText(int start, int len) {
             String result = null;
-            try (FileInputStream in = new FileInputStream(dataFile)) {
-                byte[] data = new byte[len];
-                long moved = in.skip(start);
-                if (moved < start) {
-                    long moved2 = in.skip(start - moved);
-                    if (moved2 < start - moved) {
-                        throw new IOException("Cannot seek dictionary.");
-                    }
+            if(dictFile == null){
+                try {
+                    dictFile = new RandomAccessFile(new File(dataFile), "r");
+                } catch (FileNotFoundException e){
+                    System.err.println(e.getMessage());
                 }
-                int readLen = in.read(data);
+            }
+            try {
+                byte[] data = new byte[len];
+                dictFile.seek(start);
+                int readLen = dictFile.read(data);
                 result = new String(data, 0, readLen, StandardCharsets.UTF_8);
             } catch (IOException e) {
                 System.err.println(e.getMessage());

--- a/test/src/org/omegat/core/dictionaries/StarDictTest.java
+++ b/test/src/org/omegat/core/dictionaries/StarDictTest.java
@@ -37,7 +37,7 @@ import java.util.Map.Entry;
 
 import org.junit.Test;
 import org.omegat.core.TestCore;
-import org.omegat.core.dictionaries.StarDict.StarDictDict;
+import org.omegat.core.dictionaries.StarDict.StarDictBaseDict;
 import org.omegat.util.Language;
 
 /**
@@ -53,12 +53,12 @@ public class StarDictTest extends TestCore {
 
     @Test
     public void testReadFileDict() throws Exception {
-        StarDictDict dict = (StarDictDict) new StarDict().loadDict(new File("test/data/dicts/latin-francais.ifo"),
+        StarDictBaseDict dict = (StarDictBaseDict) new StarDict().loadDict(new File("test/data/dicts/latin-francais.ifo"),
                 FRENCH);
         assertEquals(11964, dict.data.size());
 
         String word = "testudo";
-        List<Entry<String, StarDictDict.Entry>> data = dict.data.lookUp(word);
+        List<Entry<String, StarDict.Entry>> data = dict.data.lookUp(word);
         assertEquals(1, data.size());
 
         List<DictionaryEntry> result = dict.readArticles(word);
@@ -85,12 +85,12 @@ public class StarDictTest extends TestCore {
 
     @Test
     public void testReadZipDict() throws Exception {
-        StarDictDict dict = (StarDictDict) new StarDict()
+        StarDictBaseDict dict = (StarDictBaseDict) new StarDict()
                 .loadDict(new File("test/data/dicts-zipped/latin-francais.ifo"), FRENCH);
         assertEquals(11964, dict.data.size());
 
         String word = "testudo";
-        List<Entry<String, StarDictDict.Entry>> data = dict.data.lookUp(word);
+        List<Entry<String, StarDict.Entry>> data = dict.data.lookUp(word);
         assertEquals(1, data.size());
         List<DictionaryEntry> result = dict.readArticles(word);
         assertEquals(1, result.size());


### PR DESCRIPTION
Performance improvement for StarDict uncompressed file type (.dict file type).

How?

- Use RandomAccessFile
- Call constructor (and create file hundle) of RandomAccessFile only once.

Why?

- skip method of FileInputStream is slow, because it read all file data before start point.
- Call constructor each time is slow, because Making file hundle is heavy operation and maybe can't use OS's file cache.

