### PR TITLE
External TM read from different source region

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1159,8 +1159,11 @@ TMXR_WARNING_SOURCE_NOT_FOUND=Source segment could not be located \
 
 # {0} - TMX source language
 # {1} - Project source language
-TMXR_WARNING_INCORRECT_SOURCE_LANG=The TMX source language ({0}) is different \
-    from the project source language ({1}). The TMX file will continue to be loaded.
+TMXR_WARNING_INCORRECT_SOURCE_LANG_SKIP=The TMX source language ({0}) is different \
+    from the project source language ({1}). The TMX file will be skipped.
+
+TMXR_WARNING_UNMATCH_SOURCE_LANG_COUNTRY=The country code of source language is different between the TMX ({0}) \
+    and the project ({1}). The TMX file will continue to be loaded.
 
 TMXR_WARNING_UPGRADE_14X=TMX file was created by OmegaT 1.4.x or earlier. Upgrading...
 

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -102,7 +102,7 @@ public class ProjectTMX {
                 false,
                 true,
                 Preferences.isPreference(Preferences.EXT_TMX_USE_SLASH),
-                new Loader(sourceLanguage, targetLanguage, isSentenceSegmentingEnabled));
+                new Loader(sourceLanguage, targetLanguage, isSentenceSegmentingEnabled), false);
     }
 
     /**
@@ -286,7 +286,7 @@ public class ProjectTMX {
         }
 
         public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                               TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
             if (tuvSource == null) {
                 // source Tuv not found
                 return false;

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -361,6 +361,8 @@ public final class Preferences {
     public static final String EXT_TMX_SORT_KEY = "ext_tmx_sort_key";
     /** External TMX options: Whether to show fuzzy matches from foreign (non-target language) matches. */
     public static final String EXT_TMX_KEEP_FOREIGN_MATCH = "keep_foreign_matches";
+    /** External TMX options: Whether to use TM that source language region is different from project. */
+    public static final String EXT_TMX_KEEP_DIFFERENT_SOURCE_REGION = "ext_tmx_keep_different_source_region";
     /** External TMX options: Fuzzy Threshold **/
     public static final String EXT_TMX_FUZZY_MATCH_THRESHOLD = "ext_tmx_fuzzy_match_threshold";
 

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -162,28 +162,26 @@ public class ExternalTMFactoryTest extends TestCore {
         
         // Set the EXT_TMX_KEEP_FOREIGN_MATCH prop
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, true);
+        Preferences.setPreference(Preferences.EXT_TMX_KEEP_DIFFERENT_SOURCE_REGION, true);
         tmx = ExternalTMFactory.load(tmxFile);
 
-        // All foreign translations are present
-        assertEquals(14, tmx.getEntries().size());
+        // All foreign translations are present and entries of source lang is not present.
+        assertEquals(11, tmx.getEntries().size());
 
         matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
                 .collect(Collectors.toList());
-        assertEquals(8, matchingEntries.size());
+        // All foreign entries(8) - source(1)
+        assertEquals(7, matchingEntries.size());
 
         matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
                 .collect(Collectors.toList());
-        assertEquals(3, matchingEntries.size());
+        assertEquals(2, matchingEntries.size());
 
         PrepareTMXEntry entry = matchingEntries.get(0);
-        assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
-
-        entry = matchingEntries.get(1);
         assertEquals("DE", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
         assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
 
-        entry = matchingEntries.get(2);
+        entry = matchingEntries.get(1);
         assertEquals("ES", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
         assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
     }

--- a/test/src/org/omegat/util/TMXReaderTest.java
+++ b/test/src/org/omegat/util/TMXReaderTest.java
@@ -51,11 +51,11 @@ public class TMXReaderTest extends TestCore {
         new TMXReader2().readTMX(new File("test/data/tmx/test-level1.tmx"), new Language("en-US"),
                 new Language("be"), false, false, false, false, new TMXReader2.LoadCallback() {
                     public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                            TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                                           TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
                         tr.put(tuvSource.text, tuvTarget.text);
                         return true;
                     }
-                });
+                }, true);
         assertEquals("betuv", tr.get("entuv"));
         assertEquals("tr1", tr.get("lang1"));
         assertEquals("tr2", tr.get("lang2"));
