### PR TITLE
Team: Git: migrate to Apache MINA sshd (RFE#1598)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,20 +152,18 @@ dependencies {
         implementation "org.apache.lucene:lucene-analyzers-stempel:${luceneVersion}"
 
         // Team project server support
-        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r'
-        // Original JSch is unmaintained and dead, so we use forked version, mwiede/jsch
-        // to fix BUGS#1075, and to support elliptic curve ciphers and improved ssh agent
-        implementation 'com.github.mwiede:jsch:0.2.3'
-        // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.ssh.jsch
-        implementation ('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.13.1.202206130422-r') {
-            exclude module: 'jsch'
-        }
-        // For ed25519 and ecdsa support of jsch, java16+ or BC
-        implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
-        // For ssh agent support of jsch, Java16+ or junixsocket
-        implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.4.0'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache:6.5.0.202303070854-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent:6.5.0.202303070854-r'
+        implementation 'org.apache.sshd:sshd-git:2.9.2'
+        // For ed25519 and ecdsa support of ssh, java16+ or BC
+        implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+        implementation 'org.bouncycastle:bcpg-jdk15on:1.70'
+        implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+        implementation 'net.i2p.crypto:eddsa:0.3.0'
         // For gpg signing
-        implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:5.11.1.202105131744-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:6.5.0.202303070854-r'
+
         // For subversion
         implementation 'org.tmatesoft.svnkit:svnkit:1.10.9'
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2342,6 +2342,11 @@ TEAM_26_to_36_CONVERT_FAILED=Project conversion failed.\n\
 TEAM_USERPASS_TITLE=Authentication
 TEAM_USERPASS_FIRST=Enter username/password for {0}
 TEAM_USERPASS_WRONG=Wrong username/password for {0}
+TEAM_USER_FIRST=Please enter username for {0}
+TEAM_PASS_FIRST=Please enter password for {0}
+TEAM_PASS_WRONG=Wrong password for {0}
+TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
+TEAM_YESNO_ABORT=Cannot get correct answer. Abort...
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -6,7 +6,8 @@
  Copyright (C) 2012 Alex Buloichik
                2014 Alex Buloichik, Aaron Madlon-Kay
                2015 Hiroshi Miura, Aaron Madlon-Kay
-               2022 Hiroshi Miura, Thomas Cordonnier
+               2022 Thomas Cordonnier
+               2021-2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -28,6 +29,9 @@
 
 package org.omegat.core.team2.impl;
 
+import java.io.Console;
+import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,29 +40,21 @@ import java.util.regex.Pattern;
 
 import javax.swing.JOptionPane;
 
-import com.jcraft.jsch.AgentIdentityRepository;
-import com.jcraft.jsch.AgentProxyException;
-import com.jcraft.jsch.IdentityRepository;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.SSHAgentConnector;
-import com.jcraft.jsch.Session;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
-import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.URIish;
 
 import org.omegat.core.Core;
 import org.omegat.core.KnownException;
-import org.omegat.core.team2.ProjectTeamSettings;
 import org.omegat.core.team2.TeamSettings;
+import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
 /**
- * Git repository credentials provider. One credential provider created for all git instances.
+ * Git repository credentials provider. One credential provider created for all
+ * git instances.
  * <p>
  * Git supports these protocols:
  * <ul>
@@ -71,85 +67,65 @@ import org.omegat.util.OStrings;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Aaron Madlon-Kay
  * @author Hiroshi Miura
- * @see <a href="https://www.codeaffine.com/2014/12/09/jgit-authentication/">JGit Authentication Explained</a>
- * @see <a href="https://www.matez.de/index.php/2020/06/22/the-future-of-jsch-without-ssh-rsa/">matez blog</a>
+ * @see <a href=
+ *      "https://www.codeaffine.com/2014/12/09/jgit-authentication/">JGit
+ *      Authentication Explained</a>
+ * @see <a href=
+ *      "https://www.matez.de/index.php/2020/06/22/the-future-of-jsch-without-ssh-rsa/">matez
+ *      blog</a>
+ * @see <a href=
+ *      "https://github.com/apache/mina-sshd/blob/master/docs/git.md">MINA-SSHD
+ *      Git support</a>
  */
+
 public class GITCredentialsProvider extends CredentialsProvider {
 
-    private static final String PROMPT_REGEX =
-            "The authenticity of host '" + /* host */ ".*" + "' can't be established\\.\\n" +
-                    /* key_type */ "(RSA|DSA|ECDSA|EDDSA)" + " key fingerprint is " +
-                    /* key fprint */ "(([0-9a-f]{2}:){15}[0-9a-f]{2})" + "\\.\\n" +
-                    "Are you sure you want to continue connecting\\?";
+    private static final String KEY_USERNAME_SUFFIX = "username";
+    private static final String KEY_PASSWORD_SUFFIX = "password";
+    private static final String KEY_FINGERPRINT_SUFFIX = "fingerprint";
+    private static final Pattern[] fingerPrintRegex = new Pattern[] {
+            Pattern.compile("The authenticity of host '" + /* host */ ".*" + "' can't be established\\.\\n" +
+            /* key_type */ "(RSA|DSA|ECDSA|EDDSA)" + " key fingerprint is " +
+            /* key fprint */ "(?<fingerprint>([0-9a-f]{2}:){15}[0-9a-f]{2})" + "\\.\\n"
+                    + "Are you sure you want to continue connecting\\?"),
+            Pattern.compile("The authenticity of host '" + /* host */ ".*" + "' can't be established\\.\\n" +
+            /* key_type */ "(RSA|DSA|ECDSA|EDDSA)" + " key fingerprint is " +
+            /* key fprint */"SHA256:(?<fingerprint>[0-9a-zA-Z/+]+)" + "\\.\\n"
+                    + "Are you sure you want to continue connecting\\?"),
+            Pattern.compile("The authenticity of host '.*' cannot be established\\.\\n"
+                    + "The EC key's fingerprints are:\\n"
+                    + "MD5:([0-9a-f]{2}:){15}[0-9a-f]{2}\\nSHA256:(?<fingerprint>[0-9a-zA-Z/+]+)\\n"
+                    + "Accept and store this key, and continue connecting\\?") };
+    private static final String PASSWORD_PROMPT = "Password: ";
+    private static final int MAX_RETRY = 5;
 
-    static {
-        JSch.setLogger(new com.jcraft.jsch.Logger(){
-            public boolean isEnabled(final int level) {
-                return level >= WARN;
-            }
-
-            @Override
-            public void log(final int level, final String message) {
-                if (level > WARN) {
-                    Log.log(message);
-                } else if (level == WARN) {
-                    Log.logWarningRB("TEAM_GIT_SSH_CREDENTIAL_ERROR, message");
-                } else {
-                    Log.logErrorRB("TEAM_GIT_SSH_CREDENTIAL_ERROR", message);
-                }
-            }
-
-            @Override
-            public void log(final int level, final String message, final Throwable cause) {
-                Log.logErrorRB(cause, "TEAM_GIT_SSH_CREDENTIAL_ERROR", message);
-            }
-        });
-        JschConfigSessionFactory sessionFactory = new JschConfigSessionFactory() {
-
-            /**
-             * Configure ssh+git session preference.
-             * @param host
-             *            host configuration
-             * @param session
-             *            session to configure
-             */
-            @Override
-            protected void configure(OpenSshConfig.Host host, Session session) {
-                session.setConfig("StrictHostKeyChecking", "true");
-            }
-
-            /**
-             * Add ssh-agent support configuration to default JSch instance.
-             * @param jsch JSch instance.
-             */
-            @Override
-            protected void configureJSch(final JSch jsch) {
-                super.configureJSch(jsch);
-                try {
-                    // Use ssh-agent connector class provided by forked JSch project.
-                    IdentityRepository irepo = new AgentIdentityRepository(new SSHAgentConnector());
-                    JSch.setConfig("PreferredAuthentications", "publickey");
-                    jsch.setIdentityRepository(irepo);
-                } catch (AgentProxyException e) {
-                    Log.log(e);
-                }
-            }
-        };
-        SshSessionFactory.setInstance(sessionFactory);
-    }
-
-    static final String KEY_USERNAME_SUFFIX = "username";
-    static final String KEY_PASSWORD_SUFFIX = "password";
-    static final String KEY_FINGERPRINT_SUFFIX = "fingerprint";
-
-    //private ProjectTeamSettings teamSettings;
-    /** Predefined in the `omegat.project` file. */
+    /** Predefined in the omegat.project file. */
     private final Map<String, String> predefined = Collections.synchronizedMap(new HashMap<>());
 
-    public void setTeamSettings(ProjectTeamSettings teamSettings) {
-        //this.teamSettings = teamSettings;
+    /**
+     * Installation of credentials provider.
+     * <p>
+     * This static method installs GITCredentialsProvider object as default.
+     */
+    public static void install() {
+        final GITCredentialsProvider c = new GITCredentialsProvider();
+        CredentialsProvider.setDefault(c);
     }
 
+    /**
+     * Set predefined git+ssh or https credentials.
+     * <p>
+     * these credentials are automatically passed to ssh/https connection layer.
+     * 
+     * @param url
+     *            target url.
+     * @param predefinedUser
+     *            predefined username.
+     * @param predefinedPass
+     *            predefined password.
+     * @param predefinedFingerprint
+     *            predefined fingerprint of host.
+     */
     public void setPredefinedCredentials(String url, String predefinedUser, String predefinedPass,
             String predefinedFingerprint) {
         predefined.put("user." + url, predefinedUser);
@@ -158,14 +134,16 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private Credentials loadCredentials(URIish uri) {
-        String url = uri.toString(); // now we use schema://server:port but we keep this for backward compatibility
+        String url = uri.toString(); // now we use schema://server:port but we
+                                     // keep this for backward compatibility
         Credentials credentials = new Credentials();
         credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
         credentials.password = TeamUtils.decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
         if (credentials.username == null) {
             url = "" + uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort();
             credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
-            credentials.password = TeamUtils.decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
+            credentials.password = TeamUtils
+                    .decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
         }
         return credentials;
     }
@@ -173,7 +151,9 @@ public class GITCredentialsProvider extends CredentialsProvider {
     private void saveCredentials(URIish uri, Credentials credentials) {
         String url = "" + uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort();
         try {
-            TeamSettings.set(url + "!" + KEY_USERNAME_SUFFIX, credentials.username);
+            if (!credentials.username.isEmpty()) {
+                TeamSettings.set(url + "!" + KEY_USERNAME_SUFFIX, credentials.username);
+            }
             TeamSettings.set(url + "!" + KEY_PASSWORD_SUFFIX, TeamUtils.encodePassword(credentials.password));
         } catch (Exception e) {
             Core.getMainWindow().displayErrorRB(e, "TEAM_ERROR_SAVE_CREDENTIALS", null, "TF_ERROR");
@@ -194,9 +174,21 @@ public class GITCredentialsProvider extends CredentialsProvider {
         }
     }
 
+    /**
+     * Ask for the credential items to be populated.
+     *
+     * @param uri
+     *            the URI of the remote resource that needs authentication.
+     * @param items
+     *            the items the application requires to complete authentication.
+     * @return {@code true} if the request was successful and values were
+     *         supplied; {@code false} if the user canceled the request and did
+     *         not supply all requested values.
+     * @throws org.eclipse.jgit.errors.UnsupportedCredentialItem
+     *             if one of the items supplied is not supported.
+     */
     @Override
     public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
-
         // get predefined if exist
         String url = uri.toString();
         String predefinedUser = predefined.get("user." + url);
@@ -205,149 +197,194 @@ public class GITCredentialsProvider extends CredentialsProvider {
 
         // get saved
         Credentials credentials = loadCredentials(uri);
-
+        StringBuilder sb = new StringBuilder();
         boolean ok = false;
-        // theoretically, username can be unknown, but in practice it is always set, so not requested.
-        for (CredentialItem i : items) {
-            if (i instanceof CredentialItem.Username) {
+        // theoretically, username can be unknown, but in practice it is always
+        // set, so not requested.
+        for (CredentialItem item : items) {
+            if (item instanceof CredentialItem.Username) {
                 if (predefinedUser != null && predefinedPass != null) {
-                    ((CredentialItem.Username) i).setValue(predefinedUser);
+                    ((CredentialItem.Username) item).setValue(predefinedUser);
                     continue;
                 }
                 if (credentials.username == null) {
-                    credentials = askCredentials(uri, credentials);
-                    if (credentials == null) {
-                        throw new UnsupportedCredentialItem(uri,
-                                OStrings.getString("TEAM_CREDENTIALS_DENIED"));
-                    }
-                    saveCredentials(uri, credentials);
+                    credentials = askCredentials(uri, credentials, false);
                     ok = true;
                 }
-                ((CredentialItem.Username) i).setValue(credentials.username);
+                ((CredentialItem.Username) item).setValue(credentials.username);
                 continue;
-            } else if (i instanceof CredentialItem.Password) {
+            } else if (item instanceof CredentialItem.Password) {
                 if (predefinedUser != null && predefinedPass != null) {
-                    ((CredentialItem.Password) i).setValue(predefinedPass.toCharArray());
+                    ((CredentialItem.Password) item).setValue(predefinedPass.toCharArray());
                     continue;
                 }
                 if (credentials.password == null) {
-                    credentials = askCredentials(uri, credentials);
-                    if (credentials == null) {
-                        throw new UnsupportedCredentialItem(uri,
-                                OStrings.getString("TEAM_CREDENTIALS_DENIED"));
-                    }
-                    saveCredentials(uri, credentials);
+                    credentials = askCredentials(uri, credentials, true);
                     ok = true;
                 }
-                ((CredentialItem.Password) i).setValue(credentials.password.toCharArray());
+                ((CredentialItem.Password) item).setValue(credentials.password.toCharArray());
                 continue;
-            } else if (i instanceof CredentialItem.StringType) {
-                if (i.getPromptText().equals("Password: ")) {
-                    if (predefinedUser != null && predefinedPass != null) {
-                        ((CredentialItem.StringType) i).setValue(predefinedPass);
-                        continue;
-                    }
-                    if (credentials.password == null) {
-                        if (!ok) {
-                            credentials = askCredentials(uri, credentials);
-                            if (credentials == null) {
-                                throw new UnsupportedCredentialItem(uri,
-                                        OStrings.getString("TEAM_CREDENTIALS_DENIED"));
-                            }
-                            saveCredentials(uri, credentials);
-                        }
-                    }
-                    ((CredentialItem.StringType) i).setValue(credentials.password);
+            } else if (item instanceof CredentialItem.StringType) {
+                if (!item.getPromptText().equals(PASSWORD_PROMPT)) {
+                    Log.log("Git: Ignore credentials query: " + item.getPromptText());
                     continue;
-                } else if (i.getPromptText().startsWith("Passphrase for ")) {
-                    // Private key passphrase
-                    if (!ok) {
-                        String passphrase = askPassphrase(i.getPromptText());
-                        if (passphrase == null) {
-                            throw new UnsupportedCredentialItem(uri,
-                                    OStrings.getString("TEAM_CREDENTIALS_DENIED"));
-                        }
-                        ((CredentialItem.StringType) i).setValue(passphrase);
-                        continue;
-                    }
                 }
-            } else if (i instanceof CredentialItem.YesNoType) {
-                // @see constant variable PROMPT_REGEX
-                // e.g.: The authenticity of host 'mygitserver' can't be established.
-                // RSA key fingerprint is e2:d3:84:d5:86:e7:68:69:a0:aa:a6:ad:a3:a0:ab:a2.
+                if (predefinedUser != null && predefinedPass != null) {
+                    ((CredentialItem.StringType) item).setValue(predefinedPass);
+                    continue;
+                }
+                if (credentials.password == null && !ok) {
+                    credentials = askCredentials(uri, credentials, true);
+                }
+                ((CredentialItem.StringType) item).setValue(credentials.password);
+                continue;
+            } else if (item instanceof CredentialItem.YesNoType) {
+                // @see constant array fingerPrintRegex
+                // e.g.: The authenticity of host 'mygitserver' can't be
+                // established.
+                // RSA key fingerprint is
+                // e2:d3:84:d5:86:e7:68:69:a0:aa:a6:ad:a3:a0:ab:a2.
                 // Are you sure you want to continue connecting?
                 String storedFingerprint = loadFingerprint(uri);
-                String promptText = i.getPromptText();
+                // exhausted messages to promptText and reset sb
+                String promptText = sb.append(item.getPromptText()).toString();
+                sb = new StringBuilder();
                 String promptedFingerprint = extractFingerprint(promptText);
                 if (promptedFingerprint == null) {
-                    throw new UnsupportedCredentialItem(uri, "Wrong fingerprint pattern");
+                    throw new UnsupportedCredentialItem(uri,
+                            String.format("Wrong fingerprint pattern: %s", promptText));
                 }
                 if (predefinedFingerprint != null) {
-                    if (promptedFingerprint.equals(predefinedFingerprint)) {
-                        ((CredentialItem.YesNoType) i).setValue(true);
-                    } else {
-                        ((CredentialItem.YesNoType) i).setValue(false);
-                    }
+                    ((CredentialItem.YesNoType) item)
+                            .setValue(promptedFingerprint.equals(predefinedFingerprint));
                     continue;
                 }
                 if (promptedFingerprint.equals(storedFingerprint)) {
-                    ((CredentialItem.YesNoType) i).setValue(true);
+                    ((CredentialItem.YesNoType) item).setValue(true);
                     continue;
                 }
-                int choice = Core.getMainWindow().showConfirmDialog(promptText, null,
-                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-                if (choice == JOptionPane.YES_OPTION) {
-                    ((CredentialItem.YesNoType) i).setValue(true);
-                    saveFingerprint(uri, promptedFingerprint);
-                } else {
-                    ((CredentialItem.YesNoType) i).setValue(false);
-                }
+                askYesNo(item, promptText, uri, promptedFingerprint);
                 continue;
-            } else if (i instanceof CredentialItem.InformationalMessage) {
-                Log.logInfoRB("GIT_CREDENTIAL_MESSAGE", i.getPromptText());
-                Core.getMainWindow()
-                        .showTimedStatusMessageRB("GIT_CREDENTIAL_MESSAGE", i.getPromptText());
+            } else if (item instanceof CredentialItem.InformationalMessage) {
+                Log.logInfoRB("GIT_CREDENTIAL_MESSAGE", item.getPromptText());
+                Core.getMainWindow().showTimedStatusMessageRB("GIT_CREDENTIAL_MESSAGE", item.getPromptText());
                 continue;
             }
-            throw new UnsupportedCredentialItem(uri, i.getClass().getName() + ":" + i.getPromptText());
+            throw new UnsupportedCredentialItem(uri, item.getClass().getName() + ":" + item.getPromptText());
+        }
+        if (sb.length() > 0) {
+            Log.log(sb.toString());
         }
         return true;
     }
 
+    /**
+     * Check if the provider is interactive with the end-user.
+     * <p>
+     * GITCredentialsProvider is always interactive.
+     * 
+     * @return true
+     */
     @Override
     public boolean isInteractive() {
         return true;
     }
 
+    /**
+     * Check if the credentials are supported.
+     * 
+     * @param items
+     *            credential items
+     * @return true when asked username and/or password. Otherwise, false.
+     */
     @Override
     public boolean supports(CredentialItem... items) {
         for (CredentialItem i : items) {
-            if (i instanceof CredentialItem.Username) {
-                continue;
-            } else if (i instanceof CredentialItem.Password) {
-                continue;
-            } else {
+            if (!(i instanceof CredentialItem.Username || i instanceof CredentialItem.Password)) {
                 return false;
             }
         }
         return true;
     }
 
-    /**
-     * shows dialog to ask for credentials, and stores credentials.
-     *
-     * @return true when entered, false on cancel.
-     */
-    private Credentials askCredentials(URIish uri, Credentials credentials) {
-        if (Core.getMainWindow() == null) {
-            return null;
+    private boolean isGUI() {
+        return Core.getMainWindow() != null;
+    }
+
+    private void askYesNoGUI(CredentialItem item, String promptText, URIish uri, String promptedFingerprint) {
+        IMainWindow mw = Core.getMainWindow();
+        int choice = mw.showConfirmDialog(promptText, null, JOptionPane.YES_NO_OPTION,
+                JOptionPane.WARNING_MESSAGE);
+        if (choice == JOptionPane.YES_OPTION) {
+            ((CredentialItem.YesNoType) item).setValue(true);
+            saveFingerprint(uri, promptedFingerprint);
+        } else {
+            ((CredentialItem.YesNoType) item).setValue(false);
         }
-        GITUserPassDialog userPassDialog = new GITUserPassDialog(Core.getMainWindow().getApplicationFrame());
+    }
+
+    private void askYesNoCUI(CredentialItem item, String promptText, URIish uri, String promptedFingerprint) {
+        Console console = System.console();
+        if (console != null) {
+            try (PrintWriter printWriter = console.writer()) {
+                boolean succeeded = false;
+                for (int i = 0; i < MAX_RETRY; i++) {
+                    printWriter.print(promptText);
+                    String answer = console.readLine("([y]es or [n]o): ");
+                    if (answer.equalsIgnoreCase("y") || answer.equalsIgnoreCase("yes")) {
+                        ((CredentialItem.YesNoType) item).setValue(true);
+                        saveFingerprint(uri, promptedFingerprint);
+                        succeeded = true;
+                        break;
+                    } else if (answer.equalsIgnoreCase("n") || answer.equalsIgnoreCase("no")) {
+                        ((CredentialItem.YesNoType) item).setValue(false);
+                        succeeded = true;
+                        break;
+                    }
+                    printWriter.println(OStrings.getString("TEAM_YESNO_AGAIN"));
+                }
+                if (!succeeded) {
+                    printWriter.println(OStrings.getString("TEAM_YESNO_ABORT"));
+                    ((CredentialItem.YesNoType) item).setValue(false);
+                }
+            }
+        } else {
+            // When there is no console, aborting...
+            ((CredentialItem.YesNoType) item).setValue(false);
+        }
+    }
+
+    private void askYesNo(CredentialItem item, String promptText, URIish uri, String promptedFingerprint) {
+        if (isGUI()) {
+            askYesNoGUI(item, promptText, uri, promptedFingerprint);
+        } else {
+            askYesNoCUI(item, promptText, uri, promptedFingerprint);
+        }
+    }
+
+    /**
+     * GUI component to ask credentials.
+     * <p>
+     * If username is already available in uri, then we will not be asked
+     * for a username, and keep it.
+     * @param uri the repository URI
+     * @param credentials credentials holder
+     * @param passwordOnly true when want to ask only password, otherwise false.
+     * @return result as a credential object.
+     */
+    private Credentials askCredentialsGUI(URIish uri, Credentials credentials, boolean passwordOnly) {
+        IMainWindow mw = Core.getMainWindow();
+        GITUserPassDialog userPassDialog = new GITUserPassDialog(mw.getApplicationFrame());
         userPassDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
-        userPassDialog.descriptionTextArea.setText(OStrings
-                .getString(credentials.username == null ? "TEAM_USERPASS_FIRST" : "TEAM_USERPASS_WRONG",
-                        uri.getHumanishName()));
-        // if username is already available in uri, then we will not be asked for a username, so we cannot change it.
+        if (passwordOnly) {
+            userPassDialog.descriptionTextArea.setText(
+                    OStrings.getString(credentials.username == null ? "TEAM_PASS_FIRST" : "TEAM_PASS_WRONG",
+                            uri.getHumanishName()));
+        } else {
+            userPassDialog.descriptionTextArea.setText(OStrings.getString(
+                    credentials.username == null ? "TEAM_USERPASS_FIRST" : "TEAM_USERPASS_WRONG",
+                    uri.getHumanishName()));
+        }
         if (uri.getUser() != null && !"".equals(uri.getUser())) {
             userPassDialog.userText.setText(uri.getUser());
             userPassDialog.userText.setEditable(false);
@@ -356,34 +393,62 @@ public class GITCredentialsProvider extends CredentialsProvider {
         if (credentials.username != null) {
             userPassDialog.userText.setText(credentials.username);
         }
+        if (passwordOnly) {
+            userPassDialog.userText.setEditable(false);
+        }
         userPassDialog.setVisible(true);
         if (userPassDialog.getReturnStatus() == GITUserPassDialog.RET_OK) {
             credentials.username = userPassDialog.userText.getText();
             credentials.password = new String(userPassDialog.passwordField.getPassword());
             return credentials;
-        } else {
-            return null;
         }
+        return null;
     }
 
-    private String askPassphrase(String prompt) {
-        GITUserPassDialog userPassDialog = new GITUserPassDialog(Core.getMainWindow().getApplicationFrame());
-        userPassDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
-        userPassDialog.descriptionTextArea.setText(prompt);
-        userPassDialog.userText.setVisible(false);
-        userPassDialog.userLabel.setVisible(false);
-        userPassDialog.passwordField.requestFocusInWindow();
-        userPassDialog.setVisible(true);
-        if (userPassDialog.getReturnStatus() == GITUserPassDialog.RET_OK) {
-            return new String(userPassDialog.passwordField.getPassword());
-        } else {
-            return null;
+    private Credentials askCredentialsCUI(URIish uri, Credentials credentials, boolean passwordOnly) {
+        Console console = System.console();
+        if (console != null) {
+            if (uri.getUser() != null && !"".equals(uri.getUser())) {
+                credentials.username = uri.getUser();
+            } else {
+                if (!passwordOnly) {
+                    credentials.username = console
+                            .readLine(OStrings.getString("TEAM_USER_FIRST", uri.getHumanishName()));
+                }
+            }
+            char[] pass = console.readPassword(OStrings.getString("TEAM_PASS_FIRST", uri.getHumanishName()));
+            credentials.password = Arrays.toString(pass);
+            return credentials;
         }
+        Log.log("No console found.");
+        return null;
     }
 
+    private Credentials askCredentials(URIish uri, Credentials credentials, boolean passwordOnly) {
+        Credentials result;
+        if (isGUI()) {
+            result = askCredentialsGUI(uri, credentials, passwordOnly);
+        } else {
+            result = askCredentialsCUI(uri, credentials, passwordOnly);
+        }
+        if (result == null) {
+            throw new UnsupportedCredentialItem(uri, OStrings.getString("TEAM_CREDENTIALS_DENIED"));
+        }
+        saveCredentials(uri, result);
+        return result;
+    }
+
+    /**
+     * Reset connection.
+     * <p>
+     * It is called after 5 authorization failures.
+     * The transport gives up after 3 resets.
+     *
+     * @param uri
+     *            target URI.
+     */
     @Override
     public void reset(URIish uri) {
-        // reset is called after 5 authorization failures. After 3 resets, the transport gives up.
         String url = uri.toString();
         String predefinedUser = predefined.get("user." + url);
         String predefinedPass = predefined.get("pass." + url);
@@ -397,17 +462,29 @@ public class GITCredentialsProvider extends CredentialsProvider {
         saveCredentials(uri, credentials);
     }
 
-    private static String extractFingerprint(String text) {
-        Pattern p = Pattern.compile(PROMPT_REGEX);
-        Matcher fingerprintMatcher = p.matcher(text);
-        if (fingerprintMatcher.find()) {
-            int start = fingerprintMatcher.start(1);
-            int end = fingerprintMatcher.end(1);
-            return text.substring(start, end);
+    /**
+     * Extract fingerprint from a message.
+     * 
+     * @param text
+     *            message text.
+     * @return fingerprint hash string.
+     */
+    protected static String extractFingerprint(String text) {
+        Matcher fingerprintMatcher;
+        for (Pattern p : fingerPrintRegex) {
+            fingerprintMatcher = p.matcher(text);
+            if (fingerprintMatcher.find()) {
+                int start = fingerprintMatcher.start("fingerprint");
+                int end = fingerprintMatcher.end("fingerprint");
+                return text.substring(start, end);
+            }
         }
         return null;
     }
 
+    /**
+     * POJO to hold credentials.
+     */
     public static class Credentials {
         public String username = null;
         public String password = null;

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -40,10 +40,9 @@ import java.util.stream.StreamSupport;
 
 import javax.xml.namespace.QName;
 
-import org.eclipse.jgit.api.CheckoutCommand;
+import org.apache.sshd.client.SshClient;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.CommitCommand;
-import org.eclipse.jgit.api.CreateBranchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
@@ -70,9 +69,14 @@ import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.RemoteRefUpdate.Status;
+import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.transport.sshd.JGitKeyCache;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactoryBuilder;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.eclipse.jgit.treewalk.FileTreeIterator;
+import org.eclipse.jgit.util.FS;
 
 import org.omegat.core.team2.IRemoteRepository2;
 import org.omegat.core.team2.ProjectTeamSettings;
@@ -90,9 +94,11 @@ import gen.core.project.RepositoryDefinition;
 public class GITRemoteRepository2 implements IRemoteRepository2 {
     private static final Logger LOGGER = Logger.getLogger(GITRemoteRepository2.class.getName());
 
+    // allow override default remote name and branch name.
     protected static final String DEFAULT_LOCAL_BRANCH = "master";
     protected static final String REMOTE = Constants.DEFAULT_REMOTE_NAME;
 
+    // allow override timeout.
     protected static final int TIMEOUT = 30; // seconds
 
     String repositoryURL;
@@ -105,9 +111,33 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     ProjectTeamSettings projectTeamSettings;
 
     static {
-        CredentialsProvider.setDefault(new GITCredentialsProvider());
+        installSshSessionFactory();
+        GITCredentialsProvider.install();
     }
 
+    private static void installSshSessionFactory() {
+        // SSH directories
+        // Linux/macOS: ~/.ssh
+        // C:\Windows\System32\OpenSSH.exe: %USERPROFILE%\.ssh
+        SshdSessionFactory sshdSessionFactory = new SshdSessionFactoryBuilder()
+                .setPreferredAuthentications("publickey,keyboard-interactive")
+                .setHomeDirectory(FS.detect().userHome())
+                .setSshDirectory(new File(FS.detect().userHome(), ".ssh")).build(new JGitKeyCache());
+        SshSessionFactory.setInstance(sshdSessionFactory);
+    }
+
+    /**
+     * Initialize remote repository access credentials.
+     * 
+     * @param repo
+     *            repository description instance
+     * @param dir
+     *            directory for store files
+     * @param teamSettings
+     *            team settings.
+     * @throws Exception
+     *             when error happened.
+     */
     @Override
     public void init(RepositoryDefinition repo, File dir, ProjectTeamSettings teamSettings) throws Exception {
         repositoryURL = repo.getUrl();
@@ -119,65 +149,59 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         String predefinedFingerprint = repo.getOtherAttributes().get(new QName("gitFingerprint"));
         ((GITCredentialsProvider) CredentialsProvider.getDefault()).setPredefinedCredentials(repositoryURL,
                 predefinedUser, predefinedPass, predefinedFingerprint);
-        ((GITCredentialsProvider) CredentialsProvider.getDefault()).setTeamSettings(teamSettings);
 
-        File gitDir = new File(localDirectory, ".git");
-        if (gitDir.exists() && gitDir.isDirectory()) {
-            // already cloned
-            repository = Git.open(localDirectory).getRepository();
-            String defaultBranch = getDefaultBranchName(repository);
-            branch = repo.getBranch() == null? defaultBranch : repo.getBranch();
-            trackBranch = !(branch.equals(defaultBranch));
-            if (trackBranch) {
-                repository.resolve(branch);
+        SshClient client = SshClient.setUpDefaultClient();
+        try {
+            client.start();
+            File gitDir = new File(localDirectory, ".git");
+            if (gitDir.exists() && gitDir.isDirectory()) {
+                // already cloned
+                repository = Git.open(localDirectory).getRepository();
+                configRepo();
+                try (Git git = new Git(repository)) {
+                    git.submoduleInit().call();
+                    git.submoduleUpdate().setTimeout(TIMEOUT).call();
+                }
+            } else {
+                Log.logInfoRB("GIT_START", "clone");
+                CloneCommand c = Git.cloneRepository();
+                c.setURI(repositoryURL);
+                c.setDirectory(localDirectory);
+                c.setTimeout(TIMEOUT);
+                try {
+                    c.call();
+                } catch (InvalidRemoteException e) {
+                    if (localDirectory.exists()) {
+                        deleteDirectory(localDirectory);
+                    }
+                    Throwable cause = e.getCause();
+                    if (cause instanceof org.eclipse.jgit.errors.NoRemoteRepositoryException) {
+                        BadRepositoryException bre = new BadRepositoryException(cause.getLocalizedMessage());
+                        bre.initCause(e);
+                        throw bre;
+                    }
+                    throw e;
+                }
+                repository = Git.open(localDirectory).getRepository();
+                try (Git git = new Git(repository)) {
+                    git.submoduleInit().call();
+                    git.submoduleUpdate().setTimeout(TIMEOUT).call();
+                }
+                configRepo();
+                Log.logInfoRB("GIT_FINISH", "clone");
             }
-            configRepo();
+
+            // cleanup repository
             try (Git git = new Git(repository)) {
-                git.submoduleInit().call();
-                git.submoduleUpdate().setTimeout(TIMEOUT).call();
+                git.reset().setMode(ResetType.HARD).call();
             }
-        } else {
-            Log.logInfoRB("GIT_START", "clone");
-            CloneCommand c = Git.cloneRepository();
-            c.setURI(repositoryURL);
-            c.setDirectory(localDirectory);
-            c.setTimeout(TIMEOUT);
-            try {
-                c.call();
-            } catch (InvalidRemoteException e) {
-                if (localDirectory.exists()) {
-                    deleteDirectory(localDirectory);
-                }
-                Throwable cause = e.getCause();
-                if (cause instanceof org.eclipse.jgit.errors.NoRemoteRepositoryException) {
-                    BadRepositoryException bre = new BadRepositoryException(cause.getLocalizedMessage());
-                    bre.initCause(e);
-                    throw bre;
-                }
-                throw e;
-            }
-	    repository = Git.open(localDirectory).getRepository();
-    	    String defaultBranch = getDefaultBranchName(repository);
-	    branch = repo.getBranch() == null? defaultBranch : repo.getBranch();
-	    trackBranch = !(branch.equals(defaultBranch));
-	    try (Git git = new Git(repository)) {
-	        if (trackBranch) {
-	    	    git.branchCreate().setName(branch)
-			.setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
-			.setStartPoint(String.join("/", REMOTE, branch))
-			.call();
-		    CheckoutCommand checkout = git.checkout();
-		    checkout.setName(branch);
-		    checkout.call();
-	        }
-	        git.submoduleInit().call();
-	        git.submoduleUpdate().setTimeout(TIMEOUT).call();
-	    }
             configRepo();
             Log.logInfoRB("GIT_FINISH", "clone");
+        } finally {
+            client.stop();
         }
 
-        String signingkey  = repository.getConfig().getString("user", null, "signingkey");
+        String signingkey = repository.getConfig().getString("user", null, "signingkey");
         if (!StringUtil.isEmpty(signingkey)) {
             GpgSigner.setDefault(new GITExternalGpgSigner());
         }
@@ -196,7 +220,8 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         // To do auto converting, we need to change a setting:
         if ("\r\n".equals(System.lineSeparator())) {
             // on windows machines, convert text files to CRLF
-            config.setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_AUTOCRLF, true);
+            config.setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_AUTOCRLF,
+                    true);
         } else {
             // on Linux/Mac machines (using LF), don't convert text files
             // but use input format, unchanged.
@@ -208,11 +233,21 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
 
         // Perform GC synchronously to avoid locking issues
-        config.setBoolean(ConfigConstants.CONFIG_GC_SECTION, null, ConfigConstants.CONFIG_KEY_AUTODETACH, false);
+        config.setBoolean(ConfigConstants.CONFIG_GC_SECTION, null, ConfigConstants.CONFIG_KEY_AUTODETACH,
+                false);
 
         config.save();
     }
 
+    /**
+     * Get version string.
+     * 
+     * @param file
+     *            target file to check.
+     * @return version string when file exists, otherwise null.
+     * @throws IOException
+     *             when error occurred.
+     */
     @Override
     public String getFileVersion(String file) throws IOException {
         File f = new File(localDirectory, file);
@@ -222,6 +257,13 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         return getCurrentVersion();
     }
 
+    /**
+     * Get current version of repository.
+     * 
+     * @return version string.
+     * @throws IOException
+     *             when error occurred.
+     */
     protected String getCurrentVersion() throws IOException {
         try (RevWalk walk = new RevWalk(repository)) {
             RevCommit headCommit = walk.lookupCommit(repository.resolve("HEAD"));
@@ -229,6 +271,14 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Switch to git version specified.
+     * 
+     * @param version
+     *            version string to switch.
+     * @throws Exception
+     *             when error occurred.
+     */
     @Override
     public void switchToVersion(String version) throws Exception {
         try (Git git = new Git(repository)) {
@@ -248,6 +298,15 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Add directory/file to commit.
+     * 
+     * @param path
+     *            The relative path of the item from the root of the repo
+     *            (should not start with a <code>/</code>)
+     * @throws Exception
+     *             when error occurred.
+     */
     @Override
     public void addForCommit(String path) throws Exception {
         Log.logInfoRB("GIT_START", "addForCommit");
@@ -260,6 +319,15 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Add path to be deleted.
+     * 
+     * @param path
+     *            The relative path of the item from the root of the repo
+     *            (should not start with a <code>/</code>)
+     * @throws Exception
+     *             when error occurred.
+     */
     @Override
     public void addForDeletion(String path) throws Exception {
         Log.logInfoRB("GIT_START", "addForDelete");
@@ -272,11 +340,23 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Getter for local directory.
+     * 
+     * @return local directory file object.
+     */
     @Override
     public File getLocalDirectory() {
         return localDirectory;
     }
 
+    /**
+     * Get recently deleted files.
+     * 
+     * @return Array of paths of deleted files.
+     * @throws Exception
+     *             when error occurred.
+     */
     @Override
     public String[] getRecentlyDeletedFiles() throws Exception {
         final ArrayList<String> deleted = new ArrayList<>();
@@ -292,13 +372,15 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
             sinceRevision = ObjectId.fromString(sinceRevisionString);
         }
 
-        Git git = new Git(repository);
-        AbstractTreeIterator startTreeIterator = getTreeIterator(git, sinceRevision);
-        AbstractTreeIterator headTreeIterator = new FileTreeIterator(git.getRepository());
-        List<DiffEntry> diffEntries = git.diff().setOldTree(startTreeIterator).setNewTree(headTreeIterator).call();
-        for (DiffEntry diffEntry : diffEntries) {
-            if (diffEntry.getChangeType().equals(DiffEntry.ChangeType.DELETE)) {
-                deleted.add(diffEntry.getOldPath().replace('/', File.separatorChar));
+        try (Git git = new Git(repository)) {
+            AbstractTreeIterator startTreeIterator = getTreeIterator(git, sinceRevision);
+            AbstractTreeIterator headTreeIterator = new FileTreeIterator(git.getRepository());
+            List<DiffEntry> diffEntries = git.diff().setOldTree(startTreeIterator)
+                    .setNewTree(headTreeIterator).call();
+            for (DiffEntry diffEntry : diffEntries) {
+                if (diffEntry.getChangeType().equals(DiffEntry.ChangeType.DELETE)) {
+                    deleted.add(diffEntry.getOldPath().replace('/', File.separatorChar));
+                }
             }
         }
 
@@ -318,6 +400,23 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Commit files in the current stack.
+     * 
+     * @param onVersions
+     *            if a version defined, then commit must be just after this
+     *            version. Otherwise, (if a remote repository was updated after
+     *            rebase), commit shouldn't be processed and should return null.
+     *            If a version is null, then commit can be after any version,
+     *            i.e. a previous version shouldn't be checked. It can be
+     *            several versions defined since the glossary will be committed
+     *            after project_save.tmx.
+     * @param comment
+     *            comment for commit
+     * @return resulted commit name.
+     * @throws Exception
+     *             when error occurred.
+     */
     @Override
     public String commit(String[] onVersions, String comment) throws Exception {
         if (onVersions != null) {
@@ -355,7 +454,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         try (Git git = new Git(repository)) {
             CommitCommand commitCommand = git.commit();
             commitCommand.setMessage(comment);
-            commitCommand.setSign(null);  // read from git config
+            commitCommand.setSign(null); // read from git config
             RevCommit commit = commitCommand.call();
             Iterable<PushResult> results = git.push().setTimeout(TIMEOUT).setRemote(REMOTE)
                     .add(getDefaultBranchName(repository)).call();
@@ -391,7 +490,8 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
-    private static AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objId) throws Exception {
+    private static AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objId)
+            throws Exception {
         // from the commit we can build the tree which allows us to construct
         // the TreeParser
         try (RevWalk walk = new RevWalk(repository)) {
@@ -404,6 +504,13 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
         }
     }
 
+    /**
+     * Delete target directory.
+     * 
+     * @param path
+     *            to be deleted.
+     * @return true when succeeded, otherwise false.
+     */
     public static boolean deleteDirectory(File path) {
         if (path.exists()) {
             File[] files = path.listFiles();
@@ -420,8 +527,11 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
 
     /**
      * Retrieve default branch name from repository.
-     * @param repository target repository.
-     * @return default branch name, ordinary "main" (recent popular) or "master" (old default)
+     * 
+     * @param repository
+     *            target repository.
+     * @return default branch name, ordinary "main" (recent popular) or "master"
+     *         (old default)
      */
     public static String getDefaultBranchName(final Repository repository) {
         try {
@@ -456,18 +566,20 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
     }
 
     /**
-     * Determines whether or not the supplied URL represents a valid Git repository.
+     * Determines whether the supplied URL represents a valid Git repository.
      *
      * <p>
      * Does the equivalent of <code>git ls-remote <i>url</i></code>.
      *
      * @param url
      *            URL of supposed remote repository
-     * @return true if repository appears to be valid, false otherwise
+     * @return true if the repository appears to be valid, false otherwise
      */
     public static boolean isGitRepository(String url) {
         // Heuristics to save some waiting time
+        SshClient client = SshClient.setUpDefaultClient();
         try {
+            client.start();
             Collection<Ref> result = new LsRemoteCommand(null).setRemote(url).setTimeout(TIMEOUT).call();
             return !result.isEmpty();
         } catch (TransportException ex) {
@@ -476,8 +588,11 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
                     || message.contains("Too many authentication failures")
                     || message.contains("Authentication is required");
         } catch (GitAPIException | JGitInternalException ex) {
-            // JGitInternalException happens if the URL is a Subversion URL like svn://...
+            // JGitInternalException happens if the URL is a Subversion URL like
+            // svn://...
             return false;
+        } finally {
+            client.stop();
         }
     }
 }

--- a/test/src/org/omegat/core/team2/impl/GITCredentialsProviderTest.java
+++ b/test/src/org/omegat/core/team2/impl/GITCredentialsProviderTest.java
@@ -1,0 +1,72 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class GITCredentialsProviderTest {
+
+    private final String inputTest;
+    private final String expected;
+
+    public GITCredentialsProviderTest(String inputText, String expected) {
+        this.inputTest = inputText;
+        this.expected = expected;
+    }
+
+    @Test
+    public void extractFingerprint() {
+        String fingerPrint = GITCredentialsProvider.extractFingerprint(inputTest);
+        assertEquals(expected, fingerPrint);
+    }
+
+    @Parameterized.Parameters
+    public static List<String[]> unknownHostKeyMessages() {
+        return Arrays.asList(new String[][] {
+                { "The authenticity of host 'example.example.com' cannot be established.\n"
+                        + "The EC key's fingerprints are:\n"
+                        + "MD5:27:eb:84:a1:af:13:be:e6:7d:8a:20:fa:93:87:29:7b\n"
+                        + "SHA256:Pv1a78W/c6tlPKyxTuT3Ziw6n8vXLTQiGfgR+NkU6fk\n"
+                        + "Accept and store this key, and continue connecting?",
+                        "Pv1a78W/c6tlPKyxTuT3Ziw6n8vXLTQiGfgR+NkU6fk" },
+                { "The authenticity of host '192.0.2.1' can't be established.\n"
+                        + "ECDSA key fingerprint is SHA256:cdDZrkZGXs01lb5r1Q93qGPkNxd+EiMrre5C0o3dSZ1.\n"
+                        + "Are you sure you want to continue connecting?",
+                        "cdDZrkZGXs01lb5r1Q93qGPkNxd+EiMrre5C0o3dSZ1" },
+                { "The authenticity of host '192.0.2.1' can't be established.\n"
+                        + "RSA key fingerprint is 27:eb:84:a1:af:13:be:e6:7d:8a:20:fa:93:87:29:7b.\n"
+                        + "Are you sure you want to continue connecting?",
+                        "27:eb:84:a1:af:13:be:e6:7d:8a:20:fa:93:87:29:7b" } });
+    }
+}


### PR DESCRIPTION
JSch has been unmaintained and JGit goes to Apache MINA sshd for its target.
This PR migrate ssh transport to use Apache MINA sshd.

**THIS IS A CHANGE for OmegaT@6.1.0**

- Related PR #240 for OmegaT@5.8.0

- Bump JGit@6.1.0
- Fix [BUGS#1075](https://sourceforge.net/p/omegat/bugs/1075/)
- Support elliptic curve cryptography ed25519 and ecdsa keys [RFE#1598](https://sourceforge.net/p/omegat/feature-requests/1598/)
- Remove dependency for JSch and JSch agentproxy utilities.
- Use Apache MINA sshd for ssh connection and agent proxy.

Future tasks
- [x] Support ssh agent

ssh-agent support by JGit through apache MINA sshd is merged into JGit 6.0 (minimum Java 11)
https://git.eclipse.org/c/jgit/jgit.git/commit/?id=634302d2da74226cff9f78e121ad5b8216c476e6

The PR is successor of  PR #161 and #162.
