### PR TITLE
Bump DSL4j@0.4.3 and DictZip@0.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,9 +128,9 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.1'
 
         // Dictionary
-        implementation 'io.github.dictzip:dictzip:0.10.3'
+        implementation 'io.github.dictzip:dictzip:0.11.1'
         implementation 'com.github.takawitter:trie4j:0.9.8'
-        implementation 'io.github.eb4j:dsl4j:0.3.0'
+        implementation 'io.github.eb4j:dsl4j:0.4.3'
 
         // Encoding dectection
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/src/org/omegat/core/dictionaries/LingvoDSL.java
+++ b/src/org/omegat/core/dictionaries/LingvoDSL.java
@@ -29,6 +29,8 @@ package org.omegat.core.dictionaries;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +64,9 @@ public class LingvoDSL implements IDictionaryFactory {
 
     @Override
     public final IDictionary loadDict(final File file) throws Exception {
-        return new LingvoDSLDict(file);
+        Path dictPath = Paths.get(file.toURI());
+        Path indexPath = Paths.get(dictPath + ".idx");
+        return new LingvoDSLDict(dictPath, indexPath);
     }
 
     static class LingvoDSLDict implements IDictionary {
@@ -71,12 +75,13 @@ public class LingvoDSL implements IDictionaryFactory {
 
         /**
          * Constructor of LingvoDSL Dictionary driver.
-         * @param file *.dsl file object.
+         * @param dictPath *.dsl file object.
+         * @param indexPath index cache file.
          * @throws Exception when loading dictionary failed.
          */
-        LingvoDSLDict(final File file) throws Exception {
-            data = DslDictionary.loadDictionary(file);
-            htmlVisitor = new HtmlVisitor(file.getParent());
+        LingvoDSLDict(final Path dictPath, final Path indexPath) throws Exception {
+            data = DslDictionary.loadDictionary(dictPath, indexPath);
+            htmlVisitor = new HtmlVisitor(dictPath.getParent().toString());
         }
 
         /**
@@ -87,7 +92,7 @@ public class LingvoDSL implements IDictionaryFactory {
          * @return list of results.
          */
         @Override
-        public List<DictionaryEntry> readArticles(final String word) {
+        public List<DictionaryEntry> readArticles(final String word) throws IOException {
             return readEntries(data.lookup(word));
         }
 
@@ -99,7 +104,7 @@ public class LingvoDSL implements IDictionaryFactory {
          * @return list of results.
          */
         @Override
-        public List<DictionaryEntry> readArticlesPredictive(final String word) {
+        public List<DictionaryEntry> readArticlesPredictive(final String word) throws IOException {
             return readEntries(data.lookupPredictive(word));
         }
 


### PR DESCRIPTION
- LingvoDSL support
  previous support read all contents into memory when loading.
  Now dsl4j make article index at first time and save index into file.
  A performance after second time is very improved because just loading index.
  formatting in HTML is done when query word.
- DictZip
  Support mark/reset methods for InputStream interface.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>