@@ -68,11 +68,11 @@ public class TMXReaderTest extends TestCore {
         new TMXReader2().readTMX(new File("test/data/tmx/test-level2.tmx"), new Language("en-US"),
                 new Language("be"), false, false, true, false, new TMXReader2.LoadCallback() {
                     public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                            TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                                           TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
                         tr.put(tuvSource.text, tuvTarget.text);
                         return true;
                     }
-                });
+                }, true);
         assertEquals("betuv", tr.get("entuv"));
         assertEquals("tr", tr.get("2 <a0> zz <t1>xx</t1>"));
         assertEquals("tr", tr.get("3 <n0>xx</n0>"));
@@ -85,7 +85,7 @@ public class TMXReaderTest extends TestCore {
                 false, false, true, false, (tu, tuvSource, tuvTarget, isParagraphSegtype) -> {
                     tr.put(tuvSource.text, tuvTarget.text);
                     return true;
-                });
+                }, true);
         // Same content as test-level2.tmx
         assertFalse(tr.isEmpty());
         assertEquals("betuv", tr.get("entuv"));
@@ -97,10 +97,10 @@ public class TMXReaderTest extends TestCore {
     public void testZip() throws Exception {
         final Map<String, String> tr = new TreeMap<>();
         new TMXReader2().readTMX(new File("test/data/tmx/test-level2.tmx.zip"), new Language("en"), new Language("be"),
-                false, false, true, false, (tu, tuvSource, tuvTarget, isParagraphSegtype) -> {
+                false, false, true, false, (tu, tuvSource, tuvTarget, isParagraphSegtyp) -> {
                     tr.put(tuvSource.text, tuvTarget.text);
                     return true;
-                });
+                }, true);
         // Same content as test-level2.tmx
         assertFalse(tr.isEmpty());
         assertEquals("betuv", tr.get("entuv"));
@@ -114,11 +114,11 @@ public class TMXReaderTest extends TestCore {
         new TMXReader2().readTMX(new File("test/data/tmx/invalid.tmx"), new Language("en"),
                 new Language("be"), false, false, true, false, new TMXReader2.LoadCallback() {
                     public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                            TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                                           TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
                         tr.put(tuvSource.text, tuvTarget.text);
                         return true;
                     }
-                });
+                }, true);
     }
 
     @Test
@@ -127,11 +127,11 @@ public class TMXReaderTest extends TestCore {
         new TMXReader2().readTMX(new File("test/data/tmx/test-SMP.tmx"), new Language("en"),
                 new Language("be"), false, false, true, false, new TMXReader2.LoadCallback() {
                     public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                            TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                                           TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
                         tr.put(tuvSource.text, tuvTarget.text);
                         return true;
                     }
-                });
+                }, true);
         assertFalse(tr.isEmpty());
         // Assert contents are {"ABC": "DEF"} where letters are MATHEMATICAL BOLD CAPITALs (U+1D400-)
         assertEquals("\uD835\uDC03\uD835\uDC04\uD835\uDC05", tr.get("\uD835\uDC00\uD835\uDC01\uD835\uDC02"));
@@ -213,7 +213,7 @@ public class TMXReaderTest extends TestCore {
                         return true;
                     }
                     return false;
-                });
+                }, true);
         // Make sure everything is loaded despite TU missing source TUV
         assertFalse(tr.isEmpty());
         assertEquals(3, tr.size());

--- a/test/src/org/omegat/util/TMXWriterTest.java
+++ b/test/src/org/omegat/util/TMXWriterTest.java
@@ -222,7 +222,7 @@ public class TMXWriterTest extends TestFilterBase {
         new TMXReader2().readTMX(outFile, new Language("en-US"), new Language("be-BY"), false, false,
                 extLevel2, useSlash, new TMXReader2.LoadCallback() {
                     public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
-                            TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
+                                           TMXReader2.ParsedTuv tuvTarget, boolean isParagraphSegtype) {
                         if (sources != null) {
                             sources.add(tuvSource.text);
                         }
@@ -231,7 +231,7 @@ public class TMXWriterTest extends TestFilterBase {
                         }
                         return true;
                     }
-                });
+                }, true);
     }
 
     static int tagNumber = 0;


### PR DESCRIPTION
- (change behavior) Skip TM file that has different source language from project such as `en` and `fr`
- Read TM with different source region and same language   when Preference.EXT_TMX_KEEP_DIFFERENT_SOURCE_REGION is set
   - Default true
   - for example, `en-US` and `en-GB` or `en`
- Related with [RFE#1578](https://sourceforge.net/p/omegat/feature-requests/1578/)
- Preference GUI is not implemented because of [BUG#1057](https://sourceforge.net/p/omegat/bugs/1057/) prevent code modification.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>