### PR TITLE
Update HttpConnectilUtils#downloadBinaryFile

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1917,6 +1917,12 @@ SU_SCRIPT_DIR_CREATE_ERROR=It was not possible to create the script folder\n\
     inside the configuration folder. The configuration folder will be used\n\
     instead.
 
+# HttpConnectionUtils
+
+HCU_MIME_ERROR=Got unexpected MIME TYPE {0}
+
+HCU_RESPONSE_ERROR=Got unexpected HTTP response {0}
+
 # Log
 
 LOG_LEVEL_SEVERE=Error

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -141,18 +141,12 @@ public final class HttpConnectionUtils {
         int responseCode = httpURLConnection.getResponseCode();
         if (responseCode == HttpURLConnection.HTTP_OK) {
             String contentType = httpURLConnection.getContentType();
-            int contentLength = httpURLConnection.getContentLength();
+            long contentLength = httpURLConnection.getContentLength();
             if (contentType.equals("application/octet-stream") || contentType.equals("application/jar-archive")) {
                 try (InputStream inputStream = httpURLConnection.getInputStream();
                      FileOutputStream outputStream = new FileOutputStream(saveFilePath)) {
-                    int bytesRead = -1;
-                    int readLength = 0;
-                    byte[] buffer = new byte[BUFFER_SIZE];
-                    while ((bytesRead = inputStream.read(buffer)) != -1) {
-                        readLength += bytesRead;
-                        outputStream.write(buffer, 0, bytesRead);
-                    }
-                    assert (contentLength == readLength);
+                    long transferred = IOUtils.copy(inputStream, outputStream, BUFFER_SIZE);
+                    assert(transferred == contentLength);
                     result = true;
                 } catch (Exception ex) {
                     Log.log(ex);

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -147,7 +147,7 @@ public final class HttpConnectionUtils {
                      FileOutputStream outputStream = new FileOutputStream(saveFilePath)) {
                     long transferred = IOUtils.copy(inputStream, outputStream, BUFFER_SIZE);
                     if (transferred != contentLength) {
-                        throw new FlakyDownloadException("Downloaded file length and content length of header is differ.");
+                        throw new FlakyDownloadException("Downloaded file length differs from expected content length reported in header.");
                     }
                     result = true;
                 } catch (Exception ex) {

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -146,7 +146,10 @@ public final class HttpConnectionUtils {
                 try (InputStream inputStream = httpURLConnection.getInputStream();
                      FileOutputStream outputStream = new FileOutputStream(saveFilePath)) {
                     long transferred = IOUtils.copy(inputStream, outputStream, BUFFER_SIZE);
-                    assert(transferred == contentLength);
+                    if (transferred != contentLength) {
+                        throw new FlakyDownloadException(
+                                new Exception("Downloaded file length and content length of header is differ."));
+                    }
                     result = true;
                 } catch (Exception ex) {
                     Log.log(ex);

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -142,22 +142,29 @@ public final class HttpConnectionUtils {
         if (responseCode == HttpURLConnection.HTTP_OK) {
             String contentType = httpURLConnection.getContentType();
             int contentLength = httpURLConnection.getContentLength();
-            if (contentType.equals("binary/octet-stream") || contentType.equals("application/jar-archive")) {
+            if (contentType.equals("application/octet-stream") || contentType.equals("application/jar-archive")) {
                 try (InputStream inputStream = httpURLConnection.getInputStream();
                      FileOutputStream outputStream = new FileOutputStream(saveFilePath)) {
                     int bytesRead = -1;
                     int readLength = 0;
                     byte[] buffer = new byte[BUFFER_SIZE];
                     while ((bytesRead = inputStream.read(buffer)) != -1) {
+                        readLength += bytesRead;
                         outputStream.write(buffer, 0, bytesRead);
                     }
+                    assert (contentLength == readLength);
+                    result = true;
+                } catch (Exception ex) {
+                    Log.log(ex);
                 } finally {
                     httpURLConnection.disconnect();
                 }
-                result = true;
             } else {
+                Log.logErrorRB("HCU_MIME_ERROR" , contentType);
                 httpURLConnection.disconnect();
             }
+        } else {
+            Log.logErrorRB("HCU_RESPONSE_ERROR", responseCode);
         }
         return result;
     }

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -147,8 +147,7 @@ public final class HttpConnectionUtils {
                      FileOutputStream outputStream = new FileOutputStream(saveFilePath)) {
                     long transferred = IOUtils.copy(inputStream, outputStream, BUFFER_SIZE);
                     if (transferred != contentLength) {
-                        throw new FlakyDownloadException(
-                                new Exception("Downloaded file length and content length of header is differ."));
+                        throw new FlakyDownloadException("Downloaded file length and content length of header is differ.");
                     }
                     result = true;
                 } catch (Exception ex) {
@@ -401,6 +400,10 @@ public final class HttpConnectionUtils {
     @SuppressWarnings("serial")
     public static class FlakyDownloadException extends RuntimeException {
         public FlakyDownloadException(Exception cause) {
+            super(cause);
+        }
+
+        public FlakyDownloadException(String cause) {
             super(cause);
         }
     }


### PR DESCRIPTION
- Use IOUtils.copy for downloading content
- Raise FlakyDownloadError when content size is wrong
- Change MIME type to check against

Signed-off-by: Hiroshi Miura <miurahr@linux.com>