### PR TITLE
WIP: Introduce RemotePluginInformation, container of remote plugins metadata

### DIFF
--- a/src/org/omegat/core/data/RemotePluginInformation.java
+++ b/src/org/omegat/core/data/RemotePluginInformation.java
@@ -1,0 +1,59 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+public class RemotePluginInformation extends PluginInformation {
+    private final String PLUGIN_JAR_URL = "Plugin-Download-Url";
+    private final String PLUGIN_JAR_FILENAME = "Plugin-Jar-Filename";
+    private final String PLUGIN_SHA256SUM = "Plugin-Sha256Sum";
+
+    private final String remoteJarFileUrl;
+    private final String jarFilename;
+    private final String sha256Sum;
+
+    public RemotePluginInformation(String className, Manifest manifest) {
+        super(className, manifest);
+        Attributes attrs = manifest.getMainAttributes();
+        remoteJarFileUrl = attrs.getValue(PLUGIN_JAR_URL);
+        jarFilename = attrs.getValue(PLUGIN_JAR_FILENAME);
+        sha256Sum = attrs.getValue(PLUGIN_SHA256SUM);
+    }
+
+    public String getRemoteJarFileUrl() {
+        return remoteJarFileUrl;
+    }
+
+    public String getJarFilename() {
+        return jarFilename;
+    }
+
+    public String getSha256Sum() {
+        return sha256Sum;
+    }
+}

--- a/src/org/omegat/core/data/RemotePluginInformation.java
+++ b/src/org/omegat/core/data/RemotePluginInformation.java
@@ -41,7 +41,7 @@ public class RemotePluginInformation extends PluginInformation {
         super(className, manifest);
         Attributes attrs = manifest.getMainAttributes();
         remoteJarFileUrl = attrs.getValue(PLUGIN_JAR_URL);
-        jarFilename = attrs.getValue(PLUGIN_JAR_FILENAME);
+        jarFilename = getJarFilename(attrs);
         sha256Sum = attrs.getValue(PLUGIN_SHA256SUM);
     }
 
@@ -55,5 +55,25 @@ public class RemotePluginInformation extends PluginInformation {
 
     public String getSha256Sum() {
         return sha256Sum;
+    }
+
+    private String getJarFilename(Attributes attrs) {
+        String attrsName = attrs.getValue(PLUGIN_JAR_FILENAME);
+        if (attrsName != null) {
+            return attrsName;
+        }
+        if (attrs.getValue(PLUGIN_JAR_URL) != null) {
+            int from = remoteJarFileUrl.lastIndexOf("/");
+            int to = remoteJarFileUrl.indexOf("?");
+            if (from != -1) {
+                if (to == -1) {
+                    return remoteJarFileUrl.substring(from + 1);
+                } else {
+                    return remoteJarFileUrl.substring(from + 1, to);
+                }
+            }
+        }
+        String className = getClassName();
+        return className.substring(className.lastIndexOf(".") + 1);
     }
 }

--- a/test/data/plugin/plugins.MF
+++ b/test/data/plugin/plugins.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Plugin-Name: TexTra MT
+Plugin-Author: Hiroshi Miura
+OmegaT-Plugins: tokyo.northside.omegat.textra.OmegatTextraMachineTransla
+ tion
+Plugin-Description: NICT TexTra(r) Machine Translation API plugin for Om
+ egaT
+Plugin-Id: omegat-textra-plugin
+Plugin-Version: 2020.2.2.175
+Plugin-Link: https://github.com/miurahr/omegat-textra-plugin
+Plugin-Category: machinetranslator
+Created-By: 11.0.10 (Ubuntu)
+Plugin-Date: 2021-03-10T00:40:55+0900
+Plugin-Download-Url: https://github.com/miurahr/omegat-textra-plugin/releases/download/v2020.2.2/omegat-textra-plugin-2020.2.2.jar
+Plugin-Jar-Filename: omegat-textra-plugin-2020.2.2.jar
+Plugin-Sha256Sum: 5639d05d103ca297f502aca2a14323b2889f4cae1e02b6900dd095c55f4b8757

--- a/test/src/org/omegat/core/data/RemotePluginInInformationTest.java
+++ b/test/src/org/omegat/core/data/RemotePluginInInformationTest.java
@@ -1,0 +1,51 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+
+
+/**
+ * Test for RemotePluginInformation class.
+ * @author Hiroshi Miura
+ */
+public class RemotePluginInInformationTest {
+
+   @Test
+   public void test1() throws IOException {
+      try (InputStream in = new FileInputStream("test/data/plugin/plugins.MF")) {
+         Manifest m = new Manifest(in);
+         String pluginClass = m.getMainAttributes().getValue("OmegaT-Plugins");
+         RemotePluginInformation remotePluginInformation = new RemotePluginInformation(pluginClass, m);
+         assert (remotePluginInformation.getJarFilename().equals("omegat-textra-plugin-2020.2.2.jar"));
+      }
+   }
+}

--- a/test/src/org/omegat/core/data/RemotePluginInInformationTest.java
+++ b/test/src/org/omegat/core/data/RemotePluginInInformationTest.java
@@ -25,6 +25,8 @@
 
 package org.omegat.core.data;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,7 +47,7 @@ public class RemotePluginInInformationTest {
          Manifest m = new Manifest(in);
          String pluginClass = m.getMainAttributes().getValue("OmegaT-Plugins");
          RemotePluginInformation remotePluginInformation = new RemotePluginInformation(pluginClass, m);
-         assert (remotePluginInformation.getJarFilename().equals("omegat-textra-plugin-2020.2.2.jar"));
+         assertEquals("omegat-textra-plugin-2020.2.2.jar", remotePluginInformation.getJarFilename());
       }
    }
 }


### PR DESCRIPTION
- RemotePluginInformation extends PluginInformation that can hold
  URL of plugin file to be downloaded, and its SHA256 checksum.
- Add primitive test for class.

This is spin-off of PR #69

Signed-off-by: Hiroshi Miura <miurahr@linux.com>