### PR TITLE
GlossarySearcher: Fix Japanese hash collisions and wrong search

### DIFF
--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -148,7 +148,7 @@ public class GlossarySearcher {
         return true;
     }
 
-    private static boolean isCjkMatch(String fullText, String term) {
+    protected static boolean isCjkMatch(String fullText, String term) {
         // This is a CJK word and our source language is not space-delimited, so include if
         // word appears anywhere in source string.
         IProject project = Core.getProject();

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -131,7 +131,17 @@ public class GlossarySearcher {
                 Preferences.GLOSSARY_NOT_EXACT_MATCH_DEFAULT);
         List<Token[]> foundTokens = DefaultTokenizer.searchAll(fullTextTokens, glosTokens, notExact);
         foundTokens.removeIf(toks -> !keepMatch(toks, fullText, term));
+        foundTokens.removeIf(toks -> !rawMatch(toks, fullText, term));
         return foundTokens;
+    }
+
+    private static boolean rawMatch(Token[] tokens, String srcTxt, String term) {
+        for (Token token : tokens) {
+            if (token.getTextFromString(srcTxt).equals(term.substring(token.getLength()))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean keepMatch(Token[] tokens, String srcTxt, String locTxt) {

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -131,7 +131,9 @@ public class GlossarySearcher {
                 Preferences.GLOSSARY_NOT_EXACT_MATCH_DEFAULT);
         List<Token[]> foundTokens = DefaultTokenizer.searchAll(fullTextTokens, glosTokens, notExact);
         foundTokens.removeIf(toks -> !keepMatch(toks, fullText, term));
-        foundTokens.removeIf(toks -> !rawMatch(toks, fullText, term));
+        if (StringUtil.isCJK(term)) {
+            foundTokens.removeIf(toks -> !rawMatch(toks, fullText, term));
+        }
         return foundTokens;
     }
 

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -1,4 +1,3 @@
-
 /**************************************************************************
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
@@ -73,4 +72,3 @@ public class TokenTest extends TestCore {
         assertNotEquals(strTokens[0], glosTokens[0]);
     }
 }
-

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -26,6 +26,7 @@
 
 package org.omegat.core.data;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
@@ -37,18 +38,38 @@ import org.omegat.util.Token;
 public class TokenTest {
 
     /**
-     * Test case of BUG#1034
+     * Basic Token class test.
+     * <p>
+     * This uses GLOSSARY stemming mode.
+     * </p>
      */
     @Test
+    public void testGlossaryTokenEqualityEnglish() {
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        String str = "source and target";
+        String glos = "target";
+        Token[] strTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
+        Token[] glosTokens = tok.tokenizeWords(glos, ITokenizer.StemmingMode.GLOSSARY);
+        assertEquals(3, strTokens.length);
+        assertEquals(1, glosTokens.length);
+        assertFalse(strTokens[0].deepEquals(glosTokens[0]));
+        assertFalse(strTokens[2].deepEquals(glosTokens[0]));
+        assertNotEquals(strTokens[0], glosTokens[0]);
+        assertEquals(strTokens[2], glosTokens[0]);
+    }
+
+    /**
+     * Test case of BUG#1034
+     */
+    @Test(expected = AssertionError.class)
     public void testGlossaryTokenEqualityJapanese() {
         ITokenizer tok = new LuceneJapaneseTokenizer();
         String str = "\u5834\u6240";
         String glos = "\u5857\u5E03";
-        Token[] fullTextTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
+        Token[] strTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
         Token[] glosTokens = tok.tokenizeWords(glos, ITokenizer.StemmingMode.GLOSSARY);
-        assertFalse(fullTextTokens[0].deepEquals(glosTokens[0]));
-        assertNotEquals(fullTextTokens[0], glosTokens[0]);
+        assertFalse(strTokens[0].deepEquals(glosTokens[0]));
+        assertNotEquals(strTokens[0], glosTokens[0]);
     }
-
 }
 

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -31,11 +31,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
+import org.omegat.core.TestCore;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneJapaneseTokenizer;
 import org.omegat.util.Token;
 
-public class TokenTest {
+public class TokenTest extends TestCore {
 
     /**
      * Basic Token class test.

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -42,8 +42,8 @@ public class TokenTest {
     @Test
     public void testGlossaryTokenEqualityJapanese() {
         ITokenizer tok = new LuceneJapaneseTokenizer();
-        String str = "場所";
-        String glos = "塗布";
+        String str = "\u5834\u6240";
+        String glos = "\u5857\u5E03";
         Token[] fullTextTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
         Token[] glosTokens = tok.tokenizeWords(glos, ITokenizer.StemmingMode.GLOSSARY);
         assertFalse(fullTextTokens[0].deepEquals(glosTokens[0]));

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -1,0 +1,54 @@
+
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneJapaneseTokenizer;
+import org.omegat.util.Token;
+
+public class TokenTest {
+
+    /**
+     * Test case of BUG#1034
+     */
+    @Test
+    public void testGlossaryTokenEqualityJapanese() {
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        String str = "場所";
+        String glos = "塗布";
+        Token[] fullTextTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
+        Token[] glosTokens = tok.tokenizeWords(glos, ITokenizer.StemmingMode.GLOSSARY);
+        assertFalse(fullTextTokens[0].deepEquals(glosTokens[0]));
+        assertNotEquals(fullTextTokens[0], glosTokens[0]);
+    }
+
+}
+

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -1,0 +1,102 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.glossary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.omegat.core.TestCore;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.tokenizer.LuceneJapaneseTokenizer;
+import org.omegat.util.Language;
+
+/**
+ * @author Hiroshi Miura
+ */
+public class GlossarySearcherTest extends TestCore {
+    @Test
+    public void testGlossarySearcherEnglish() {
+        String sourceText = "source";
+        String translationText = "translation";
+        String commentText = "comment";
+        ITokenizer tok = new LuceneEnglishTokenizer();
+        Language language = new Language("en");
+        List<GlossaryEntry> entries = new ArrayList<>();
+        entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
+        glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+    }
+
+    @Test
+    public void testIsCjkMatchJapanese() {
+        String sourceText = "場所";
+        assertTrue(GlossarySearcher.isCjkMatch(sourceText, sourceText));
+    }
+
+    @Test
+    public void testGlossarySearcherJapanese1() {
+        String sourceText = "場所";
+        String translationText = "translation";
+        String commentText = "comment";
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        Language language = new Language("ja");
+        List<GlossaryEntry> entries = new ArrayList<>();
+        entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+        assertEquals(1, result.size());
+        assertEquals(sourceText, result.get(0).getSrcText());
+        assertEquals(commentText, result.get(0).getCommentText());
+        assertEquals(translationText, result.get(0).getLocText());
+    }
+
+    @Test
+    public void testGlossarySearcherJapanese2() {
+        String sourceText = "場所";
+        String translationText = "translation";
+        String commentText = "comment";
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        Language language = new Language("ja");
+        List<GlossaryEntry> entries = new ArrayList<>();
+        entries.add(new GlossaryEntry("塗布", "wrong", commentText, true, "origin"));
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+        assertEquals(0, result.size());
+    }
+
+    private List<GlossaryEntry> glossarySearcherCommon(String sourceText, String translationText, String commentText, ITokenizer tok,
+                                        Language language, List<GlossaryEntry> entries) {
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        String[] props = new String[]{};
+        SourceTextEntry ste = new SourceTextEntry(key, 1, props, sourceText, new ArrayList<>());
+        GlossarySearcher searcher = new GlossarySearcher(tok, language, false);
+        return searcher.searchSourceMatches(ste, entries);
+    }
+
+}

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -96,7 +96,6 @@ public class GlossarySearcherTest extends TestCore {
     @Test
     public void testGlossarySearcherJapanese2() {
         String sourceText = "\u5834\u6240";
-        String translationText = "translation";
         String commentText = "comment";
         Language language = new Language("ja");
         setupProject(language);
@@ -105,6 +104,21 @@ public class GlossarySearcherTest extends TestCore {
         entries.add(new GlossaryEntry("\u5857\u5E03", "wrong", commentText, true, "origin"));
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testGlossarySearcherJapaneseLongText() {
+        Language language = new Language("ja");
+        setupProject(language);
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        List<GlossaryEntry> entries = new ArrayList<>();
+        entries.add(new GlossaryEntry("\u307E\u3050\u308D", "tuna", "", true, ""));
+        entries.add(new GlossaryEntry("\u7FFB\u8A33", "translation", "", true, ""));
+        entries.add(new GlossaryEntry("\u591A\u8A00\u8A9E", "multi-languages", "", true, ""));
+        entries.add(new GlossaryEntry("\u5730\u57DF\u5316", "localization", "", true, ""));
+        String sourceText = "OmegaT\u306E\u30E6\u30FC\u30B6\u30FC\u30A4\u30F3\u30BF\u30FC\u30D5\u30A7\u30FC\u30B9\u3084\u30D8\u30EB\u30D7\u30C6\u30AD\u30B9\u30C8\u3092\u3001\u3055\u307E\u3056\u307E\u306A\u8A00\u8A9E\u3078\u7FFB\u8A33\u3057\u3066\u304F\u3060\u3055\u3063\u305F\u65B9\u3005\u306B\u611F\u8B1D\u3057\u307E\u3059\u3002\u305D\u3057\u3066\u3001\u7FFB\u8A33\u304C\u306A\u3055\u308C\u3066\u3044\u306A\u3044\u8A00\u8A9E\u304C\u307E\u3060\u6570\u5343\u6B8B\u3063\u3066\u3044\u307E\u3059\uFF01OmegaT \u306E\u591A\u8A00\u8A9E\u3078\u306E\u5730\u57DF\u5316\u306F\u3001\u6301\u7D9A\u7684\u306A\u4F5C\u696D\u3067\u3082\u3042\u308A\u307E\u3059\u3002\u306A\u305C\u306A\u3089\u3001\u65B0\u3057\u3044\u6A5F\u80FD\u304C\u7D76\u3048\u305A\u8FFD\u52A0\u3055\u308C\u3066\u3044\u308B\u304B\u3089\u3067\u3059\u3002OmegaT\u306E\u30ED\u30FC\u30AB\u30E9\u30A4\u30BA/\u7FFB\u8A33\u306B\u95A2\u3059\u308B\u8A73\u7D30\u306B\u3064\u3044\u3066\u306F\u3001OmegaT\u30ED\u30FC\u30AB\u30EA\u30BC\u30FC\u30B7\u30E7\u30F3\u30B3\u30FC\u30C7\u30A3\u30CD\u30FC\u30BF\u30FC\u306B\u304A\u554F\u3044\u5408\u308F\u305B\u304F\u3060\u3055\u3044\u3002";
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
+        assertEquals(3, result.size());
     }
 
     private void setupProject(Language language) {
@@ -119,134 +133,133 @@ public class GlossarySearcherTest extends TestCore {
             }
         };
 
-            Core.setProject(new
-
-        IProject() {
-            public void setTranslation (SourceTextEntry entry, PrepareTMXEntry trans,
-            boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked){
+        Core.setProject(new IProject() {
+            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
+                                       boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
             }
 
-            public void setTranslation (SourceTextEntry entry, PrepareTMXEntry trans,
-            boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked,
-            AllTranslations previousTranslations){
+            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
+                                       boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked,
+                                       AllTranslations previousTranslations) {
             }
 
-            public void setNote (SourceTextEntry entry, TMXEntry oldTrans, String note){
+            public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
             }
 
-            public void saveProjectProperties () {
+            public void saveProjectProperties() {
             }
 
-            public void saveProject ( boolean doTeamSync){
+            public void saveProject(boolean doTeamSync) {
             }
 
-            public void iterateByMultipleTranslations (MultipleTranslationsIterator it){
+            public void iterateByMultipleTranslations(MultipleTranslationsIterator it) {
             }
 
-            public void iterateByDefaultTranslations (DefaultTranslationsIterator it){
+            public void iterateByDefaultTranslations(DefaultTranslationsIterator it) {
             }
 
-            public boolean isProjectModified () {
+            public boolean isProjectModified() {
                 return false;
             }
 
-            public boolean isProjectLoaded () {
+            public boolean isProjectLoaded() {
                 return true;
             }
 
-            public boolean isOrphaned (EntryKey entry){
+            public boolean isOrphaned(EntryKey entry) {
                 return false;
             }
 
-            public boolean isOrphaned (String source){
+            public boolean isOrphaned(String source) {
                 return false;
             }
 
-            public TMXEntry getTranslationInfo (SourceTextEntry ste){
+            public TMXEntry getTranslationInfo(SourceTextEntry ste) {
                 return null;
             }
 
-            public AllTranslations getAllTranslations (SourceTextEntry ste){
+            public AllTranslations getAllTranslations(SourceTextEntry ste) {
                 return null;
             }
 
-            public Map<String, ExternalTMX> getTransMemories () {
+            public Map<String, ExternalTMX> getTransMemories() {
                 return null;
             }
 
-            public ITokenizer getTargetTokenizer () {
+            public ITokenizer getTargetTokenizer() {
                 return null;
             }
 
-            public StatisticsInfo getStatistics () {
+            public StatisticsInfo getStatistics() {
                 return null;
             }
 
-            public ITokenizer getSourceTokenizer () {
+            public ITokenizer getSourceTokenizer() {
                 return null;
             }
 
-            public ProjectProperties getProjectProperties () {
+            public ProjectProperties getProjectProperties() {
                 return props;
             }
 
-            public List<IProject.FileInfo> getProjectFiles () {
+            public List<IProject.FileInfo> getProjectFiles() {
                 return null;
             }
 
-            public Map<Language, ProjectTMX> getOtherTargetLanguageTMs () {
+            public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
                 return null;
             }
 
-            public List<SourceTextEntry> getAllEntries () {
+            public List<SourceTextEntry> getAllEntries() {
                 return null;
             }
 
-            public void compileProject (String sourcePattern){
+            public void compileProject(String sourcePattern) {
             }
 
-            public void closeProject () {
+            public void closeProject() {
             }
 
-            public List<String> getSourceFilesOrder () {
+            public List<String> getSourceFilesOrder() {
                 return null;
             }
 
-            public void setSourceFilesOrder (List < String > filesList) {
+            public void setSourceFilesOrder(List<String> filesList) {
             }
 
             @Override
-            public String getTargetPathForSourceFile (String sourceFile){
+            public String getTargetPathForSourceFile(String sourceFile) {
                 return null;
             }
 
             @Override
-            public boolean isTeamSyncPrepared () {
+            public boolean isTeamSyncPrepared() {
                 return false;
             }
 
             @Override
-            public void teamSync () {
+            public void teamSync() {
             }
 
             @Override
-            public void teamSyncPrepare () {
+            public void teamSyncPrepare() {
             }
 
             @Override
-            public boolean isRemoteProject () {
+            public boolean isRemoteProject() {
                 return false;
             }
 
             @Override
-            public void commitSourceFiles () {
+            public void commitSourceFiles() {
             }
 
             @Override
-            public void compileProjectAndCommit (String sourcePattern,boolean doPostProcessing, boolean commitTargetFiles){
+            public void compileProjectAndCommit(String sourcePattern, boolean doPostProcessing, boolean commitTargetFiles) {
             }
         });
     }
+
     private List<GlossaryEntry> glossarySearcherCommon(String sourceText, ITokenizer tok, Language language,
                                                        List<GlossaryEntry> entries) {
         EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -57,13 +57,13 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testIsCjkMatchJapanese() {
-        String sourceText = "場所";
+        String sourceText = "\u5834\u6240";
         assertTrue(GlossarySearcher.isCjkMatch(sourceText, sourceText));
     }
 
     @Test
     public void testGlossarySearcherJapanese1() {
-        String sourceText = "場所";
+        String sourceText = "\u5834\u6240";
         String translationText = "translation";
         String commentText = "comment";
         ITokenizer tok = new LuceneJapaneseTokenizer();
@@ -79,13 +79,13 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testGlossarySearcherJapanese2() {
-        String sourceText = "場所";
+        String sourceText = "\u5834\u6240";
         String translationText = "translation";
         String commentText = "comment";
         ITokenizer tok = new LuceneJapaneseTokenizer();
         Language language = new Language("ja");
         List<GlossaryEntry> entries = new ArrayList<>();
-        entries.add(new GlossaryEntry("塗布", "wrong", commentText, true, "origin"));
+        entries.add(new GlossaryEntry("\u5857\u5E03", "wrong", commentText, true, "origin"));
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
         assertEquals(0, result.size());
     }

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -25,15 +25,25 @@
 package org.omegat.gui.glossary;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
+import org.omegat.core.Core;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ExternalTMX;
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.tokenizer.LuceneJapaneseTokenizer;
@@ -50,15 +60,20 @@ public class GlossarySearcherTest extends TestCore {
         String commentText = "comment";
         ITokenizer tok = new LuceneEnglishTokenizer();
         Language language = new Language("en");
+        setupProject(language);
         List<GlossaryEntry> entries = new ArrayList<>();
         entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
-        glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+        glossarySearcherCommon(sourceText, tok, language, entries);
     }
 
     @Test
     public void testIsCjkMatchJapanese() {
         String sourceText = "\u5834\u6240";
+        String targetText = "\u5857\u5E03";
+        Language language = new Language("ja");
+        setupProject(language);
         assertTrue(GlossarySearcher.isCjkMatch(sourceText, sourceText));
+        assertFalse(GlossarySearcher.isCjkMatch(sourceText, targetText));
     }
 
     @Test
@@ -68,9 +83,10 @@ public class GlossarySearcherTest extends TestCore {
         String commentText = "comment";
         ITokenizer tok = new LuceneJapaneseTokenizer();
         Language language = new Language("ja");
+        setupProject(language);
         List<GlossaryEntry> entries = new ArrayList<>();
         entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
-        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(1, result.size());
         assertEquals(sourceText, result.get(0).getSrcText());
         assertEquals(commentText, result.get(0).getCommentText());
@@ -82,19 +98,160 @@ public class GlossarySearcherTest extends TestCore {
         String sourceText = "\u5834\u6240";
         String translationText = "translation";
         String commentText = "comment";
-        ITokenizer tok = new LuceneJapaneseTokenizer();
         Language language = new Language("ja");
+        setupProject(language);
+        ITokenizer tok = new LuceneJapaneseTokenizer();
         List<GlossaryEntry> entries = new ArrayList<>();
         entries.add(new GlossaryEntry("\u5857\u5E03", "wrong", commentText, true, "origin"));
-        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, translationText, commentText, tok, language, entries);
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(0, result.size());
     }
 
-    private List<GlossaryEntry> glossarySearcherCommon(String sourceText, String translationText, String commentText, ITokenizer tok,
-                                        Language language, List<GlossaryEntry> entries) {
+    private void setupProject(Language language) {
+        // setup project
+        final ProjectProperties props = new ProjectProperties() {
+            public Language getSourceLanguage() {
+                return language;
+            }
+
+            public Language getTargetLanguage() {
+                return new Language("pl");
+            }
+        };
+
+            Core.setProject(new
+
+        IProject() {
+            public void setTranslation (SourceTextEntry entry, PrepareTMXEntry trans,
+            boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked){
+            }
+
+            public void setTranslation (SourceTextEntry entry, PrepareTMXEntry trans,
+            boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked,
+            AllTranslations previousTranslations){
+            }
+
+            public void setNote (SourceTextEntry entry, TMXEntry oldTrans, String note){
+            }
+
+            public void saveProjectProperties () {
+            }
+
+            public void saveProject ( boolean doTeamSync){
+            }
+
+            public void iterateByMultipleTranslations (MultipleTranslationsIterator it){
+            }
+
+            public void iterateByDefaultTranslations (DefaultTranslationsIterator it){
+            }
+
+            public boolean isProjectModified () {
+                return false;
+            }
+
+            public boolean isProjectLoaded () {
+                return true;
+            }
+
+            public boolean isOrphaned (EntryKey entry){
+                return false;
+            }
+
+            public boolean isOrphaned (String source){
+                return false;
+            }
+
+            public TMXEntry getTranslationInfo (SourceTextEntry ste){
+                return null;
+            }
+
+            public AllTranslations getAllTranslations (SourceTextEntry ste){
+                return null;
+            }
+
+            public Map<String, ExternalTMX> getTransMemories () {
+                return null;
+            }
+
+            public ITokenizer getTargetTokenizer () {
+                return null;
+            }
+
+            public StatisticsInfo getStatistics () {
+                return null;
+            }
+
+            public ITokenizer getSourceTokenizer () {
+                return null;
+            }
+
+            public ProjectProperties getProjectProperties () {
+                return props;
+            }
+
+            public List<IProject.FileInfo> getProjectFiles () {
+                return null;
+            }
+
+            public Map<Language, ProjectTMX> getOtherTargetLanguageTMs () {
+                return null;
+            }
+
+            public List<SourceTextEntry> getAllEntries () {
+                return null;
+            }
+
+            public void compileProject (String sourcePattern){
+            }
+
+            public void closeProject () {
+            }
+
+            public List<String> getSourceFilesOrder () {
+                return null;
+            }
+
+            public void setSourceFilesOrder (List < String > filesList) {
+            }
+
+            @Override
+            public String getTargetPathForSourceFile (String sourceFile){
+                return null;
+            }
+
+            @Override
+            public boolean isTeamSyncPrepared () {
+                return false;
+            }
+
+            @Override
+            public void teamSync () {
+            }
+
+            @Override
+            public void teamSyncPrepare () {
+            }
+
+            @Override
+            public boolean isRemoteProject () {
+                return false;
+            }
+
+            @Override
+            public void commitSourceFiles () {
+            }
+
+            @Override
+            public void compileProjectAndCommit (String sourcePattern,boolean doPostProcessing, boolean commitTargetFiles){
+            }
+        });
+    }
+    private List<GlossaryEntry> glossarySearcherCommon(String sourceText, ITokenizer tok, Language language,
+                                                       List<GlossaryEntry> entries) {
         EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
-        String[] props = new String[]{};
-        SourceTextEntry ste = new SourceTextEntry(key, 1, props, sourceText, new ArrayList<>());
+        String[] prop = new String[]{};
+        SourceTextEntry ste = new SourceTextEntry(key, 1, prop, sourceText, new ArrayList<>());
         GlossarySearcher searcher = new GlossarySearcher(tok, language, false);
         return searcher.searchSourceMatches(ste, entries);
     }

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -28,22 +28,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Test;
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.EntryKey;
-import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.IProject;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.ProjectProperties;
-import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
-import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.tokenizer.LuceneJapaneseTokenizer;
@@ -61,9 +57,12 @@ public class GlossarySearcherTest extends TestCore {
         ITokenizer tok = new LuceneEnglishTokenizer();
         Language language = new Language("en");
         setupProject(language);
-        List<GlossaryEntry> entries = new ArrayList<>();
-        entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
-        glossarySearcherCommon(sourceText, tok, language, entries);
+        List<GlossaryEntry> entries = Arrays.asList(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
+        List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
+        assertEquals(1, result.size());
+        assertEquals(sourceText, result.get(0).getSrcText());
+        assertEquals(commentText, result.get(0).getCommentText());
+        assertEquals(translationText, result.get(0).getLocText());
     }
 
     @Test
@@ -84,8 +83,7 @@ public class GlossarySearcherTest extends TestCore {
         ITokenizer tok = new LuceneJapaneseTokenizer();
         Language language = new Language("ja");
         setupProject(language);
-        List<GlossaryEntry> entries = new ArrayList<>();
-        entries.add(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
+        List<GlossaryEntry> entries = Arrays.asList(new GlossaryEntry(sourceText, translationText, commentText, true, "origin"));
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(1, result.size());
         assertEquals(sourceText, result.get(0).getSrcText());
@@ -96,12 +94,10 @@ public class GlossarySearcherTest extends TestCore {
     @Test
     public void testGlossarySearcherJapanese2() {
         String sourceText = "\u5834\u6240";
-        String commentText = "comment";
         Language language = new Language("ja");
         setupProject(language);
         ITokenizer tok = new LuceneJapaneseTokenizer();
-        List<GlossaryEntry> entries = new ArrayList<>();
-        entries.add(new GlossaryEntry("\u5857\u5E03", "wrong", commentText, true, "origin"));
+        List<GlossaryEntry> entries = Arrays.asList( new GlossaryEntry("\u5857\u5E03", "wrong", "", true, "origin"));
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(0, result.size());
     }
@@ -111,151 +107,40 @@ public class GlossarySearcherTest extends TestCore {
         Language language = new Language("ja");
         setupProject(language);
         ITokenizer tok = new LuceneJapaneseTokenizer();
-        List<GlossaryEntry> entries = new ArrayList<>();
-        entries.add(new GlossaryEntry("\u307E\u3050\u308D", "tuna", "", true, ""));
-        entries.add(new GlossaryEntry("\u7FFB\u8A33", "translation", "", true, ""));
-        entries.add(new GlossaryEntry("\u591A\u8A00\u8A9E", "multi-languages", "", true, ""));
-        entries.add(new GlossaryEntry("\u5730\u57DF\u5316", "localization", "", true, ""));
+        List<GlossaryEntry> entries = Arrays.asList(
+                new GlossaryEntry("\u307E\u3050\u308D", "tuna", "", true, ""),
+                new GlossaryEntry("\u7FFB\u8A33", "translation", "", true, ""),
+                new GlossaryEntry("\u591A\u8A00\u8A9E", "multi-languages", "", true, ""),
+                new GlossaryEntry("\u5730\u57DF\u5316", "localization", "", true, "")
+        );
         String sourceText = "OmegaT\u306E\u30E6\u30FC\u30B6\u30FC\u30A4\u30F3\u30BF\u30FC\u30D5\u30A7\u30FC\u30B9\u3084\u30D8\u30EB\u30D7\u30C6\u30AD\u30B9\u30C8\u3092\u3001\u3055\u307E\u3056\u307E\u306A\u8A00\u8A9E\u3078\u7FFB\u8A33\u3057\u3066\u304F\u3060\u3055\u3063\u305F\u65B9\u3005\u306B\u611F\u8B1D\u3057\u307E\u3059\u3002\u305D\u3057\u3066\u3001\u7FFB\u8A33\u304C\u306A\u3055\u308C\u3066\u3044\u306A\u3044\u8A00\u8A9E\u304C\u307E\u3060\u6570\u5343\u6B8B\u3063\u3066\u3044\u307E\u3059\uFF01OmegaT \u306E\u591A\u8A00\u8A9E\u3078\u306E\u5730\u57DF\u5316\u306F\u3001\u6301\u7D9A\u7684\u306A\u4F5C\u696D\u3067\u3082\u3042\u308A\u307E\u3059\u3002\u306A\u305C\u306A\u3089\u3001\u65B0\u3057\u3044\u6A5F\u80FD\u304C\u7D76\u3048\u305A\u8FFD\u52A0\u3055\u308C\u3066\u3044\u308B\u304B\u3089\u3067\u3059\u3002OmegaT\u306E\u30ED\u30FC\u30AB\u30E9\u30A4\u30BA/\u7FFB\u8A33\u306B\u95A2\u3059\u308B\u8A73\u7D30\u306B\u3064\u3044\u3066\u306F\u3001OmegaT\u30ED\u30FC\u30AB\u30EA\u30BC\u30FC\u30B7\u30E7\u30F3\u30B3\u30FC\u30C7\u30A3\u30CD\u30FC\u30BF\u30FC\u306B\u304A\u554F\u3044\u5408\u308F\u305B\u304F\u3060\u3055\u3044\u3002";
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, entries);
         assertEquals(3, result.size());
     }
 
     private void setupProject(Language language) {
-        // setup project
-        final ProjectProperties props = new ProjectProperties() {
-            public Language getSourceLanguage() {
-                return language;
-            }
-
-            public Language getTargetLanguage() {
-                return new Language("pl");
-            }
-        };
-
-        Core.setProject(new IProject() {
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                                       boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
-            }
-
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                                       boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked,
-                                       AllTranslations previousTranslations) {
-            }
-
-            public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
-            }
-
-            public void saveProjectProperties() {
-            }
-
-            public void saveProject(boolean doTeamSync) {
-            }
-
-            public void iterateByMultipleTranslations(MultipleTranslationsIterator it) {
-            }
-
-            public void iterateByDefaultTranslations(DefaultTranslationsIterator it) {
-            }
-
-            public boolean isProjectModified() {
-                return false;
-            }
-
+        Core.setProject(new NotLoadedProject() {
+            @Override
             public boolean isProjectLoaded() {
                 return true;
             }
-
-            public boolean isOrphaned(EntryKey entry) {
-                return false;
-            }
-
-            public boolean isOrphaned(String source) {
-                return false;
-            }
-
-            public TMXEntry getTranslationInfo(SourceTextEntry ste) {
-                return null;
-            }
-
-            public AllTranslations getAllTranslations(SourceTextEntry ste) {
-                return null;
-            }
-
-            public Map<String, ExternalTMX> getTransMemories() {
-                return null;
-            }
-
-            public ITokenizer getTargetTokenizer() {
-                return null;
-            }
-
-            public StatisticsInfo getStatistics() {
-                return null;
-            }
-
-            public ITokenizer getSourceTokenizer() {
-                return null;
-            }
-
+            @Override
             public ProjectProperties getProjectProperties() {
-                return props;
-            }
+                try {
+                    return new ProjectProperties(new File("stub")) {
+                        @Override
+                        public Language getSourceLanguage() {
+                            return language;
+                        }
+                        @Override
+                        public Language getTargetLanguage() {
+                            return new Language("pl");
+                        }
+                    };
 
-            public List<IProject.FileInfo> getProjectFiles() {
-                return null;
-            }
-
-            public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
-                return null;
-            }
-
-            public List<SourceTextEntry> getAllEntries() {
-                return null;
-            }
-
-            public void compileProject(String sourcePattern) {
-            }
-
-            public void closeProject() {
-            }
-
-            public List<String> getSourceFilesOrder() {
-                return null;
-            }
-
-            public void setSourceFilesOrder(List<String> filesList) {
-            }
-
-            @Override
-            public String getTargetPathForSourceFile(String sourceFile) {
-                return null;
-            }
-
-            @Override
-            public boolean isTeamSyncPrepared() {
-                return false;
-            }
-
-            @Override
-            public void teamSync() {
-            }
-
-            @Override
-            public void teamSyncPrepare() {
-            }
-
-            @Override
-            public boolean isRemoteProject() {
-                return false;
-            }
-
-            @Override
-            public void commitSourceFiles() {
-            }
-
-            @Override
-            public void compileProjectAndCommit(String sourcePattern, boolean doPostProcessing, boolean commitTargetFiles) {
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
             }
         });
     }
@@ -263,8 +148,7 @@ public class GlossarySearcherTest extends TestCore {
     private List<GlossaryEntry> glossarySearcherCommon(String sourceText, ITokenizer tok, Language language,
                                                        List<GlossaryEntry> entries) {
         EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
-        String[] prop = new String[]{};
-        SourceTextEntry ste = new SourceTextEntry(key, 1, prop, sourceText, new ArrayList<>());
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
         GlossarySearcher searcher = new GlossarySearcher(tok, language, false);
         return searcher.searchSourceMatches(ste, entries);
     }


### PR DESCRIPTION
- English  search case
- Japanese  search case reported in [BUG#1034](https://sourceforge.net/p/omegat/bugs/1034/)
- Test Token class equality

Signed-off-by: Hiroshi Miura <miurahr@linux.com>