### PR TITLE
DictionaryPane performance hack

### DIFF
--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -242,6 +243,8 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
             scrollPane.notify(true);
         }
 
+        final int old = scrollPane.getVerticalScrollBarPolicy();
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
         StringBuilder txt = new StringBuilder();
         boolean wasPrev = false;
         int i = 0;
@@ -264,6 +267,7 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
             }
         }
         appendText(txt.toString());
+        scrollPane.setVerticalScrollBarPolicy(old);
     }
 
     private void appendText(final String txt) {


### PR DESCRIPTION
This improve performance BUGS#1069

- Fix Vertical scrollbar policy to always show during update document
- Create and set new Document instead of updating document

Call tree caputures, before
![capture_before](https://user-images.githubusercontent.com/123720/132085100-4479d0eb-67fe-48a8-b70f-34e84a049e9c.png)

after
![capture_improved](https://user-images.githubusercontent.com/123720/132085105-5831f3e1-4483-4584-bd16-f7507590bd4f.png)

Both are captured by  same seanario.