### PR TITLE
Gradle: bump dictzip@0.9.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ sourceSets {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
     maven {
         url 'https://dl.bintray.com/omegat-org/maven'
@@ -124,7 +125,7 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.0'
 
         // Dictionary
-        implementation 'org.dict.zip:dictzip-lib:0.9.1'
+        implementation 'io.github.dictzip:dictzip:0.9.5'
         implementation 'com.github.takawitter:trie4j:0.9.8'
 
         // Encoding dectection


### PR DESCRIPTION
dictzip moves to mavenCentral

Signed-off-by: Hiroshi Miura <miurahr@linux.com>