### PR TITLE
Prefer xdg-open on Linux instead of java.awt.Desktop browse/open

### DIFF
--- a/src/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
+++ b/src/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
@@ -26,7 +26,6 @@
 package org.omegat.externalfinder.gui;
 
 import java.awt.Color;
-import java.awt.Desktop;
 import java.awt.Window;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,6 +41,7 @@ import org.omegat.externalfinder.item.ExternalFinderItem;
 import org.omegat.externalfinder.item.ExternalFinderItemURL;
 import org.omegat.externalfinder.item.ExternalFinderValidationException;
 import org.omegat.util.OStrings;
+import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.StaticUIUtils;
 
 /**
@@ -130,7 +130,7 @@ public class ExternalFinderItemURLEditorController {
 
         panel.testButton.addActionListener(e -> {
             try {
-                Desktop.getDesktop().browse(builder.generateSampleURL());
+                DesktopWrapper.browse(builder.generateSampleURL());
             } catch (Exception ex) {
                 Logger.getLogger(ExternalFinderItemURLEditorController.class.getName()).log(Level.SEVERE,
                         null, ex);

--- a/src/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
+++ b/src/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
@@ -25,7 +25,6 @@
 
 package org.omegat.externalfinder.item;
 
-import java.awt.Desktop;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -42,6 +41,7 @@ import org.omegat.externalfinder.ExternalFinder;
 import org.omegat.externalfinder.item.ExternalFinderItem.SCOPE;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.gui.DesktopWrapper;
 import org.openide.awt.Mnemonics;
 
 public class ExternalFinderItemMenuGenerator implements IExternalFinderItemMenuGenerator {
@@ -118,7 +118,7 @@ public class ExternalFinderItemMenuGenerator implements IExternalFinderItemMenuG
                     }
 
                     try {
-                        Desktop.getDesktop().browse(url.generateURL(targetWords));
+                        DesktopWrapper.browse(url.generateURL(targetWords));
                     } catch (Exception ex) {
                         Logger.getLogger(ExternalFinderItemMenuGenerator.class.getName()).log(Level.SEVERE,
                                 null, ex);

--- a/src/org/omegat/gui/dialogs/VersionCheckDialog.java
+++ b/src/org/omegat/gui/dialogs/VersionCheckDialog.java
@@ -25,7 +25,6 @@
 
 package org.omegat.gui.dialogs;
 
-import java.awt.Desktop;
 import java.awt.Window;
 import java.net.URI;
 
@@ -38,6 +37,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.VersionChecker;
+import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.StaticUIUtils;
 
 public class VersionCheckDialog {
@@ -91,7 +91,7 @@ public class VersionCheckDialog {
                 panel.autoCheckCheckBox.isSelected()));
         panel.goToDownloadsButton.addActionListener(e -> {
             try {
-                Desktop.getDesktop().browse(URI.create(DOWNLOAD_URL));
+                DesktopWrapper.browse(URI.create(DOWNLOAD_URL));
                 StaticUIUtils.closeWindowByEvent(dialog);
             } catch (Exception ex) {
                 Log.log(ex);

--- a/src/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -34,7 +34,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Point;
@@ -108,6 +107,7 @@ import org.omegat.util.Preferences;
 import org.omegat.util.StreamUtil;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.DataTableStyling;
+import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.DragTargetOverlay;
 import org.omegat.util.gui.DragTargetOverlay.FileDropInfo;
 import org.omegat.util.gui.OSXIntegration;
@@ -400,7 +400,7 @@ public class ProjectFilesListController {
             }
             stream.forEach(f -> {
                 try {
-                    Desktop.getDesktop().open(f);
+                    DesktopWrapper.open(f);
                 } catch (IOException ex) {
                     Log.log(ex);
                 }

--- a/src/org/omegat/gui/glossary/taas/TaaSPreferencesController.java
+++ b/src/org/omegat/gui/glossary/taas/TaaSPreferencesController.java
@@ -26,7 +26,6 @@
 
 package org.omegat.gui.glossary.taas;
 
-import java.awt.Desktop;
 import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,6 +42,7 @@ import org.omegat.gui.preferences.IPreferencesController;
 import org.omegat.gui.preferences.view.GlossaryPreferencesController;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.gui.DesktopWrapper;
 
 /**
  * @author Aaron Madlon-Kay
@@ -71,7 +71,7 @@ public class TaaSPreferencesController extends BasePreferencesController {
         panel = new TaaSPreferencesPanel();
         panel.getKeyButton.addActionListener(e -> {
             try {
-                Desktop.getDesktop().browse(URI.create(TAAS_KEY_URL));
+                DesktopWrapper.browse(URI.create(TAAS_KEY_URL));
             } catch (Exception ex) {
                 JOptionPane.showConfirmDialog(panel, ex.getLocalizedMessage(),
                         OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -37,7 +37,6 @@
 package org.omegat.gui.main;
 
 import java.awt.Component;
-import java.awt.Desktop;
 import java.awt.KeyboardFocusManager;
 import java.io.File;
 import java.util.List;
@@ -87,6 +86,7 @@ import org.omegat.util.StaticUtils;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TagUtil;
 import org.omegat.util.TagUtil.Tag;
+import org.omegat.util.gui.DesktopWrapper;
 
 /**
  * Handler for main menu items.
@@ -361,7 +361,7 @@ public final class MainWindowMenuHandler {
             return;
         }
         try {
-            Desktop.getDesktop().open(path);
+            DesktopWrapper.open(path);
         } catch (Exception ex) {
             Log.logErrorRB(ex, "RPF_ERROR");
             Core.getMainWindow().displayErrorRB(ex, "RPF_ERROR");

--- a/src/org/omegat/gui/preferences/view/GeneralOptionsController.java
+++ b/src/org/omegat/gui/preferences/view/GeneralOptionsController.java
@@ -25,7 +25,6 @@
 
 package org.omegat.gui.preferences.view;
 
-import java.awt.Desktop;
 import java.io.File;
 
 import javax.swing.JComponent;
@@ -36,6 +35,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
+import org.omegat.util.gui.DesktopWrapper;
 
 /**
  * @author Aaron Madlon-Kay
@@ -74,7 +74,7 @@ public class GeneralOptionsController extends BasePreferencesController {
             return;
         }
         try {
-            Desktop.getDesktop().open(path);
+            DesktopWrapper.open(path);
         } catch (Exception ex) {
             Log.logErrorRB(ex, "RPF_ERROR");
             Core.getMainWindow().displayErrorRB(ex, "RPF_ERROR");

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -25,7 +25,6 @@
 
 package org.omegat.gui.preferences.view;
 
-import java.awt.Desktop;
 import java.net.URI;
 
 import javax.swing.JComponent;
@@ -33,6 +32,7 @@ import javax.swing.JOptionPane;
 
 import org.omegat.gui.preferences.BasePreferencesController;
 import org.omegat.util.OStrings;
+import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.TableColumnSizer;
 
 /**
@@ -62,7 +62,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
         TableColumnSizer.autoSize(panel.tablePluginsInfo, 0, true);
         panel.browsePluginsButton.addActionListener(e -> {
             try {
-                Desktop.getDesktop().browse(URI.create(PLUGINS_WIKI_URL));
+                DesktopWrapper.browse(URI.create(PLUGINS_WIKI_URL));
             } catch (Exception ex) {
                 JOptionPane.showConfirmDialog(panel, ex.getLocalizedMessage(),
                         OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);

--- a/src/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/org/omegat/gui/scripting/ScriptingWindow.java
@@ -29,7 +29,6 @@ package org.omegat.gui.scripting;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
@@ -99,6 +98,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
+import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.OSXIntegration;
 import org.omegat.util.gui.StaticUIUtils;
 import org.openide.awt.Mnemonics;
@@ -902,7 +902,7 @@ public class ScriptingWindow {
                 return;
             }
             try {
-                Desktop.getDesktop().open(m_scriptsDirectory);
+                DesktopWrapper.open(m_scriptsDirectory);
             } catch (Exception ex) {
                 Log.logErrorRB(ex, "RPF_ERROR");
                 Core.getMainWindow().displayErrorRB(ex, "RPF_ERROR");

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -29,7 +29,6 @@
 
 package org.omegat.help;
 
-import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +43,7 @@ import java.util.Random;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;
+import org.omegat.util.gui.DesktopWrapper;
 
 /**
  * A utility class for accessing bundled local or online documentation.
@@ -73,7 +73,7 @@ public final class Help {
 
     public static void showJavadoc() throws IOException {
         URI uri = URI.create(ONLINE_JAVADOC_URL);
-        Desktop.getDesktop().browse(uri);
+        DesktopWrapper.browse(uri);
     }
 
     /**
@@ -87,7 +87,7 @@ public final class Help {
         if (uri == null) {
             uri = URI.create(ONLINE_HELP_URL);
         }
-        Desktop.getDesktop().browse(uri);
+        DesktopWrapper.browse(uri);
     }
 
     public static URI getHelpFileURI(String filename) {

--- a/src/org/omegat/util/gui/DesktopWrapper.java
+++ b/src/org/omegat/util/gui/DesktopWrapper.java
@@ -36,9 +36,8 @@ import java.net.URI;
 /**
  * Wrapper class for java.awt.Desktop with `xdg-open` path on Linux platform.
  */
