### PR TITLE
Make PrepareTMXEntry as a TMXEntry builder

### DIFF
--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -7,6 +7,7 @@
                2012 Thomas CORDONNIER
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -43,9 +44,9 @@ public class ExternalTMX {
 
     private final String name;
 
-    private final List<PrepareTMXEntry> entries;
+    private final List<TMXEntry> entries;
 
-    ExternalTMX(String name, List<PrepareTMXEntry> entries) {
+    ExternalTMX(String name, List<TMXEntry> entries) {
         this.name = name;
         this.entries = entries;
     }
@@ -54,7 +55,7 @@ public class ExternalTMX {
         return name;
     }
 
-    public List<PrepareTMXEntry> getEntries() {
+    public List<TMXEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }
 }

--- a/src/org/omegat/core/data/IProject.java
+++ b/src/org/omegat/core/data/IProject.java
@@ -7,6 +7,7 @@
                2010 Didier Briel
                2014-2015 Alex Buloichik
                2017 Didier Briel
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -142,15 +143,43 @@ public interface IProject {
     /**
      * Set translation for entry.
      *
+     * @param ste source text entry.
+     * @param tmxEntry tmx entry.
+     */
+    void setTranslation(SourceTextEntry ste, TMXEntry tmxEntry);
+
+    /**
+     * Set translation for entry.
+     *
      * Optimistic locking will not be checked.
+     * for backward compatibility.
      *
      * @param entry
      *            entry
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked);
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked) {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked));
+    }
+
+    /**
+     * Set translation for entry with optimistic lock checking: if previous translation is not the same like
+     * in storage, OptimisticLockingFail exception will be generated. Use when user has typed a new
+     * translation.
+     * for backward compatibility.
+     *
+     * @param entry
+     *            entry
+     * @param trans
+     *            translation. It can't be null
+     */
+    default void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+                               TMXEntry.ExternalLinked externalLinked, AllTranslations previous)
+            throws OptimisticLockingFail {
+        setTranslation(entry, new TMXEntry(trans, defaultTranslation, externalLinked), previous);
+    }
 
     /**
      * Set translation for entry with optimistic lock checking: if previous translation is not the same like
@@ -162,8 +191,7 @@ public interface IProject {
      * @param trans
      *            translation. It can't be null
      */
-    void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked, AllTranslations previousTranslations)
+    void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
             throws OptimisticLockingFail;
 
     /**

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -6,6 +6,7 @@
  Copyright (C) 2014 Alex Buloichik, Didier Briel
                2019 Aaron Madlon-Kay
                2020 Briac Pilpre
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.omegat.util.StringUtil;
 import org.omegat.util.TMXProp;
 
 /**
@@ -66,7 +66,7 @@ public class ImportFromAutoTMX {
      */
     void process(ExternalTMX tmx, boolean isEnforcedTMX) {
 
-        for (PrepareTMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
+        for (TMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
             List<SourceTextEntry> list = existEntries.get(e.source);
             if (list == null) {
                 continue; // there is no entries for this source
@@ -128,7 +128,7 @@ public class ImportFromAutoTMX {
         }
     }
 
-    private boolean isAltTranslation(PrepareTMXEntry entry) {
+    private boolean isAltTranslation(TMXEntry entry) {
         if (entry.otherProperties == null) {
             return false;
         }
@@ -148,7 +148,7 @@ public class ImportFromAutoTMX {
         return EntryKey.isIgnoreFileContext() ? hasOtherProp : hasFileProp;
     }
 
-    private boolean altTranslationMatches(PrepareTMXEntry entry, EntryKey key) {
+    private boolean altTranslationMatches(TMXEntry entry, EntryKey key) {
         if (entry.otherProperties == null) {
             return false;
         }
@@ -172,21 +172,16 @@ public class ImportFromAutoTMX {
         return key.equals(new EntryKey(file, entry.source, id, prev, next, path));
     }
 
-    private void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
-        if (StringUtil.isEmpty(trans.note)) {
-            trans.note = null;
-        }
-
-        trans.source = entry.getSrcText();
-
+    private void setTranslation(SourceTextEntry entry, TMXEntry trans, boolean defaultTranslation,
+                                TMXEntry.ExternalLinked externalLinkedMode) {
         TMXEntry newTrEntry;
-
         if (trans.translation == null && trans.note == null) {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
+            // create new entry with default translation flag and external link mode.
+            PrepareTMXEntry prepare = new PrepareTMXEntry(trans);
+            newTrEntry = prepare.toTMXEntry(defaultTranslation, externalLinkedMode);
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
     }

--- a/src/org/omegat/core/data/NotLoadedProject.java
+++ b/src/org/omegat/core/data/NotLoadedProject.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.filters2.TranslationException;
 import org.omegat.tokenizer.ITokenizer;
@@ -91,6 +90,8 @@ public class NotLoadedProject implements IProject {
     public void iterateByMultipleTranslations(MultipleTranslationsIterator it) {
     }
 
+    /** {@inheritDoc} */
+    @Override
     public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
     }
 
@@ -102,6 +103,8 @@ public class NotLoadedProject implements IProject {
         return false;
     }
 
+    /** {@inheritDoc} */
+    @Override
     public Map<String, ExternalTMX> getTransMemories() {
         return null;
     }
@@ -139,12 +142,15 @@ public class NotLoadedProject implements IProject {
     public void saveProjectProperties() throws IOException {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked) {
+    /** {@inheritDoc} */
+    @Override
+    public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
     }
 
-    public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            ExternalLinked externalLinked, AllTranslations previousTranslations) throws OptimisticLockingFail {
+    /** {@inheritDoc} */
+    @Override
+    public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations)
+            throws OptimisticLockingFail {
     }
 
     public ITokenizer getSourceTokenizer() {

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -98,6 +98,23 @@ public class PrepareTMXEntry {
         return false;
     }
 
+    public TMXEntry toTMXEntry() {
+        return toTMXEntry(true, null);
+    }
+
+    public TMXEntry toTMXEntry(final boolean defaultTranslation, final TMXEntry.ExternalLinked linked) {
+        return toTMXEntry(defaultTranslation, linked, false);
+    }
+
+    public TMXEntry toTMXEntry(final boolean defaultTranslation, final TMXEntry.ExternalLinked linked,
+                               final boolean withProp) {
+        if (withProp) {
+            return new TMXEntry(this, defaultTranslation, linked, otherProperties);
+        } else {
+            return new TMXEntry(this, defaultTranslation, linked, null);
+        }
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -5,6 +5,7 @@
 
  Copyright (C) 2012 Alex Buloichik
                2013-2014 Aaron Madlon-Kay, Alex Buloichik
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -44,6 +45,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
+import org.omegat.util.TMXProp;
 import org.omegat.util.TMXReader2;
 import org.omegat.util.TMXWriter2;
 
@@ -316,7 +318,6 @@ public class ProjectTMX {
                 for (int i = 0; i < sources.size(); i++) {
                     String segmentSource = sources.get(i);
                     String segmentTranslation = targets.get(i);
-
                     PrepareTMXEntry te = new PrepareTMXEntry();
                     te.source = segmentSource;
                     te.translation = segmentTranslation;
@@ -327,53 +328,48 @@ public class ProjectTMX {
                     te.note = tu.note;
                     te.otherProperties = tu.props;
 
-                    String id = te.getPropValue(PROP_ID);
-                    if (id == null) {
+                    String id;
+                    String propId = getProp(tu, PROP_ID);
+                    if (propId != null) {
+                        id = propId;
+                    } else {
                         // Use TMX @tuid if available and "id" prop was not
                         // present
-                        id = te.getPropValue(ATTR_TUID);
+                        id = getProp(tu, ATTR_TUID);
                     }
 
-                    EntryKey key = new EntryKey(te.getPropValue(PROP_FILE), te.source,
-                            id, te.getPropValue(PROP_PREV), te.getPropValue(PROP_NEXT),
-                            te.getPropValue(PROP_PATH));
+                    EntryKey key = new EntryKey(getProp(tu, PROP_FILE), segmentSource,
+                            id, getProp(tu, PROP_PREV), getProp(tu, PROP_NEXT), getProp(tu, PROP_PATH));
 
-                    TMXEntry.ExternalLinked externalLinkedMode = calcExternalLinkedMode(te);
+                    TMXEntry.ExternalLinked externalLinkedMode = calcExternalLinkedMode(tu, id);
 
                     boolean defaultTranslation = key.file == null;
-                    if (te.otherProperties != null && te.otherProperties.isEmpty()) {
-                        te.otherProperties = null;
-                    }
-
                     if (defaultTranslation) {
                         // default translation
-                        defaults.put(segmentSource, new TMXEntry(te, true, externalLinkedMode));
+                        defaults.put(segmentSource, te.toTMXEntry(true, externalLinkedMode));
                     } else {
                         // multiple translation
-                        alternatives.put(key, new TMXEntry(te, false, externalLinkedMode));
+                        alternatives.put(key, te.toTMXEntry(false, externalLinkedMode));
                     }
                 }
             }
             return true;
         }
-    };
+    }
 
-    private TMXEntry.ExternalLinked calcExternalLinkedMode(PrepareTMXEntry te) {
-        String id = te.getPropValue(PROP_ID);
-        if (id == null) {
-            id = te.getPropValue(ATTR_TUID);
+    private TMXEntry.ExternalLinked calcExternalLinkedMode(final TMXReader2.ParsedTu tu, final String id) {
+        String prop = getProp(tu, PROP_XICE);
+        if (prop != null && prop.equals(id)) {
+            return TMXEntry.ExternalLinked.xICE;
         }
-        TMXEntry.ExternalLinked externalLinked = null;
-        if (externalLinked == null && te.hasPropValue(PROP_XICE, id)) {
-            externalLinked = TMXEntry.ExternalLinked.xICE;
+        prop = getProp(tu, PROP_X100PC);
+        if (prop != null && prop.equals(id)) {
+            return TMXEntry.ExternalLinked.x100PC;
         }
-        if (externalLinked == null && te.hasPropValue(PROP_X100PC, id)) {
-            externalLinked = TMXEntry.ExternalLinked.x100PC;
+        if (getProp(tu, PROP_XAUTO) != null) {
+            return TMXEntry.ExternalLinked.xAUTO;
         }
-        if (externalLinked == null && te.hasPropValue(PROP_XAUTO, null)) {
-            externalLinked = TMXEntry.ExternalLinked.xAUTO;
-        }
-        return externalLinked;
+        return null;
     }
 
     /**
@@ -388,6 +384,17 @@ public class ProjectTMX {
      */
     public Collection<TMXEntry> getAlternatives() {
         return alternatives.values();
+    }
+
+    private String getProp(final TMXReader2.ParsedTu tu, final String key) {
+        List<TMXProp> props = tu.props;
+        for (int i = 0, propsSize = props.size(); i < propsSize; i++) {
+            TMXProp prop = props.get(i);
+            if (prop.getType().equals(key)) {
+                return prop.getValue();
+            }
+        }
+        return null;
     }
 
     public interface CheckOrphanedCallback {

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik, Aaron Madlon-Kay
+               2021 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -28,7 +29,10 @@
 
 package org.omegat.core.data;
 
+import java.util.List;
 import java.util.Objects;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Storage for TMX entry.
@@ -55,10 +59,16 @@ public class TMXEntry {
     public final String creator;
     public final long creationDate;
     public final String note;
+    public final List<TMXProp> otherProperties;
     public final boolean defaultTranslation;
     public final ExternalLinked linked;
 
     TMXEntry(PrepareTMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        this(from, defaultTranslation, linked, null);
+    }
+
+    TMXEntry(final PrepareTMXEntry from, final boolean defaultTranslation, final ExternalLinked linked,
+        final List<TMXProp> prop) {
         this.source = from.source;
         this.translation = from.translation;
         this.changer = from.changer;
@@ -66,17 +76,49 @@ public class TMXEntry {
         this.creator = from.creator;
         this.creationDate = from.creationDate;
         this.note = from.note;
-
+        this.otherProperties = prop;
         this.defaultTranslation = defaultTranslation;
         this.linked = linked;
     }
 
+    /**
+     * Check entry already have translation.
+     * @return true when entry has translated text, otherwise false.
+     */
     public boolean isTranslated() {
         return translation != null;
     }
 
+    /**
+     * Check entry has note.
+     * @return true when entry has note, otherwise false.
+     */
     public boolean hasNote() {
         return note != null;
+    }
+
+    /**
+     * Check entry have specified type of property, and that is specified value.
+     * @param propType property type to check.
+     * @param propValue value to check equality.
+     * @return true when entry have specified type of propety that is as same as specified value.
+     */
+    public boolean hasPropValue(String propType, String propValue) {
+        if (otherProperties == null) {
+            return false;
+        }
+        for (int i = 0; i < otherProperties.size(); i++) {
+            TMXProp kv = otherProperties.get(i);
+            if (propType.equals(kv.getType())) {
+                if (propValue == null) {
+                    return true;
+                }
+                if (propValue.equals(kv.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -125,9 +167,8 @@ public class TMXEntry {
                 defaultTranslation, source);
     }
 
-    /**
-     * Two TMXEntrys are considered interchangeable if this method returns true,
-     * even if equals() != true.
+    /* Two TMXEntrys are considered interchangeable if this method returns true,
+       even if equals() != true.
      */
     public boolean equalsTranslation(TMXEntry other) {
         if (other == null) {

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -358,7 +358,7 @@ public class Searcher {
             if (!searchExpression.searchAuthor && !searchExpression.searchDateAfter && !searchExpression.searchDateBefore) {
                 for (Map.Entry<String, ExternalTMX> tmEn : m_project.getTransMemories().entrySet()) {
                     final String fileTM = tmEn.getKey();
-                    searchEntries(tmEn.getValue().getEntries(), fileTM);
+                    searchEntriesAlternative(tmEn.getValue().getEntries(), fileTM);
                     checkStop.checkInterrupted();
                 }
                 for (Map.Entry<Language, ProjectTMX> tmEn : m_project.getOtherTargetLanguageTMs().entrySet()) {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -44,7 +44,6 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.data.IProject.MultipleTranslationsIterator;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
@@ -227,7 +226,7 @@ public class FindMatches {
             if (matcher.find()) {
                 penalty = Integer.parseInt(matcher.group(1));
             }
-            for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
+            for (TMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
                 if (tmen.source == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -114,14 +114,14 @@ public class ReplaceFilter implements IEditorFilter {
             List<SearchMatch> found = getReplacementsForEntry(trans);
             if (found != null) {
                 int off = 0;
-                StringBuilder o = new StringBuilder(trans);
+                StringBuilder sb = new StringBuilder(trans);
                 for (SearchMatch m : found) {
-                    o.replace(m.getStart() + off, m.getEnd() + off, m.getReplacement());
+                    sb.replace(m.getStart() + off, m.getEnd() + off, m.getReplacement());
                     off += m.getReplacement().length() - m.getLength();
                 }
                 PrepareTMXEntry prepare = new PrepareTMXEntry(en);
-                prepare.translation = o.toString();
-                Core.getProject().setTranslation(ste, prepare, en.defaultTranslation, null);
+                prepare.translation = sb.toString();
+                Core.getProject().setTranslation(ste, prepare.toTMXEntry(en.defaultTranslation, null));
             }
         }
         EditorController ec = (EditorController) Core.getEditor();

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -44,6 +44,7 @@ import org.madlonkay.supertmxmerge.SuperTmxMerge;
 import org.madlonkay.supertmxmerge.data.ITuv;
 import org.madlonkay.supertmxmerge.data.Key;
 import org.madlonkay.supertmxmerge.data.ResolutionStrategy;
+
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.TestCoreInitializer;
@@ -178,10 +179,9 @@ public final class TestTeamIntegrationChild {
 
     static void changeConcurrent() throws Exception {
         checkAll();
-
         PrepareTMXEntry prep = new PrepareTMXEntry();
         prep.translation = "" + System.currentTimeMillis();
-        Core.getProject().setTranslation(steC, prep, true, null);
+        Core.getProject().setTranslation(steC, prep.toTMXEntry());
         Log.log("Wrote: " + prep.source + "=" + prep.translation);
     }
 
@@ -252,7 +252,7 @@ public final class TestTeamIntegrationChild {
     static void saveTranslation(SourceTextEntry ste, long value) {
         PrepareTMXEntry prep = new PrepareTMXEntry();
         prep.translation = "" + value;
-        Core.getProject().setTranslation(ste, prep, true, null);
+        Core.getProject().setTranslation(ste, prep.toTMXEntry());
         Log.log("Wrote: " + prep.source + "=" + prep.translation);
         Core.getProject().saveProject(true);
     }

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -64,12 +64,9 @@ public class AutoTmxTest {
                 .setDoSegmenting(props.isSentenceSegmentingEnabled())
                 .load(props.getSourceLanguage(), props.getTargetLanguage());
 
-        PrepareTMXEntry e1 = autoTMX.getEntries().get(0);
-        checkListValues(e1, ProjectTMX.PROP_XICE, "11");
-
-        PrepareTMXEntry e2 = autoTMX.getEntries().get(1);
-        checkListValues(e2, ProjectTMX.PROP_XICE, "12");
-        checkListValues(e2, ProjectTMX.PROP_X100PC, "10");
+        assertTrue(autoTMX.getEntries().get(0).hasPropValue(ProjectTMX.PROP_XICE, "11"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_XICE, "12"));
+        assertTrue(autoTMX.getEntries().get(1).hasPropValue(ProjectTMX.PROP_X100PC, "10"));
 
         Core.initializeConsole(new HashMap<String, String>());
 
@@ -131,10 +128,6 @@ public class AutoTmxTest {
     SourceTextEntry createSTE(String id, String source) {
         EntryKey ek = new EntryKey("file", source, id, null, null, null);
         return new SourceTextEntry(ek, 0, null, null, new ArrayList<ProtectedPart>());
-    }
-
-    void checkListValues(PrepareTMXEntry en, String propType, String propValue) {
-        assertTrue(en.hasPropValue(propType, propValue));
     }
 
     void checkTranslation(SourceTextEntry ste, String expectedTranslation,

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -156,9 +156,9 @@ public class ExternalTMFactoryTest extends TestCore {
         // Only 5 FR translations
         assertEquals(5, tmx.getEntries().size());
 
-        List<PrepareTMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(3, matchingEntries.size());
+
+        assertEquals(3,
+                tmx.getEntries().stream().filter(t -> t.source.equals("Hello " + "World!")).count());
         
         // Set the EXT_TMX_KEEP_FOREIGN_MATCH prop
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, true);
@@ -167,24 +167,21 @@ public class ExternalTMFactoryTest extends TestCore {
         // All foreign translations are present
         assertEquals(14, tmx.getEntries().size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
-                .collect(Collectors.toList());
-        assertEquals(8, matchingEntries.size());
+        assertEquals(8,
+                tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!")).count());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
+        List<TMXEntry> matchingEntries = tmx.getEntries().stream()
+                .filter(t -> t.source.equals("This is an english sentence."))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
 
-        PrepareTMXEntry entry = matchingEntries.get(0);
-        assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "EN-US"));
+        assertTrue(matchingEntries.get(0).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(1);
-        assertEquals("DE", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "DE"));
+        assertTrue(matchingEntries.get(1).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
 
-        entry = matchingEntries.get(2);
-        assertEquals("ES", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
-        assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE, "ES"));
+        assertTrue(matchingEntries.get(2).hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true"));
     }
 }

--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -161,19 +161,19 @@ public class RealProjectTest {
     private void setDefault(String source, String translation) {
         EntryKey key = new EntryKey(null, source, null, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, true, null), true);
+        PrepareTMXEntry prepare = new PrepareTMXEntry();
+        prepare.source = source;
+        prepare.translation = translation;
+        tmx.setTranslation(ste, prepare.toTMXEntry(true, null), true);
     }
 
     private void setAlternative(String id, String source, String translation) {
         EntryKey key = new EntryKey("test", source, id, null, null, null);
         SourceTextEntry ste = new SourceTextEntry(key, 0, null, translation, new ArrayList<ProtectedPart>());
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, false, null), false);
+        PrepareTMXEntry prepare = new PrepareTMXEntry();
+        prepare.source = source;
+        prepare.translation = translation;
+        tmx.setTranslation(ste, prepare.toTMXEntry(false, null), false);
     }
 
     private void checkDefault(String source, String translation) {
@@ -220,6 +220,6 @@ public class RealProjectTest {
     }
 
     public static TMXEntry createEmptyTMXEntry() {
-        return new TMXEntry(new PrepareTMXEntry(), true, null);
+        return new PrepareTMXEntry().toTMXEntry();
     }
 }

--- a/test/src/org/omegat/core/data/TmxComplianceTests.java
+++ b/test/src/org/omegat/core/data/TmxComplianceTests.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.html2.HTMLFilter2;
 import org.omegat.filters2.html2.HTMLOptions;
@@ -389,9 +390,9 @@ public class TmxComplianceTests extends TmxComplianceBase {
     }
 
     TMXEntry createTMXEntry(String source, String translation, boolean def) {
-        PrepareTMXEntry tr = new PrepareTMXEntry();
-        tr.source = source;
-        tr.translation = translation;
-        return new TMXEntry(tr, def, null);
+        PrepareTMXEntry prepare = new PrepareTMXEntry();
+        prepare.source = source;
+        prepare.translation = translation;
+        return prepare.toTMXEntry(def, null);
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.Test;
+
 import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -82,14 +82,12 @@ public class POFilterTest extends TestFilterBase {
         ExternalTMX tmEntries = fi.referenceEntries;
         assertEquals(2, tmEntries.getEntries().size());
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(0);
-            assertEquals("True fuzzy!", entry.source);
-            assertEquals("trans5", entry.translation);
+            assertEquals("True fuzzy!", tmEntries.getEntries().get(0).source);
+            assertEquals("trans5", tmEntries.getEntries().get(0).translation);
         }
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(1);
-            assertEquals("True fuzzy 2!", entry.source);
-            assertEquals("trans6", entry.translation);
+            assertEquals("True fuzzy 2!", tmEntries.getEntries().get(1).source);
+            assertEquals("trans6", tmEntries.getEntries().get(1).translation);
         }
     }
 

--- a/test/src/org/omegat/languagetools/FalseFriendsTest.java
+++ b/test/src/org/omegat/languagetools/FalseFriendsTest.java
@@ -33,17 +33,16 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.languagetools.LanguageToolWrapper.LanguageToolMarker;
@@ -67,15 +66,6 @@ public class FalseFriendsTest extends TestCore {
         };
 
         Core.setProject(new IProject() {
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
-            }
-
-            public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, ExternalLinked externalLinked,
-                    AllTranslations previousTranslations) throws OptimisticLockingFail {
-            }
-
             public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
             }
 
@@ -145,6 +135,12 @@ public class FalseFriendsTest extends TestCore {
 
             public List<SourceTextEntry> getAllEntries() {
                 return null;
+            }
+
+            public void setTranslation(SourceTextEntry ste, TMXEntry trans) {
+            }
+
+            public void setTranslation(SourceTextEntry entry, TMXEntry trans, AllTranslations previousTranslations) {
             }
 
             public void compileProject(String sourcePattern) throws Exception {


### PR DESCRIPTION
This is another approach of #184, that take approach to avoid introducing new class and use PrepareTMXEntry as a builder class.

## Proposed changes

This includes following commits that every changes work well.

### Part 0. Preparation

1. Tweaks AutoTmxTest and PoFilterTtest
    Hide explicit variable of PrepareTMXEntry, for future replacement to TMXEntry
2. TMXEntry hold otherProperties
    TMXEntry also hold otherProperties which PrepareTMXEntry has. This make TMXEntry  immutable version of PrepareTMXEntry, and allow using it for replacement of PrepareTMXEntry in some place
 
### Part 1 . Introduce builder methods

3. Introduce `PrepareTMXEntry#toTMXEntry` builder method

### part 2. add Public API with TMXEntry and use it

5. Add `IProject#setTranslation` methods with TMXEntry object
    this prepare future replacement of the method equivalence.

### part 3. use builder methods in classes

6. ProjectTMX: use TMXEntry::Builder

7. ReplaceFilter: use TMXEntry::Builder

### part 5. use builder methods in tests

10. TMXComplianceTest
11. integrationTest

### part 6. ExternalTM should have immutable entry

12. ExternalTMFactory: return immutable TMXEntry
     this changes public API of external TMX file handling.  

## API change

### changed
This series of patches make public API modification at part1. 6

* `ExternalTMX` has a  `List<TMXEntry>` field instead of `List<PrepareTMXEntry>`, and changes constructor and return type of `getEntries`.

### added

There are several public API additions in part 2

* `IProject#setTranslation` which accept TMXEntry


## Idea for further improvements

* Add setters to `PrepareTMXEntry` that allows set chaining, and change all fields as private in order to make `PrepareTMXEntry`  a concrete builder, disallowing get values from it without `toTMXEntry` builder method.