### PR TITLE
Work around for menu focus issue (BUGS#1073)

### DIFF
--- a/src/org/omegat/gui/theme/DefaultClassicTheme.java
+++ b/src/org/omegat/gui/theme/DefaultClassicTheme.java
@@ -44,6 +44,7 @@ import org.omegat.util.OStrings;
 import org.omegat.util.gui.UIDesignManager;
 
 
+@SuppressWarnings("serial")
 public class DefaultClassicTheme extends DelegatingLookAndFeel {
 
     private static final String NAME = OStrings.getString("THEME_OMEGAT_CLASSIC_NAME");

--- a/src/org/omegat/gui/theme/DefaultFlatTheme.java
+++ b/src/org/omegat/gui/theme/DefaultFlatTheme.java
@@ -50,6 +50,7 @@ import org.omegat.util.gui.RoundedCornerBorder;
 import org.omegat.util.gui.UIDesignManager;
 
 
+@SuppressWarnings("serial")
 public class DefaultFlatTheme extends DelegatingLookAndFeel {
 
     private static final String NAME = OStrings.getString("THEME_OMEGAT_DEFAULT_NAME");

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -35,6 +35,7 @@ import javax.swing.LayoutStyle;
 import javax.swing.LookAndFeel;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.plaf.basic.BasicLookAndFeel;
 
 import org.madlonkay.desktopsupport.DesktopSupport;
 import org.omegat.util.gui.ResourcesUtil;
@@ -48,7 +49,8 @@ import org.omegat.util.gui.ResourcesUtil;
  *
  * @author Aaron Madlon-Kay
  */
-public abstract class DelegatingLookAndFeel extends LookAndFeel {
+@SuppressWarnings("serial")
+public abstract class DelegatingLookAndFeel extends BasicLookAndFeel {
     /**
      * Load icon from classpath.
      *


### PR DESCRIPTION
This intend to fix an issue that the focus is sticky on edit pane when calling menu by Alt/Key combination, and
cannot select menu item with keyboard shortcut or cursor keys.
It is caused when default LaFs are selected.

The bug is exist on default LaFs are inherited from LookAndFeel abstract class, not from BasicLookAndFeel abstract
class. All known system LaFs, such as gtk, metal, nimbus, and aqua, are descendants of BasicLookAndFeel
that is direct known subclass of LookAndFeel class.

These classes implement serializable and incompatible with known MultiLookAndFeel subclass of LookAndFeel.
We brings limitation for users to allow system LaFs only a descendant of BasicLookAndFeel.

Now users have a way to use arbitrary theme/LaF as plugin. So it is not a problem.

- resolve [BUGS#1073](https://sourceforge.net/p/omegat/bugs/1073/)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>