### PR TITLE
Update JGit to 5.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,8 @@ dependencies {
         implementation "org.apache.lucene:lucene-analyzers-stempel:${luceneVersion}"
 
         // Team project server support
-        implementation 'org.eclipse.jgit:org.eclipse.jgit:4.11.8.201904181247-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.11.1.202105131744-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.1.202105131744-r'
         implementation 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
         // Specify the following two here just to make sure all jsch.agentproxy libs are the same version.
         implementation 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -248,7 +248,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     public String[] getRecentlyDeletedFiles() throws Exception {
         final ArrayList<String> deleted = new ArrayList<>();
 
-        ObjectId head = repository.getAllRefs().get("HEAD").getObjectId();
+        ObjectId head = repository.getRefDatabase().findRef("HEAD").getObjectId();
 
         String settingKey = "lastDeleteCheckForName" + localDirectory.getName();
         String sinceRevisionString = projectTeamSettings.get(settingKey);


### PR DESCRIPTION
- Update JGit to v5.11
- Replace deprecated getAllRefs() method with recommended  getRefDatabase()
- We can use 'https://user:token@github.com/...' style repository URL for integration test

Signed-off-by: Hiroshi Miura <miurahr@linux.com>