### PR TITLE
Improve plugin information management

### DIFF
--- a/docs_devel/HowToCreateFilterPlugin.md
+++ b/docs_devel/HowToCreateFilterPlugin.md
@@ -25,7 +25,7 @@ Omegat 5.3.0 also supports to provide additional information (valid for both fla
 You can **optionally** provide name, version, author and description. 
 
 OmegaT 5.5.0 can show the plugin name and author in Preferences. You are recommended to set these parameters.
-
+You can **optionally** provide an URL of your plugin home page, license and category.
 For each there are different manifest entry alternatives, and OmegaT will pick the first one present in the order from 
 left to right as described in the table below:
 
@@ -35,6 +35,9 @@ left to right as described in the table below:
 | Version     | Plugin-Version, Bundle-Version, Implementation-Version |
 | Author      | Plugin-Author, Implementation-Vendor, Built-By         |
 | Description | Plugin-Description                                     |
+| Link        | Plugin-Link                                            |
+| License     | Plugin-License                                         |
+| Category    | Plugin-Category                                        |
 
 ### plugins for OmegaT 2.1.3 and up
 A plugin should be declared in `META-INF/MANIFEST.MF`:
@@ -58,6 +61,8 @@ A plugin should be declared in `META-INF/MANIFEST.MF`:
     [Plugin-Version: x.y.z]
     [Plugin-Author: …]
     [Plugin-Description: …]
+    [Plugin-Link: https://..]
+    [Plugin-Category: filter]
     OmegaT-Plugins: <classname>
 
 where classname is the fully qualified classname of the plugin's initialization class. Multiple classnames can be defined, 
@@ -114,6 +119,28 @@ and next checks the version number.
 The `loadPlugins()` method shouldn't execute any long operations.
 The `unloadPlugins()` method executes on application shutdown. Usually, it should be just an empty method, but it can 
 be used to free some resources.
+
+## Plugin categories
+
+Plugin manifest has a mandatory entry `Plugin-Category`:
+
+    [Plugin-Category: filter]
+
+You can choose a value from following list. A value is not affected the plugin behavior
+but it is used when showing a plugin list on preference dialog.
+
+1. filter
+2. tokenizer
+3. marker
+4. machinetranslator
+5. base
+6. glossary
+7. dictionary
+8. miscellaneous
+
+When plugin has a value other than above, OmegaT will show it as 'unknown' category.
+The list of values above is a superset of possible values for 'Omegat-Plugin:' field in
+OmegaT 2.1.3 above definition.
 
 # Set up your development project
 When you develop your plugin, you will extend classes from the OmegaT project, or call methods. To be able to compile 

--- a/src/org/omegat/core/data/PluginInformation.java
+++ b/src/org/omegat/core/data/PluginInformation.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2020 Briac Pilpre
+               2021,2022 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,102 +26,115 @@
 
 package org.omegat.core.data;
 
+import java.net.URL;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-public class PluginInformation {
-    private static final String PLUGIN_NAME = "Plugin-Name";
-    private static final String PLUGIN_VERSION = "Plugin-Version";
-    private static final String PLUGIN_AUTHOR = "Plugin-Author";
-    private static final String PLUGIN_DESCRIPTION = "Plugin-Description";
+import org.omegat.filters2.master.PluginUtils;
 
-    private static final String IMPLEMENTATION_VENDOR = "Implementation-Vendor";
-    private static final String IMPLEMENTATION_TITLE = "Implementation-Title";
-    private static final String IMPLEMENTATION_VERSION = "Implementation-Version";
-    private static final String BUNDLE_VERSION = "Bundle-Version";
-    private static final String BUNDLE_NAME = "Bundle-Name";
-    private static final String BUILT_BY = "Built-By";
+/**
+ * Plugin information POJO data class.
+ * @author Briac Pilpre
+ * @author Hiroshi Miura
+ */
+public class PluginInformation {
+
+    public enum Status {
+        INSTALLED,
+        BUNDLED,
+    }
 
     private final String className;
     private final String name;
     private final String version;
     private final String author;
     private final String description;
+    private final PluginUtils.PluginType category;
+    private final String link;
+    private final URL url;
+    private final Status status;
 
-    public PluginInformation(String className, Manifest manifest) {
+    /* The class is recommend to build from builder. */
+    private PluginInformation(String className, String name, String version, String author, String description,
+                             PluginUtils.PluginType category, String link, URL url, Status status) {
         this.className = className;
-        Attributes attrs = manifest.getMainAttributes();
-        name = findName(manifest);
-        version = findVersion(manifest);
-        author = findAuthor(manifest);
-        description = attrs.getValue(PLUGIN_DESCRIPTION);
+        this.name = name;
+        this.version = version;
+        this.author = author;
+        this.description = description;
+        this.category = category;
+        this.link = link;
+        this.url = url;
+        this.status = status;
     }
 
-    public PluginInformation(String className, Properties props) {
-        this.className = className;
-        name = null;
-        version = null;
-        author = null;
-        description = null;
-    }
-
-    private String findName(Manifest m) {
-        Attributes attrs = m.getMainAttributes();
-        if (attrs.getValue(PLUGIN_NAME) != null) {
-            return attrs.getValue(PLUGIN_NAME);
-        } else if (attrs.getValue(BUNDLE_NAME) != null) {
-            return attrs.getValue(BUNDLE_NAME);
-        } else if (attrs.getValue(IMPLEMENTATION_TITLE) != null) {
-            return attrs.getValue(IMPLEMENTATION_TITLE);
-        }
-        return null;
-    }
-
-    private String findVersion(Manifest m) {
-        Attributes attrs = m.getMainAttributes();
-        if (attrs.getValue(PLUGIN_VERSION) != null) {
-            return attrs.getValue(PLUGIN_VERSION);
-        } else if (attrs.getValue(BUNDLE_VERSION) != null) {
-            return attrs.getValue(BUNDLE_VERSION);
-        } else if (attrs.getValue(IMPLEMENTATION_VERSION) != null) {
-            return attrs.getValue(IMPLEMENTATION_VERSION);
-        }
-        return null;
-    }
-
-    private String findAuthor(Manifest m) {
-        Attributes attrs = m.getMainAttributes();
-        if (attrs.getValue(PLUGIN_AUTHOR) != null) {
-            return attrs.getValue(PLUGIN_AUTHOR);
-        } else if (attrs.getValue(IMPLEMENTATION_VENDOR) != null) {
-            return attrs.getValue(IMPLEMENTATION_VENDOR);
-        } else if (attrs.getValue(BUILT_BY) != null) {
-            return attrs.getValue(BUILT_BY);
-        }
-        return null;
-    }
-
+    /**
+     * @return className of plugin entry point
+     */
     public String getClassName() {
         return className;
     }
 
+    /**
+     * @return name of plugin
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return version of plugin
+     */
     public String getVersion() {
         return version;
     }
 
+    /**
+     * @return description of plugin features
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * @return author(s) of plugin
+     */
     public String getAuthor() {
         return author;
     }
 
+    /**
+     * @return category type of plugin as PluginType enum
+     */
+    public final PluginUtils.PluginType getCategory() {
+        return category;
+    }
+
+    /**
+     * @return link URL of plugin homepage
+     */
+    public final String getLink() {
+        return link;
+    }
+
+    /**
+     * @return manifest URL of plugin jar
+     */
+    public URL getUrl() {
+        return url;
+    }
+
+    /**
+     * @return true if plugin is bundled with OmegaT distribution, otherwise false when 3rd party plugin
+     */
+    public final boolean isBundled() {
+        return status == Status.BUNDLED;
+    }
+
+    /**
+     * @return string expression of PluginInformation class.
+     */
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -130,6 +144,10 @@ public class PluginInformation {
         return builder.toString();
     }
 
+    /**
+     * It is identical if status is differed.
+     * @return hashCode of plugin
+     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -173,4 +191,109 @@ public class PluginInformation {
         return true;
     }
 
+
+    /**
+     * Builder class.
+     */
+    public static final class Builder {
+        private static final String PLUGIN_NAME = "Plugin-Name";
+        private static final String PLUGIN_VERSION = "Plugin-Version";
+        private static final String PLUGIN_AUTHOR = "Plugin-Author";
+        private static final String PLUGIN_DESCRIPTION = "Plugin-Description";
+        private static final String PLUGIN_CATEGORY = "Plugin-Category";
+        private static final String PLUGIN_LINK = "Plugin-Link";
+        private static final String PLUGIN_TYPE = "OmegaT-Plugin";
+        private static final String IMPLEMENTATION_VENDOR = "Implementation-Vendor";
+        private static final String IMPLEMENTATION_TITLE = "Implementation-Title";
+        private static final String IMPLEMENTATION_VERSION = "Implementation-Version";
+        private static final String BUNDLE_VERSION = "Bundle-Version";
+        private static final String BUNDLE_NAME = "Bundle-Name";
+        private static final String BUILT_BY = "Built-By";
+
+        /**
+         * Disable default constructor.
+         */
+        private Builder() {
+        }
+
+        /**
+         * Build PluginInformation from Manifest attributes.
+         * @param className Plugin class name.
+         * @param manifest metadata of plugin.
+         * @param mu URL of manifest
+         * @param status Plugin status, bundled or installed
+         * @return PluginInformation object.
+         */
+        public static PluginInformation fromManifest(final String className, final Manifest manifest, final URL mu,
+                                                     final Status status) {
+            Attributes mainAttrs = manifest.getMainAttributes();
+            Attributes attrs = manifest.getEntries().get(className);
+            if (attrs == null) {
+                  attrs = manifest.getMainAttributes();
+            }
+            return new PluginInformation(className, findName(className, attrs),
+                    findVersion(attrs, mainAttrs), findAuthor(mainAttrs), attrs.getValue(PLUGIN_DESCRIPTION),
+                    PluginUtils.PluginType.getTypeByValue(findCategoryKey(attrs)),
+                    attrs.getValue(PLUGIN_LINK), mu, status);
+        }
+
+        /**
+         * Build PluginInformation from properties.
+         * @param className Plugin class name.
+         * @param props plugin properties bundled with OmegaT.
+         * @param key plugin type string.
+         * @param mu URL of property
+         * @param status Plugin status, bundled or installed
+         * @return PluginInformation object.
+         */
+        public static PluginInformation fromProperties(String className, Properties props, final String key,
+                                                       final URL mu, final Status status) {
+            return new PluginInformation(className, findName(className, null),
+                    null, null, null,
+                    PluginUtils.PluginType.getTypeByValue(key),
+                    null, mu, status);
+        }
+
+        private static String findCategoryKey(Attributes attrs) {
+            return lookupAttribute(attrs, PLUGIN_CATEGORY, PLUGIN_TYPE);
+        }
+
+        private static String findName(String className, Attributes attrs) {
+            if (attrs != null) {
+                String name = lookupAttribute(attrs, PLUGIN_NAME, BUNDLE_NAME, IMPLEMENTATION_TITLE);
+                if (name != null) {
+                    return name;
+                }
+            }
+            return className.substring(className.lastIndexOf(".") + 1);
+        }
+
+        private static String findVersion(Attributes attrs, Attributes mainAttrs) {
+            String version = lookupAttribute(attrs, PLUGIN_VERSION, BUNDLE_VERSION, IMPLEMENTATION_VERSION);
+            if (version != null) {
+                return version;
+            }
+            version = lookupAttribute(mainAttrs, PLUGIN_VERSION, BUNDLE_VERSION, IMPLEMENTATION_VERSION);
+            if (version != null) {
+                return version;
+            }
+            return "unknown";
+        }
+
+        private static String findAuthor(Attributes attrs) {
+            if ("org.omegat.Main".equals(attrs.getValue("Main-Class"))) {
+                return "OmegaT team";
+            }
+            return lookupAttribute(attrs, PLUGIN_AUTHOR, IMPLEMENTATION_VENDOR, BUILT_BY);
+        }
+
+        private static String lookupAttribute(Attributes attrs, String... candidates) {
+            for (String key : candidates) {
+                if (attrs.getValue(key) != null) {
+                    return attrs.getValue(key);
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/src/org/omegat/gui/preferences/view/PluginInfoTableModel.java
+++ b/src/org/omegat/gui/preferences/view/PluginInfoTableModel.java
@@ -51,7 +51,7 @@ public class PluginInfoTableModel extends DefaultTableModel {
     public PluginInfoTableModel() {
         PluginUtils.getPluginInformations().stream()
                 .sorted(Comparator.comparing(PluginInformation::getClassName))
-                .forEach(info -> listPlugins.add(info));
+                .forEach(listPlugins::add);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class PluginInfoTableModel extends DefaultTableModel {
 
     @Override
     public int getRowCount() {
-        return listPlugins == null ? 0 : listPlugins.size();
+        return listPlugins.size();
     }
 
     @Override

--- a/test/data/plugin/MANIFEST.MF
+++ b/test/data/plugin/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Plugin-Name: Filters for OmegaT
+Plugin-Author: Example Author
+Plugin-Description: Example Description.
+Plugin-Link: https://example.com
+Plugin-Category: filter
+OmegaT-Plugins: com.example.ExampleFilter

--- a/test/src/org/omegat/core/data/PluginInformationTest.java
+++ b/test/src/org/omegat/core/data/PluginInformationTest.java
@@ -1,0 +1,66 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+
+import org.omegat.filters2.master.PluginUtils;
+
+
+/**
+ * Test for PluginInformation class.
+ * @author Hiroshi Miura
+ */
+public class PluginInformationTest {
+
+   @Test
+   public void test1() throws IOException {
+      File manifest = new File("test/data/plugin/MANIFEST.MF");
+      URL mu = manifest.toURI().toURL();
+      try (InputStream in = new FileInputStream(manifest)) {
+         Manifest m = new Manifest(in);
+         String pluginClass = m.getMainAttributes().getValue("OmegaT-Plugins");
+         PluginInformation pluginInformation = PluginInformation.Builder
+                 .fromManifest(pluginClass, m, mu, PluginInformation.Status.INSTALLED);
+         assertEquals("Filters for OmegaT", pluginInformation.getName());
+         assertEquals("Example Author", pluginInformation.getAuthor());
+         assertEquals(PluginUtils.PluginType.FILTER, pluginInformation.getCategory());
+         assertEquals("https://example.com", pluginInformation.getLink());
+         assertEquals(mu, pluginInformation.getUrl());
+         assertFalse(pluginInformation.isBundled());
+      }
+   }
+}


### PR DESCRIPTION
- Manage plugins status whether is bundled or installed
- Better version and author detection
    - Set "OmegaT team" for bundled plugins
    - Set version as same as OmegaT for bundled plugins
- Support extended metadata plugin-link  [RFE#1544](https://sourceforge.net/p/omegat/feature-requests/1544/)
- Plugin category name from plugin-category or old OmegaT-Plugin metadata.

- PluginInformation class is now POJO data class, and introduce its builder 
