### PR TITLE
Add test cases for MagicComment class

### DIFF
--- a/test/src/org/omegat/util/MagicCommentTest.java
+++ b/test/src/org/omegat/util/MagicCommentTest.java
@@ -60,17 +60,35 @@ public class MagicCommentTest {
                 MagicComment.parse("# comment -*- foo: bar; -*- coding: UTF-8"));
         assertEquals(Collections.emptyMap(), MagicComment.parse("# comment -*- foo: bar; coding: UTF-8"));
         assertEquals(Collections.emptyMap(), MagicComment.parse("# comment foo: bar; coding: UTF-8 -*-"));
+        assertEquals(Collections.emptyMap(), MagicComment.parse((String) null));
     }
 
     @SuppressWarnings("serial")
     public void testParseFile() throws IOException {
         Map<String, String> result = MagicComment.parse(new File("test/data/glossaries/test-magiccomment.tab"));
-        assertEquals(new HashMap<String, String>() {{ put("coding", "UTF-8"); }}, result);
+        assertEquals(new HashMap<String, String>() {{ put("coding", "utf-8"); }}, result);
     }
 
     @SuppressWarnings("serial")
     public void testParseFileBom() throws IOException {
         Map<String, String> result = MagicComment.parse(new File("test/data/glossaries/test-magiccomment-bom.tab"));
-        assertEquals(new HashMap<String, String>() {{ put("coding", "UTF-8"); }}, result);
+        assertEquals(new HashMap<String, String>() {{ put("coding", "utf-8"); }}, result);
     }
-}
+
+    @SuppressWarnings("serial")
+    public void testParseEmpty() throws IOException {
+        Map<String, String> result = MagicComment.parse(new File("test/data/glossaries/empty.txt"));
+        assertEquals(Collections.emptyMap(), result);
+    }
+
+    @SuppressWarnings("serial")
+    public void testParseFileTab() throws IOException {
+        Map<String, String> result = MagicComment.parse(new File("test/data/glossaries/test.tab"));
+        assertEquals(Collections.emptyMap(), result);
+    }
+
+    @SuppressWarnings("serial")
+    public void testParseFileUTF16() throws IOException {
+        Map<String, String> result = MagicComment.parse(new File("test/data/glossaries/testUTF16LE.txt"));
+        assertEquals(Collections.emptyMap(), result);
+    }}


### PR DESCRIPTION
- Add some corner cases
- Set many as skipped  to reuse in future
- Fix expectation typo

Signed-off-by: Hiroshi Miura <miurahr@linux.com>