### PR TITLE
Fix error on Java 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
         implementation 'org.slf4j:slf4j-jdk14:1.7.25'
 
         // macOS integration
-        implementation 'org.madlonkay:desktopsupport:0.5.0'
+        implementation 'org.madlonkay:desktopsupport:0.6.0'
 
         api 'javax.xml.bind:jaxb-api:2.3.1'
         implementation 'com.sun.xml.bind:jaxb-core:2.3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
         implementation 'org.slf4j:slf4j-jdk14:1.7.25'
 
         // macOS integration
-        implementation 'org.madlonkay:desktopsupport:0.4.0'
+        implementation 'org.madlonkay:desktopsupport:0.5.0'
 
         api 'javax.xml.bind:jaxb-api:2.3.1'
         implementation 'com.sun.xml.bind:jaxb-core:2.3.0.1'

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -62,8 +62,20 @@ public abstract class DelegatingLookAndFeel extends LookAndFeel {
     protected final LookAndFeel systemLookAndFeel;
 
     public DelegatingLookAndFeel() throws Exception {
-        systemLookAndFeel = (LookAndFeel) Class.forName(UIManager.getSystemLookAndFeelClassName())
-                .getDeclaredConstructor().newInstance();
+        // When loading GTK LaF on Java16 / Linux by Class#forName method,
+        // it cause error "java.desktop does not export com.sun.java.swing.plaf.gtk"
+        // (Bug#1052)
+        String systemLaF = UIManager.getSystemLookAndFeelClassName();
+        if (systemLaF.equals("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")) {
+             try {
+                UIManager.setLookAndFeel(systemLaF);
+             } catch (Exception ignore) {
+             }
+             systemLookAndFeel = UIManager.getLookAndFeel();
+        } else {
+            systemLookAndFeel = (LookAndFeel) Class.forName(UIManager.getSystemLookAndFeelClassName())
+                    .getDeclaredConstructor().newInstance();
+        }
     }
 
     @Override

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -62,20 +62,12 @@ public abstract class DelegatingLookAndFeel extends LookAndFeel {
     protected final LookAndFeel systemLookAndFeel;
 
     public DelegatingLookAndFeel() throws Exception {
-        // When loading GTK LaF on Java16 / Linux by Class#forName method,
-        // it cause error "java.desktop does not export com.sun.java.swing.plaf.gtk"
-        // (Bug#1052)
-        String systemLaF = UIManager.getSystemLookAndFeelClassName();
-        if (systemLaF.equals("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")) {
-             try {
-                UIManager.setLookAndFeel(systemLaF);
-             } catch (Exception ignore) {
-             }
-             systemLookAndFeel = UIManager.getLookAndFeel();
-        } else {
-            systemLookAndFeel = (LookAndFeel) Class.forName(UIManager.getSystemLookAndFeelClassName())
-                    .getDeclaredConstructor().newInstance();
-        }
+        // Get System LaF instance.
+        // Calling Class.forName(UIManager.getSystemLookAndFeelClassName()).newInstance()
+        // on Java16 throw error "java.desktop does not export com.sun.java.swing.plaf.gtk"
+        // on Linux, and for aqua LaF on macOS. (Bug#1052)
+         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+         systemLookAndFeel = UIManager.getLookAndFeel();
     }
 
     @Override

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -66,8 +66,8 @@ public abstract class DelegatingLookAndFeel extends LookAndFeel {
         // Calling Class.forName(UIManager.getSystemLookAndFeelClassName()).newInstance()
         // on Java16 throw error "java.desktop does not export com.sun.java.swing.plaf.gtk"
         // on Linux, and for aqua LaF on macOS. (Bug#1052)
-         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-         systemLookAndFeel = UIManager.getLookAndFeel();
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        systemLookAndFeel = UIManager.getLookAndFeel();
     }
 
     @Override

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -34,7 +34,9 @@ import javax.swing.JComponent;
 import javax.swing.LayoutStyle;
 import javax.swing.LookAndFeel;
 import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
 
+import org.madlonkay.desktopsupport.DesktopSupport;
 import org.omegat.util.gui.ResourcesUtil;
 
 /**
@@ -62,12 +64,18 @@ public abstract class DelegatingLookAndFeel extends LookAndFeel {
     protected final LookAndFeel systemLookAndFeel;
 
     public DelegatingLookAndFeel() throws Exception {
-        // Get System LaF instance.
-        // Calling Class.forName(UIManager.getSystemLookAndFeelClassName()).newInstance()
-        // on Java16 throw error "java.desktop does not export com.sun.java.swing.plaf.gtk"
-        // on Linux, and for aqua LaF on macOS. (Bug#1052)
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        systemLookAndFeel = UIManager.getLookAndFeel();
+        String systemLafClass = UIManager.getSystemLookAndFeelClassName();
+        String systemLafName = null;
+        for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+            if (info.getClassName().equals(systemLafClass)) {
+                systemLafName = info.getName();
+            }
+        }
+        if (systemLafName == null) {
+            // Should never happen: system LAF is guaranteed to be installed
+            throw new RuntimeException("Could not identify system LAF name");
+        }
+        systemLookAndFeel = DesktopSupport.getSupport().createLookAndFeel(systemLafName);
     }
 
     @Override


### PR DESCRIPTION
When loading GTK LaF on Java16 / Linux by Class#forName method,
it cause error "java.desktop does not export com.sun.java.swing.plaf.gtk"  (Bug#1052) and break UI/Theme.

I know OmegaT  support Java 8 and 11, not Java 16,
but this reduces a known issue.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>