### PR TITLE
unify DTD URI to local URI

### DIFF
--- a/doc_src/en/App_Dictionaries.xml
+++ b/doc_src/en/App_Dictionaries.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <appendix id="appendix.dictionaries">
   <title>Dictionaries</title>
 

--- a/doc_src/en/App_Regexp.xml
+++ b/doc_src/en/App_Regexp.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <appendix id="appendix.regexp">
   <title>Regular expressions</title>
 

--- a/doc_src/en/Dialogs_Preferences.xml
+++ b/doc_src/en/Dialogs_Preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="dialogs.preferences">
   <title>General Preferences</title>
 

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="dialogs.projectproperties">
   <title>Project Properties</title>
 

--- a/doc_src/en/HowTo_ManageRTL.xml
+++ b/doc_src/en/HowTo_ManageRTL.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.managerighttoleft">
   <title>Manage Right-To-Left languages</title>
 

--- a/doc_src/en/HowTo_PreventDataLoss.xml
+++ b/doc_src/en/HowTo_PreventDataLoss.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.preventdataloss">
   <title>Prevent data loss</title>
 

--- a/doc_src/en/HowTo_ReuseTM.xml
+++ b/doc_src/en/HowTo_ReuseTM.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.reusetm">
   <title>Reuse Translation Memories</title>
 

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.setupteamproject">
   <title>Set up a Team Project</title>
 

--- a/doc_src/en/HowTo_TranslatePDF.xml
+++ b/doc_src/en/HowTo_TranslatePDF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.translatepdf">
   <title>Translate a PDF file</title>
 

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="howto.useteamproject">
   <title>Use a Team Project</title>
 

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.edit">
   <title>Edit</title>
 

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.goto">
   <title>Go To</title>
 

--- a/doc_src/en/Menus_Help.xml
+++ b/doc_src/en/Menus_Help.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.help">
   <title>Help</title>
 

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.options">
   <title>Options</title>
 

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.project">
   <title>Project</title>
 

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.tools">
   <title>Tools</title>
 

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.view">
   <title>View</title>
 

--- a/doc_src/en/OmegaT4_Appendices.xml
+++ b/doc_src/en/OmegaT4_Appendices.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter>
   <title>Appendices</title>
 

--- a/doc_src/en/OmegaT4_EditorsPanes.xml
+++ b/doc_src/en/OmegaT4_EditorsPanes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="panes">
   <title>Panes</title>
 

--- a/doc_src/en/OmegaT4_HowTo.xml
+++ b/doc_src/en/OmegaT4_HowTo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="howtos">
   <title>How To...</title>
 

--- a/doc_src/en/OmegaT4_Menus.xml
+++ b/doc_src/en/OmegaT4_Menus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="menus">
   <title>Menus</title>
 

--- a/doc_src/en/OmegaT4_ProjectFolder.xml
+++ b/doc_src/en/OmegaT4_ProjectFolder.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="project.folder">
   <title>Project folder</title>
 

--- a/doc_src/en/OmegaT4_Troubleshooting.xml
+++ b/doc_src/en/OmegaT4_Troubleshooting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter>
   <title>Troubleshooting</title>
 </chapter>

--- a/doc_src/en/OmegaT4_WindowsAndDialogs.xml
+++ b/doc_src/en/OmegaT4_WindowsAndDialogs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="windows.and.dialogs">
   <title>Windows and dialogs</title>
 

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.aligner">
   <title>Aligner</title>
 

--- a/doc_src/en/Windows_ProjectFiles.xml
+++ b/doc_src/en/Windows_ProjectFiles.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.projectfiles">
   <title>Project Files</title>
 

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.scripts">
   <title>Scripts</title>
 

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.textreplace">
   <title>Text Replace</title>
 

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.textsearch">
   <title>Text Search</title>
 


### PR DESCRIPTION
The /doc_src/Readme.md file says:

> For efficiency reason, the path to the DTD in the DocBook files (e.g.,
> `AboutOmegaT.xml`) has been changed to a local path
> (`../../../docbook-xml-4.5/docbookx.dtd` instead of an `http://`
> reference).

But there was a discrepancy in the files, some had the local URI some had the absolute URI.

This patch unifies the URI to the local path given in the Readme.md file.