### PR TITLE
gradle: jacoco test report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'signing'
     id 'eclipse'
     id 'checkstyle'
+    id 'jacoco'
     id 'com.github.spotbugs' version '4.7.0'
     id 'de.gliderpilot.jnlp' version '1.2.6'
     id 'org.hidetake.ssh' version '2.10.1'
@@ -905,6 +906,21 @@ task spotlessChangedApply {
         spotlessJava.target = changedOnBranch.files.findAll {
             it.path.endsWith('.java')
         }
+    }
+}
+
+jacoco {
+    toolVersion="0.8.6"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // tests are required to run before generating the report
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.enabled = true  // coveralls plugin depends on xml format report
+        html.enabled = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -915,9 +915,6 @@ jacoco {
 
 tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
-}
-
-tasks.jacocoTestReport {
     reports {
         xml.enabled = true  // coveralls plugin depends on xml format report
         html.enabled = true


### PR DESCRIPTION
Utilize Jacoco test report to see coverage and  details from web browser or IDE browser.

Do you want to check a test coverage?

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
![image](https://user-images.githubusercontent.com/123720/123204598-64e80200-d4f3-11eb-9249-12694f70fc16.png)
