### PR TITLE
Bump dependency dictzip@0.10.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.1'
 
         // Dictionary
-        implementation 'io.github.dictzip:dictzip:0.9.5'
+        implementation 'io.github.dictzip:dictzip:0.10.3'
         implementation 'com.github.takawitter:trie4j:0.9.8'
         implementation 'io.github.eb4j:dsl4j:0.3.0'
 


### PR DESCRIPTION
There is no big change for usage by OmegaT.

- Changes: fix compressing feature
- Build with Eclipse temurin/Adoptium OpenJDK 8

Signed-off-by: Hiroshi Miura <miurahr@linux.com>