### PR TITLE
Plugin: drop old tokenizer loader

### DIFF
--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -343,10 +343,6 @@ public final class PluginUtils {
             String key = e.getKey();
             Attributes attrs = e.getValue();
             String sType = attrs.getValue("OmegaT-Plugin");
-            if ("true".equals(attrs.getValue("OmegaT-Tokenizer"))) {
-                // TODO remove after release new tokenizers
-                sType = "tokenizer";
-            }
             if (sType == null) {
                 // WebStart signing section, or other section
                 continue;


### PR DESCRIPTION
This part of source was added 10 years ago and have a comment 

```
// TODO remove after release new tokenizers
```

This patch remove it.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>