### PR TITLE
Introduce TMXEntry::Builder

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -8,6 +8,7 @@
                2012 Aaron Madlon-Kay
                2013 Kyle Katarn, Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -59,7 +60,6 @@ import org.omegat.convert.ConvertConfigs;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.NotLoadedProject;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RealProject;
 import org.omegat.core.data.SourceTextEntry;
@@ -445,17 +445,23 @@ public final class Main {
         }
 
         // prepare tmx
-        Map<String, PrepareTMXEntry> data = new HashMap<>();
+        Map<String, TMXEntry> data = new HashMap<>();
+        TMXEntry entry;
         for (SourceTextEntry ste : entries) {
-            PrepareTMXEntry entry = new PrepareTMXEntry();
-            entry.source = ste.getSrcText();
             switch (pseudoTranslateType) {
-            case EQUAL:
-                entry.translation = ste.getSrcText();
-                break;
-            case EMPTY:
-                entry.translation = "";
-                break;
+                case EQUAL:
+                    entry = new TMXEntry.Builder()
+                            .setSource(ste.getSrcText())
+                            .setTranslation(ste.getSrcText())
+                            .build();
+                    break;
+                case EMPTY:
+                default:
+                    entry = new TMXEntry.Builder()
+                            .setSource(ste.getSrcText())
+                            .setTranslation("")
+                            .build();
+                    break;
             }
             data.put(ste.getSrcText(), entry);
         }
@@ -497,14 +503,8 @@ public final class Main {
         System.out.println(StringUtil.format(OStrings.getString("CONSOLE_ALIGN_AGAINST"), dir));
 
         Map<String, TMXEntry> data = p.align(p.getProjectProperties(), new File(dir));
-        Map<String, PrepareTMXEntry> result = new TreeMap<>();
-        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
-            result.put(en.getKey(), new PrepareTMXEntry(en.getValue()));
-        }
-
         String tmxFile = p.getProjectProperties().getProjectInternal() + "align.tmx";
-
-        TMXWriter.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), result);
+        TMXWriter.buildTMXFile(tmxFile, false, false, p.getProjectProperties(), data);
 
         p.closeProject();
         System.out.println(OStrings.getString("CONSOLE_FINISHED"));

