### PR TITLE
Preference: font selection to limit one can show emoji Unicode

### DIFF
--- a/src/org/omegat/gui/preferences/view/FontSelectionController.java
+++ b/src/org/omegat/gui/preferences/view/FontSelectionController.java
@@ -48,6 +48,8 @@ public class FontSelectionController extends BasePreferencesController {
 
     private FontSelectionPanel panel;
     private Font oldFont;
+    private String[] unicodeFontNames;
+    private String[] fontNames;
 
     @Override
     public JComponent getGui() {
@@ -65,16 +67,19 @@ public class FontSelectionController extends BasePreferencesController {
 
     private void initGui() {
         panel = new FontSelectionPanel();
-        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(StaticUtils.getFontNames());
+        fontNames = StaticUtils.getFontNames();
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(fontNames);
         panel.fontComboBox.setModel(model);
         panel.fontComboBox.addActionListener(e -> panel.previewTextArea.setFont(getSelectedFont()));
         panel.sizeSpinner.addChangeListener(e -> panel.previewTextArea.setFont(getSelectedFont()));
         panel.limitFontsUnicodeCheckBox.addActionListener(e -> {
             model.removeAllElements();
-            if (panel.applyToProjectFilesCheckBox.isSelected()) {
-                Arrays.stream(StaticUtils.getUnicodeFontNames()).forEach(model::addElement);
+            if (panel.limitFontsUnicodeCheckBox.isSelected()) {
+                if (unicodeFontNames == null)
+                    unicodeFontNames = StaticUtils.getUnicodeFontNames();
+                Arrays.stream(unicodeFontNames).forEach(model::addElement);
             } else {
-                Arrays.stream(StaticUtils.getFontNames()).forEach(model::addElement);
+                Arrays.stream(fontNames).forEach(model::addElement);
             }
         });
     }

--- a/src/org/omegat/gui/preferences/view/FontSelectionController.java
+++ b/src/org/omegat/gui/preferences/view/FontSelectionController.java
@@ -28,6 +28,7 @@
 package org.omegat.gui.preferences.view;
 
 import java.awt.Font;
+import java.util.Arrays;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComponent;
@@ -64,9 +65,18 @@ public class FontSelectionController extends BasePreferencesController {
 
     private void initGui() {
         panel = new FontSelectionPanel();
-        panel.fontComboBox.setModel(new DefaultComboBoxModel<>(StaticUtils.getFontNames()));
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(StaticUtils.getFontNames());
+        panel.fontComboBox.setModel(model);
         panel.fontComboBox.addActionListener(e -> panel.previewTextArea.setFont(getSelectedFont()));
         panel.sizeSpinner.addChangeListener(e -> panel.previewTextArea.setFont(getSelectedFont()));
+        panel.limitFontsUnicodeCheckBox.addActionListener(e -> {
+            model.removeAllElements();
+            if (panel.applyToProjectFilesCheckBox.isSelected()) {
+                Arrays.stream(StaticUtils.getUnicodeFontNames()).forEach(model::addElement);
+            } else {
+                Arrays.stream(StaticUtils.getFontNames()).forEach(model::addElement);
+            }
+        });
     }
 
     @Override
@@ -87,6 +97,7 @@ public class FontSelectionController extends BasePreferencesController {
         panel.fontComboBox.setSelectedItem(oldFont.getName());
         panel.sizeSpinner.setValue(oldFont.getSize());
         panel.applyToProjectFilesCheckBox.setSelected(false);
+        panel.limitFontsUnicodeCheckBox.setSelected(false);
     }
 
     private Font getSelectedFont() {

--- a/src/org/omegat/gui/preferences/view/FontSelectionPanel.form
+++ b/src/org/omegat/gui/preferences/view/FontSelectionPanel.form
@@ -55,7 +55,7 @@
       </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="10" weightX="1.0" weightY="0.0"/>
+          <GridBagConstraints gridX="1" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="10" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -67,7 +67,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -97,7 +97,7 @@
       </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="2" gridWidth="0" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="3" gridWidth="0" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -107,12 +107,31 @@
           <ResourceString bundle="org/omegat/Bundle.properties" key="TF_APPLY_TO_PROJECT_FILES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="applyToProjectFilesCheckBoxActionPerformed"/>
+      </Events>
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
       </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="3" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="0" gridY="4" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="limitFontsUnicodeCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Show only fonts that can display emoji"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="limitFontsUnicodeCheckBoxActionPerformed"/>
+      </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/src/org/omegat/gui/preferences/view/FontSelectionPanel.java
+++ b/src/org/omegat/gui/preferences/view/FontSelectionPanel.java
@@ -57,6 +57,7 @@ public class FontSelectionPanel extends javax.swing.JPanel {
         sizeLabel = new javax.swing.JLabel();
         previewTextArea = new javax.swing.JTextArea();
         applyToProjectFilesCheckBox = new javax.swing.JCheckBox();
+        limitFontsUnicodeCheckBox = new javax.swing.JCheckBox();
         filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 32767));
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
@@ -81,7 +82,7 @@ public class FontSelectionPanel extends javax.swing.JPanel {
         add(fontLabel, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
@@ -90,7 +91,7 @@ public class FontSelectionPanel extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(sizeLabel, OStrings.getString("TF_SELECT_FONTSIZE")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
@@ -105,29 +106,54 @@ public class FontSelectionPanel extends javax.swing.JPanel {
         previewTextArea.setPreferredSize(new java.awt.Dimension(116, 100));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridy = 3;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         add(previewTextArea, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(applyToProjectFilesCheckBox, OStrings.getString("TF_APPLY_TO_PROJECT_FILES")); // NOI18N
+        applyToProjectFilesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                applyToProjectFilesCheckBoxActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 4;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         add(applyToProjectFilesCheckBox, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(limitFontsUnicodeCheckBox, "Show only fonts that can display emoji");
+        limitFontsUnicodeCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                limitFontsUnicodeCheckBoxActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 1;
+        add(limitFontsUnicodeCheckBox, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.weighty = 1.0;
         add(filler1, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
+
+    private void applyToProjectFilesCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_applyToProjectFilesCheckBoxActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_applyToProjectFilesCheckBoxActionPerformed
+
+    private void limitFontsUnicodeCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_limitFontsUnicodeCheckBoxActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_limitFontsUnicodeCheckBoxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     javax.swing.JCheckBox applyToProjectFilesCheckBox;
     private javax.swing.Box.Filler filler1;
     javax.swing.JComboBox<String> fontComboBox;
     private javax.swing.JLabel fontLabel;
+    javax.swing.JCheckBox limitFontsUnicodeCheckBox;
     javax.swing.JTextArea previewTextArea;
     private javax.swing.JLabel sizeLabel;
     javax.swing.JSpinner sizeSpinner;

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -145,10 +145,10 @@ public final class StaticUtils {
     public static String[] getUnicodeFontNames() {
         int sp;
         Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
-        final int dspcp = "\uD83D\uDE03".codePointAt(0); // facemark in Emoji-1.0 specification
+        final String dspstr = "a\uD83D\uDE03"; // facemark in Emoji-1.0 specification
         Set<String> fontNames = new HashSet<>();
         for (Font font : fonts)
-            if (font.canDisplay(dspcp)) fontNames.add(font.getFamily());
+            if (font.canDisplay(dspstr.codePointAt(0)) && font.canDisplay(dspstr.codePointAt(1))) fontNames.add(font.getFamily());
         return fontNames.toArray(new String[0]);
     }
 

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -31,6 +31,7 @@
 
 package org.omegat.util;
 
+import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -42,8 +43,10 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -133,6 +136,20 @@ public final class StaticUtils {
         GraphicsEnvironment graphics;
         graphics = GraphicsEnvironment.getLocalGraphicsEnvironment();
         return graphics.getAvailableFontFamilyNames();
+    }
+
+    /**
+     * Returns the names of all font which can display emoji.
+     * @return Set of names.
+     */
+    public static String[] getUnicodeFontNames() {
+        int sp;
+        Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
+        final int dspcp = "\uD83D\uDE03".codePointAt(0); // facemark in Emoji-1.0 specification
+        Set<String> fontNames = new HashSet<>();
+        for (Font font : fonts)
+            if (font.canDisplay(dspcp)) fontNames.add(font.getFamily());
+        return fontNames.toArray(new String[0]);
     }
 
     /** Caching install dir */

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -43,6 +43,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -133,9 +134,7 @@ public final class StaticUtils {
      * Returns the names of all font families available.
      */
     public static String[] getFontNames() {
-        GraphicsEnvironment graphics;
-        graphics = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        return graphics.getAvailableFontFamilyNames();
+        return getFontNamesCanShow(Arrays.asList("a", "1", "ó"));
     }
 
     /**
@@ -143,12 +142,16 @@ public final class StaticUtils {
      * @return Set of names.
      */
     public static String[] getUnicodeFontNames() {
-        int sp;
+        return getFontNamesCanShow(Arrays.asList("a", "\uD83D\uDE03")); // facemark in Emoji-1.0 specification
+    }
+
+    private static String[] getFontNamesCanShow(List<String> dispstr) {
         Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
-        final String dspstr = "a\uD83D\uDE03"; // facemark in Emoji-1.0 specification
         Set<String> fontNames = new HashSet<>();
-        for (Font font : fonts)
-            if (font.canDisplay(dspstr.codePointAt(0)) && font.canDisplay(dspstr.codePointAt(1))) fontNames.add(font.getFamily());
+        for (Font font : fonts) {
+            if (dispstr.stream().allMatch(str -> font.canDisplay(str.codePointAt(0))))
+                fontNames.add(font.getFamily());
+        }
         return fontNames.toArray(new String[0]);
     }
 


### PR DESCRIPTION
- Implement the requirement from BUG#1043
- Update preference -> font selection UI to limit Font comboBox to show only fonts that can display emoji characters

Signed-off-by: Hiroshi Miura <miurahr@linux.com>