### PR TITLE
Refactoring PrepareTMXEntry and TMXEntry classes

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -8,6 +8,7 @@
                2012 Aaron Madlon-Kay
                2013 Kyle Katarn, Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -59,7 +60,6 @@ import org.omegat.convert.ConvertConfigs;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.NotLoadedProject;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RealProject;
 import org.omegat.core.data.SourceTextEntry;
@@ -445,17 +445,23 @@ public final class Main {
         }
 
         // prepare tmx
-        Map<String, PrepareTMXEntry> data = new HashMap<>();
+        Map<String, TMXEntry> data = new HashMap<>();
+        TMXEntry entry;
         for (SourceTextEntry ste : entries) {
-            PrepareTMXEntry entry = new PrepareTMXEntry();
-            entry.source = ste.getSrcText();
             switch (pseudoTranslateType) {
-            case EQUAL:
-                entry.translation = ste.getSrcText();
-                break;
-            case EMPTY:
-                entry.translation = "";
-                break;
+                case EQUAL:
+                    entry = new TMXEntry.Builder()
+                            .setSource(ste.getSrcText())
+                            .setTranslation(ste.getSrcText())
+                            .build();
+                    break;
+                case EMPTY:
+                default:
+                    entry = new TMXEntry.Builder()
+                            .setSource(ste.getSrcText())
+                            .setTranslation("")
+                            .build();
+                    break;
             }
             data.put(ste.getSrcText(), entry);
         }
@@ -497,14 +503,8 @@ public final class Main {
         System.out.println(StringUtil.format(OStrings.getString("CONSOLE_ALIGN_AGAINST"), dir));
 
         Map<String, TMXEntry> data = p.align(p.getProjectProperties(), new File(dir));
-        Map<String, PrepareTMXEntry> result = new TreeMap<>();
-        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
-            result.put(en.getKey(), new PrepareTMXEntry(en.getValue()));
-        }
-
         String tmxFile = p.getProjectProperties().getProjectInternal() + "align.tmx";
-
-        TMXWriter.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), result);
+        TMXWriter.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), data);
 
         p.closeProject();
         System.out.println(OStrings.getString("CONSOLE_FINISHED"));

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -81,7 +81,7 @@ import org.omegat.util.Preferences;
 import org.omegat.util.ProjectFileStorage;
 import org.omegat.util.RuntimePreferences;
 import org.omegat.util.StringUtil;
-import org.omegat.util.TMXWriter;
+import org.omegat.util.TMXWriter2;
 import org.omegat.util.gui.OSXIntegration;
 
 import com.vlsolutions.swing.docking.DockingDesktop;
@@ -468,7 +468,7 @@ public final class Main {
 
         try {
             // Write OmegaT-project-compatible TMX:
-            TMXWriter.buildTMXFile(fname, false, false, config, data);
+            TMXWriter2.buildTMXFile(fname, false, false, config, data);
         } catch (IOException e) {
             Log.logErrorRB("CT_ERROR_CREATING_TMX");
             Log.log(e);
@@ -504,7 +504,7 @@ public final class Main {
 
         Map<String, TMXEntry> data = p.align(p.getProjectProperties(), new File(dir));
         String tmxFile = p.getProjectProperties().getProjectInternal() + "align.tmx";
-        TMXWriter.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), data);
+        TMXWriter2.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), data);
 
         p.closeProject();
         System.out.println(OStrings.getString("CONSOLE_FINISHED"));

--- a/src/org/omegat/core/data/DataUtils.java
+++ b/src/org/omegat/core/data/DataUtils.java
@@ -31,6 +31,6 @@ public final class DataUtils {
     }
 
     public static boolean isDuplicate(SourceTextEntry ste, TMXEntry te) {
-        return ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT && te.defaultTranslation;
+        return ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT && te.isDefaultTranslation();
     }
 }

--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -7,6 +7,7 @@
                2012 Thomas CORDONNIER
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -43,9 +44,9 @@ public class ExternalTMX {
 
     private final String name;
 
-    private final List<PrepareTMXEntry> entries;
+    private final List<TMXEntry> entries;
 
-    ExternalTMX(String name, List<PrepareTMXEntry> entries) {
+    ExternalTMX(String name, List<TMXEntry> entries) {
         this.name = name;
         this.entries = entries;
     }
@@ -54,7 +55,7 @@ public class ExternalTMX {
         return name;
     }
 
-    public List<PrepareTMXEntry> getEntries() {
+    public List<TMXEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }
 }

--- a/src/org/omegat/core/data/IProject.java
+++ b/src/org/omegat/core/data/IProject.java
@@ -7,6 +7,7 @@
                2010 Didier Briel
                2014-2015 Alex Buloichik
                2017 Didier Briel
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -142,15 +143,44 @@ public interface IProject {
     /**
      * Set translation for entry.
      *
+     * @param ste source text entry.
+     * @param tmxEntry tmx entry.
+     */
+    void setTranslation(SourceTextEntry ste, TMXEntry tmxEntry);
+
+    /**
+     * Set translation for entry.
+     *
      * Optimistic locking will not be checked.
+     * for backward compatibility.
      *
      * @param entry
      *            entry
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked);
+    @Deprecated
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked) throws OptimisticLockingFail {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked));
+    }
+
+    /**
+     * Set translation for entry with optimistic lock checking: if previous translation is not the same like
+     * in storage, OptimisticLockingFail exception will be generated. Use when user has typed a new
+     * translation.
+     * for backward compatibility.
+     *
+     * @param entry
+     *            entry
+     * @param trans
+     *            translation. It can't be null
+     */
+    @Deprecated
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked, AllTranslations previous) throws OptimisticLockingFail {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked), previous);
+    }
 
     /**
      * Set translation for entry with optimistic lock checking: if previous translation is not the same like
@@ -162,8 +192,7 @@ public interface IProject {
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked, AllTranslations previousTranslations)
+    void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
             throws OptimisticLockingFail;
 
     /**

--- a/src/org/omegat/core/data/ITranslationEntry.java
+++ b/src/org/omegat/core/data/ITranslationEntry.java
@@ -1,0 +1,63 @@
+/*
+ * *************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2021 Hiroshi Miura.
+ *                Home page: http://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  *************************************************************************
+ *
+ */
+
+package org.omegat.core.data;
+
+import java.util.List;
+
+import org.omegat.util.TMXProp;
+
+public interface ITranslationEntry {
+    String getSource();
+
+    boolean isTranslated();
+
+    String getTranslation();
+
+    String getChanger();
+
+    long getChangeDate();
+
+    String getCreator();
+
+    long getCreationDate();
+
+    String getNote();
+
+    boolean hasNote();
+
+    boolean hasProperties();
+
+    String getPropValue(String propType);
+
+    boolean hasPropValue(String propType, String propValue);
+
+    Iterable<TMXProp> getProperties();
+
+    List<TMXProp> getRawProperties();
+}

--- a/src/org/omegat/core/data/NotLoadedProject.java
+++ b/src/org/omegat/core/data/NotLoadedProject.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.filters2.TranslationException;
 import org.omegat.tokenizer.ITokenizer;
