### PR TITLE
Changing the flow of updating teamwork omegat.project

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -492,6 +492,7 @@ TF_COMMIT_TARGET_START=Committing target files
 TF_COMMIT_TARGET_DONE=Target files committed
 
 TF_PROJECT_PROPERTIES_ERROR=Failed to update project properties
+TF_REMOTE_PROJECT_LACKS_GIT_SETTING=Remote project file lacks git setting. This may be intentional, but likely an oversight.
 
 MW_PROMPT_SEG_NR_MSG=Enter the segment number:
 

--- a/src/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -260,6 +260,28 @@ public class RemoteRepositoryProvider {
     }
 
     /**
+     * Copy omegat.project from remote git server mapped to local
+     * directory under the name, omegat.project.NEW
+     *
+     * This is used only for that purpose, but follows the code of
+     * copyFilesFromReposToProject() because we have to go through the
+     * hoops of mapping to find out where the remote omegat.project
+     * file is.
+     *
+     * @param localPath
+     *            directory name or file name. This has to be "omegat.project".
+     */
+    public void copyFilesFromReposToProjectTempNew(String localPath) throws IOException {
+        String[] myForceExcludes = "".equals(localPath) ? forceExcludes : new String[]{};
+        for (Mapping m : getMappings(localPath, myForceExcludes)) {
+            m.copyFromRepoToProjectTempNew();
+            // if ("".equals(localPath)) {
+            //    m.propagateDeletes();
+            //}
+        }
+    }
+
+    /**
      * Copy all mappings that under specified directory path into repository directory.
      *
      * @param localPath
@@ -438,6 +460,40 @@ public class RemoteRepositoryProvider {
                 copyFile(from, to, null);
             }
         }
+      //
+      // This function is only used to copy remote omegat.project to local omegat.project.NEW
+      //
+        public void copyFromRepoToProjectTempNew() throws IOException {
+            if (!matches()) {
+                throw new RuntimeException("Path doesn't match with mapping");
+            }
+            // Remove leading slashes on child args to avoid doing `new
+            // File("foo", "/")` which treats the "/" as an actual child element
+            // name and prevents proper slash normalization later on.
+            File from = new File(getRepositoryDir(repoDefinition), withoutLeadingSlash(repoMapping.getRepository()));
+            // originally to was directory, but here we want to copy remote "omegat.project" to "omegat.project.NEW".
+            File to = new File(projectRoot, withoutLeadingSlash(repoMapping.getLocal()) + "omegat.project.NEW");
+
+
+            if (from.isDirectory()) {
+                // directory mapping
+                List<String> excludes = new ArrayList<>(repoMapping.getExcludes());
+                excludes.addAll(forceExcludes);
+                copyTempNew(from, to, filterPrefix, repoMapping.getIncludes(), excludes, null);
+            } else if (!from.exists()) {
+                //e.g. you opened an omegat.properties to download a team project, but it refers to a remote repo location that doesn't exist.
+                throw new RuntimeException("Location '"+withoutLeadingSlash(repoMapping.getRepository())+"' does not exist in repository "+repoDefinition.getUrl());
+            } else {
+                // file mapping
+                if (!filterPrefix.equals("/")) {
+                    throw new RuntimeException(
+                            "Filter prefix should have been / for file mapping, but was " + filterPrefix);
+                }
+                copyFile(from, to, null);
+            }
+        }
+
+
 
         public void copyFromProjectToRepo(String eolConversionCharset) throws Exception {
             if (!matches()) {
@@ -478,6 +534,37 @@ public class RemoteRepositoryProvider {
 
         public String getVersion() throws Exception {
             return repo.getFileVersion(new File(repoMapping.getRepository(), filterPrefix).getPath());
+        }
+
+
+        /**
+         * Specialized version of copy() to copy omegat.project in remote repository to
+         * omegat.project.NEW
+         *
+         * @return Relative paths of copied files, <em>with <code>/</code> at
+         *         start and end</em>
+         */
+        protected List<String> copyTempNew(File from, File to, String prefix, List<String> includes,
+                                    List<String> excludes, String eolConversionCharset) throws IOException {
+            prefix = withSlashes(prefix);
+            List<String> relativeFiles = FileUtil.buildRelativeFilesList(from, includes, excludes);
+            List<String> copied = new ArrayList<>();
+            for (String rf : relativeFiles) {
+                rf = withSlashes(rf);
+                if (rf.startsWith("/.repositories/")) {
+                    continue; // list from root - shouldn't travel to .repositories/
+                }
+                if (prefix.isEmpty() || prefix.equals("/") || rf.startsWith(prefix)) {
+                    // rf was /omegat.project/
+                    // from: /projectrootdir/.repositories/https_git.example.com_remote_repostory.git
+                    // to:   /projectrootdir/omegat.project.NEW
+                    // So the next line should be copyFile(new File(from, rf), new File(to, ""), eolConversionCharset);
+                    // Instead of copyFile(new File(from, rf), new File(to, rf), eolConversionCharset);
+                    copyFile(new File(from, rf), new File(to, ""), eolConversionCharset);
+                    copied.add(rf);
+                }
+            }
+            return copied;
         }
 
         /**


### PR DESCRIPTION
This patch changes the flow of updating local teamwork "omegat.project" file with the content of remote copy of
"omegat.project" on the git server.

Before this patch, the content of remote copy overwrites the local copy first, and then if the content lacks the git setting, it was
added and then the "omegat.project" was updated to reflect the addition.

However, if OmegaT terminated early, such update may not happen and thus rendering the teamwork without proper git setting.  When the remote copy of "omegat.project" lacks git setting, on the next opening, the project may no longer be a teamwork project (!).  This confuses the end users to no end.

This patch changes the workflow of update as follows.

1. Content of the remote copy of "omegat.project" on the server is written to local file, "omegat.project.NEW".

2. The content of this file is parsed.

3. If git-setting is missing in the content, it is added from then current setting from the local copy of "omegat.project".
   In this case, rewriting from the content of the remote copy does not happen.
   
4. Only if the remote copy is good enough to replace the current local copy, then we create a backup copy of the old "omegat.project" in "omegat.project.TIMESTAMP.bak".  Then we RENAME "omegat.project.NEW"  to "omegat.project".

With this flow, there is always a working copy of omegat.project on the local computer even if OmegaT terminates early.  So we don't end up with incorrect non-teamwork copy even if the remote copy of "omegat.project" lacks git setting.

Also, this patch displays a warning dialog to warn the user when the remote copy of "omegat.project" on the git server lacks git setting. This should help end users to detect the misconfiguration early on.

modified:   src/org/omegat/Bundle.properties
        Added TF_REMOTE_PROJECT_LACKS_GIT_SETTING
        Oops, I might have forgotten to define a few more strings for
        logging.
modified:   src/org/omegat/core/team2/RemoteRepositoryProvider.java
        Added two helper functions that specialize in copying the
        remote "omegat.project" to local "omegat.project.NEW".
        These need to emulate the functions of existing functions
        to find the location of remote copy of "omegat.project"
        correctly in the presence of "mapping".
modified:   src/org/omegat/gui/main/ProjectUICommands.java
        Change of workflow as described above, and add a couple of
        log lines and warning dialog.
        
PS: When I say git-setting, I am referring to the whole repositories ... /repositories section in the project file.
The manual refers to "mapping" and is a bit confusing. This is because a mapping can be a combination a simple mapping against a differernt git server, i.e., there can be many "repository" pairs inside "repositories" section of "omegat.project" file.