### PR TITLE
Support markUnknown feature of Apertium

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2179,6 +2179,7 @@ APERTIUM_CUSTOM_SERVER_URL_LABEL=Custom server URL
 APERTIUM_CUSTOM_SERVER_KEY_LABEL=API Key (optional)
 APERTIUM_CUSTOM_SERVER_NOTFOUND=Unable to connect to server. Ensure the server URL is correct.
 APERTIUM_CUSTOM_SERVER_INVALID=The server is not a valid Apertium server. Ensure the URL is correct.
+APERTIUM_MARKUNKNOWN_LABEL=Mark unknown words
 
 MT_ENGINE_GOOGLE2_API_KEY_LABEL=API Key:
 MT_ENGINE_GOOGLE2_PREMIUM_LABEL=Premium Edition


### PR DESCRIPTION
Untested! I'd like to add support for markUnknown, but I get this error when building:
```
$ /snap/bin/gradle assembleDist

Welcome to Gradle 6.8.3!

Here are the highlights of this release:
 - Faster Kotlin DSL script compilation
 - Vendor selection for Java toolchains
 - Convenient execution of tasks in composite builds
 - Consistent dependency resolution

For more details see https://docs.gradle.org/6.8.3/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/home/me/src/omegat/build.gradle' line: 10

* What went wrong:
Plugin [id: 'com.github.spotbugs', version: '4.7.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'com.github.spotbugs:com.github.spotbugs.gradle.plugin:4.7.0')
  Searched in the following repositories:
    Gradle Central Plugin Repository

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 10s
```

@MarcRiera I based it off your PR https://github.com/omegat-org/omegat/pull/37 you may be interested in this too