### PR TITLE
LingvoDSL: update copyright holder name in source header

### DIFF
--- a/src/org/omegat/core/dictionaries/LingvoDSL.java
+++ b/src/org/omegat/core/dictionaries/LingvoDSL.java
@@ -5,7 +5,7 @@
 
  Copyright (C) 2010 Alex Buloichik
                2015 Aaron Madlon-Kay
-               2021 Aaron Madlon-Kay, Gabix, Hiroshi Miura
+               2021 Aaron Madlon-Kay, Dmitri Gabinski, Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 


### PR DESCRIPTION
The author contributed a lot for researching DSL tags specification,
made a proposal of all the regex replacements, and tested with
actual dictionaries. The improvements are not able to be realized
without the efforts.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>