### PR TITLE
team/git: allow arbitrary name for default branch

### DIFF
--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -199,7 +199,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     public void switchToVersion(String version) throws Exception {
         try (Git git = new Git(repository)) {
             if (version == null) {
-                version = REMOTE + "/" + getDefaultBranchName(repositoryURL);
+                version = String.join("/", REMOTE, getDefaultBranchName(repositoryURL));
                 // TODO fetch
                 git.fetch().setRemote(REMOTE).setTimeout(TIMEOUT).call();
             }

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -389,14 +389,21 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     public static String getDefaultBranchName(final String repositoryUrl) {
         String branch;
         try {
-            Ref head = Git.lsRemoteRepository().setRemote(repositoryUrl).callAsMap().get("HEAD");
+            Map<String, Ref> gitMap = Git.lsRemoteRepository().setRemote(repositoryUrl).callAsMap();
+            Ref head = gitMap.get("HEAD");
             if (head != null) {
                 if (head.isSymbolic()) {
                     String b = head.getTarget().getName();
                     return b.substring(b.lastIndexOf('/') + 1);
                 } else {
                     AnyObjectId id = head.getObjectId();
-                    return id.getName();
+                    for (String b : gitMap.keySet()) {
+                        if (b.startsWith("refs/heads/")) {
+                            if (id.equals(gitMap.get(b).getObjectId())) {
+                                return b.substring(b.lastIndexOf('/') + 1);
+                            }
+                        }
+                    }
                 }
             }
         } catch (GitAPIException ignore) {

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -298,7 +298,7 @@ public final class TestTeamIntegration {
         File repoDir = Stream.of(new File(dir, RemoteRepositoryProvider.REPO_SUBDIR).listFiles())
                 .filter(File::isDirectory).findFirst().get();
         if (url.startsWith("git") || url.endsWith(".git")) {
-            return new GitTeam(repoDir, url);
+            return new GitTeam(repoDir);
         } else if (url.startsWith("svn") || url.startsWith("http") || url.endsWith(".svn")) {
             return new SvnTeam(repoDir, url);
         } else {
@@ -376,13 +376,11 @@ public final class TestTeamIntegration {
 
     public static class GitTeam implements Team {
         final Repository repository;
-        final String repositoryUrl;
         final File dir;
 
-        public GitTeam(File dir, String url) throws Exception {
+        public GitTeam(File dir) throws Exception {
             this.dir = dir;
             repository = Git.open(dir).getRepository();
-            repositoryUrl = url;
         }
 
         public List<String> listRevisions(String from) throws Exception {
@@ -403,7 +401,7 @@ public final class TestTeamIntegration {
         public void update() throws Exception {
             try (Git git = new Git(repository)) {
                 git.fetch().call();
-                git.checkout().setName(GITRemoteRepository2.getDefaultBranchName(repository, repositoryUrl)).call();
+                git.checkout().setName(GITRemoteRepository2.getDefaultBranchName(repository)).call();
             }
         }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -45,6 +45,7 @@ import org.omegat.core.data.ProjectTMX.CheckOrphanedCallback;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
 import org.omegat.core.team2.impl.SVNAuthenticationManager;
 import org.omegat.util.Language;
 import org.omegat.util.ProjectFileStorage;
@@ -297,7 +298,7 @@ public final class TestTeamIntegration {
         File repoDir = Stream.of(new File(dir, RemoteRepositoryProvider.REPO_SUBDIR).listFiles())
                 .filter(File::isDirectory).findFirst().get();
         if (url.startsWith("git") || url.endsWith(".git")) {
-            return new GitTeam(repoDir);
+            return new GitTeam(repoDir, url);
         } else if (url.startsWith("svn") || url.startsWith("http") || url.endsWith(".svn")) {
             return new SvnTeam(repoDir, url);
         } else {
@@ -375,11 +376,13 @@ public final class TestTeamIntegration {
 
     public static class GitTeam implements Team {
         final Repository repository;
+        final String repositoryUrl;
         final File dir;
 
-        public GitTeam(File dir) throws Exception {
+        public GitTeam(File dir, String url) throws Exception {
             this.dir = dir;
             repository = Git.open(dir).getRepository();
+            repositoryUrl = url;
         }
 
         public List<String> listRevisions(String from) throws Exception {
@@ -400,7 +403,7 @@ public final class TestTeamIntegration {
         public void update() throws Exception {
             try (Git git = new Git(repository)) {
                 git.fetch().call();
-                git.checkout().setName("origin/master").call();
+                git.checkout().setName(GITRemoteRepository2.getDefaultBranchName(repositoryUrl)).call();
             }
         }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -403,7 +403,7 @@ public final class TestTeamIntegration {
         public void update() throws Exception {
             try (Git git = new Git(repository)) {
                 git.fetch().call();
-                git.checkout().setName(GITRemoteRepository2.getDefaultBranchName(repositoryUrl)).call();
+                git.checkout().setName(GITRemoteRepository2.getDefaultBranchName(repository, repositoryUrl)).call();
             }
         }
 


### PR DESCRIPTION
- Detect remote default branch name in cloned project.
  - Get remote/origin  from remote repository URL
  - Get default branch from HEAD name when isSymbolic() is true, otherwise check all 'ref/heads/*' ObjectId.
  - When the attempt failed, use "origin/master" 
- Resolve [RFE#1531](https://sourceforge.net/p/omegat/feature-requests/1531/) and [BUG#1041](https://sourceforge.net/p/omegat/bugs/1041/)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>