### PR TITLE
Linux Desktop Entry

### DIFF
--- a/release/linux-specific/linux-install.sh
+++ b/release/linux-specific/linux-install.sh
@@ -125,4 +125,15 @@ sudo ln -s -b /opt/omegat/OmegaT-default/omegat.kaptn /usr/local/bin/omegat.kapt
 
 sudo chmod +x /usr/local/bin/omegat /usr/local/bin/omegat.kaptn
 
+# install icons
+icon_sizes=( 32 128 256 512 )
+for size in "${icon_sizes[@]}"
+do
+	sudo xdg-icon-resource install --novendor --noupdate --mode system --size $size /opt/omegat/OmegaT-default/images/OmegaT.iconset/icon_$size\x$size.png omegat
+done
+sudo xdg-icon-resource forceupdate --mode system
+
+# install desktop file
+sudo xdg-desktop-menu install --novendor --mode system /opt/omegat/OmegaT-default/omegat.desktop
+
 exit

--- a/release/linux-specific/omegat.desktop
+++ b/release/linux-specific/omegat.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=OmegaT
+Comment=the free translation memory tool
+Type=Application
+Categories=Office;
+Icon=omegat
+Exec=omegat %f
+Terminal=false

--- a/release/linux-specific/omegat.desktop
+++ b/release/linux-specific/omegat.desktop
@@ -1,6 +1,22 @@
 [Desktop Entry]
 Name=OmegaT
 Comment=the free translation memory tool
+Comment[ru]=свободная программа для автоматизации перевода
+Comment[mfe]=Enn Zouti Lib Memwar Tradiksion
+Comment[nl]=het gratis programma met vertaalgeheugen
+Comment[pt]=A ferramenta memória de tradução gratuita
+Comment[co]=L’attrezzu liberu di memoria di traduzzione
+Comment[pt_BR]=A ferramenta de memória de tradução livre
+Comment[it]=lo strumento gratuito per memorie di traduzione
+Comment[es]=La herramienta TAO gratuita
+Comment[zh_CN]=免费的翻译记忆工具
+Comment[ja]=自由に使える翻訳メモリツール
+Comment[uk]=безкоштовна програма для перекладу
+Comment[fr]=l'outil libre de TAO
+Comment[ia]=Le application gratuite pro memorias de traduction
+Comment[de]=Das kostenlose Translation-Memory-Tool
+Comment[fi]=vapaa käännöstyökalu
+Comment[ca]=l'eina lliure de memòria de traducció
 Type=Application
 Categories=Office;
 Icon=omegat


### PR DESCRIPTION
In its current iteration, the `linux-install.sh` script takes care of copying OmegaT to `/opt/omegat` and symlinking an executable to `/usr/local/bin/omegat`. While this works and you can run OmegaT from a terminal or (if your distribution has it) via a command runner invoked by a key combination like Alt+F2, it's much less comfortable than what you might be used to from other applications on your modern, mostly graphical Linux distribution. Creating your own menu entry with an icon can be daunting and/or tedious, as even if you do have the technical knowledge this must be done every time you install OmegaT on a fresh system.

I think this topic has been brought up several times on the mailing list and faintly remember writing that I'd look into this years ago...

## Changes introduced in this PR
- add a `omegat.desktop` file compliant with the [Desktop Entry Specification of the freedesktop project](https://specifications.freedesktop.org/desktop-entry-spec/latest/)
- modify `linux-install.sh` to 
  - install the OmegaT icon (all sizes provided in `images/OmegaT.iconset`) to the system-wide icon folder 
  - install the `omegat.desktop` file to the system-wide application folder

Immediately after running the installation script, an OmegaT entry with the correct icon will appear in your applications menu. If that menu uses categories, OmegaT will be listed under Office ([see Desktop Menu Specification of the freedesktop project](https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry)).

## Does this work on every Linux Desktop?
Probably not, but I've successfully run it in the following (virtualized) environments:

- [x] Elementary OS 6 Beta 2 (Pantheon)
- [x] Ubuntu 20.10 (Gnome)
- [x] Fedora Workstation 34 (Gnome)
- [x] openSuse 15.3 (KDE)
- [x] Linux Mint 20.3 (Cinnamon)

## Open Issues

### Localization

This part of the .desktop file could/should probably be localized:

`Comment=the free translation memory tool`

Localized strings can be added [like this](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html):

`Comment[fr_FR]=l'outil libre de TAO`

### Orphaned when removing OmegaT

This adds a bit of garbage lying around on you system after you "uninstall" OmegaT by deleting `/opt/omegat`. This is already the case with the `/usr/bin/omegat` symlink, but having an orphaned entry in your Applications menu certainly is slightly worse. Maybe a `linux-uninstall.sh` script would do it?