### PR TITLE
Dictionary: API for supporting online dictionary (RFE#1597)

### DIFF
--- a/src/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/org/omegat/core/dictionaries/DictionariesManager.java
@@ -6,6 +6,7 @@
  Copyright (C) 2009 Alex Buloichik
                2011 Didier Briel
                2015 Aaron Madlon-Kay
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -58,16 +59,17 @@ import org.omegat.util.Preferences;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Didier Briel
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  */
 public class DictionariesManager implements DirectoryMonitor.Callback {
     public static final String IGNORE_FILE = "ignore.txt";
-    public static final String DICTIONARY_SUBDIR = "dictionary";
 
     private final IDictionaries pane;
     protected DirectoryMonitor monitor;
-    protected final List<IDictionaryFactory> factories = new ArrayList<IDictionaryFactory>();
-    protected final Map<String, IDictionary> dictionaries = new TreeMap<String, IDictionary>();
-    protected final Set<String> ignoreWords = new TreeSet<String>();
+    protected final List<IDictionaryFactory> factories = new ArrayList<>();
+    protected final Map<String, IDictionary> dictionaries = new TreeMap<>();
+    protected final List<IDictionary> onlineDictionaries = new ArrayList<>();
+    protected final Set<String> ignoreWords = new TreeSet<>();
 
     private Language indexLanguage;
     private ITokenizer tokenizer;
@@ -80,6 +82,10 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
         tokenizer = new DefaultTokenizer();
     }
 
+    /**
+     * Add dictionary factory.
+     * @param dict factory to register.
+     */
     public void addDictionaryFactory(IDictionaryFactory dict) {
         synchronized (factories) {
             factories.add(dict);
@@ -90,9 +96,33 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
         }
     }
 
+    /**
+     * Remove dictionary Factory.
+     * @param factory factory to unregister.
+     */
     public void removeDictionaryFactory(IDictionaryFactory factory) {
         synchronized (factories) {
             factories.remove(factory);
+        }
+    }
+
+    /**
+     * Add online dictionary(dictionary without local data).
+     * @param dict dictionary lookup driver.
+     */
+    public void addOnlineDictionary(IDictionary dict) {
+        synchronized (onlineDictionaries) {
+            onlineDictionaries.add(dict);
+        }
+    }
+
+    /**
+     * Remove online dictionary.
+     * @param dict dictionary lookup driver to remove from registration.
+     */
+    public void removeOnlineDictionary(IDictionary dict) {
+        synchronized (onlineDictionaries) {
+            onlineDictionaries.remove(dict);
         }
     }
 
@@ -230,32 +260,52 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
     public List<DictionaryEntry> findWords(Collection<String> words) {
         List<IDictionary> dicts;
         synchronized (this) {
-            dicts = new ArrayList<IDictionary>(dictionaries.values());
+            dicts = new ArrayList<>(dictionaries.values());
+            dicts.addAll(onlineDictionaries);
         }
-        return words.stream().filter(word -> !isIgnoreWord(word)).flatMap(word -> {
-            return dicts.stream().flatMap(dict -> doLookUp(dict, word).stream());
-        }).collect(Collectors.toList());
+        Collection<String> queryWords = words.stream()
+                .filter(word -> !isIgnoreWord(word) && !isStopWord(word))
+                .collect(Collectors.toList());
+        return dicts.parallelStream()
+                .map(dict -> doLookUp(dict, queryWords))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 
-    private List<DictionaryEntry> doLookUp(IDictionary dict, String word) {
-        String[] stemmed = getStemmedWords(word);
-        if (stemmed.length == 0) {
-            // Stop word. Skip.
+    private List<DictionaryEntry> doLookUp(IDictionary dict, Collection<String> words) {
+        List<DictionaryEntry> result;
+        try {
+            result = dict.retrieveArticles(words);
+        } catch (Exception ex) {
+            Log.log(ex);
             return Collections.emptyList();
         }
+        if (!doFuzzyMatching()) {
+            return result;
+        }
+        // The verbatim word didn't get any hits; try the stem.
         try {
-            List<DictionaryEntry> result = dict.readArticles(word);
-            if (!result.isEmpty()) {
-                return result;
+            List<String> notFound = new ArrayList<>(words);
+            notFound.removeAll(result.stream().map(DictionaryEntry::getQuery).collect(Collectors.toSet()));
+            List<String> predictive = new ArrayList<>();
+            for (String word : notFound) {
+                String[] stemmed = tokenizer.tokenizeWordsToStrings(word, StemmingMode.MATCHING);
+                if (stemmed.length > 1) {
+                    predictive.add(stemmed[0]);
+                }
             }
-            // The verbatim word didn't get any hits; try the stem.
-            if (stemmed.length > 1 && doFuzzyMatching()) {
-                return dict.readArticlesPredictive(stemmed[0]);
+            if (predictive.size() > 0) {
+                result.addAll(dict.retrieveArticlesPredictive(predictive));
             }
         } catch (Exception ex) {
             Log.log(ex);
         }
-        return Collections.emptyList();
+        return result;
+    }
+
+    private boolean isStopWord(final String word) {
+        String[] stemmed = tokenizer.tokenizeWordsToStrings(word, StemmingMode.MATCHING);
+        return stemmed.length == 0;
     }
 
     public void setIndexLanguage(Language indexLanguage) {

--- a/src/org/omegat/core/dictionaries/IDictionary.java
+++ b/src/org/omegat/core/dictionaries/IDictionary.java
@@ -27,6 +27,8 @@
 package org.omegat.core.dictionaries;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -76,8 +78,25 @@ public interface IDictionary extends AutoCloseable {
      * @return List of entries. May be empty, but cannot be null.
      */
     default List<DictionaryEntry> readArticlesPredictive(String word) throws Exception {
-        // Default implementation for backwards compatibility
         return readArticles(word);
+    }
+
+    default List<DictionaryEntry> retrieveArticles(Collection<String> words) throws Exception {
+        // Default implementation for backwards compatibility
+        List<DictionaryEntry> result = new ArrayList<>();
+        for (String word : words) {
+            result.addAll(readArticles(word));
+        }
+        return result;
+    }
+
+    default List<DictionaryEntry> retrieveArticlesPredictive(Collection<String> words) throws Exception {
+        // Default implementation for backwards compatibility
+        List<DictionaryEntry> result = new ArrayList<>();
+        for (String word : words) {
+            result.addAll(readArticlesPredictive(word));
+        }
+        return result;
     }
 
     /**

--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -66,6 +66,7 @@ import org.omegat.core.data.IProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.dictionaries.DictionariesManager;
 import org.omegat.core.dictionaries.DictionaryEntry;
+import org.omegat.core.dictionaries.IDictionary;
 import org.omegat.core.dictionaries.IDictionaryFactory;
 import org.omegat.core.events.IEditorEventListener;
 import org.omegat.gui.common.EntryInfoSearchThread;
@@ -466,6 +467,16 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
     @Override
     public void removeDictionaryFactory(IDictionaryFactory factory) {
         manager.removeDictionaryFactory(factory);
+    }
+
+    @Override
+    public void addDictionary(IDictionary dictionary) {
+        manager.addOnlineDictionary(dictionary);
+    }
+
+    @Override
+    public void removeDictionary(IDictionary dictionary) {
+        manager.removeOnlineDictionary(dictionary);
     }
 
     @Override

--- a/src/org/omegat/gui/dictionaries/IDictionaries.java
+++ b/src/org/omegat/gui/dictionaries/IDictionaries.java
@@ -25,6 +25,7 @@
 
 package org.omegat.gui.dictionaries;
 
+import org.omegat.core.dictionaries.IDictionary;
 import org.omegat.core.dictionaries.IDictionaryFactory;
 
 public interface IDictionaries {
@@ -36,6 +37,10 @@ public interface IDictionaries {
     void addDictionaryFactory(IDictionaryFactory factory);
 
     void removeDictionaryFactory(IDictionaryFactory factory);
+
+    void addDictionary(IDictionary dictionary);
+
+    void removeDictionary(IDictionary dictionary);
 
     void searchText(String text);
 }

--- a/test/src/org/omegat/core/dictionaries/DictionariesManagerTest.java
+++ b/test/src/org/omegat/core/dictionaries/DictionariesManagerTest.java
@@ -72,6 +72,14 @@ public class DictionariesManagerTest {
             }
 
             @Override
+            public void addDictionary(IDictionary dictionary) {
+            }
+
+            @Override
+            public void removeDictionary(IDictionary dictionary) {
+            }
+
+            @Override
             public void searchText(String text) {
             }
 

--- a/test/src/org/omegat/core/dictionaries/OnlineDictionaryTest.java
+++ b/test/src/org/omegat/core/dictionaries/OnlineDictionaryTest.java
@@ -1,0 +1,195 @@
+/*
+ * *************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2022 Hiroshi Miura
+ *                Home page: http://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  *************************************************************************
+ *
+ */
+
+package org.omegat.core.dictionaries;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.gui.dictionaries.IDictionaries;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.util.Language;
+
+public class OnlineDictionaryTest {
+
+    private static final String HEAD_WORD = "head_word";
+    private static final String ARTICLE = "article";
+    private static final String ARTICLE2 = "article2";
+    private static final int EXPECTED_NUM_RESULT = 4;
+
+    private DictionariesManager manager;
+    private IDictionary mock1;
+    private IDictionary mock2;
+
+    /**
+     * Test online dictionary API with mocks.
+     * <p>
+     *    A test with two mock drivers with two query words.
+     *    Drivers returns tow results in thread, so we get
+     *    four results.
+     *    One mock returns head words equals with query words.
+     *    The other returns a static head word.
+     */
+    @Test
+    public void onlineDictionaryTest() {
+        List<String> words = new ArrayList<>();
+        words.add("testudo");
+        words.add("tete");
+        List<DictionaryEntry> result = manager.findWords(words);
+        assertEquals(EXPECTED_NUM_RESULT, result.size());
+        // assert variations
+        for (DictionaryEntry en: result) {
+            if (en.getWord().equals(en.getQuery())) {
+                assertEquals(ARTICLE, en.getArticle());
+            } else {
+                assertEquals(HEAD_WORD, en.getWord());
+                assertEquals(ARTICLE2, en.getArticle());
+            }
+        }
+    }
+
+    /**
+     * Test DictionaryManager#addOnlineDictionary interface.
+     * @throws Exception when error occurred.
+     */
+    @Before
+    public final void setUp() throws Exception {
+        mock1 = new OnlineDictionaryMock();
+        mock2 = new OnlineDictionaryMock2();
+        manager = new DictionariesManager(new IDictionaries() {
+            @Override
+            public void refresh() {
+            }
+            @Override
+            public void addDictionaryFactory(IDictionaryFactory factory) {
+            }
+            @Override
+            public void removeDictionaryFactory(IDictionaryFactory factory) {
+            }
+            @Override
+            public void addDictionary(IDictionary dictionary) {
+            }
+            @Override
+            public void removeDictionary(IDictionary dictionary) {
+            }
+            @Override
+            public void searchText(String text) {
+            }
+        }) {
+            @Override
+            public boolean doFuzzyMatching() {
+                return true;
+            }
+        };
+        manager.setIndexLanguage(new Language(Locale.ENGLISH));
+        manager.setTokenizer(new DefaultTokenizer());
+        manager.addOnlineDictionary(mock1);
+        manager.addOnlineDictionary(mock2);
+    }
+
+    /**
+     * Test DictionaryManager#removeOnlineDictionary interface.
+     */
+    @After
+    public void tearDown() {
+        manager.removeOnlineDictionary(mock1);
+        manager.removeOnlineDictionary(mock2);
+    }
+
+    public static final class OnlineDictionaryMock2 extends OnlineDictionaryMock implements IDictionary {
+        private static final int DELAY = 10;
+        @Override
+        public List<DictionaryEntry> retrieveArticles(final Collection<String> words) throws Exception {
+            List<DictionaryEntry> result = new ArrayList<>();
+            for (String word: words) {
+                result.add(new DictionaryEntry(word, HEAD_WORD, ARTICLE2));
+            }
+            // insert 10ms delay like as online query
+            Thread.sleep(DELAY);
+            return result;
+        }
+
+    }
+
+    public static class OnlineDictionaryMock implements IDictionary {
+        /**
+         * Read article's text.
+         *
+         * @param word The word to look up in the dictionary
+         * @return List of entries. May be empty, but cannot be null.
+         */
+        @Override
+        public List<DictionaryEntry> readArticles(final String word) throws Exception {
+            return retrieveArticles(Collections.singletonList(word));
+        }
+
+        /**
+         * Retrieve article's text.
+         * @param words query words
+         * @return list of results.
+         * @throws Exception when network error occurred.
+         */
+        @Override
+        public List<DictionaryEntry> retrieveArticles(final Collection<String> words) throws Exception {
+            List<DictionaryEntry> result = new ArrayList<>();
+            for (String word: words) {
+                result.add(new DictionaryEntry(word, word, ARTICLE));
+            }
+            return result;
+        }
+
+        /**
+         * Retrieve article's text with predictive word query.
+         * @param words query words.
+         * @return list of results.
+         * @throws Exception when network error occurred.
+         */
+        @Override
+        public List<DictionaryEntry> retrieveArticlesPredictive(final Collection<String> words)
+                throws Exception {
+            return retrieveArticles(words);
+        }
+
+        /**
+         * Dispose IDictionary. Default is no action.
+         */
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}


### PR DESCRIPTION
Support online dictionary plugins/driver.

1. Introduce registration API for online dictionary; register driver without dictionary file. 

  *  `IDictionaries#addDictionary(IDictionary dictionary)`
  *  `iDictionaries#removeDictionary(IDictionary dictionary)`

2. Introduce query API for parallel bulk query 

  * `IDictionary#retrieveArticles(Collection<String> words)`
  * `IDictionary#retrieveArticlesPredictive(Collection<String> words)`

3. Introduce methods of `DictionariesManager`

  * `DictionariesManager#addOnlineDictionary`
  * `DictionariesManager#removeOnlineDictionary`

4. Refactoring `DictionariesManager` 

  * `DictionariesManager#doLookup` calls the API introduced in No.2: ` result = dict.retrieveArticles(words);`
  * `DictionariesManager#findWords` improved to run in parallel to speed-up on multi-core PC

```java
`        return dicts.parallelStream()
                .map(dict -> doLookUp(dict, queryWords))
                .flatMap(Collection::stream)
                .collect(Collectors.toList());
```

- This resolves RFE#1597