### PR TITLE
Replace text with trText in an argument of cleanSpacesAroundTags

### DIFF
--- a/src/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/src/org/omegat/core/machinetranslators/Google2Translate.java
@@ -129,7 +129,7 @@ public class Google2Translate extends BaseTranslate {
 
         tr = unescapeHTML(tr);
 
-        tr = cleanSpacesAroundTags(tr, text);
+        tr = cleanSpacesAroundTags(tr, trText);
 
         putToCache(sLang, tLang, trText, tr);
         return tr;


### PR DESCRIPTION
DeepLTranslate.java and Google2Translate.java have duplicate code.
Based on pattern analysis, an argument of cleanSpacesAroundTags in Google2Translate.java should be trText. Please refer to Line number 124 in DeepLTranslate.java.
