### PR TITLE
Linux: load openjfx when exist

### DIFF
--- a/release/linux-specific/OmegaT
+++ b/release/linux-specific/OmegaT
@@ -1,15 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # readlink follows any symbolic links to get the real file
-REALOMEGATPATH=`dirname "$(readlink -nf $0)"`
+REAL_OMEGAT_PATH=$(dirname "$(readlink -nf "$0")")
 
 JAVA="java"
-BUNDLED_JAVA="${REALOMEGATPATH}/jre/bin/java"
-[ -f "${BUNDLED_JAVA}" ] && JAVA="${BUNDLED_JAVA}"
+BUNDLED_JAVA="$REAL_OMEGAT_PATH/jre/bin/java"
+[ -f "$BUNDLED_JAVA" ] && JAVA="$BUNDLED_JAVA"
 
-version=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{print $1}')
-if [[ "${OPENJFX_CLASSPATH}" ]] && [[ "${version}" == "11" ]]; then
-  "${JAVA}" --module-path ${OPENJFX_CLASSPATH} --add-modules=javafx.base,javafx.controls,javafx.swing,javafx.web -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
-else
-  "${JAVA}" -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
+JAVA_VERSION=$("$JAVA" -version 2>&1 | sed -nE 's/.*version "([0-9_.]+)".*/\1/p')
+
+OPENJFX_OPTS=
+if [ -n "$OPENJFX_CLASSPATH" ] && [[ "$JAVA_VERSION" =~ ^11\. ]]; then
+    OPENJFX_OPTS=(
+        "--module-path" "$OPENJFX_CLASSPATH"
+        "--add-modules=javafx.base,javafx.controls,javafx.swing,javafx.web"
+    )
 fi
+
+"$JAVA" "${OPENJFX_OPTS[@]}" -jar -Xmx1024M "$REAL_OMEGAT_PATH/@JAR_SUBST@" "$@"

--- a/release/linux-specific/OmegaT
+++ b/release/linux-specific/OmegaT
@@ -7,4 +7,9 @@ JAVA="java"
 BUNDLED_JAVA="${REALOMEGATPATH}/jre/bin/java"
 [ -f "${BUNDLED_JAVA}" ] && JAVA="${BUNDLED_JAVA}"
 
-"${JAVA}" -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
+version=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{print $1}')
+if [[ "${OPENJFX_CLASSPATH}" ]] && [[ "${version}" == "11" ]]; then
+  "${JAVA}" --module-path ${OPENJFX_CLASSPATH} --add-modules=javafx.base,javafx.controls,javafx.swing,javafx.web -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
+else
+  "${JAVA}" -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
+fi

--- a/release/linux-specific/OmegaT
+++ b/release/linux-specific/OmegaT
@@ -13,7 +13,7 @@ OPENJFX_OPTS=
 if [ -n "$OPENJFX_CLASSPATH" ] && [[ "$JAVA_VERSION" =~ ^11\. ]]; then
     OPENJFX_OPTS=(
         "--module-path" "$OPENJFX_CLASSPATH"
-        "--add-modules=javafx.base,javafx.controls,javafx.swing,javafx.web"
+        "--add-modules" "javafx.base,javafx.controls,javafx.swing,javafx.web"
     )
 fi
 


### PR DESCRIPTION
When java is 11 and openjfx is specified by OPENJFX_CLASSPATH
automatically load openjfx as module.
This help plugin which use javafx.swing GUI component working.

Current distribution with JRE bundles AdoptOpenJDK 8 that does not support JavaFX.

When user downloads OmegaT distribution without JRE, and use java environment on Linux, 
there may be a OpenJDK 11 and it can be with OpenJFX.

This modification support the situation. 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>