### PR TITLE
Migrate languagetool to use Jackson/Json parser(RFE#1575)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,10 @@ dependencies {
         api 'javax.xml.bind:jaxb-api:2.3.1'
         implementation 'com.sun.xml.bind:jaxb-impl:2.3.4'
 
+        // JSON parser
+        implementation "com.fasterxml.jackson.core:jackson-core:2.12.3"
+        implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
+
         // Data: inline data URL handler
         implementation 'tokyo.northside:url-protocol-handler:0.1.4'
 


### PR DESCRIPTION
- Support Java 11
  - Drop dependency for deprecated javascript engine in Java 11 
  - [JEP 335: Deprecate the Nashorn JavaScript Engine](https://openjdk.java.net/jeps/335)
- LanguageToolNetworkBridge to use Jackson
- Implement [RFE#1575](https://sourceforge.net/p/omegat/feature-requests/1575/)
- related PR #180
