### PR TITLE
Refactor tmx entry

### DIFF
--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -43,7 +43,7 @@ public class ExternalTMX {
 
     private final String name;
 
-    private final List<PrepareTMXEntry> entries;
+    private final List<? extends ITMXEntry> entries;
 
     ExternalTMX(String name, List<PrepareTMXEntry> entries) {
         this.name = name;
@@ -54,7 +54,7 @@ public class ExternalTMX {
         return name;
     }
 
-    public List<PrepareTMXEntry> getEntries() {
+    public List<ITMXEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }
 }

--- a/src/org/omegat/core/data/ITMXEntry.java
+++ b/src/org/omegat/core/data/ITMXEntry.java
@@ -25,6 +25,9 @@
 
 package org.omegat.core.data;
 
+import java.util.List;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Common interface for any object storing a pair source / translation text
@@ -62,4 +65,14 @@ public interface ITMXEntry extends ITranslationEntry {
     default boolean hasNote() {
         return getNote() != null;
     }
+
+    /* --------------------- Properties ------------ */
+
+    boolean hasProperties();
+
+    String getPropValue(String propType);
+
+    boolean hasPropValue(String propType, String propValue);
+
+    List<TMXProp> getProperties();
 }

--- a/src/org/omegat/core/data/ITMXEntry.java
+++ b/src/org/omegat/core/data/ITMXEntry.java
@@ -1,0 +1,65 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Thomas Cordonnier
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+
+/**
+ * Common interface for any object storing a pair source / translation text
+ * with date and author
+ *
+ * @author Thomas Cordonnier
+ */
+public interface ITMXEntry extends ITranslationEntry {
+
+    /**
+     * Gets the initial creator of the entry
+     */
+    String getCreator();
+
+    /**
+     * Gets the initial creation date as an EPOCH timestamp
+     */
+    long getCreationDate();
+
+    /**
+     * Gets the author of last change in the entry
+     */
+    String getChanger();
+
+    /**
+     * Gets the EPOCH timestamp for last change in this entry
+     */
+    long getChangeDate();
+
+    /**
+     * Gets text note (markup &lt;note&gt; in TMX format)
+     */
+    String getNote();
+
+    default boolean hasNote() {
+        return getNote() != null;
+    }
+}

--- a/src/org/omegat/core/data/ITranslationEntry.java
+++ b/src/org/omegat/core/data/ITranslationEntry.java
@@ -1,0 +1,53 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Thomas Cordonnier
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+
+/**
+ * Common interface for any object storing a pair source / translation text
+ *
+ * @author Thomas Cordonnier
+ */
+public interface ITranslationEntry {
+
+    /**
+     * Gets the source text
+     */
+    String getSourceText();
+
+    /**
+     * Gets translation text
+     */
+    String getTranslationText();
+
+    /**
+     * Check whenever there is a translation
+     */
+    default boolean isTranslated() {
+        return getTranslationText() != null;
+    }
+
+}

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.omegat.util.StringUtil;
 import org.omegat.util.TMXProp;
 
 /**
@@ -66,8 +65,8 @@ public class ImportFromAutoTMX {
      */
     void process(ExternalTMX tmx, boolean isEnforcedTMX) {
 
-        for (PrepareTMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
-            List<SourceTextEntry> list = existEntries.get(e.source);
+        for (ITMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
+            List<SourceTextEntry> list = existEntries.get(e.getSourceText());
             if (list == null) {
                 continue; // there is no entries for this source
             }
@@ -113,13 +112,13 @@ public class ImportFromAutoTMX {
                             || existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
                         // already contains x-ice
                         if (hasICE
-                                && !Objects.equals(existTranslation.translation, e.translation)) {
+                                && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
                             setTranslation(ste, e, false, TMXEntry.ExternalLinked.xICE);
                         }
                     } else if (existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
                         // already contains x-100pc
                         if (has100PC
-                                && !Objects.equals(existTranslation.translation, e.translation)) {
+                                && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
                             setTranslation(ste, e, false, TMXEntry.ExternalLinked.x100PC);
                         }
                     }
@@ -128,13 +127,13 @@ public class ImportFromAutoTMX {
         }
     }
 
-    private boolean isAltTranslation(PrepareTMXEntry entry) {
-        if (entry.otherProperties == null) {
+    private boolean isAltTranslation(ITMXEntry entry) {
+        if (!entry.hasProperties()) {
             return false;
         }
         boolean hasFileProp = false;
         boolean hasOtherProp = false;
-        for (TMXProp p : entry.otherProperties) {
+        for (TMXProp p : entry.getProperties()) {
             if (p.getType().equals(ProjectTMX.PROP_FILE)) {
                 hasFileProp = true;
             } else if (p.getType().equals(ProjectTMX.PROP_ID)
@@ -148,12 +147,12 @@ public class ImportFromAutoTMX {
         return EntryKey.isIgnoreFileContext() ? hasOtherProp : hasFileProp;
     }
 
-    private boolean altTranslationMatches(PrepareTMXEntry entry, EntryKey key) {
-        if (entry.otherProperties == null) {
+    private boolean altTranslationMatches(ITMXEntry entry, EntryKey key) {
+        if (!entry.hasProperties()) {
             return false;
         }
         String file = null, id = null, next = null, prev = null, path = null;
-        for (TMXProp p : entry.otherProperties) {
+        for (TMXProp p : entry.getProperties()) {
             if (ProjectTMX.PROP_FILE.equals(p.getType())) {
                 file = p.getValue();
             } else if (ProjectTMX.PROP_ID.equals(p.getType())) {
@@ -169,20 +168,14 @@ public class ImportFromAutoTMX {
                 path = p.getValue();
             }
         }
-        return key.equals(new EntryKey(file, entry.source, id, prev, next, path));
+        return key.equals(new EntryKey(file, entry.getSourceText(), id, prev, next, path));
     }
 
-    private void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+    private void setTranslation(SourceTextEntry entry, ITMXEntry trans, boolean defaultTranslation,
             TMXEntry.ExternalLinked externalLinked) {
-        if (StringUtil.isEmpty(trans.note)) {
-            trans.note = null;
-        }
-
-        trans.source = entry.getSrcText();
-
         TMXEntry newTrEntry;
 
-        if (trans.translation == null && trans.note == null) {
+        if ((!trans.isTranslated()) && (!trans.hasNote())) {
             // no translation, no note
             newTrEntry = null;
         } else {

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -95,6 +95,14 @@ public class PrepareTMXEntry implements ITMXEntry {
         return note;
     }
 
+    public boolean hasProperties() {
+        return (otherProperties != null) && (otherProperties.size() > 0);
+    }
+
+    public List<TMXProp> getProperties() {
+        return otherProperties;
+    }
+
     public String getPropValue(String propType) {
         if (otherProperties == null) {
             return null;

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -44,7 +44,7 @@ import org.omegat.util.TMXProp;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class PrepareTMXEntry {
+public class PrepareTMXEntry implements ITMXEntry {
     public String source;
     public String translation;
     public String changer;
@@ -65,6 +65,34 @@ public class PrepareTMXEntry {
         creator = e.creator;
         creationDate = e.creationDate;
         note = e.note;
+    }
+
+    public String getSourceText() {
+        return source;
+    }
+
+    public String getTranslationText() {
+        return translation;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    public String getChanger() {
+        return changer;
+    }
+
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    public String getNote() {
+        return note;
     }
 
     public String getPropValue(String propType) {

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -28,7 +28,10 @@
 
 package org.omegat.core.data;
 
+import java.util.List;
 import java.util.Objects;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Storage for TMX entry.
@@ -58,14 +61,14 @@ public class TMXEntry implements ITMXEntry {
     public final boolean defaultTranslation;
     public final ExternalLinked linked;
 
-    TMXEntry(PrepareTMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
-        this.source = from.source;
-        this.translation = from.translation;
-        this.changer = from.changer;
-        this.changeDate = from.changeDate;
-        this.creator = from.creator;
-        this.creationDate = from.creationDate;
-        this.note = from.note;
+    TMXEntry(ITMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        this.source = from.getSourceText();
+        this.translation = from.getTranslationText();
+        this.changer = from.getChanger();
+        this.changeDate = from.getChangeDate();
+        this.creator = from.getCreator();
+        this.creationDate = from.getCreationDate();
+        this.note = from.getNote();
 
         this.defaultTranslation = defaultTranslation;
         this.linked = linked;
@@ -163,5 +166,21 @@ public class TMXEntry implements ITMXEntry {
             return false;
         }
         return true;
+    }
+
+    public boolean hasProperties() {
+        return false;
+    }
+
+    public String getPropValue(String propType) {
+        return null; // for the moment internal entries do not store properties
+    }
+
+    public boolean hasPropValue(String propType, String propValue) {
+        return false; // for the moment internal entries do not store properties
+    }
+
+    public List<TMXProp> getProperties() {
+        return null; // for the moment internal entries do not store properties
     }
 }

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class TMXEntry {
+public class TMXEntry implements ITMXEntry {
     public enum ExternalLinked {
         // declares how this entry linked to external TMX in the tm/auto/
         xICE, x100PC, xAUTO, xENFORCED
@@ -71,12 +71,32 @@ public class TMXEntry {
         this.linked = linked;
     }
 
-    public boolean isTranslated() {
-        return translation != null;
+    public String getSourceText() {
+        return source;
     }
 
-    public boolean hasNote() {
-        return note != null;
+    public String getTranslationText() {
+        return translation;
+    }
+    
+    public String getCreator() {
+        return creator;
+    }
+
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    public String getChanger() {
+        return changer;
+    }
+
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    public String getNote() {
+        return note;
     }
 
     @Override

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -44,7 +44,7 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.data.IProject.MultipleTranslationsIterator;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
@@ -227,13 +227,13 @@ public class FindMatches {
             if (matcher.find()) {
                 penalty = Integer.parseInt(matcher.group(1));
             }
-            for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
+            for (ITMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
-                if (tmen.source == null) {
+                if (tmen.getSourceText() == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.
                     continue;
                 }
-                if (requiresTranslation && tmen.translation == null) {
+                if (requiresTranslation && tmen.getTranslationText() == null) {
                     continue;
                 }
 
@@ -242,9 +242,9 @@ public class FindMatches {
                     tmenPenalty += foreignPenalty;
                 }
 
-                processEntry(null, tmen.source, tmen.translation, NearString.MATCH_SOURCE.TM, false, tmenPenalty,
-                        en.getKey(), tmen.creator, tmen.creationDate, tmen.changer, tmen.changeDate,
-                        tmen.otherProperties);
+                processEntry(null, tmen.getSourceText(), tmen.getTranslationText(), NearString.MATCH_SOURCE.TM, false, tmenPenalty,
+                        en.getKey(), tmen.getCreator(), tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(),
+                        tmen.getProperties());
             }
         }
 

--- a/src/org/omegat/gui/glossary/GlossaryEntry.java
+++ b/src/org/omegat/gui/glossary/GlossaryEntry.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.omegat.core.data.ITranslationEntry;
 import org.omegat.util.StringUtil;
 
 /**
@@ -40,7 +41,7 @@ import org.omegat.util.StringUtil;
  * @author Aaron Madlon-Kay
  * @author Alex Buloichik
  */
-public class GlossaryEntry {
+public class GlossaryEntry implements ITranslationEntry {
     public GlossaryEntry(String src, String[] loc, String[] com, boolean[] fromPriorityGlossary, String[] origins) {
         mSource = StringUtil.normalizeUnicode(src);
         mTargets = loc;
@@ -60,6 +61,16 @@ public class GlossaryEntry {
         return mSource;
     }
 
+    /* Method for ITranslationEntry */
+    public String getSourceText() {
+        return mSource;
+    }
+    
+    /* Method for ITranslationEntry */
+    public String getTranslationText() {
+        return mTargets.length > 0 ? mTargets[0] : "";
+    }
+    
     /**
      * Return the first target-language term string.
      *

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -64,10 +64,10 @@ public class AutoTmxTest {
                 .setDoSegmenting(props.isSentenceSegmentingEnabled())
                 .load(props.getSourceLanguage(), props.getTargetLanguage());
 
-        PrepareTMXEntry e1 = autoTMX.getEntries().get(0);
+        ITMXEntry e1 = autoTMX.getEntries().get(0);
         checkListValues(e1, ProjectTMX.PROP_XICE, "11");
 
-        PrepareTMXEntry e2 = autoTMX.getEntries().get(1);
+        ITMXEntry e2 = autoTMX.getEntries().get(1);
         checkListValues(e2, ProjectTMX.PROP_XICE, "12");
         checkListValues(e2, ProjectTMX.PROP_X100PC, "10");
 
@@ -133,7 +133,7 @@ public class AutoTmxTest {
         return new SourceTextEntry(ek, 0, null, null, new ArrayList<ProtectedPart>());
     }
 
-    void checkListValues(PrepareTMXEntry en, String propType, String propValue) {
+    void checkListValues(ITMXEntry en, String propType, String propValue) {
         assertTrue(en.hasPropValue(propType, propValue));
     }
 

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -89,10 +89,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslationText());
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(1013, tmx.getEntries().size());
-        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).source);
+        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).getSourceText());
         assertEquals(
                 "\u0412\u044B\u043B\u0443\u0447\u044D\u043D\u044C\u043D\u0435 "
                         + "&\u043A\u043E\u043B\u0435\u0440\u0430\u043C "
                         + "\u0441\u044B\u043D\u0442\u0430\u043A\u0441\u044B\u0441\u0443",
-                tmx.getEntries().get(0).translation);
-        assertEquals("< Auto >", tmx.getEntries().get(1).source);
+                tmx.getEntries().get(0).getTranslationText());
+        assertEquals("< Auto >", tmx.getEntries().get(1).getSourceText());
         assertEquals("\u041F\u0440\u0430 \u043F\u0440\u0430\u0433\u0440\u0430\u043C\u0443",
-                tmx.getEntries().get(1).translation);
+                tmx.getEntries().get(1).getTranslationText());
     }
 
     @Test
@@ -128,10 +128,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(33, tmx.getEntries().size());
-        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).source);
-        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).translation);
-        assertEquals("Download %s in your language", tmx.getEntries().get(1).source);
-        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).translation);
+        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Download %s in your language", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).getTranslationText());
     }
 
     /**
@@ -156,7 +156,7 @@ public class ExternalTMFactoryTest extends TestCore {
         // Only 5 FR translations
         assertEquals(5, tmx.getEntries().size());
 
-        List<PrepareTMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
+        List<ITMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("Hello World!"))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
         
@@ -167,15 +167,15 @@ public class ExternalTMFactoryTest extends TestCore {
         // All foreign translations are present
         assertEquals(14, tmx.getEntries().size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
+        matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("Hello World!"))
                 .collect(Collectors.toList());
         assertEquals(8, matchingEntries.size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
+        matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("This is an english sentence."))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
 
-        PrepareTMXEntry entry = matchingEntries.get(0);
+        ITMXEntry entry = matchingEntries.get(0);
         assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
         assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
 

--- a/test/src/org/omegat/core/data/TmxSegmentationTest.java
+++ b/test/src/org/omegat/core/data/TmxSegmentationTest.java
@@ -64,8 +64,8 @@ public class TmxSegmentationTest {
                 });
 
         assertEquals(2, tmx.defaults.size());
-        assertEquals("Ceci est un test.", tmx.defaults.get("This is test.").translation);
-        assertEquals("Juste un test.", tmx.defaults.get("Just a test.").translation);
+        assertEquals("Ceci est un test.", tmx.defaults.get("This is test.").getTranslationText());
+        assertEquals("Juste un test.", tmx.defaults.get("Just a test.").getTranslationText());
     }
 
     @Test
@@ -74,9 +74,9 @@ public class TmxSegmentationTest {
                 .setDoSegmenting(true).load(new Language("en"), new Language("fr"));
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslationText());
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 import org.junit.Test;
 import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITMXEntry;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -82,14 +82,14 @@ public class POFilterTest extends TestFilterBase {
         ExternalTMX tmEntries = fi.referenceEntries;
         assertEquals(2, tmEntries.getEntries().size());
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(0);
-            assertEquals("True fuzzy!", entry.source);
-            assertEquals("trans5", entry.translation);
+            ITMXEntry entry = tmEntries.getEntries().get(0);
+            assertEquals("True fuzzy!", entry.getSourceText());
+            assertEquals("trans5", entry.getTranslationText());
         }
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(1);
-            assertEquals("True fuzzy 2!", entry.source);
-            assertEquals("trans6", entry.translation);
+            ITMXEntry entry = tmEntries.getEntries().get(1);
+            assertEquals("True fuzzy 2!", entry.getSourceText());
+            assertEquals("trans6", entry.getTranslationText());
         }
     }
 


### PR DESCRIPTION
Introduce interfaces to TMXEntry

These interfaces have multiple goals.

In short term, they enable to merge functions actually duplicated, as you can see in my second patch (in Searcher class)

In middle term (I did only one example in patch 3) they enable to create an immutable view to (maybe) mutable entries: now users of ExternalTMX cannot modify its contents. We could do the same for ProjectTMX: store mutable entries in the maps, but return ITMXEntry in getDefaultTranslation/getMultipleTranslation
As @amake mentionned in the discussion list, PrepareTMXEntry actually looks like mutable variant of TMXEntry. That was initial meaning, but if you look where they are used, you will see that since ExternalTMX continued to use PrepareTMXEntry, it has been used as something similar to external TMX entry.
One other difference between these two classes is that PrepareTMXEntry can contain any kind of properties (as it can be read from any kind of TMX) while TMXEntry stores only properties a project_save.tmx should contain (actually no property but already stores externalLinked): this enforces the idea that TMXEntry means, in reality, internal TMX entry.
Then we can ask ourselves: why does ExternalTMX store mutable entries while internal (project) TMX contains immutable entries? Shouldn't the contrary be more logical?

In long term, these two interfaces could ensure stability of the code even if you change the definition of TMXEntry/PrepareTMXEntry (as @miurahr wanted to do), even if you finally remove one of them or rewrite it completely: all code using the interfaces would not need to be changed. 
But it requires that we inventory where the classes are used, and for each use case, whenever it requires writing (else it should use interface instead). 