### PR TITLE
Bump pdfbox@2.0.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ dependencies {
         implementation 'com.sun.xml.bind:jaxb-impl:2.3.2'
 
         // PDF Filter
-        implementation 'org.apache.pdfbox:pdfbox:2.0.23'
+        implementation 'org.apache.pdfbox:pdfbox:2.0.24'
 
         // Aligner
         implementation 'net.loomchild:maligna:3.0.0'


### PR DESCRIPTION
- Security Advisories
  - Uncontrolled memory consumption / GHSA-fg3j-q579-v8x4
  - Infinite loop / GHSA-7grw-6pjh-jpc9

Affected versions: 4.0.1...5.5.0

Signed-off-by: Hiroshi Miura <miurahr@linux.com>