### PR TITLE
key/value filter: strip quote of value when exist

### DIFF
--- a/src/org/omegat/filters2/text/ini/INIFilter.java
+++ b/src/org/omegat/filters2/text/ini/INIFilter.java
@@ -97,6 +97,7 @@ public class INIFilter extends AbstractFilter {
 
         while ((str = lbpr.readLine()) != null) {
             String trimmed = str.trim();
+            boolean hasQuote = false;
 
             // skipping empty strings and comments
             if (trimmed.isEmpty() || trimmed.codePointAt(0) == '#' || trimmed.codePointAt(0) == ';') {
@@ -138,6 +139,11 @@ public class INIFilter extends AbstractFilter {
             String value = str.substring(afterEqualsPos);
 
             value = leftTrim(value);
+            if (value.startsWith("\"") && value.endsWith("\"")) {
+                value = value.substring(value.offsetByCodePoints(0, 1),
+                        value.offsetByCodePoints(value.length(), -1));
+                hasQuote = true;
+            }
 
             if (entryAlignCallback != null) {
                 align.put(key, value);
@@ -148,7 +154,11 @@ public class INIFilter extends AbstractFilter {
                 if (trans == null) {
                     trans = value;
                 }
-                outfile.write(trans);
+                if (hasQuote) {
+                    outfile.write(String.format("\"%s\"", trans));
+                } else {
+                    outfile.write(trans);
+                }
 
                 // outfile.write("\n");
                 outfile.write(lbpr.getLinebreak()); // fix for bug 1462566

--- a/test/data/filters/ini/file-INIFilter.ini
+++ b/test/data/filters/ini/file-INIFilter.ini
@@ -4,3 +4,5 @@ nsID=Value
 ID=Value
 
 ID2=Value2
+
+ID3="Value3"

--- a/test/src/org/omegat/filters/INIFilterTest.java
+++ b/test/src/org/omegat/filters/INIFilterTest.java
@@ -49,6 +49,7 @@ public class INIFilterTest extends TestFilterBase {
         checkMulti("Value", "nsID", null, null, null, null);
         checkMulti("Value", "Section/ID", null, null, null, null);
         checkMulti("Value2", "Section/ID2", null, null, null, null);
+        checkMulti("Value3", "Section/ID3", null, null, null, null);
         checkMultiEnd();
     }
 }


### PR DESCRIPTION
Implement [RFE#1328](https://sourceforge.net/p/omegat/feature-requests/1328/) that request 
to support joomla message catalog, which has double-quote for value.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>