### PR TITLE
Bump dsl4j@0.4.5 and dictzip@0.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,9 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.1'
 
         // Dictionary
-        implementation 'io.github.dictzip:dictzip:0.11.1'
+        implementation 'io.github.dictzip:dictzip:0.11.2'
         implementation 'com.github.takawitter:trie4j:0.9.8'
-        implementation 'io.github.eb4j:dsl4j:0.4.4'
+        implementation 'io.github.eb4j:dsl4j:0.4.5'
 
         // Encoding dectection
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
+++ b/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
@@ -30,9 +30,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import io.github.eb4j.dsl.DslResult;
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import org.omegat.core.dictionaries.LingvoDSL.LingvoDSLDict;
@@ -47,6 +52,20 @@ public class LingvoDSLTest {
 
     private static final File TEST_DICT = new File("test/data/dicts-lingvo/test.dsl");
     private static final File TEST_DICT_DZ = new File("test/data/dicts-lingvo-dz/test.dsl.dz");
+    private static final Path TEST_DICT_IDX = Paths.get(Paths.get(TEST_DICT.toURI()) + ".idx");
+    private static final Path TEST_DICT_DZ_IDX = Paths.get(Paths.get(TEST_DICT_DZ.toURI()) + ".idx");
+
+    @AfterClass
+    public static void cleanUp() {
+        try {
+            Files.deleteIfExists(TEST_DICT_IDX);
+        } catch (IOException ignored) {
+        }
+        try {
+            Files.deleteIfExists(TEST_DICT_DZ_IDX);
+        } catch (IOException ignored) {
+        }
+    }
 
     @Test
     public void testReadFileDict() throws Exception {


### PR DESCRIPTION
- Fix broken article when using open-dsl-dict data.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>