### PR TITLE
Gradle: allow GnuPG for signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1074,7 +1074,11 @@ publishing {
 
 signing {
     sign publishing.publications.mavenJava
+    if (!findProperty("signing.keyId") || findProperty("signing.keyId").equals("")) {
+        useGpgCmd()
+    }
 }
+
 
 remotes {
     sourceforgeWeb {

--- a/build.gradle
+++ b/build.gradle
@@ -1074,7 +1074,7 @@ publishing {
 
 signing {
     sign publishing.publications.mavenJava
-    if (!findProperty("signing.keyId") || findProperty("signing.keyId").equals("")) {
+    if (!findProperty("signing.keyId")) {
         useGpgCmd()
     }
 }

--- a/local.properties.example
+++ b/local.properties.example
@@ -41,6 +41,10 @@ signing.keyId=
 signing.password=
 # Exported as e.g. `gpg --export-secret-keys > secring.gpg`
 signing.secretKeyRingFile=
+## When you want to use GnuPG command instead of exported keyring
+## uncommented and add key ID
+#signing.gnupg.keyName=
+#signing.gnupg.executable=gpg
 
 ## SourceForge web
 sourceforgeWebUser=

--- a/local.properties.example
+++ b/local.properties.example
@@ -36,26 +36,16 @@ ossrhUser=
 ossrhKey=
 
 ## Signing for Maven Central
+#
+# Option 1: Supply key ID and password directly in this file
+# Option 2: Leave signing.* properties blank to use the system gpg2 command; see
+#   https://docs.gradle.org/current/userguide/signing_plugin.html#sec:sec:gnupg_signatory_configuration
+#
 # Last 8 characters of full key ID
 signing.keyId=
 signing.password=
 # Exported as e.g. `gpg --export-secret-keys > secring.gpg`
 signing.secretKeyRingFile=
-
-# When you don't define signing.keyId, gradle try to use GnuPG command
-# (GnupgSignatory) instead of the default PgpSignatory.
-# The GnupgSignatory relies on the gpg2 program to sign the artifacts.
-# Please see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:sec:gnupg_signatory_configuration
-# for configurations details.
-#
-# - signing.gnupg.executable=gpg
-#    The gpg executable that is invoked for signing.
-# - signing.gnupg.keyName=
-#    The id of the key that should be used for signing. If not given then
-#    the default key configured in GnuPG will be used.
-# - signing.gnupg.passphrase
-#    The passphrase for unlocking the secret key. If not given then
-#    the gpg-agent program is used for getting the passphrase.
 
 ## SourceForge web
 sourceforgeWebUser=

--- a/local.properties.example
+++ b/local.properties.example
@@ -41,10 +41,21 @@ signing.keyId=
 signing.password=
 # Exported as e.g. `gpg --export-secret-keys > secring.gpg`
 signing.secretKeyRingFile=
-## When you want to use GnuPG command instead of exported keyring
-## uncommented and add key ID
-#signing.gnupg.keyName=
-#signing.gnupg.executable=gpg
+
+# When you don't define signing.keyId, gradle try to use GnuPG command
+# (GnupgSignatory) instead of the default PgpSignatory.
+# The GnupgSignatory relies on the gpg2 program to sign the artifacts.
+# Please see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:sec:gnupg_signatory_configuration
+# for configurations details.
+#
+# - signing.gnupg.executable=gpg
+#    The gpg executable that is invoked for signing.
+# - signing.gnupg.keyName=
+#    The id of the key that should be used for signing. If not given then
+#    the default key configured in GnuPG will be used.
+# - signing.gnupg.passphrase
+#    The passphrase for unlocking the secret key. If not given then
+#    the gpg-agent program is used for getting the passphrase.
 
 ## SourceForge web
 sourceforgeWebUser=


### PR DESCRIPTION
It is convenient for developer who use GnuPG and want to publish OmegaT to localMaven to develop plugins.
It is even safer, because Gradle ask password interactively when running publish, and no need to write key password on property file.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>