### PR TITLE
CLI: use TMXWriter2 for producing pseudo project TMX and  aligner

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1814,7 +1814,7 @@ public class RealProject implements IProject {
             this.config = props;
         }
 
-        Map<String, TMXEntry> data = new HashMap<>();
+        Map<String, TMXEntry> data = new TreeMap<>();
         private ProjectProperties config;
 
         @Override

--- a/src/org/omegat/util/TMXWriter.java
+++ b/src/org/omegat/util/TMXWriter.java
@@ -45,6 +45,7 @@ import org.omegat.core.data.ProjectProperties;
  * @author Maxym Mykhalchuk
  *
  */
+@Deprecated
 public final class TMXWriter {
 
     private TMXWriter() {


### PR DESCRIPTION
This is a proposal to migrate TMXWriter2 to produce pseudo/empty project TMX in Main CLI function.

### Problem 

GUI mode use TMXWriter2 to write project TMX file, but CLI use old TMXWriter. This code duplication and separation can be a nest of future bugs.

### Background

~TMXEntry is package-private and all fields are public. Main cannot call TMXEntry constructor, so it use its writer.~

Calling `TMXWriter2#writeEntry` from Main class solves the issue. 

### Approach

~1. Introduce `TMXWriter2#buildTMXFile` that has same functionality with `TMXWriter#buildTMXFile`~
~2. Introduce `PrepareTMXEntry#getTMXEntry` small builder utility method that work as a proxy for TMXEntry constructor.~
3. Update `Main#runCreatePseudoTranslateTMX` and `Main#runConsoleAlign`
4. Add `@Deprecated` annotation to `TMXWriter` class