@@ -139,12 +138,11 @@ public class NotLoadedProject implements IProject {
     public void saveProjectProperties() throws IOException {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked) {
+    public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked, AllTranslations previousTranslations) throws OptimisticLockingFail {
+    public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
+            throws OptimisticLockingFail {
     }
 
     public ITokenizer getSourceTokenizer() {

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -28,6 +29,7 @@
 
 package org.omegat.core.data;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.omegat.util.TMXProp;
@@ -44,7 +46,8 @@ import org.omegat.util.TMXProp;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class PrepareTMXEntry {
+@Deprecated
+public class PrepareTMXEntry implements ITranslationEntry {
     public String source;
     public String translation;
     public String changer;
@@ -57,14 +60,15 @@ public class PrepareTMXEntry {
     public PrepareTMXEntry() {
     }
 
-    public PrepareTMXEntry(TMXEntry e) {
-        source = e.source;
-        translation = e.translation;
-        changer = e.changer;
-        changeDate = e.changeDate;
-        creator = e.creator;
-        creationDate = e.creationDate;
-        note = e.note;
+    public PrepareTMXEntry(ITranslationEntry e) {
+        source = e.getSource();
+        translation = e.getTranslation();
+        changer = e.getChanger();
+        changeDate = e.getChangeDate();
+        creator = e.getCreator();
+        creationDate = e.getCreationDate();
+        note = e.getNote();
+        otherProperties = e.getRawProperties();
     }
 
     public String getPropValue(String propType) {
@@ -99,6 +103,20 @@ public class PrepareTMXEntry {
     }
 
     @Override
+    public Iterable<TMXProp> getProperties() {
+        return Collections.unmodifiableCollection(otherProperties);
+    }
+
+    @Override
+    public List<TMXProp> getRawProperties() {
+        return otherProperties;
+    }
+
+    public boolean hasProperties() {
+        return otherProperties != null;
+    }
+
+    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("PrepareTMXEntry [source=").append(source).append(", translation=").append(translation)
@@ -108,4 +126,48 @@ public class PrepareTMXEntry {
         return builder.toString();
     }
 
+    @Override
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public boolean isTranslated() {
+        return translation != null;
+    }
+
+    @Override
+    public String getTranslation() {
+        return translation;
+    }
+
+    @Override
+    public String getChanger() {
+        return changer;
+    }
+
+    @Override
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    @Override
+    public String getCreator() {
+        return creator;
+    }
+
+    @Override
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    @Override
+    public String getNote() {
+        return note;
+    }
+
+    @Override
+    public boolean hasNote() {
+        return note != null;
+    }
 }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1486,6 +1486,7 @@ public class RealProject implements IProject {
             boolean isDefaultTranslation = trans.isDefaultTranslation();
             TMXEntry.Builder builder = new TMXEntry.Builder()
                     .setSource(entry.getSrcText())
+                    .setTranslation(trans.getTranslation())
                     .setDefaultTranslation(isDefaultTranslation)
                     .setChanger(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR, System.getProperty("user.name")))
                     .setChangeDate(System.currentTimeMillis())

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -202,9 +202,7 @@ public class RealProject implements IProject {
     /** This instance returned if translation not exist. */
     private static final TMXEntry EMPTY_TRANSLATION;
     static {
-        PrepareTMXEntry empty = new PrepareTMXEntry();
-        empty.source = "";
-        EMPTY_TRANSLATION = new TMXEntry(empty, true, null);
+        EMPTY_TRANSLATION = new TMXEntry.Builder().setSource("").setDefaultTranslation(true).build();
     }
 
     private final boolean allowTranslationEqualToSource = Preferences.isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
@@ -1223,15 +1221,14 @@ public class RealProject implements IProject {
                     continue;
                 }
 
-                PrepareTMXEntry prepare = new PrepareTMXEntry();
-                prepare.source = ste.getSrcText();
+                TMXEntry.Builder prepare = new TMXEntry.Builder().setSource(ste.getSrcText());
                 // project with default translations
                 TMXEntry en = projectTMX.getMultipleTranslation(ste.getKey());
                 if (config.isSupportDefaultTranslations()) {
                     // bug#969 - Alternative translations were not taken into account
                     // if no default translation is set.
                     if (en != null) {
-                        prepare.translation = ste.getSourceTranslation();
+                        prepare.setTranslation(ste.getSourceTranslation());
                         projectTMX.setTranslation(ste, en, false);
                         continue;
                     }
@@ -1239,8 +1236,8 @@ public class RealProject implements IProject {
                     TMXEntry enDefault = projectTMX.getDefaultTranslation(ste.getSrcText());
                     if (enDefault == null) {
                         // default not exist yet - yes, we can
-                        prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new TMXEntry(prepare, true, null), true);
+                        prepare.setTranslation(ste.getSourceTranslation());
+                        projectTMX.setTranslation(ste, prepare.setDefaultTranslation(true).build(), true);
                         allowToImport.put(ste.getSrcText(), ste.getSourceTranslation());
                     } else {
                         // default translation already exist - did we just
@@ -1250,16 +1247,16 @@ public class RealProject implements IProject {
                         if (justImported != null && !ste.getSourceTranslation().equals(justImported)) {
                             // we just imported default and it doesn't equals to
                             // current - import as alternative
-                            prepare.translation = ste.getSourceTranslation();
-                            projectTMX.setTranslation(ste, new TMXEntry(prepare, false, null), false);
+                            prepare.setTranslation(ste.getSourceTranslation());
+                            projectTMX.setTranslation(ste, prepare.setDefaultTranslation(false).build(), false);
                         }
                     }
                 } else { // project without default translations
                     // can we import as alternative translation ?
                     if (en == null) {
                         // not exist yet - yes, we can
-                        prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new TMXEntry(prepare, false, null), false);
+                        prepare.setTranslation(ste.getSourceTranslation());
+                        projectTMX.setTranslation(ste, prepare.setDefaultTranslation(false).build(), false);
                     }
                 }
             }
@@ -1423,8 +1420,18 @@ public class RealProject implements IProject {
     }
 
     @Override
+    @Deprecated
     public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked, AllTranslations previous) throws OptimisticLockingFail {
+                               ExternalLinked externalLinked, AllTranslations previous) throws OptimisticLockingFail {
+        if (trans == null) {
+            throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
+        }
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked), previous);
+    }
+
+    @Override
+    public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previous)
+            throws OptimisticLockingFail {
         if (trans == null) {
             throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
         }
@@ -1432,83 +1439,87 @@ public class RealProject implements IProject {
         synchronized (projectTMX) {
             AllTranslations current = getAllTranslations(entry);
             boolean wasAlternative = current.alternativeTranslation.isTranslated();
-            if (defaultTranslation) {
+            if (trans.isDefaultTranslation()) {
                 if (!current.defaultTranslation.equals(previous.defaultTranslation)) {
-                    throw new OptimisticLockingFail(previous.getDefaultTranslation().translation,
-                            current.getDefaultTranslation().translation, current);
+                    throw new OptimisticLockingFail(previous.getDefaultTranslation().getTranslation(),
+                            current.getDefaultTranslation().getTranslation(), current);
                 }
                 if (wasAlternative) {
                     // alternative -> default
                     if (!current.alternativeTranslation.equals(previous.alternativeTranslation)) {
-                        throw new OptimisticLockingFail(previous.getAlternativeTranslation().translation,
-                                current.getAlternativeTranslation().translation, current);
+                        throw new OptimisticLockingFail(previous.getAlternativeTranslation().getTranslation(),
+                                current.getAlternativeTranslation().getTranslation(), current);
                     }
                     // remove alternative
-                    setTranslation(entry, new PrepareTMXEntry(), false, null);
+                    setTranslation(entry, new TMXEntry.Builder().setDefaultTranslation(false).build());
                 }
             } else {
                 // new is alternative translation
                 if (!current.alternativeTranslation.equals(previous.alternativeTranslation)) {
-                    throw new OptimisticLockingFail(previous.getAlternativeTranslation().translation,
-                            current.getAlternativeTranslation().translation, current);
+                    throw new OptimisticLockingFail(previous.getAlternativeTranslation().getTranslation(),
+                            current.getAlternativeTranslation().getTranslation(), current);
                 }
             }
 
-            setTranslation(entry, trans, defaultTranslation, externalLinked);
+            setTranslation(entry, trans);
         }
     }
 
+    /**
+     * Set translation for entry.
+     *
+     * @param entry     source text entry.
+     * @param trans     tmx translation entry.
+     */
     @Override
-    public void setTranslation(final SourceTextEntry entry, final PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
+    public void setTranslation(final SourceTextEntry entry, final TMXEntry trans) {
         if (trans == null) {
             throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
         }
-
-        TMXEntry prevTrEntry = defaultTranslation ? projectTMX.getDefaultTranslation(entry.getSrcText())
+        TMXEntry prevTrEntry = trans.isDefaultTranslation() ? projectTMX.getDefaultTranslation(entry.getSrcText())
                 : projectTMX.getMultipleTranslation(entry.getKey());
-
-        trans.changer = Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,
-                System.getProperty("user.name"));
-        trans.changeDate = System.currentTimeMillis();
-
-        if (prevTrEntry == null) {
-            // there was no translation yet
-            prevTrEntry = EMPTY_TRANSLATION;
-            trans.creationDate = trans.changeDate;
-            trans.creator = trans.changer;
-        } else {
-            trans.creationDate = prevTrEntry.creationDate;
-            trans.creator = prevTrEntry.creator;
-        }
-
-        if (StringUtil.isEmpty(trans.note)) {
-            trans.note = null;
-        }
-
-        trans.source = entry.getSrcText();
-
-        TMXEntry newTrEntry;
-
-        if (trans.translation == null && trans.note == null) {
-            // no translation, no note
-            newTrEntry = null;
-        } else {
-            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
-        }
-
         setProjectModified(true);
-
-        projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
+        if (trans.getTranslation() == null && trans.getNote() == null) {
+            // no translation, no note
+            projectTMX.setTranslation(entry, null, trans.isDefaultTranslation());
+        } else {
+            boolean isDefaultTranslation = trans.isDefaultTranslation();
+            TMXEntry.Builder builder = new TMXEntry.Builder()
+                    .setSource(entry.getSrcText())
+                    .setDefaultTranslation(isDefaultTranslation)
+                    .setChanger(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR, System.getProperty("user.name")))
+                    .setChangeDate(System.currentTimeMillis())
+                    .setExternalLinked(trans.getLinked());
+            if (prevTrEntry == null) {
+                // there was no translation yet
+                prevTrEntry = EMPTY_TRANSLATION;
+                builder.setCreationDate(trans.getChangeDate());
+                builder.setCreator(trans.getChanger());
+            } else {
+                builder.setCreationDate(prevTrEntry.getCreationDate());
+                builder.setCreator(prevTrEntry.getCreator());
+            }
+            if (StringUtil.isEmpty(trans.getNote())) {
+                builder.setNote(null);
+            }
+            projectTMX.setTranslation(entry, builder.build(), isDefaultTranslation);
+        }
 
         /*
          * Calculate how to statistics should be changed.
          */
-        int diff = prevTrEntry.translation == null ? 0 : -1;
-        diff += trans.translation == null ? 0 : +1;
+        int diff = prevTrEntry.getTranslation() == null ? 0 : -1;
+        diff += trans.getTranslation() == null ? 0 : +1;
         hotStat.numberOfTranslatedSegments = Math.max(0,
                 Math.min(hotStat.numberOfUniqueSegments, hotStat.numberOfTranslatedSegments + diff));
     }
+
+    @Override
+    @Deprecated
+    public void setTranslation(final SourceTextEntry entry, final PrepareTMXEntry trans, boolean defaultTranslation,
+            TMXEntry.ExternalLinked externalLinked) {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked));
+   }
 
     @Override
     public void setNote(final SourceTextEntry entry, final TMXEntry oldTE, String note) {
@@ -1521,20 +1532,25 @@ public class RealProject implements IProject {
             note = null;
         }
 
-        TMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX
+        TMXEntry prevTrEntry = oldTE.isDefaultTranslation() ? projectTMX
                 .getDefaultTranslation(entry.getSrcText()) : projectTMX
                 .getMultipleTranslation(entry.getKey());
         if (prevTrEntry != null) {
-            PrepareTMXEntry en = new PrepareTMXEntry(prevTrEntry);
-            en.note = note;
-            projectTMX.setTranslation(entry, new TMXEntry(en, prevTrEntry.defaultTranslation,
-                    prevTrEntry.linked), prevTrEntry.defaultTranslation);
+            TMXEntry en = new TMXEntry.Builder()
+                    .setSource(prevTrEntry.getSource())
+                    .setTranslation(prevTrEntry.getTranslation())
+                    .setNote(note)
+                    .setDefaultTranslation(prevTrEntry.isDefaultTranslation())
+                    .setExternalLinked(prevTrEntry.getLinked())
+                    .build();
+            projectTMX.setTranslation(entry, en, prevTrEntry.isDefaultTranslation());
         } else {
-            PrepareTMXEntry en = new PrepareTMXEntry();
-            en.source = entry.getSrcText();
-            en.note = note;
-            en.translation = null;
-            projectTMX.setTranslation(entry, new TMXEntry(en, true, null), true);
+            TMXEntry en = new TMXEntry.Builder()
+                    .setSource(entry.getSrcText())
+                    .setNote(note)
+                    .setDefaultTranslation(true)
+                    .build();
+            projectTMX.setTranslation(entry, en, true);
         }
 
         setProjectModified(true);
@@ -1804,7 +1820,7 @@ public class RealProject implements IProject {
             if (tr == null) {
                 tr = projectTMX.getDefaultTranslation(ek.sourceText);
             }
-            return tr != null ? tr.translation : null;
+            return tr != null ? tr.getTranslation() : null;
         }
     }
 
@@ -1826,7 +1842,6 @@ public class RealProject implements IProject {
                 String sourceS = ParseEntry.stripSomeChars(source, spr, config.isRemoveTags(), removeSpaces);
                 String transS = ParseEntry.stripSomeChars(translation, spr, config.isRemoveTags(), removeSpaces);
 
-                PrepareTMXEntry tr = new PrepareTMXEntry();
                 if (config.isSentenceSegmentingEnabled()) {
                     List<String> segmentsSource = Core.getSegmenter().segment(config.getSourceLanguage(), sourceS, null,
                             null);
@@ -1836,9 +1851,9 @@ public class RealProject implements IProject {
                         if (isFuzzy) {
                             transS = "[" + filter.getFuzzyMark() + "] " + transS;
                         }
-                        tr.source = sourceS;
-                        tr.translation = transS;
-                        data.put(sourceS, new TMXEntry(tr, true, null));
+                        TMXEntry entry = new TMXEntry.Builder()
+                                .setSource(sourceS).setTranslation(transS).setDefaultTranslation(true).build();
+                        data.put(sourceS, entry);
                     } else {
                         for (short i = 0; i < segmentsSource.size(); i++) {
                             String oneSrc = segmentsSource.get(i);
@@ -1846,18 +1861,24 @@ public class RealProject implements IProject {
                             if (isFuzzy) {
                                 oneTrans = "[" + filter.getFuzzyMark() + "] " + oneTrans;
                             }
-                            tr.source = oneSrc;
-                            tr.translation = oneTrans;
-                            data.put(sourceS, new TMXEntry(tr, true, null));
+                            TMXEntry entry = new TMXEntry.Builder()
+                                    .setSource(oneSrc)
+                                    .setTranslation(oneTrans)
+                                    .setDefaultTranslation(true)
+                                    .build();
+                            data.put(sourceS, entry);
                         }
                     }
                 } else {
                     if (isFuzzy) {
                         transS = "[" + filter.getFuzzyMark() + "] " + transS;
                     }
-                    tr.source = sourceS;
-                    tr.translation = transS;
-                    data.put(sourceS, new TMXEntry(tr, true, null));
+                    TMXEntry entry = new TMXEntry.Builder()
+                            .setSource(sourceS)
+                            .setTranslation(transS)
+                            .setDefaultTranslation(true)
+                            .build();
+                    data.put(sourceS, entry);
                 }
             }
         }

--- a/src/org/omegat/core/data/SyncTMX.java
+++ b/src/org/omegat/core/data/SyncTMX.java
@@ -85,7 +85,7 @@ public final class SyncTMX implements ITmx {
     }
 
     private Key makeKey(Object entryKey, TMXEntry tmxEntry) {
-        Key key = new Key(tmxEntry.source, entryKey);
+        Key key = new Key(tmxEntry.getSource(), entryKey);
         if (entryKey instanceof EntryKey) {
             EntryKey ek = (EntryKey) entryKey;
             key.addProp("file", ek.file);
@@ -280,7 +280,7 @@ public final class SyncTMX implements ITmx {
 
         @Override
         public String getContent() {
-            return tmxEntry.translation;
+            return tmxEntry.getTranslation();
         }
 
         @Override

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik, Aaron Madlon-Kay
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -28,7 +29,12 @@
 
 package org.omegat.core.data;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Storage for TMX entry.
@@ -42,7 +48,8 @@ import java.util.Objects;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class TMXEntry {
+public class TMXEntry implements ITranslationEntry {
+
     public enum ExternalLinked {
         // declares how this entry linked to external TMX in the tm/auto/
         xICE, x100PC, xAUTO, xENFORCED
@@ -55,20 +62,56 @@ public class TMXEntry {
     public final String creator;
     public final long creationDate;
     public final String note;
+    public List<TMXProp> otherProperties;
     public final boolean defaultTranslation;
     public final ExternalLinked linked;
 
-    TMXEntry(PrepareTMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
-        this.source = from.source;
-        this.translation = from.translation;
-        this.changer = from.changer;
-        this.changeDate = from.changeDate;
-        this.creator = from.creator;
-        this.creationDate = from.creationDate;
-        this.note = from.note;
+    TMXEntry(ITranslationEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        this.source = from.getSource();
+        this.translation = from.getTranslation();
+        this.changer = from.getChanger();
+        this.changeDate = from.getChangeDate();
+        this.creator = from.getCreator();
+        this.creationDate = from.getCreationDate();
+        this.note = from.getNote();
 
         this.defaultTranslation = defaultTranslation;
         this.linked = linked;
+    }
+
+    @Override
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public String getTranslation() {
+        return translation;
+    }
+
+    @Override
+    public String getChanger() {
+        return changer;
+    }
+
+    @Override
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    @Override
+    public String getCreator() {
+        return creator;
+    }
+
+    @Override
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    @Override
+    public String getNote() {
+        return note;
     }
 
     public boolean isTranslated() {
@@ -77,6 +120,60 @@ public class TMXEntry {
 
     public boolean hasNote() {
         return note != null;
+    }
+
+    @Override
+    public boolean hasProperties() {
+        return false;
+    }
+
+    public String getPropValue(String propType) {
+        if (otherProperties == null) {
+            return null;
+        }
+        for (int i = 0; i < otherProperties.size(); i++) {
+            TMXProp kv = otherProperties.get(i);
+            if (propType.equals(kv.getType())) {
+                return kv.getValue();
+            }
+        }
+        return null;
+    }
+
+    public boolean hasPropValue(String propType, String propValue) {
+        if (otherProperties == null) {
+            return false;
+        }
+        for (int i = 0; i < otherProperties.size(); i++) {
+            TMXProp kv = otherProperties.get(i);
+            if (propType.equals(kv.getType())) {
+                if (propValue == null) {
+                    return true;
+                }
+                if (propValue.equals(kv.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterable<TMXProp> getProperties() {
+        return Collections.unmodifiableCollection(otherProperties);
+    }
+
+    @Override
+    public List<TMXProp> getRawProperties() {
+        return otherProperties;
+    }
+
+    public ExternalLinked getLinked() {
+        return linked;
+    }
+
+    public boolean isDefaultTranslation() {
+        return defaultTranslation;
     }
 
     @Override
@@ -143,5 +240,157 @@ public class TMXEntry {
             return false;
         }
         return true;
+    }
+
+    /* provide builder for TMXEntry.
+       other classes can build TMXEntry by calling such as
+       TMXEntry::Builder.setSource(source).setTranslation(translation).build();
+     */
+    private TMXEntry(final String source, final String translation, final String changer, final long changeDate,
+                     final String creator, final long creationDate, final String note,
+                     final List<TMXProp> otherProperties,
+                     final boolean defaultTranslation,
+                     final ExternalLinked linked) {
+        this.source = source;
+        this.translation = translation;
+        this.changer = changer;
+        this.changeDate = changeDate;
+        this.creator = creator;
+        this.creationDate = creationDate;
+        this.note = note;
+        this.otherProperties = otherProperties;
+        this.defaultTranslation = defaultTranslation;
+        this.linked = linked;
+    }
+
+    /**
+     * TMXEntry object builder.
+     */
+    public static final class Builder {
+        private String source;
+        private String translation;
+        private String changer;
+        private long changeDate;
+        private String creator;
+        private long creationDate;
+        private String note;
+        public List<TMXProp> otherProperties;
+        private boolean defaultTranslation;
+        private ExternalLinked linked;
+
+        public Builder() {
+        }
+
+        /**
+         * build method for TMXEntry object.
+         * @return TMXEntry object.
+         */
+        public TMXEntry build() {
+            return new TMXEntry(source, translation, changer, changeDate, creator, creationDate, note,
+                    otherProperties, defaultTranslation, linked);
+        }
+
+        /**
+         * Set source text.
+         * @param source text.
+         * @return builder.
+         */
+        public Builder setSource(final String source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Set translation text.
+         * @param translation text.
+         * @return builder.
+         */
+        public Builder setTranslation(final String translation) {
+            this.translation = translation;
+            return this;
+        }
+
+        /**
+         * Set changer name.
+         * @param changer name.
+         * @return builder.
+         */
+        public Builder setChanger(final String changer) {
+            this.changer = changer;
+            return this;
+        }
+
+        /**
+         * Set change date.
+         * @param changeDate long date value.
+         * @return builder.
+         */
+        public Builder setChangeDate(final long changeDate) {
+            this.changeDate = changeDate;
+            return this;
+        }
+
+        /**
+         * Set creator name
+         * @param creator name.
+         * @return builder.
+         */
+        public Builder setCreator(final String creator) {
+            this.creator = creator;
+            return this;
+        }
+
+        /**
+         * Set creation date.
+         * @param creationDate long value of date.
+         * @return builder.
+         */
+        public Builder setCreationDate(final long creationDate) {
+            this.creationDate = creationDate;
+            return this;
+        }
+
+        /**
+         * Set note.
+         * @param note text.
+         * @return builder.
+         */
+        public Builder setNote(final String note) {
+            this.note = note;
+            return this;
+        }
+
+        /**
+         * Set whether it is default translation.
+         * @param defaultTranslation true when defualt translation.
+         * @return builder.
+         */
+        public Builder setDefaultTranslation(final boolean defaultTranslation) {
+            this.defaultTranslation = defaultTranslation;
+            return this;
+        }
+
+        /**
+         * Set external link.
+         * @param linked external link.
+         * @return builder.
+         */
+        public Builder setExternalLinked(final ExternalLinked linked) {
+            this.linked = linked;
+            return this;
+        }
+
+        public Builder setProperties(final List<TMXProp> properties) {
+            otherProperties = properties;
+            return this;
+        }
+
+        public Builder setProperty(String propType, String propValue) {
+            if (otherProperties == null) {
+                otherProperties = new ArrayList<>();
+            }
+            otherProperties.add(new TMXProp(propType, propValue));
+            return this;
+        }
     }
 }

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -11,6 +11,7 @@
                2014 Alex Buloichik, Piotr Kulik, Aaron Madlon-Kay
                2015 Aaron Madlon-Kay
                2017-2018 Thomas Cordonnier
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -385,7 +386,7 @@ public class Searcher {
                 SourceTextEntry ste = allEntries.get(i);
                 TMXEntry te = m_project.getTranslationInfo(ste);
 
-                checkEntry(ste.getSrcText(), te.translation, te.note, ste.getRawProperties(), te, i, null);
+                checkEntry(ste.getSrcText(), te.getTranslation(), te.getNote(), ste.getRawProperties(), te, i, null);
                 checkStop.checkInterrupted();
             }
 
@@ -401,7 +402,8 @@ public class Searcher {
                         }
                         checkStop.checkInterrupted();
                         if (m_project.isOrphaned(source)) {
-                            checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
+                            checkEntry(en.getSource(), en.getTranslation(), en.getNote(), null, en, ENTRY_ORIGIN_ORPHAN,
+                                    file);
                         }
                     }
                 });
@@ -416,7 +418,8 @@ public class Searcher {
                         }
                         checkStop.checkInterrupted();
                         if (m_project.isOrphaned(source)) {
-                            checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
+                            checkEntry(en.getSource(), en.getTranslation(), en.getNote(), null, en, ENTRY_ORIGIN_ORPHAN,
+                                    file);
                         }
                     }
                 });
@@ -475,7 +478,7 @@ public class Searcher {
             // and real translation
             // - although the 'translation' is used as 'source', we search it as translation, else we cannot show to
             // which real source it belongs
-            checkEntry(tm.source, tm.translation, tm.note, null, null, ENTRY_ORIGIN_ALTERNATIVE, tmxID);
+            checkEntry(tm.getSource(), tm.getTranslation(), tm.getNote(), null, null, ENTRY_ORIGIN_ALTERNATIVE, tmxID);
 
             checkStop.checkInterrupted();
         }
@@ -564,10 +567,10 @@ public class Searcher {
         if ((srcMatches != null || targetMatches != null || srcOrTargetMatches != null || noteMatches != null
                 || propertyMatches != null)
                 && (!searchExpression.searchAuthor || searchAuthor(entry))
-                && (!searchExpression.searchDateBefore
-                        || entry != null && entry.changeDate != 0 && entry.changeDate < searchExpression.dateBefore)
-                && (!searchExpression.searchDateAfter
-                        || entry != null && entry.changeDate != 0 && entry.changeDate > searchExpression.dateAfter)) {
+                && (!searchExpression.searchDateBefore || entry != null
+                    && entry.getChangeDate() != 0 && entry.getChangeDate() < searchExpression.dateBefore)
+                && (!searchExpression.searchDateAfter || entry != null && entry.getChangeDate() != 0
+                    && entry.getChangeDate() > searchExpression.dateAfter)) {
             // found
             foundString(entryNum, intro, srcText, locText, note, firstMatchedProperty,
                     srcMatches, targetMatches, noteMatches, propertyMatches);
@@ -777,18 +780,18 @@ public class Searcher {
 
         if (m_author.pattern().pattern().equals("")) {
             // Handle search for null author.
-            return te.changer == null && te.creator == null;
+            return te.getChanger() == null && te.getCreator() == null;
         }
 
-        if (te.changer != null) {
-            m_author.reset(te.changer);
+        if (te.getChanger() != null) {
+            m_author.reset(te.getChanger());
             if (m_author.find()) {
                 return true;
             }
         }
 
-        if (te.creator != null) {
-            m_author.reset(te.creator);
+        if (te.getCreator() != null) {
+            m_author.reset(te.getCreator());
             if (m_author.find()) {
                 return true;
             }

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -53,7 +53,6 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.FileInfo;
 import org.omegat.core.data.ParseEntry;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.ProtectedPart;
@@ -364,8 +363,8 @@ public class Searcher {
                 }
                 for (Map.Entry<Language, ProjectTMX> tmEn : m_project.getOtherTargetLanguageTMs().entrySet()) {
                     final Language langTM = tmEn.getKey();
-                    searchEntriesAlternative(tmEn.getValue().getDefaults(), langTM.getLanguage());
-                    searchEntriesAlternative(tmEn.getValue().getAlternatives(), langTM.getLanguage());
+                    searchEntries(tmEn.getValue().getDefaults(), langTM.getLanguage());
+                    searchEntries(tmEn.getValue().getAlternatives(), langTM.getLanguage());
                     checkStop.checkInterrupted();
                 }
             }
@@ -448,25 +447,7 @@ public class Searcher {
      * @param tmxID identifier of the TMX. E.g. the filename or language code
      * @throws SearchLimitReachedException when nr of found matches exceeds requested nr of results
      */
-    private void searchEntries(Collection<PrepareTMXEntry> tmEn, final String tmxID) throws SearchLimitReachedException {
-        for (PrepareTMXEntry tm : tmEn) {
-            // stop searching if the max. nr of hits has been reached
-            if (m_numFinds >= searchExpression.numberOfResults) {
-                throw new SearchLimitReachedException();
-            }
-
-            // for alternative translations:
-            // - it is not feasible to get the SourceTextEntry that matches the tm.source, so we cannot get the entryNum
-            // and real translation
-            // - although the 'translation' is used as 'source', we search it as translation, else we cannot show to
-            // which real source it belongs
-            checkEntry(tm.source, tm.translation, tm.note, null, null, ENTRY_ORIGIN_TRANSLATION_MEMORY, tmxID);
-
-            checkStop.checkInterrupted();
-        }
-    }
-
-    private void searchEntriesAlternative(Collection<TMXEntry> tmEn, final String tmxID) throws SearchLimitReachedException {
+    private void searchEntries(Collection<TMXEntry> tmEn, final String tmxID) throws SearchLimitReachedException {
         for (TMXEntry tm : tmEn) {
             // stop searching if the max. nr of hits has been reached
             if (m_numFinds >= searchExpression.numberOfResults) {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -7,6 +7,7 @@
                2008 Alex Buloichik
                2012 Thomas Cordonnier, Martin Fleurke
                2013 Aaron Madlon-Kay, Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -185,13 +186,13 @@ public class FindMatches {
                         // skip original==original entry comparison
                         return;
                     }
-                    if (requiresTranslation && trans.translation == null) {
+                    if (requiresTranslation && trans.getTranslation() == null) {
                         return;
                     }
                     String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
-                    processEntry(null, source, trans.translation, NearString.MATCH_SOURCE.MEMORY, false, 0,
-                            fileName, trans.creator, trans.creationDate, trans.changer, trans.changeDate,
-                            null);
+                    processEntry(null, source, trans.getTranslation(), NearString.MATCH_SOURCE.MEMORY, false, 0,
+                            fileName, trans.getCreator(), trans.getCreationDate(), trans.getChanger(),
+                            trans.getChangeDate(), null);
                 }
             });
         }
@@ -202,13 +203,13 @@ public class FindMatches {
                     // skip original==original entry comparison
                     return;
                 }
-                if (requiresTranslation && trans.translation == null) {
+                if (requiresTranslation && trans.getTranslation() == null) {
                     return;
                 }
                 String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
-                processEntry(source, source.sourceText, trans.translation, NearString.MATCH_SOURCE.MEMORY,
-                        false, 0, fileName, trans.creator, trans.creationDate, trans.changer,
-                        trans.changeDate, null);
+                processEntry(source, source.sourceText, trans.getTranslation(), NearString.MATCH_SOURCE.MEMORY,
+                        false, 0, fileName, trans.getCreator(), trans.getCreationDate(), trans.getChanger(),
+                        trans.getChangeDate(), null);
             }
         });
 
@@ -229,11 +230,11 @@ public class FindMatches {
             }
             for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
-                if (tmen.source == null) {
+                if (tmen.getSource() == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.
                     continue;
                 }
-                if (requiresTranslation && tmen.translation == null) {
+                if (requiresTranslation && tmen.getTranslation() == null) {
                     continue;
                 }
 
@@ -242,9 +243,9 @@ public class FindMatches {
                     tmenPenalty += foreignPenalty;
                 }
 
-                processEntry(null, tmen.source, tmen.translation, NearString.MATCH_SOURCE.TM, false, tmenPenalty,
-                        en.getKey(), tmen.creator, tmen.creationDate, tmen.changer, tmen.changeDate,
-                        tmen.otherProperties);
+                processEntry(null, tmen.getSource(), tmen.getTranslation(), NearString.MATCH_SOURCE.TM, false, tmenPenalty,
+                        en.getKey(), tmen.getCreator(), tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(),
+                        tmen.getRawProperties());
             }
         }
 

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -45,7 +45,7 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.data.IProject.MultipleTranslationsIterator;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITranslationEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
@@ -228,7 +228,7 @@ public class FindMatches {
             if (matcher.find()) {
                 penalty = Integer.parseInt(matcher.group(1));
             }
-            for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
+            for (ITranslationEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
                 if (tmen.getSource() == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.

--- a/src/org/omegat/core/tagvalidation/ErrorReport.java
+++ b/src/org/omegat/core/tagvalidation/ErrorReport.java
@@ -59,7 +59,7 @@ public class ErrorReport {
         this.ste = ste;
         this.source = ste.getSrcText();
         this.tmxEntry = tmxEntry;
-        this.translation = tmxEntry.translation;
+        this.translation = tmxEntry.getTranslation();
         this.entryNum = ste.entryNum();
     }
 

--- a/src/org/omegat/gui/editor/ModificationInfoManager.java
+++ b/src/org/omegat/gui/editor/ModificationInfoManager.java
@@ -146,7 +146,7 @@ public final class ModificationInfoManager {
     }
 
     public static String apply(TMXEntry trans) {
-        if (trans.changeDate == 0) {
+        if (trans.getChangeDate() == 0) {
             return defaultTemplateND.apply(trans);
         } else {
             return defaultTemplate.apply(trans);
@@ -161,49 +161,49 @@ public final class ModificationInfoManager {
 
         @Override
         public String expandVariables(TMXEntry trans) {
-            Date creationDate = new Date(trans.creationDate);
-            Date changeDate = new Date(trans.changeDate);
+            Date creationDate = new Date(trans.getCreationDate());
+            Date changeDate = new Date(trans.getChangeDate());
 
             // do not modify template directly, so that we can reuse for another change
             String localTemplate = this.template;
 
-            localTemplate = localTemplate.replace(VAR_CREATION_ID, trans.creator == null
-                    ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR") : trans.creator);
+            localTemplate = localTemplate.replace(VAR_CREATION_ID, trans.getCreator() == null
+                    ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR") : trans.getCreator());
             localTemplate = localTemplate.replace(VAR_CREATION_DATE,
-                    trans.creationDate == 0 ? "" : DATE_FORMAT.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : DATE_FORMAT.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_DATE_COUNTRY,
-                    trans.creationDate == 0 ? "" : DATE_FORMAT_COUNTRY.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : DATE_FORMAT_COUNTRY.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_DATE_SHORT,
-                    trans.creationDate == 0 ? "" : DATE_FORMAT_SHORT.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : DATE_FORMAT_SHORT.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_DATE_SHORT_COUNTRY,
-                    trans.creationDate == 0 ? "" : DATE_FORMAT_SHORT_COUNTRY.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : DATE_FORMAT_SHORT_COUNTRY.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_TIME,
-                    trans.creationDate == 0 ? "" : TIME_FORMAT.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : TIME_FORMAT.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_TIME_COUNTRY,
-                    trans.creationDate == 0 ? "" : TIME_FORMAT_COUNTRY.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : TIME_FORMAT_COUNTRY.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_TIME_SHORT,
-                    trans.creationDate == 0 ? "" : TIME_FORMAT_SHORT.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : TIME_FORMAT_SHORT.format(creationDate));
             localTemplate = localTemplate.replace(VAR_CREATION_TIME_SHORT_COUNTRY,
-                    trans.creationDate == 0 ? "" : TIME_FORMAT_SHORT_COUNTRY.format(creationDate));
+                    trans.getCreationDate() == 0 ? "" : TIME_FORMAT_SHORT_COUNTRY.format(creationDate));
 
-            localTemplate = localTemplate.replace(VAR_CHANGED_ID, trans.changer == null
-                    ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR") : trans.changer);
+            localTemplate = localTemplate.replace(VAR_CHANGED_ID, trans.getChanger() == null
+                    ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR") : trans.getChanger());
             localTemplate = localTemplate.replace(VAR_CHANGED_DATE,
-                    trans.changeDate == 0 ? "" : DATE_FORMAT.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : DATE_FORMAT.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_DATE_COUNTRY,
-                    trans.changeDate == 0 ? "" : DATE_FORMAT_COUNTRY.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : DATE_FORMAT_COUNTRY.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_DATE_SHORT,
-                    trans.changeDate == 0 ? "" : DATE_FORMAT_SHORT.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : DATE_FORMAT_SHORT.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_DATE_SHORT_COUNTRY,
-                    trans.changeDate == 0 ? "" : DATE_FORMAT_SHORT_COUNTRY.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : DATE_FORMAT_SHORT_COUNTRY.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_TIME,
-                    trans.changeDate == 0 ? "" : TIME_FORMAT.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : TIME_FORMAT.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_TIME_COUNTRY,
-                    trans.changeDate == 0 ? "" : TIME_FORMAT_COUNTRY.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : TIME_FORMAT_COUNTRY.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_TIME_SHORT,
-                    trans.changeDate == 0 ? "" : TIME_FORMAT_SHORT.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : TIME_FORMAT_SHORT.format(changeDate));
             localTemplate = localTemplate.replace(VAR_CHANGED_TIME_SHORT_COUNTRY,
-                    trans.changeDate == 0 ? "" : TIME_FORMAT_SHORT_COUNTRY.format(changeDate));
+                    trans.getChangeDate() == 0 ? "" : TIME_FORMAT_SHORT_COUNTRY.format(changeDate));
 
             return localTemplate;
         }

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -167,7 +167,7 @@ public class SegmentBuilder {
      * @return OmElementSegment
      */
     public void createSegmentElement(final boolean isActive, TMXEntry trans) {
-        createSegmentElement(isActive, doc.getLength(), trans, trans.defaultTranslation);
+        createSegmentElement(isActive, doc.getLength(), trans, trans.isDefaultTranslation());
     }
 
     public void createSegmentElement(final boolean isActive, TMXEntry trans, final boolean defaultTranslation) {
@@ -175,7 +175,7 @@ public class SegmentBuilder {
     }
 
     public void prependSegmentElement(final boolean isActive, TMXEntry trans) {
-        createSegmentElement(isActive, 0, trans, trans.defaultTranslation);
+        createSegmentElement(isActive, 0, trans, trans.isDefaultTranslation());
     }
 
     public void createSegmentElement(final boolean isActive, int initialOffset, TMXEntry trans, final boolean defaultTranslation) {
@@ -274,7 +274,7 @@ public class SegmentBuilder {
                 TMXEntry altTrans = entry.getValue().getDefaultTranslation(ste.getSrcText());
                 if (altTrans != null && altTrans.isTranslated()) {
                     Language language = entry.getKey();
-                    addOtherLanguagePart(altTrans.translation, language);
+                    addOtherLanguagePart(altTrans.getTranslation(), language);
                 }
             }
 
@@ -283,7 +283,7 @@ public class SegmentBuilder {
 
             if (trans.isTranslated()) {
                 //translation exist
-                translationText = trans.translation;
+                translationText = trans.getTranslation();
             } else {
                 boolean insertSource = !Preferences.isPreference(Preferences.DONT_INSERT_SOURCE_TEXT);
                 if (controller.entriesFilter != null && controller.entriesFilter.isSourceAsEmptyTranslation()) {
@@ -347,7 +347,7 @@ public class SegmentBuilder {
 
         if (trans.isTranslated()) {
             // translation exist
-            translationText = trans.translation;
+            translationText = trans.getTranslation();
             if (StringUtil.isEmpty(translationText)) {
                 translationText = OStrings.getString("EMPTY_TRANSLATION");
             }
@@ -526,12 +526,12 @@ public class SegmentBuilder {
         if (Preferences.isPreference(Preferences.VIEW_OPTION_TEMPLATE_ACTIVE)) {
              text = ModificationInfoManager.apply(trans);
         } else {
-            String author = (trans.changer == null ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR")
-                    : trans.changer);
+            String author = (trans.getChanger() == null ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR")
+                    : trans.getChanger());
             String template;
-            if (trans.changeDate != 0) {
+            if (trans.getChangeDate() != 0) {
                 template = OStrings.getString("TF_CUR_SEGMENT_AUTHOR_DATE");
-                Date changeDate = new Date(trans.changeDate);
+                Date changeDate = new Date(trans.getChangeDate());
                 String changeDateString = DateFormat.getDateInstance().format(changeDate);
                 String changeTimeString = DateFormat.getTimeInstance().format(changeDate);
                 Object[] args = { author, changeDateString, changeTimeString };

--- a/src/org/omegat/gui/editor/SegmentExportImport.java
+++ b/src/org/omegat/gui/editor/SegmentExportImport.java
@@ -100,7 +100,7 @@ public class SegmentExportImport {
 
         String s1 = ste.getSrcText();
         TMXEntry te = Core.getProject().getTranslationInfo(ste);
-        String s2 = te.isTranslated() ? te.translation : "";
+        String s2 = te.isTranslated() ? te.getTranslation() : "";
 
         File sourceFile = getFile(SOURCE_EXPORT);
         File targetFile = getFile(TARGET_EXPORT);

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.omegat.core.Core;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.search.SearchMatch;
@@ -108,7 +107,7 @@ public class ReplaceFilter implements IEditorFilter {
                 continue;
             }
             // Avoid to replace more than once with variables when entries have duplicates
-            if ((en.defaultTranslation) && (ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT)) {
+            if ((en.isDefaultTranslation()) && (ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT)) {
                 continue; // Already replaced when we parsed the first entry
             }
             List<SearchMatch> found = getReplacementsForEntry(trans);
@@ -119,9 +118,12 @@ public class ReplaceFilter implements IEditorFilter {
                     o.replace(m.getStart() + off, m.getEnd() + off, m.getReplacement());
                     off += m.getReplacement().length() - m.getLength();
                 }
-                PrepareTMXEntry prepare = new PrepareTMXEntry(en);
-                prepare.translation = o.toString();
-                Core.getProject().setTranslation(ste, prepare, en.defaultTranslation, null);
+                TMXEntry tmxEntry = new TMXEntry.Builder()
+                        .setSource(en.getSource())
+                        .setTranslation(o.toString())
+                        .setDefaultTranslation(en.isDefaultTranslation())
+                        .build();
+                Core.getProject().setTranslation(ste, tmxEntry);
             }
         }
         EditorController ec = (EditorController) Core.getEditor();
@@ -238,7 +240,7 @@ public class ReplaceFilter implements IEditorFilter {
      */
     private String getEntryText(SourceTextEntry ste, TMXEntry en) {
         if (en.isTranslated()) {
-            return en.translation;
+            return en.getTranslation();
         } else if (searcher.getExpression().replaceUntranslated) {
             return ste.getSrcText();
         } else {

--- a/src/org/omegat/gui/editor/history/HistoryCompleter.java
+++ b/src/org/omegat/gui/editor/history/HistoryCompleter.java
@@ -77,7 +77,7 @@ public class HistoryCompleter extends AutoCompleterListView {
                 if (lastEntry != null && !wasTranslated) {
                     TMXEntry newTranslation = project.getTranslationInfo(lastEntry);
                     if (newTranslation.isTranslated()) {
-                        trainString(newTranslation.translation);
+                        trainString(newTranslation.getTranslation());
                     }
                 }
                 currentEntry = newEntry;
@@ -102,8 +102,8 @@ public class HistoryCompleter extends AutoCompleterListView {
         }
         long start = System.currentTimeMillis();
         wordCompleter.reset();
-        project.iterateByDefaultTranslations((source, trans) -> trainString(trans.translation));
-        project.iterateByMultipleTranslations((source, trans) -> trainString(trans.translation));
+        project.iterateByDefaultTranslations((source, trans) -> trainString(trans.getTranslation()));
+        project.iterateByMultipleTranslations((source, trans) -> trainString(trans.getTranslation()));
         long time = System.currentTimeMillis() - start;
         LOGGER.finer(() -> String.format("Time to train History Completer: %d ms", time));
     }

--- a/src/org/omegat/gui/editor/history/HistoryPredictor.java
+++ b/src/org/omegat/gui/editor/history/HistoryPredictor.java
@@ -77,7 +77,7 @@ public class HistoryPredictor extends AutoCompleterListView {
                 if (lastEntry != null && !wasTranslated) {
                     TMXEntry newTranslation = project.getTranslationInfo(lastEntry);
                     if (newTranslation.isTranslated()) {
-                        trainString(newTranslation.translation);
+                        trainString(newTranslation.getTranslation());
                     }
                 }
                 currentEntry = newEntry;
@@ -102,8 +102,8 @@ public class HistoryPredictor extends AutoCompleterListView {
         }
         long start = System.currentTimeMillis();
         predictor.reset();
-        project.iterateByDefaultTranslations((source, trans) -> trainString(trans.translation));
-        project.iterateByMultipleTranslations((source, trans) -> trainString(trans.translation));
+        project.iterateByDefaultTranslations((source, trans) -> trainString(trans.getTranslation()));
+        project.iterateByMultipleTranslations((source, trans) -> trainString(trans.getTranslation()));
         long time = System.currentTimeMillis() - start;
         LOGGER.finer(() -> String.format("Time to train History Predictor: %d ms", time));
     }

--- a/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -58,11 +58,11 @@ public class ComesFromAutoTMMarker implements IMarker {
             return null;
         }
         TMXEntry e = Core.getProject().getTranslationInfo(ste);
-        if (e.linked == null) {
+        if (e.getLinked() == null) {
             return null;
         }
         Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
-        switch (e.linked) {
+        switch (e.getLinked()) {
         case xICE:
             m.painter = PAINTER_XICE;
             break;

--- a/src/org/omegat/gui/issues/SimpleIssue.java
+++ b/src/org/omegat/gui/issues/SimpleIssue.java
@@ -66,7 +66,7 @@ public abstract class SimpleIssue implements IIssue {
     public Component getDetailComponent() {
         IssueDetailSplitPanel panel = new IssueDetailSplitPanel();
         panel.firstTextPane.setText(sourceEntry.getSrcText());
-        panel.lastTextPane.setText(targetEntry.translation);
+        panel.lastTextPane.setText(targetEntry.getTranslation());
         panel.setMinimumSize(new Dimension(0, panel.firstTextPane.getFont().getSize() * 6));
         return panel;
     }

--- a/src/org/omegat/gui/issues/SpellingIssueProvider.java
+++ b/src/org/omegat/gui/issues/SpellingIssueProvider.java
@@ -69,7 +69,7 @@ class SpellingIssueProvider implements IIssueProvider {
 
     @Override
     public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
-        List<Token> misspelled = Core.getSpellChecker().getMisspelledTokens(tmxEntry.translation);
+        List<Token> misspelled = Core.getSpellChecker().getMisspelledTokens(tmxEntry.getTranslation());
         return misspelled.isEmpty() ? Collections.emptyList()
                 : Arrays.asList(new SpellingIssue(sourceEntry, tmxEntry, misspelled));
     }
@@ -118,7 +118,7 @@ class SpellingIssueProvider implements IIssueProvider {
 
         @Override
         public String getDescription() {
-            return misspelledTokens.stream().map(tok -> tok.getTextFromString(tmxEntry.translation)).distinct()
+            return misspelledTokens.stream().map(tok -> tok.getTextFromString(tmxEntry.getTranslation())).distinct()
                     .collect(Collectors.joining(OStrings.getString("ISSUES_SPELLING_WORD_DELIMITER")));
         }
 
@@ -126,7 +126,7 @@ class SpellingIssueProvider implements IIssueProvider {
         public Component getDetailComponent() {
             IssueDetailSplitPanel panel = new IssueDetailSplitPanel();
             panel.firstTextPane.setText(ste.getSrcText());
-            panel.lastTextPane.setText(tmxEntry.translation);
+            panel.lastTextPane.setText(tmxEntry.getTranslation());
             StyledDocument doc = panel.lastTextPane.getStyledDocument();
             for (Token tok : misspelledTokens) {
                 doc.setCharacterAttributes(tok.getOffset(), tok.getLength(), ERROR_STYLE, false);
@@ -144,7 +144,7 @@ class SpellingIssueProvider implements IIssueProvider {
         public List<? extends JMenuItem> getMenuComponents() {
             List<JMenuItem> result = new ArrayList<>();
             ISpellChecker checker = Core.getSpellChecker();
-            misspelledTokens.stream().map(tok -> tok.getTextFromString(tmxEntry.translation)).distinct()
+            misspelledTokens.stream().map(tok -> tok.getTextFromString(tmxEntry.getTranslation())).distinct()
                     .forEach(word -> {
                         boolean enabled = !checker.isIgnoredWord(word) && !checker.isLearnedWord(word);
                         JMenuItem item = new JMenuItem(

--- a/src/org/omegat/gui/issues/TagIssue.java
+++ b/src/org/omegat/gui/issues/TagIssue.java
@@ -45,6 +45,8 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+import org.openide.awt.Mnemonics;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.tagvalidation.ErrorReport;
@@ -55,7 +57,6 @@ import org.omegat.util.StringUtil;
 import org.omegat.util.TagUtil.Tag;
 import org.omegat.util.gui.CharacterWrapEditorKit;
 import org.omegat.util.gui.Styles.EditorColor;
-import org.openide.awt.Mnemonics;
 
 /**
  * A class representing problems with tags in a translation. One instance holds
@@ -206,7 +207,7 @@ public class TagIssue implements IIssue {
     private static boolean doFix(ErrorReport report, String fixed) {
         // Make sure the translation hasn't changed in the editor.
         TMXEntry prevTrans = Core.getProject().getTranslationInfo(report.ste);
-        if (!report.translation.equals(prevTrans.translation)) {
+        if (!report.translation.equals(prevTrans.getTranslation())) {
             return false;
         }
 

--- a/src/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -79,7 +79,7 @@ class TerminologyIssueProvider implements IIssueProvider {
             return Collections.emptyList();
         }
         return entries.stream().map(e -> {
-            List<String> trgTerms = Core.getGlossaryManager().searchTargetMatches(tmxEntry.translation,
+            List<String> trgTerms = Core.getGlossaryManager().searchTargetMatches(tmxEntry.getTranslation(),
                     sourceEntry.getProtectedParts(), e);
             return trgTerms.isEmpty() ? new TerminologyIssue(sourceEntry, tmxEntry, e) : null;
         }).filter(Objects::nonNull).collect(Collectors.toList());
@@ -202,7 +202,7 @@ class TerminologyIssueProvider implements IIssueProvider {
         private Component getSplitPanel() {
             IssueDetailSplitPanel splitPanel = new IssueDetailSplitPanel();
             splitPanel.firstTextPane.setText(ste.getSrcText());
-            splitPanel.lastTextPane.setText(tmxEntry.translation);
+            splitPanel.lastTextPane.setText(tmxEntry.getTranslation());
             StyledDocument doc = splitPanel.firstTextPane.getStyledDocument();
             for (Token[] toks : Core.getGlossaryManager().searchSourceMatchTokens(ste, glossaryEntry)) {
                 for (Token tok : toks) {

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -519,7 +519,7 @@ public final class MainWindowMenuHandler {
             SourceTextEntry ste = Core.getEditor().getCurrentEntry();
             TMXEntry te = Core.getProject().getTranslationInfo(ste);
             if (te.isTranslated()) {
-                selection = te.translation;
+                selection = te.getTranslation();
             } else {
                 selection = ste.getSrcText();
             }

--- a/src/org/omegat/gui/multtrans/MultipleTransPane.java
+++ b/src/org/omegat/gui/multtrans/MultipleTransPane.java
@@ -142,11 +142,11 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
             DisplayedEntry de = new DisplayedEntry();
             de.entry = e;
             de.start = o.length();
-            if (e.entry.translation == null) {
+            if (e.entry.getTranslation() == null) {
                 continue;
             }
             if (e.key != null) {
-                o.append(e.entry.translation).append('\n');
+                o.append(e.entry.getTranslation()).append('\n');
                 o.append('<').append(e.key.file);
                 if (e.key.id != null) {
                     o.append('/').append(e.key.id);
@@ -157,7 +157,7 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
                     o.append(" <...> ").append(StringUtil.truncate(e.key.next, 10)).append(")\n");
                 }
             } else {
-                o.append(e.entry.translation).append('\n');
+                o.append(e.entry.getTranslation()).append('\n');
             }
             de.end = o.length();
             entries.add(de);
@@ -236,7 +236,7 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
         item.setEnabled(de != null && de.entry.key != null);
         if (de != null && de.entry.key != null) {
             item.addActionListener(e -> {
-                Core.getEditor().replaceEditText(de.entry.entry.translation);
+                Core.getEditor().replaceEditText(de.entry.entry.getTranslation());
                 Core.getEditor().setAlternateTranslationForCurrentEntry(false);
                 Core.getEditor().commitAndLeave();
             });
@@ -245,7 +245,7 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
         item = popup.add(OStrings.getString("MULT_POPUP_REPLACE"));
         item.setEnabled(de != null);
         if (de != null) {
-            item.addActionListener(e -> Core.getEditor().replaceEditText(de.entry.entry.translation));
+            item.addActionListener(e -> Core.getEditor().replaceEditText(de.entry.entry.getTranslation()));
         }
 
         item = popup.add(OStrings.getString("MULT_POPUP_GOTO"));

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -335,19 +335,19 @@ public class SegmentPropertiesArea implements IPaneMenu {
         if (!entry.isTranslated()) {
             return;
         }
-        if (entry.changeDate != 0) {
-            setProperty(KEY_CHANGED, dateFormat.format(new Date(entry.changeDate)) + " "
-                    + timeFormat.format(new Date(entry.changeDate)));
+        if (entry.getChangeDate() != 0) {
+            setProperty(KEY_CHANGED, dateFormat.format(new Date(entry.getChangeDate())) + " "
+                    + timeFormat.format(new Date(entry.getChangeDate())));
         }
-        setProperty(KEY_CHANGER, entry.changer);
-        if (entry.creationDate != 0) {
-            setProperty(KEY_CREATED, dateFormat.format(new Date(entry.creationDate)) + " "
-                    + timeFormat.format(new Date(entry.creationDate)));
+        setProperty(KEY_CHANGER, entry.getChanger());
+        if (entry.getCreationDate() != 0) {
+            setProperty(KEY_CREATED, dateFormat.format(new Date(entry.getCreationDate())) + " "
+                    + timeFormat.format(new Date(entry.getCreationDate())));
         }
-        setProperty(KEY_CREATOR, entry.creator);
-        if (!entry.defaultTranslation) {
+        setProperty(KEY_CREATOR, entry.getCreator());
+        if (!entry.isDefaultTranslation()) {
             setProperty(KEY_ISALT, true);
         }
-        setProperty(KEY_LINKED, entry.linked);
+        setProperty(KEY_LINKED, entry.getLinked());
     }
 }

--- a/src/org/omegat/languagetools/LanguageToolIssueProvider.java
+++ b/src/org/omegat/languagetools/LanguageToolIssueProvider.java
@@ -63,8 +63,8 @@ public class LanguageToolIssueProvider implements IIssueProvider {
     public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
         ILanguageToolBridge bridge = LanguageToolWrapper.getBridge();
         if (bridge != null) {
-            return bridge.getCheckResults(sourceEntry.getSrcText(), tmxEntry.translation).stream()
-                    .map(match -> new LanguageToolIssue(sourceEntry, tmxEntry.translation, match))
+            return bridge.getCheckResults(sourceEntry.getSrcText(), tmxEntry.getTranslation()).stream()
+                    .map(match -> new LanguageToolIssue(sourceEntry, tmxEntry.getTranslation(), match))
                     .collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/org/omegat/util/TMXWriter.java
+++ b/src/org/omegat/util/TMXWriter.java
@@ -35,8 +35,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITranslationEntry;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.TMXEntry;
 
 /**
  * Class that store TMX (Translation Memory Exchange) files.
@@ -67,7 +68,7 @@ public final class TMXWriter {
      * @throws IOException
      */
     public static void buildTMXFile(final String filename, final boolean forceValidTMX,
-            final boolean levelTwo, final ProjectProperties config, final Map<String, PrepareTMXEntry> data)
+            final boolean levelTwo, final ProjectProperties config, final Map<String, TMXEntry> data)
             throws IOException {
         // we got this far, so assume lang codes are proper
         String sourceLocale = config.getSourceLanguage().toString();
@@ -115,18 +116,18 @@ public final class TMXWriter {
         String langAttr = levelTwo ? "xml:lang" : "lang";
 
         // Write TUs
-        String source = null;
-        String target = null;
+        String source;
+        String target;
         String note = null;
         TMXDateParser dateParser = new TMXDateParser();
-        for (Map.Entry<String, PrepareTMXEntry> en : data.entrySet()) {
-            PrepareTMXEntry transEntry = en.getValue();
+        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
+            ITranslationEntry transEntry = en.getValue();
             source = forceValidTMX ? TagUtil.stripXmlTags(en.getKey()) : en.getKey();
-            target = forceValidTMX ? TagUtil.stripXmlTags(transEntry.translation) : transEntry.translation;
+            target = forceValidTMX ? TagUtil.stripXmlTags(transEntry.getTranslation()) : transEntry.getTranslation();
             source = StringUtil.makeValidXML(source);
             target = StringUtil.makeValidXML(target);
-            if (transEntry.note != null) {
-                note = forceValidTMX ? TagUtil.stripXmlTags(transEntry.note) : transEntry.note;
+            if (!transEntry.hasNote()) {
+                note = forceValidTMX ? TagUtil.stripXmlTags(transEntry.getNote()) : transEntry.getNote();
                 note = StringUtil.makeValidXML(note);
             }
             // TO DO: This *possibly* converts occurrences in the actual text of
@@ -136,10 +137,10 @@ public final class TMXWriter {
                 source = makeLevelTwo(source);
                 target = makeLevelTwo(target);
             }
-            String changeIdPropertyString = (transEntry.changer != null && !"".equals(transEntry.changer)
-                    ? " changeid=\"" + transEntry.changer + "\"" : "");
-            String changeDatePropertyString = (transEntry.changeDate != 0 ? " changedate=\""
-                    + dateParser.getTMXDate(transEntry.changeDate) + "\"" : "");
+            String changeIdPropertyString = (transEntry.getChanger() != null && !"".equals(transEntry.getChanger())
+                    ? " changeid=\"" + transEntry.getChanger() + "\"" : "");
+            String changeDatePropertyString = (transEntry.getChangeDate() != 0 ? " changedate=\""
+                    + dateParser.getTMXDate(transEntry.getChangeDate()) + "\"" : "");
             out.println("    <tu>");
             out.println("      <tuv " + langAttr + "=\"" + sourceLocale + "\">");
             out.println("        <seg>" + source + "</seg>");

--- a/src/org/omegat/util/TMXWriter.java
+++ b/src/org/omegat/util/TMXWriter.java
@@ -35,9 +35,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.omegat.core.data.ITranslationEntry;
+import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
-import org.omegat.core.data.TMXEntry;
 
 /**
  * Class that store TMX (Translation Memory Exchange) files.
@@ -68,7 +67,7 @@ public final class TMXWriter {
      * @throws IOException
      */
     public static void buildTMXFile(final String filename, final boolean forceValidTMX,
-            final boolean levelTwo, final ProjectProperties config, final Map<String, TMXEntry> data)
+            final boolean levelTwo, final ProjectProperties config, final Map<String, PrepareTMXEntry> data)
             throws IOException {
         // we got this far, so assume lang codes are proper
         String sourceLocale = config.getSourceLanguage().toString();
@@ -116,17 +115,17 @@ public final class TMXWriter {
         String langAttr = levelTwo ? "xml:lang" : "lang";
 
         // Write TUs
-        String source;
-        String target;
+        String source = null;
+        String target = null;
         String note = null;
         TMXDateParser dateParser = new TMXDateParser();
-        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
-            ITranslationEntry transEntry = en.getValue();
+        for (Map.Entry<String, PrepareTMXEntry> en : data.entrySet()) {
+            PrepareTMXEntry transEntry = en.getValue();
             source = forceValidTMX ? TagUtil.stripXmlTags(en.getKey()) : en.getKey();
             target = forceValidTMX ? TagUtil.stripXmlTags(transEntry.getTranslation()) : transEntry.getTranslation();
             source = StringUtil.makeValidXML(source);
             target = StringUtil.makeValidXML(target);
-            if (!transEntry.hasNote()) {
+            if (transEntry.hasNote()) {
                 note = forceValidTMX ? TagUtil.stripXmlTags(transEntry.getNote()) : transEntry.getNote();
                 note = StringUtil.makeValidXML(note);
             }

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -160,8 +160,8 @@ public class TMXWriter2 {
      */
     public void writeEntry(String source, String translation, TMXEntry entry, List<String> propValues)
             throws Exception {
-        writeEntry(source, translation, entry.note, entry.creator, entry.creationDate, entry.changer, entry.changeDate,
-                propValues);
+        writeEntry(source, translation, entry.getNote(), entry.getCreator(), entry.getCreationDate(),
+                entry.getChanger(), entry.getChangeDate(), propValues);
     }
 
     public void writeEntry(String source, String translation, String note, String creator, long creationDate,

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -34,9 +34,11 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,6 +46,7 @@ import java.util.regex.Pattern;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.TMXEntry;
 
 /**
@@ -145,6 +148,23 @@ public class TMXWriter2 {
         }
     }
 
+    public static void buildTMXFile(final String filename, final boolean forceValidTMX,
+                                    final boolean levelTwo, final ProjectProperties config,
+                                    final Map<String, TMXEntry> data) throws Exception {
+        TMXWriter2 wr = new TMXWriter2(new File(filename), config.getSourceLanguage(), config.getTargetLanguage(),
+                config.isSentenceSegmentingEnabled(), levelTwo, forceValidTMX);
+        List<String> p = new ArrayList<>();
+        try {
+            for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
+                TMXEntry transEntry = en.getValue();
+                wr.writeEntry(en.getKey(), transEntry.translation, transEntry.note, transEntry.creator,
+                        transEntry.creationDate, transEntry.changer, transEntry.changeDate, p);
+            }
+        } finally {
+            wr.close();
+        }
+    }
+
     public void writeComment(String comment) throws Exception {
         xml.writeComment(comment);
         xml.writeCharacters(lineSeparator);
@@ -160,8 +180,8 @@ public class TMXWriter2 {
      */
     public void writeEntry(String source, String translation, TMXEntry entry, List<String> propValues)
             throws Exception {
-        writeEntry(source, translation, entry.getNote(), entry.getCreator(), entry.getCreationDate(),
-                entry.getChanger(), entry.getChangeDate(), propValues);
+        writeEntry(source, translation, entry.note, entry.creator, entry.creationDate, entry.changer, entry.changeDate,
+                propValues);
     }
 
     public void writeEntry(String source, String translation, String note, String creator, long creationDate,

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -178,11 +178,12 @@ public final class TestTeamIntegrationChild {
 
     static void changeConcurrent() throws Exception {
         checkAll();
-
-        PrepareTMXEntry prep = new PrepareTMXEntry();
-        prep.translation = "" + System.currentTimeMillis();
-        Core.getProject().setTranslation(steC, prep, true, null);
-        Log.log("Wrote: " + prep.source + "=" + prep.translation);
+        TMXEntry entry = new TMXEntry.Builder()
+                .setTranslation("" + System.currentTimeMillis())
+                .setDefaultTranslation(true)
+                .build();
+        Core.getProject().setTranslation(steC, entry);
+        Log.log("Wrote: " + entry.getSource() + "=" + entry.getTranslation());
     }
 
     static void checksavecheck(int index) throws Exception {
@@ -211,7 +212,7 @@ public final class TestTeamIntegrationChild {
                 if (prev == null) {
                     prev = 0L;
                 }
-                long curr = Long.parseLong(trans.translation);
+                long curr = Long.parseLong(trans.getTranslation());
                 if (curr < prev) {
                     throw new RuntimeException(source + ": Wrong value in " + source + ": current(" + curr
                             + ") less than previous(" + prev + ")");
@@ -222,7 +223,7 @@ public final class TestTeamIntegrationChild {
 
     static void checkTranslation(int index) {
         TMXEntry en = Core.getProject().getTranslationInfo(ste[index]);
-        String sv = en == null || !en.isTranslated() ? "" : en.translation;
+        String sv = en == null || !en.isTranslated() ? "" : en.getTranslation();
         if (v[index] == 0 && sv.isEmpty()) {
             return;
         }
@@ -230,12 +231,12 @@ public final class TestTeamIntegrationChild {
             return;
         }
         throw new RuntimeException(source + ": Wrong value in " + source + "/" + index + ": expected "
-                + v[index] + " but contains " + en.translation);
+                + v[index] + " but contains " + en.getTranslation());
     }
 
     static void checkTranslationFromFile(ProjectTMX tmx, int index) throws Exception {
         TMXEntry en = tmx.getDefaultTranslation(ste[index].getSrcText());
-        String sv = en == null || !en.isTranslated() ? "" : en.translation;
+        String sv = en == null || !en.isTranslated() ? "" : en.getTranslation();
         if (v[index] == 0 && sv.isEmpty()) {
             return;
         }
@@ -250,10 +251,12 @@ public final class TestTeamIntegrationChild {
      * Save new translation.
      */
     static void saveTranslation(SourceTextEntry ste, long value) {
-        PrepareTMXEntry prep = new PrepareTMXEntry();
-        prep.translation = "" + value;
-        Core.getProject().setTranslation(ste, prep, true, null);
-        Log.log("Wrote: " + prep.source + "=" + prep.translation);
+        TMXEntry en = new TMXEntry.Builder()
+                .setTranslation("" + value)
+                .setDefaultTranslation(true)
+                .build();
+        Core.getProject().setTranslation(ste, en);
+        Log.log("Wrote: " + en.getSource() + "=" + en.getTranslation());
         Core.getProject().saveProject(true);
     }
 
@@ -626,13 +629,13 @@ public final class TestTeamIntegrationChild {
                 use(e);
             }
             for (TMXEntry e : headTMX.getDefaults()) {
-                TMXEntry eb = baseTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
+                TMXEntry eb = baseTMX.getDefaultTranslation(e.getSource());
+                if (CONCURRENT_NAME.equals(e.getSource())) { // concurrent
                     if (v(eb) > v(e)) {
                         throw new RuntimeException("Rebase HEAD: wrong concurrent" + s);
                     }
                     use(e);
-                } else if (e.source.startsWith(source + "/")) { // my segments
+                } else if (e.getSource().startsWith(source + "/")) { // my segments
                     if (v(eb) != v(e)) {
                         throw new RuntimeException("Rebase HEAD: not equals for current project" + s);
                     }
@@ -644,12 +647,12 @@ public final class TestTeamIntegrationChild {
                 }
             }
             for (TMXEntry e : projectTMX.getDefaults()) {
-                TMXEntry em = mergedTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
+                TMXEntry em = mergedTMX.getDefaultTranslation(e.getSource());
+                if (CONCURRENT_NAME.equals(e.getSource())) { // concurrent
                     if (v(e) > v(em)) {
                         use(e);
                     }
-                } else if (e.source.startsWith(source + "/")) { // my segments
+                } else if (e.getSource().startsWith(source + "/")) { // my segments
                     if (v(e) < v(em)) {
                         throw new RuntimeException("Rebase me: less value" + s);
                     }
@@ -663,8 +666,8 @@ public final class TestTeamIntegrationChild {
         }
 
         void use(TMXEntry en) {
-            EntryKey k = new EntryKey("file", en.source, null, null, null, null);
-            SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.source, Collections.emptyList());
+            EntryKey k = new EntryKey("file", en.getSource(), null, null, null, null);
+            SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.getSource(), Collections.emptyList());
             mergedTMX.setTranslation(ste, en, true);
         }
 
@@ -672,7 +675,7 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return 0;
             } else {
-                return Long.parseLong(e.translation);
+                return Long.parseLong(e.getTranslation());
             }
         }
 
@@ -680,7 +683,7 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return "null";
             } else {
-                return e.source;
+                return e.getSource();
             }
         }
 
@@ -688,16 +691,16 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return "null";
             } else {
-                return e.translation;
+                return e.getTranslation();
             }
         }
 
         String trans(ProjectTMX tmx, TMXEntry e) {
-            TMXEntry en = tmx.getDefaultTranslation(e.source);
+            TMXEntry en = tmx.getDefaultTranslation(e.getSource());
             if (en == null) {
                 return "null";
             } else {
-                return en.translation;
+                return en.getTranslation();
             }
         }
     }

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -64,12 +64,9 @@ public class AutoTmxTest {
                 .setDoSegmenting(props.isSentenceSegmentingEnabled())
                 .load(props.getSourceLanguage(), props.getTargetLanguage());
 
-        PrepareTMXEntry e1 = autoTMX.getEntries().get(0);
-        checkListValues(e1, ProjectTMX.PROP_XICE, "11");
-
-        PrepareTMXEntry e2 = autoTMX.getEntries().get(1);
-        checkListValues(e2, ProjectTMX.PROP_XICE, "12");
-        checkListValues(e2, ProjectTMX.PROP_X100PC, "10");
+        assertTrue(autoTMX.getEntries().get(0).hasPropValue(ProjectTMX.PROP_XICE, "11"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_XICE, "12"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_X100PC, "10"));
 
         Core.initializeConsole(new HashMap<String, String>());
 
@@ -133,15 +130,11 @@ public class AutoTmxTest {
         return new SourceTextEntry(ek, 0, null, null, new ArrayList<ProtectedPart>());
     }
 
-    void checkListValues(PrepareTMXEntry en, String propType, String propValue) {
-        assertTrue(en.hasPropValue(propType, propValue));
-    }
-
     void checkTranslation(SourceTextEntry ste, String expectedTranslation,
             TMXEntry.ExternalLinked expectedExternalLinked) {
         TMXEntry e = p.getTranslationInfo(ste);
         assertTrue(e.isTranslated());
-        assertEquals(expectedTranslation, e.translation);
-        assertEquals(expectedExternalLinked, e.linked);
+        assertEquals(expectedTranslation, e.getTranslation());
+        assertEquals(expectedExternalLinked, e.getLinked());
     }
 }

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -89,10 +89,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSource());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslation());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSource());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslation());
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(1013, tmx.getEntries().size());
-        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).source);
+        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).getSource());
         assertEquals(
                 "\u0412\u044B\u043B\u0443\u0447\u044D\u043D\u044C\u043D\u0435 "
                         + "&\u043A\u043E\u043B\u0435\u0440\u0430\u043C "
                         + "\u0441\u044B\u043D\u0442\u0430\u043A\u0441\u044B\u0441\u0443",
-                tmx.getEntries().get(0).translation);
-        assertEquals("< Auto >", tmx.getEntries().get(1).source);
+                tmx.getEntries().get(0).getTranslation());
+        assertEquals("< Auto >", tmx.getEntries().get(1).getSource());
         assertEquals("\u041F\u0440\u0430 \u043F\u0440\u0430\u0433\u0440\u0430\u043C\u0443",
-                tmx.getEntries().get(1).translation);
+                tmx.getEntries().get(1).getTranslation());
     }
 
     @Test
@@ -128,10 +128,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(33, tmx.getEntries().size());
-        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).source);
-        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).translation);
-        assertEquals("Download %s in your language", tmx.getEntries().get(1).source);
-        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).translation);
+        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).getSource());
+        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).getTranslation());
+        assertEquals("Download %s in your language", tmx.getEntries().get(1).getSource());
+        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).getTranslation());
     }
 
     /**
@@ -156,9 +156,9 @@ public class ExternalTMFactoryTest extends TestCore {
         // Only 5 FR translations
         assertEquals(5, tmx.getEntries().size());
 
-        List<PrepareTMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(3, matchingEntries.size());
+
+        assertEquals(3,
+                tmx.getEntries().stream().filter(t -> t.getSource().equals("Hello " + "World!")).count());
         
         // Set the EXT_TMX_KEEP_FOREIGN_MATCH prop
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, true);
@@ -167,24 +167,21 @@ public class ExternalTMFactoryTest extends TestCore {
         // All foreign translations are present
         assertEquals(14, tmx.getEntries().size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(8, matchingEntries.size());
+        assertEquals(8,
+                tmx.getEntries().stream().filter(t -> t.getSource().equals("Hello World!")).count());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
+        List<ITranslationEntry> matchingEntries = tmx.getEntries().stream()
+                .filter(t -> t.getSource().equals("This is an english sentence."))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
 
-        PrepareTMXEntry entry = matchingEntries.get(0);
-        assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "EN-US"));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(1);
-        assertEquals("DE", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "DE"));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(2);
-        assertEquals("ES", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "ES"));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
     }
 }

--- a/test/src/org/omegat/core/data/MergeTest.java
+++ b/test/src/org/omegat/core/data/MergeTest.java
@@ -26,6 +26,7 @@ package org.omegat.core.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
@@ -54,44 +55,76 @@ public class MergeTest {
 
     @Test
     public void testEquals() throws Exception {
-        PrepareTMXEntry e1 = new PrepareTMXEntry();
-        e1.translation = "trans";
-        e1.changeDate = 123456999;
-        PrepareTMXEntry e2 = new PrepareTMXEntry();
-        e2.translation = "trans";
-        e2.changeDate = 123456999;
+        TMXEntry e1 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e2 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e3 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456000)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e4 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123457000)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e5 = new TMXEntry.Builder()
+                .setTranslation("t")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e6 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setNote("n")
+                .build();
+        TMXEntry e7 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChanger("c")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e8 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setExternalLinked(ExternalLinked.xICE)
+                .build();
+        TMXEntry e9 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setExternalLinked(ExternalLinked.x100PC)
+                .build();
 
         // test equals
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertEquals(e1, e2);
 
-        e2.changeDate = 123456000;
         // test truncated time
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertEquals(e1, e3);
 
-        e2.changeDate = 123457000;
         // test other time
-        assertFalse(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
-        e2.changeDate = 123456999;
+        assertNotEquals(e1, e4);
 
-        e2.translation = "t";
         // test different translation
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.translation = "trans";
+        assertFalse(e1.equalsTranslation(e5));
 
-        e2.note = "n";
         // test different note
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.note = null;
+        assertFalse(e1.equalsTranslation(e6));
 
-        e2.changer = "c";
         // test different changer
-        assertTrue(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.changer = null;
+        assertTrue(e1.equalsTranslation(e7));
 
         // test different linked
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE).equalsTranslation(new TMXEntry(e2, true,
-                ExternalLinked.x100PC)));
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE)
-                .equalsTranslation(new TMXEntry(e2, true, null)));
+        assertFalse(e8.equalsTranslation(e9));
+        assertFalse(e8.equalsTranslation(e2));
     }
 }

--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -161,19 +161,23 @@ public class RealProjectTest {
     private void setDefault(String source, String translation) {
         EntryKey key = new EntryKey(null, source, null, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, true, null), true);
+        TMXEntry entry = new TMXEntry.Builder()
+                .setSource(source)
+                .setTranslation(translation)
+                .setDefaultTranslation(true)
+                .build();
+        tmx.setTranslation(ste, entry, true);
     }
 
-    private void setAlternative(String id, String source, String translation) {
+    private void setAlternative(final String id, final String source, final String translation) {
         EntryKey key = new EntryKey("test", source, id, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, false, null), false);
+        TMXEntry en = new TMXEntry.Builder()
+                .setSource(source)
+                .setTranslation(translation)
+                .setDefaultTranslation(false)
+                .build();
+        tmx.setTranslation(ste, en, false);
     }
 
     private void checkDefault(String source, String translation) {
@@ -220,6 +224,8 @@ public class RealProjectTest {
     }
 
     public static TMXEntry createEmptyTMXEntry() {
-        return new TMXEntry(new PrepareTMXEntry(), true, null);
+        return new TMXEntry.Builder()
+                .setDefaultTranslation(true)
+                .build();
     }
 }

--- a/test/src/org/omegat/core/data/TmxComplianceTests.java
+++ b/test/src/org/omegat/core/data/TmxComplianceTests.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.html2.HTMLFilter2;
 import org.omegat.filters2.html2.HTMLOptions;
@@ -389,9 +390,6 @@ public class TmxComplianceTests extends TmxComplianceBase {
     }
 
     TMXEntry createTMXEntry(String source, String translation, boolean def) {
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        return new TMXEntry(tr, def, null);
+        return new TMXEntry.Builder().setSource(source).setTranslation(translation).setDefaultTranslation(def).build();
     }
 }

--- a/test/src/org/omegat/core/data/TmxSegmentationTest.java
+++ b/test/src/org/omegat/core/data/TmxSegmentationTest.java
@@ -74,9 +74,9 @@ public class TmxSegmentationTest {
                 .setDoSegmenting(true).load(new Language("en"), new Language("fr"));
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSource());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslation());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSource());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslation());
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.Test;
+
 import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -82,14 +82,12 @@ public class POFilterTest extends TestFilterBase {
         ExternalTMX tmEntries = fi.referenceEntries;
         assertEquals(2, tmEntries.getEntries().size());
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(0);
-            assertEquals("True fuzzy!", entry.source);
-            assertEquals("trans5", entry.translation);
+            assertEquals("True fuzzy!", tmEntries.getEntries().get(0).getSource());
+            assertEquals("trans5", tmEntries.getEntries().get(0).getTranslation());
         }
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(1);
-            assertEquals("True fuzzy 2!", entry.source);
-            assertEquals("trans6", entry.translation);
+            assertEquals("True fuzzy 2!", tmEntries.getEntries().get(1).getSource());
+            assertEquals("trans6", tmEntries.getEntries().get(1).getTranslation());
         }
     }
 

--- a/test/src/org/omegat/languagetools/FalseFriendsTest.java
+++ b/test/src/org/omegat/languagetools/FalseFriendsTest.java
@@ -33,17 +33,16 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.languagetools.LanguageToolWrapper.LanguageToolMarker;
@@ -67,15 +66,6 @@ public class FalseFriendsTest extends TestCore {
         };
 
         Core.setProject(new IProject() {
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
-            }
-
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, ExternalLinked externalLinked,
-                    AllTranslations previousTranslations) throws OptimisticLockingFail {
-            }
-
             public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
             }
 
@@ -145,6 +135,12 @@ public class FalseFriendsTest extends TestCore {
 
             public List<SourceTextEntry> getAllEntries() {
                 return null;
+            }
+
+            public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
+            }
+
+            public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations) {
             }
 
             public void compileProject(String sourcePattern) throws Exception {


### PR DESCRIPTION
Refactoring TMXEntry and PrepareTMXEntry classes based on [omegat-development ML discussion](https://sourceforge.net/p/omegat/mailman/omegat-development/thread/ab740468-a692-1cc6-dc9f-5540928da99f%40northside.tokyo/#msg37405978)

### Changes

- I don't change existent PrepareTMXEntry/TMXEntry public API
- add @Deprecate IProject#setTranslation with PrepareTMXEntry as argument
- `TMXEntry` and `PrepareTMXEntry`  now has common interface `ITranslationEntry`
- Extend `TMXEntry` class to hold `List<TMXProp> otherproperties` 
-  `ExternalTMX` hold immutable `TMXEntry` instead of mutable `PrepareTMXEntry`
    -  The change is motivated by a comment of @t-cordonnier that external TMXs are basically immutable.
    - `ExternalTMXFactory` uses TMXEntry::Builder
- Searcher:
```
private void searchEntries(Collection < PrepareTMXEntry > tmEn, final String tmxID) throws SearchLimitReachedException
private void searchEntriesAlternative(Collection < TMXEntry > tmEn, final String tmxID) throws SearchLimitReachedException
```
consolidated into
```
private void searchEntries(Iterable < ITMXEntry > tmEn, final String tmxID) throws SearchLimitReachedException
```

### A present for holiday season! 🎁 