-public class DesktopWrapper {
+public final class DesktopWrapper {
 
-    private final static Desktop awtDesktop = Desktop.getDesktop();
     private final static boolean useXDGOpen;
 
     static {
@@ -57,7 +56,7 @@ public class DesktopWrapper {
         if (useXDGOpen) {
             xdgOpen(uri.toString());
         } else {
-            awtDesktop.browse(uri);
+            Desktop.getDesktop().browse(uri);
         }
     }
 
@@ -65,7 +64,7 @@ public class DesktopWrapper {
         if (useXDGOpen) {
             xdgOpen(file.getPath());
         } else {
-            awtDesktop.open(file);
+            Desktop.getDesktop().open(file);
         }
     }
 

--- a/src/org/omegat/util/gui/DesktopWrapper.java
+++ b/src/org/omegat/util/gui/DesktopWrapper.java
@@ -1,0 +1,88 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Lev Abashkin
+ Home page: http://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util.gui;
+
+
+import org.omegat.util.Platform;
+
+import java.awt.Desktop;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Wrapper class for java.awt.Desktop with `xdg-open` path on Linux platform.
+ */
+public class DesktopWrapper {
+
+    private final static Desktop awtDesktop = Desktop.getDesktop();
+    private final static boolean useXDGOpen;
+
+    static {
+        boolean hasXDGOpen = false;
+        if (Platform.isLinux()) {
+            try {
+                hasXDGOpen = xdgOpen("--help");
+            } catch (IOException ex) {
+                // Do nothing
+            }
+        }
+        useXDGOpen = hasXDGOpen;
+    }
+
+    public static void browse(URI uri) throws IOException {
+        if (useXDGOpen) {
+            xdgOpen(uri.toString());
+        } else {
+            awtDesktop.browse(uri);
+        }
+    }
+
+    public static void open(File file) throws IOException {
+        if (useXDGOpen) {
+            xdgOpen(file.getPath());
+        } else {
+            awtDesktop.open(file);
+        }
+    }
+
+    private static boolean xdgOpen(String s) throws IOException {
+        File devNull = new File("/dev/null");
+        ProcessBuilder pb = new ProcessBuilder("xdg-open", s);
+        pb.redirectOutput(devNull);
+        pb.redirectError(devNull);
+        Process p = pb.start();
+
+        try {
+            return p.waitFor() == 0;
+        } catch (InterruptedException ex) {
+            return false;
+        }
+    }
+
+    private DesktopWrapper() {
+    }
+}

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -25,7 +25,6 @@
 package org.omegat.util.gui;
 
 import java.awt.Cursor;
-import java.awt.Desktop;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -256,7 +255,7 @@ public final class JTextPaneLinkifier {
                 @Override
                 public void execute() {
                     try {
-                        Desktop.getDesktop().browse(target);
+                        DesktopWrapper.browse(target);
                     } catch (Exception e) {
                         JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
                                 OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
This PR aims to alleviate java.awt.Desktop shortcomings on Linux platform. OmegaT uses two methods of this class: `browse` and `open` so the wrapper implements only them. While `browse` is not supported at all in some DEs like KDE Plasma, the `open` method also has its problems. On my PC when I open a directory from OmegaT main menu (for example project root) Java starts VSCodium to open the directory. I wasn't frustrated enough to find where it's configured, but `xdg-open` handles directory paths correctly launching default file manager.

The code was tested only on Linux though it's simple enough to assume other platform should behave nicely.