--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -7,6 +7,7 @@
                2012 Thomas CORDONNIER
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -43,9 +44,9 @@ public class ExternalTMX {
 
     private final String name;
 
-    private final List<PrepareTMXEntry> entries;
+    private final List<TMXEntry> entries;
 
-    ExternalTMX(String name, List<PrepareTMXEntry> entries) {
+    ExternalTMX(String name, List<TMXEntry> entries) {
         this.name = name;
         this.entries = entries;
     }
@@ -54,7 +55,7 @@ public class ExternalTMX {
         return name;
     }
 
-    public List<PrepareTMXEntry> getEntries() {
+    public List<TMXEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }
 }

--- a/src/org/omegat/core/data/IProject.java
+++ b/src/org/omegat/core/data/IProject.java
@@ -7,6 +7,7 @@
                2010 Didier Briel
                2014-2015 Alex Buloichik
                2017 Didier Briel
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -142,15 +143,42 @@ public interface IProject {
     /**
      * Set translation for entry.
      *
+     * @param ste source text entry.
+     * @param tmxEntry tmx entry.
+     */
+    void setTranslation(SourceTextEntry ste, TMXEntry tmxEntry);
+
+    /**
+     * Set translation for entry.
+     *
      * Optimistic locking will not be checked.
+     * for backward compatibility.
      *
      * @param entry
      *            entry
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked);
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked) throws OptimisticLockingFail {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked));
+    }
+
+    /**
+     * Set translation for entry with optimistic lock checking: if previous translation is not the same like
+     * in storage, OptimisticLockingFail exception will be generated. Use when user has typed a new
+     * translation.
+     * for backward compatibility.
+     *
+     * @param entry
+     *            entry
+     * @param trans
+     *            translation. It can't be null
+     */
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked, AllTranslations previous) throws OptimisticLockingFail {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked), previous);
+    }
 
     /**
      * Set translation for entry with optimistic lock checking: if previous translation is not the same like
@@ -162,8 +190,7 @@ public interface IProject {
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked, AllTranslations previousTranslations)
+    void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
             throws OptimisticLockingFail;
 
     /**

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -6,6 +6,7 @@
  Copyright (C) 2014 Alex Buloichik, Didier Briel
                2019 Aaron Madlon-Kay
                2020 Briac Pilpre
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.omegat.util.StringUtil;
 import org.omegat.util.TMXProp;
 
 /**
@@ -66,7 +66,7 @@ public class ImportFromAutoTMX {
      */
     void process(ExternalTMX tmx, boolean isEnforcedTMX) {
 
-        for (PrepareTMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
+        for (TMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
             List<SourceTextEntry> list = existEntries.get(e.source);
             if (list == null) {
                 continue; // there is no entries for this source
@@ -128,7 +128,7 @@ public class ImportFromAutoTMX {
         }
     }
 
-    private boolean isAltTranslation(PrepareTMXEntry entry) {
+    private boolean isAltTranslation(TMXEntry entry) {
         if (entry.otherProperties == null) {
             return false;
         }
@@ -148,7 +148,7 @@ public class ImportFromAutoTMX {
         return EntryKey.isIgnoreFileContext() ? hasOtherProp : hasFileProp;
     }
 
-    private boolean altTranslationMatches(PrepareTMXEntry entry, EntryKey key) {
+    private boolean altTranslationMatches(TMXEntry entry, EntryKey key) {
         if (entry.otherProperties == null) {
             return false;
         }
@@ -172,21 +172,15 @@ public class ImportFromAutoTMX {
         return key.equals(new EntryKey(file, entry.source, id, prev, next, path));
     }
 
-    private void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
-        if (StringUtil.isEmpty(trans.note)) {
-            trans.note = null;
-        }
-
-        trans.source = entry.getSrcText();
-
+    private void setTranslation(SourceTextEntry entry, TMXEntry trans, boolean defaultTranslation,
+                                TMXEntry.ExternalLinked externalLinkedMode) {
         TMXEntry newTrEntry;
-
         if (trans.translation == null && trans.note == null) {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
+            // create new entry with default translation flag and external link mode.
+            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinkedMode);
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
     }

--- a/src/org/omegat/core/data/NotLoadedProject.java
+++ b/src/org/omegat/core/data/NotLoadedProject.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.filters2.TranslationException;
 import org.omegat.tokenizer.ITokenizer;
@@ -139,12 +138,11 @@ public class NotLoadedProject implements IProject {
     public void saveProjectProperties() throws IOException {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked) {
+    public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked, AllTranslations previousTranslations) throws OptimisticLockingFail {
+    public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
+            throws OptimisticLockingFail {
     }
 
     public ITokenizer getSourceTokenizer() {

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik, Aaron Madlon-Kay
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -28,7 +29,12 @@
 
 package org.omegat.core.data;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Storage for TMX entry.
@@ -55,8 +61,21 @@ public class TMXEntry {
     public final String creator;
     public final long creationDate;
     public final String note;
+    public List<TMXProp> otherProperties;
     public final boolean defaultTranslation;
     public final ExternalLinked linked;
+
+    TMXEntry(TMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        this.source = from.source;
+        this.translation = from.translation;
+        this.changer = from.changer;
+        this.changeDate = from.changeDate;
+        this.creator = from.creator;
+        this.creationDate = from.creationDate;
+        this.note = from.note;
+        this.linked = linked;
+        this.defaultTranslation = defaultTranslation;
+    }
 
     TMXEntry(PrepareTMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
         this.source = from.source;
@@ -77,6 +96,49 @@ public class TMXEntry {
 
     public boolean hasNote() {
         return note != null;
+    }
+
+    public String getPropValue(String propType) {
+        if (otherProperties == null) {
+            return null;
+        }
+        for (int i = 0; i < otherProperties.size(); i++) {
+            TMXProp kv = otherProperties.get(i);
+            if (propType.equals(kv.getType())) {
+                return kv.getValue();
+            }
+        }
+        return null;
+    }
+
+    public boolean hasPropValue(String propType, String propValue) {
+        if (otherProperties == null) {
+            return false;
+        }
+        for (int i = 0; i < otherProperties.size(); i++) {
+            TMXProp kv = otherProperties.get(i);
+            if (propType.equals(kv.getType())) {
+                if (propValue == null) {
+                    return true;
+                }
+                if (propValue.equals(kv.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public Iterable<TMXProp> getProperties() {
+        return Collections.unmodifiableCollection(otherProperties);
+    }
+
+    public ExternalLinked getLinked() {
+        return linked;
+    }
+
+    public boolean isDefaultTranslation() {
+        return defaultTranslation;
     }
 
     @Override

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -206,4 +206,156 @@ public class TMXEntry {
         }
         return true;
     }
+
+    /* provide builder for TMXEntry.
+       other classes can build TMXEntry by calling such as
+       TMXEntry::Builder.setSource(source).setTranslation(translation).build();
+     */
+    private TMXEntry(final String source, final String translation, final String changer, final long changeDate,
+                     final String creator, final long creationDate, final String note,
+                     final List<TMXProp> otherProperties,
+                     final boolean defaultTranslation,
+                     final ExternalLinked linked) {
+        this.source = source;
+        this.translation = translation;
+        this.changer = changer;
+        this.changeDate = changeDate;
+        this.creator = creator;
+        this.creationDate = creationDate;
+        this.note = note;
+        this.otherProperties = otherProperties;
+        this.defaultTranslation = defaultTranslation;
+        this.linked = linked;
+    }
+
+    /**
+     * TMXEntry object builder.
+     */
+    public static final class Builder {
+        private String source;
+        private String translation;
+        private String changer;
+        private long changeDate;
+        private String creator;
+        private long creationDate;
+        private String note;
+        public List<TMXProp> otherProperties;
+        private boolean defaultTranslation;
+        private ExternalLinked linked;
+
+        public Builder() {
+        }
+
+        /**
+         * build method for TMXEntry object.
+         * @return TMXEntry object.
+         */
+        public TMXEntry build() {
+            return new TMXEntry(source, translation, changer, changeDate, creator, creationDate, note,
+                    otherProperties, defaultTranslation, linked);
+        }
+
+        /**
+         * Set source text.
+         * @param source text.
+         * @return builder.
+         */
+        public Builder setSource(final String source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Set translation text.
+         * @param translation text.
+         * @return builder.
+         */
+        public Builder setTranslation(final String translation) {
+            this.translation = translation;
+            return this;
+        }
+
+        /**
+         * Set changer name.
+         * @param changer name.
+         * @return builder.
+         */
+        public Builder setChanger(final String changer) {
+            this.changer = changer;
+            return this;
+        }
+
+        /**
+         * Set change date.
+         * @param changeDate long date value.
+         * @return builder.
+         */
+        public Builder setChangeDate(final long changeDate) {
+            this.changeDate = changeDate;
+            return this;
+        }
+
+        /**
+         * Set creator name
+         * @param creator name.
+         * @return builder.
+         */
+        public Builder setCreator(final String creator) {
+            this.creator = creator;
+            return this;
+        }
+
+        /**
+         * Set creation date.
+         * @param creationDate long value of date.
+         * @return builder.
+         */
+        public Builder setCreationDate(final long creationDate) {
+            this.creationDate = creationDate;
+            return this;
+        }
+
+        /**
+         * Set note.
+         * @param note text.
+         * @return builder.
+         */
+        public Builder setNote(final String note) {
+            this.note = note;
+            return this;
+        }
+
+        /**
+         * Set whether it is default translation.
+         * @param defaultTranslation true when defualt translation.
+         * @return builder.
+         */
+        public Builder setDefaultTranslation(final boolean defaultTranslation) {
+            this.defaultTranslation = defaultTranslation;
+            return this;
+        }
+
+        /**
+         * Set external link.
+         * @param linked external link.
+         * @return builder.
+         */
+        public Builder setExternalLinked(final ExternalLinked linked) {
+            this.linked = linked;
+            return this;
+        }
+
+        public Builder setProperties(final List<TMXProp> properties) {
+            otherProperties = properties;
+            return this;
+        }
+
+        public Builder setProperty(String propType, String propValue) {
+            if (otherProperties == null) {
+                otherProperties = new ArrayList<>();
+            }
+            otherProperties.add(new TMXProp(propType, propValue));
+            return this;
+        }
+    }
 }

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -358,7 +358,7 @@ public class Searcher {
             if (!searchExpression.searchAuthor && !searchExpression.searchDateAfter && !searchExpression.searchDateBefore) {
                 for (Map.Entry<String, ExternalTMX> tmEn : m_project.getTransMemories().entrySet()) {
                     final String fileTM = tmEn.getKey();
-                    searchEntries(tmEn.getValue().getEntries(), fileTM);
+                    searchEntriesAlternative(tmEn.getValue().getEntries(), fileTM);
                     checkStop.checkInterrupted();
                 }
                 for (Map.Entry<Language, ProjectTMX> tmEn : m_project.getOtherTargetLanguageTMs().entrySet()) {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -44,7 +44,6 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.data.IProject.MultipleTranslationsIterator;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
@@ -227,7 +226,7 @@ public class FindMatches {
             if (matcher.find()) {
                 penalty = Integer.parseInt(matcher.group(1));
             }
-            for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
+            for (TMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
                 if (tmen.source == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.omegat.core.Core;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.search.SearchMatch;
@@ -119,9 +118,12 @@ public class ReplaceFilter implements IEditorFilter {
                     o.replace(m.getStart() + off, m.getEnd() + off, m.getReplacement());
                     off += m.getReplacement().length() - m.getLength();
                 }
-                PrepareTMXEntry prepare = new PrepareTMXEntry(en);
-                prepare.translation = o.toString();
-                Core.getProject().setTranslation(ste, prepare, en.defaultTranslation, null);
+                TMXEntry tmxEntry = new TMXEntry.Builder()
+                        .setSource(en.source)
+                        .setTranslation(o.toString())
+                        .setDefaultTranslation(en.isDefaultTranslation())
+                        .build();
+                Core.getProject().setTranslation(ste, tmxEntry);
             }
         }
         EditorController ec = (EditorController) Core.getEditor();

--- a/src/org/omegat/util/TMXWriter.java
+++ b/src/org/omegat/util/TMXWriter.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.TMXEntry;
 
 /**
  * Class that store TMX (Translation Memory Exchange) files.
@@ -67,7 +67,7 @@ public final class TMXWriter {
      * @throws IOException
      */
     public static void buildTMXFile(final String filename, final boolean forceValidTMX,
-            final boolean levelTwo, final ProjectProperties config, final Map<String, PrepareTMXEntry> data)
+            final boolean levelTwo, final ProjectProperties config, final Map<String, TMXEntry> data)
             throws IOException {
         // we got this far, so assume lang codes are proper
         String sourceLocale = config.getSourceLanguage().toString();
@@ -115,12 +115,12 @@ public final class TMXWriter {
         String langAttr = levelTwo ? "xml:lang" : "lang";
 
         // Write TUs
-        String source = null;
-        String target = null;
+        String source;
+        String target;
         String note = null;
         TMXDateParser dateParser = new TMXDateParser();
-        for (Map.Entry<String, PrepareTMXEntry> en : data.entrySet()) {
-            PrepareTMXEntry transEntry = en.getValue();
+        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
+            TMXEntry transEntry = en.getValue();
             source = forceValidTMX ? TagUtil.stripXmlTags(en.getKey()) : en.getKey();
             target = forceValidTMX ? TagUtil.stripXmlTags(transEntry.translation) : transEntry.translation;
             source = StringUtil.makeValidXML(source);

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -178,11 +178,12 @@ public final class TestTeamIntegrationChild {
 
     static void changeConcurrent() throws Exception {
         checkAll();
-
-        PrepareTMXEntry prep = new PrepareTMXEntry();
-        prep.translation = "" + System.currentTimeMillis();
-        Core.getProject().setTranslation(steC, prep, true, null);
-        Log.log("Wrote: " + prep.source + "=" + prep.translation);
+        TMXEntry entry = new TMXEntry.Builder()
+                .setTranslation("" + System.currentTimeMillis())
+                .setDefaultTranslation(true)
+                .build();
+        Core.getProject().setTranslation(steC, entry);
+        Log.log("Wrote: " + entry.source + "=" + entry.translation);
     }
 
     static void checksavecheck(int index) throws Exception {
@@ -250,10 +251,12 @@ public final class TestTeamIntegrationChild {
      * Save new translation.
      */
     static void saveTranslation(SourceTextEntry ste, long value) {
-        PrepareTMXEntry prep = new PrepareTMXEntry();
-        prep.translation = "" + value;
-        Core.getProject().setTranslation(ste, prep, true, null);
-        Log.log("Wrote: " + prep.source + "=" + prep.translation);
+        TMXEntry en = new TMXEntry.Builder()
+                .setTranslation("" + value)
+                .setDefaultTranslation(true)
+                .build();
+        Core.getProject().setTranslation(ste, en);
+        Log.log("Wrote: " + en.source + "=" + en.translation);
         Core.getProject().saveProject(true);
     }
 

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -64,12 +64,9 @@ public class AutoTmxTest {
                 .setDoSegmenting(props.isSentenceSegmentingEnabled())
                 .load(props.getSourceLanguage(), props.getTargetLanguage());
 
-        PrepareTMXEntry e1 = autoTMX.getEntries().get(0);
-        checkListValues(e1, ProjectTMX.PROP_XICE, "11");
-
-        PrepareTMXEntry e2 = autoTMX.getEntries().get(1);
-        checkListValues(e2, ProjectTMX.PROP_XICE, "12");
-        checkListValues(e2, ProjectTMX.PROP_X100PC, "10");
+        assertTrue(autoTMX.getEntries().get(0).hasPropValue(ProjectTMX.PROP_XICE, "11"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_XICE, "12"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_X100PC, "10"));
 
         Core.initializeConsole(new HashMap<String, String>());
 
@@ -131,10 +128,6 @@ public class AutoTmxTest {
     SourceTextEntry createSTE(String id, String source) {
         EntryKey ek = new EntryKey("file", source, id, null, null, null);
         return new SourceTextEntry(ek, 0, null, null, new ArrayList<ProtectedPart>());
-    }
-
-    void checkListValues(PrepareTMXEntry en, String propType, String propValue) {
-        assertTrue(en.hasPropValue(propType, propValue));
     }
 
     void checkTranslation(SourceTextEntry ste, String expectedTranslation,

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -156,9 +156,9 @@ public class ExternalTMFactoryTest extends TestCore {
         // Only 5 FR translations
         assertEquals(5, tmx.getEntries().size());
 
-        List<PrepareTMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(3, matchingEntries.size());
+
+        assertEquals(3,
+                tmx.getEntries().stream().filter(t -> t.source.equals("Hello " + "World!")).count());
         
         // Set the EXT_TMX_KEEP_FOREIGN_MATCH prop
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, true);
@@ -167,24 +167,21 @@ public class ExternalTMFactoryTest extends TestCore {
         // All foreign translations are present
         assertEquals(14, tmx.getEntries().size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(8, matchingEntries.size());
+        assertEquals(8,
+                tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!")).count());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
+        List<TMXEntry> matchingEntries = tmx.getEntries().stream()
+                .filter(t -> t.source.equals("This is an english sentence."))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
 
-        PrepareTMXEntry entry = matchingEntries.get(0);
-        assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "EN-US"));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(1);
-        assertEquals("DE", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "DE"));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(2);
-        assertEquals("ES", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "ES"));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
     }
 }

--- a/test/src/org/omegat/core/data/MergeTest.java
+++ b/test/src/org/omegat/core/data/MergeTest.java
@@ -26,6 +26,7 @@ package org.omegat.core.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
@@ -54,44 +55,76 @@ public class MergeTest {
 
     @Test
     public void testEquals() throws Exception {
-        PrepareTMXEntry e1 = new PrepareTMXEntry();
-        e1.translation = "trans";
-        e1.changeDate = 123456999;
-        PrepareTMXEntry e2 = new PrepareTMXEntry();
-        e2.translation = "trans";
-        e2.changeDate = 123456999;
+        TMXEntry e1 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e2 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e3 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456000)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e4 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123457000)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e5 = new TMXEntry.Builder()
+                .setTranslation("t")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e6 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setNote("n")
+                .build();
+        TMXEntry e7 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChanger("c")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .build();
+        TMXEntry e8 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setExternalLinked(ExternalLinked.xICE)
+                .build();
+        TMXEntry e9 = new TMXEntry.Builder()
+                .setTranslation("trans")
+                .setChangeDate(123456999)
+                .setDefaultTranslation(true)
+                .setExternalLinked(ExternalLinked.x100PC)
+                .build();
 
         // test equals
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertEquals(e1, e2);
 
-        e2.changeDate = 123456000;
         // test truncated time
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertEquals(e1, e3);
 
-        e2.changeDate = 123457000;
         // test other time
-        assertFalse(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
-        e2.changeDate = 123456999;
+        assertNotEquals(e1, e4);
 
-        e2.translation = "t";
         // test different translation
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.translation = "trans";
+        assertFalse(e1.equalsTranslation(e5));
 
-        e2.note = "n";
         // test different note
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.note = null;
+        assertFalse(e1.equalsTranslation(e6));
 
-        e2.changer = "c";
         // test different changer
-        assertTrue(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
-        e2.changer = null;
+        assertTrue(e1.equalsTranslation(e7));
 
         // test different linked
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE).equalsTranslation(new TMXEntry(e2, true,
-                ExternalLinked.x100PC)));
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE)
-                .equalsTranslation(new TMXEntry(e2, true, null)));
+        assertFalse(e8.equalsTranslation(e9));
+        assertFalse(e8.equalsTranslation(e2));
     }
 }

--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -161,19 +161,23 @@ public class RealProjectTest {
     private void setDefault(String source, String translation) {
         EntryKey key = new EntryKey(null, source, null, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, true, null), true);
+        TMXEntry entry = new TMXEntry.Builder()
+                .setSource(source)
+                .setTranslation(translation)
+                .setDefaultTranslation(true)
+                .build();
+        tmx.setTranslation(ste, entry, true);
     }
 
     private void setAlternative(String id, String source, String translation) {
         EntryKey key = new EntryKey("test", source, id, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, false, null), false);
+        TMXEntry en = new TMXEntry.Builder()
+                .setSource(source)
+                .setTranslation(translation)
+                .setDefaultTranslation(false)
+                .build();
+        tmx.setTranslation(ste, en, false);
     }
 
     private void checkDefault(String source, String translation) {
@@ -220,6 +224,8 @@ public class RealProjectTest {
     }
 
     public static TMXEntry createEmptyTMXEntry() {
-        return new TMXEntry(new PrepareTMXEntry(), true, null);
+        return new TMXEntry.Builder()
+                .setDefaultTranslation(true)
+                .build();
     }
 }

--- a/test/src/org/omegat/core/data/TmxComplianceTests.java
+++ b/test/src/org/omegat/core/data/TmxComplianceTests.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.html2.HTMLFilter2;
 import org.omegat.filters2.html2.HTMLOptions;
@@ -389,9 +390,6 @@ public class TmxComplianceTests extends TmxComplianceBase {
     }
 
     TMXEntry createTMXEntry(String source, String translation, boolean def) {
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        return new TMXEntry(tr, def, null);
+        return new TMXEntry.Builder().setSource(source).setTranslation(translation).setDefaultTranslation(def).build();
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.Test;
+
 import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -82,14 +82,12 @@ public class POFilterTest extends TestFilterBase {
         ExternalTMX tmEntries = fi.referenceEntries;
         assertEquals(2, tmEntries.getEntries().size());
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(0);
-            assertEquals("True fuzzy!", entry.source);
-            assertEquals("trans5", entry.translation);
+            assertEquals("True fuzzy!", tmEntries.getEntries().get(0).source);
+            assertEquals("trans5", tmEntries.getEntries().get(0).translation);
         }
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(1);
-            assertEquals("True fuzzy 2!", entry.source);
-            assertEquals("trans6", entry.translation);
+            assertEquals("True fuzzy 2!", tmEntries.getEntries().get(1).source);
+            assertEquals("trans6", tmEntries.getEntries().get(1).translation);
         }
     }
 

--- a/test/src/org/omegat/languagetools/FalseFriendsTest.java
+++ b/test/src/org/omegat/languagetools/FalseFriendsTest.java
@@ -33,17 +33,16 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.languagetools.LanguageToolWrapper.LanguageToolMarker;
@@ -67,15 +66,6 @@ public class FalseFriendsTest extends TestCore {
         };
 
         Core.setProject(new IProject() {
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
-            }
-
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, ExternalLinked externalLinked,
-                    AllTranslations previousTranslations) throws OptimisticLockingFail {
-            }
-
             public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
             }
 
@@ -145,6 +135,12 @@ public class FalseFriendsTest extends TestCore {
 
             public List<SourceTextEntry> getAllEntries() {
                 return null;
+            }
+
+            public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
+            }
+
+            public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations) {
             }
 
             public void compileProject(String sourcePattern) throws Exception {


### PR DESCRIPTION
This is minimalist approach of #182
Here does same as #182,  but not refactoring for getter replacement.

This includes commits;

1. TMXEntry hold otherProperties
    TMXEntry also hold otherProperties which PrepareTMXEntry has. This make TMXEntry  immutable version of PrepareTMXEntry, and allow using it for replacement of PrepareTMXEntry in some place
2. Update AutoTmxTest and PoFilterTtest
    Hide explicit variable of PrepareTMXEntry, for future replacement to TMXEntry
3. Introduce TMXEntry::Builder
4. MergeTest to test with TMXEntry::Builder
    MergeTest tests equivalence of objects. For future replacement from PrepareTMXEntry to TMXEntry, this checks equivalence.
5. ReplaceFilter: use TMXEntry::Builder
6. Main use TMXEntry::Builder and TMXWtiter accept TMXEntry as argument
7. TMXComplianceTest: use TMXEntry::Builder
8. ProjectTMX: use TMXEntry::Builder
    This looks many changes, but it carefully remove PreapreTMXEntry object used as an intermediate variable.
9. Add IProject#setTranslation methods with TMXEntry object
    this prepare future replacement of the method
10. integrationTest: use TMXEntry::Builder
     the test code depends IProject#setTranslation
11. ExternalTMXFactory: return immutable TMXEntry
     this changes public API of external TMX file handlings.  