### PR TITLE
dictionary:   Improve StarDict access with stardict4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ dependencies {
         implementation 'io.github.dictzip:dictzip:0.11.2'
         implementation 'com.github.takawitter:trie4j:0.9.8'
         implementation 'io.github.eb4j:dsl4j:0.4.5'
+        implementation 'io.github.eb4j:stardict4j:0.3.0'
 
         // Encoding dectection
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/src/org/omegat/core/dictionaries/StarDict.java
+++ b/src/org/omegat/core/dictionaries/StarDict.java
@@ -6,6 +6,7 @@
  Copyright (C) 2009 Alex Buloichik
                2015-2016 Hiroshi Miura, Aaron Madlon-Kay
                2020 Suguru Oho, Aaron Madlon-Kay
+               2022 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -27,47 +28,32 @@
 
 package org.omegat.core.dictionaries;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.RandomAccessFile;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.HashMap;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.GZIPInputStream;
 
-import org.dict.zip.DictZipInputStream;
-import org.dict.zip.RandomAccessInputStream;
+import io.github.eb4j.stardict.StarDictDictionary;
+
 import org.omegat.util.Language;
-import org.omegat.util.Log;
 
 /**
- * Dictionary implementation for StarDict format.
+ * Stardict Dictionary support.
  * <p>
  * StarDict format described on
  * https://github.com/huzheng001/stardict-3/blob/master/dict/doc/StarDictFileFormat
  * <p>
- * <h1>Files</h1>
+ * A stardict dictionary plugin uses Stardict4j access library.
  * Every dictionary consists of these files:
  * <ol><li>somedict.ifo
  * <li>somedict.idx or somedict.idx.gz
  * <li>somedict.dict or somedict.dict.dz
  * <li>somedict.syn (optional)
  * </ol>
+ *
+ * This driver handle entry types 'm': mean, 'h': html and 't': phonetics.
+ * Other entries such as mediawiki markup are not shown.
  *
  * @author Alex Buloichik <alex73mail@gmail.com>
  * @author Hiroshi Miura
@@ -87,254 +73,55 @@ public class StarDict implements IDictionaryFactory {
     }
 
     @Override
-    public IDictionary loadDict(File ifoFile, Language language) throws Exception {
-        Map<String, String> header = readIFO(ifoFile);
-        String version = header.get("version");
-        if (!"2.4.2".equals(version) && !"3.0.0".equals(version)) {
-            throw new Exception("Invalid version of dictionary: " + version);
-        }
-        String sametypesequence = header.get("sametypesequence");
-        if (!"g".equals(sametypesequence)
-                && !"m".equals(sametypesequence)
-                && !"x".equals(sametypesequence)
-                && !"h".equals(sametypesequence)) {
-            throw new Exception("Invalid type of dictionary: " + sametypesequence);
-        }
-
-        /*
-         * Field in StarDict .ifo file, added in version 3.0.0. This must be
-         * retained in order to support idxoffsetbits=64 dictionaries (not yet
-         * implemented).
-         */
-        int idxoffsetbits = 32;
-        if ("3.0.0".equals(version)) {
-            String bitsString = header.get("idxoffsetbits");
-            if (bitsString != null) {
-                idxoffsetbits = Integer.parseInt(bitsString);
-            }
-        }
-
-        if (idxoffsetbits != 32) {
-            throw new Exception("StarDict dictionaries with idxoffsetbits=64 are not supported.");
-        }
-
-        String f = ifoFile.getPath();
-        if (f.endsWith(".ifo")) {
-            f = f.substring(0, f.length() - ".ifo".length());
-        }
-        String dictName = f;
-
-        File idxFile = getFile(dictName, ".idx.gz", ".idx")
-                .orElseThrow(() -> new FileNotFoundException("No .idx file could be found"));
-        DictionaryData<Entry> data = loadData(idxFile, language);
-
-        File dictFile = getFile(dictName, ".dict.dz", ".dict")
-                .orElseThrow(() -> new FileNotFoundException("No .dict.dz or .dict files were found for " + dictName));
-
-        try {
-            if (dictFile.getName().endsWith(".dz")) {
-                DictZipInputStream dataFile = new DictZipInputStream(new RandomAccessInputStream(new RandomAccessFile(dictFile, "r")));
-                return new StarDictZipDict(dataFile, data);
-            } else {
-                RandomAccessFile dataFile = new RandomAccessFile(dictFile, "r");
-                return new StarDictFileDict(dataFile, data);
-            }
-        } catch (FileNotFoundException ex) {
-            throw new FileNotFoundException("No .dict.dz or .dict files were found for " + dictName);
-        }
+    public IDictionary loadDict(final File file, final Language language) throws Exception {
+        return new StarDictDict(file, language);
     }
 
-    /**
-     * Read header.
-     */
-    private Map<String, String> readIFO(File ifoFile) throws Exception {
-        Map<String, String> result = new TreeMap<>();
-        try (BufferedReader rd = Files.newBufferedReader(ifoFile.toPath(), StandardCharsets.UTF_8)) {
-            String line;
-            String first = rd.readLine();
-            if (!"StarDict's dict ifo file".equals(first)) {
-                throw new Exception("Invalid header of .ifo file: " + first);
-            }
-            while ((line = rd.readLine()) != null) {
-                if (line.trim().isEmpty()) {
-                    continue;
-                }
-                int pos = line.indexOf('=');
-                if (pos < 0) {
-                    throw new Exception("Invalid format of .ifo file: " + line);
-                }
-                result.put(line.substring(0, pos), line.substring(pos + 1));
-            }
-        }
-        return result;
-    }
+    static class StarDictDict implements IDictionary {
 
-    private Optional<File> getFile(String basename, String... suffixes) {
-        return Stream.of(suffixes).map(suff -> new File(basename + suff)).filter(f -> f.isFile())
-                .findFirst();
-    }
+        protected final StarDictDictionary dictionary;
+        protected final Language language;
 
-    private DictionaryData<Entry> loadData(File idxFile, Language language) throws IOException {
-        InputStream is = new FileInputStream(idxFile);
-        if (idxFile.getName().endsWith(".gz")) {
-            // BufferedInputStream.DEFAULT_BUFFER_SIZE = 8192
-            is = new GZIPInputStream(is, 8192);
-        }
-        DictionaryData<Entry> newData = new DictionaryData<>(language);
-        try (DataInputStream idx = new DataInputStream(new BufferedInputStream(is));
-              ByteArrayOutputStream mem = new ByteArrayOutputStream()) {
-            while (true) {
-                int b = idx.read();
-                if (b == -1) {
-                    break;
-                }
-                if (b == 0) {
-                    String key = new String(mem.toByteArray(), 0, mem.size(), StandardCharsets.UTF_8);
-                    mem.reset();
-                    int bodyOffset = idx.readInt();
-                    int bodyLength = idx.readInt();
-                    newData.add(key, new Entry(bodyOffset, bodyLength));
-                } else {
-                    mem.write(b);
-                }
-            }
-        }
-        is.close();
-        newData.done();
-        return newData;
-    }
-
-    /**
-     * Simple container for offsets+lengths of entries in StarDict dictionary.
-     * Subclasses of StarDictDict know how to read this from the underlying data
-     * file.
-     */
-    static class Entry {
-        private final int start;
-        private final int len;
-
-        Entry(int start, int len) {
-            this.start = start;
-            this.len = len;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(len, start);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            Entry other = (Entry) obj;
-            return len == other.len && start == other.start;
-        }
-    }
-
-    static abstract class StarDictBaseDict implements IDictionary {
-
-        protected final DictionaryData<Entry> data;
-
-        private final Map<Entry, String> cache = new HashMap<>();
-
-        /**
-         * @param data collection of <code>Entry</code>s loaded from file
-         */
-        StarDictBaseDict(DictionaryData<Entry> data) {
-            this.data = data;
+        StarDictDict(final File file, Language language) throws Exception {
+            dictionary = StarDictDictionary.loadDictionary(file, 1_000, Duration.ofMinutes(30));
+            // Max cache size  to 1,000 items and expiry to 30 min.
+            this.language = language;
         }
 
         @Override
         public List<DictionaryEntry> readArticles(String word) throws Exception {
-            return data.lookUp(word).stream().map(e -> new DictionaryEntry(e.getKey(), getArticle(e.getValue())))
+            List<StarDictDictionary.Entry> result = dictionary.readArticles(word);
+            if (result.isEmpty()) {
+                result = dictionary.readArticles(word.toLowerCase(language.getLocale()));
+            }
+            return result.stream()
+                    .filter(StarDictDict::useEntry)
+                    .map(StarDictDict::convertEntry)
                     .collect(Collectors.toList());
         }
 
         @Override
         public List<DictionaryEntry> readArticlesPredictive(String word) {
-            return data.lookUpPredictive(word).stream()
-                    .map(e -> new DictionaryEntry(e.getKey(), getArticle(e.getValue()))).collect(Collectors.toList());
-        }
-
-        private synchronized String getArticle(Entry entry) {
-            return cache.computeIfAbsent(entry, (e) -> {
-                return readArticle(e.start, e.len).replace("\n", "<br>");
-            });
-        }
-
-        /**
-         * Read data from the underlying file.
-         *
-         * @param start
-         *            Start offset in data file
-         * @param len
-         *            Length of article data
-         * @return Raw article text
-         */
-        protected abstract String readArticle(int start, int len);
-    }
-
-    static private class StarDictFileDict extends StarDictBaseDict {
-        private final RandomAccessFile dataFile;
-
-        public StarDictFileDict(RandomAccessFile dataFile, DictionaryData<Entry> data) {
-            super(data);
-            this.dataFile = dataFile;
-        }
-
-        @Override
-        protected String readArticle(int start, int len) {
-            String result = null;
-            try {
-                byte[] data = new byte[len];
-                dataFile.seek(start);
-                int readLen = dataFile.read(data);
-                result = new String(data, 0, readLen, StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                Log.log(e);
+            List<StarDictDictionary.Entry> result = dictionary.readArticlesPredictive(word);
+            if (result.isEmpty()) {
+                result = dictionary.readArticlesPredictive(word.toLowerCase(language.getLocale()));
             }
-            return result;
+            return result.stream()
+                    .filter(StarDictDict::useEntry)
+                    .map(StarDictDict::convertEntry)
+                    .collect(Collectors.toList());
         }
 
-        @Override
-        public void close() throws IOException {
-            dataFile.close();
-        }
-    }
-
-    static private class StarDictZipDict extends StarDictBaseDict {
-        private final DictZipInputStream dataFile;
-
-        public StarDictZipDict(DictZipInputStream dataFile, DictionaryData<Entry> data) {
-            super(data);
-            this.dataFile = dataFile;
+        private static boolean useEntry(StarDictDictionary.Entry entry) {
+            StarDictDictionary.EntryType type = entry.getType();
+            return type == StarDictDictionary.EntryType.MEAN
+                    || type == StarDictDictionary.EntryType.PHONETIC
+                    || type == StarDictDictionary.EntryType.HTML;
         }
 
-        @Override
-        protected String readArticle(int start, int len) {
-            String result = null;
-            try {
-                dataFile.seek(start);
-                byte[] data = new byte[len];
-                dataFile.readFully(data);
-                result = new String(data, StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                Log.log(e);
-            }
-            return result;
+        private static DictionaryEntry convertEntry(StarDictDictionary.Entry entry) {
+            return new DictionaryEntry(entry.getWord(), entry.getArticle().replace("\n", "<br>"));
         }
 
-        @Override
-        public void close() throws IOException {
-            dataFile.close();
-        }
     }
 }

--- a/test/src/org/omegat/core/dictionaries/StarDictTest.java
+++ b/test/src/org/omegat/core/dictionaries/StarDictTest.java
@@ -33,11 +33,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map.Entry;
 
+import io.github.eb4j.stardict.StarDictDictionary;
 import org.junit.Test;
+
 import org.omegat.core.TestCore;
-import org.omegat.core.dictionaries.StarDict.StarDictBaseDict;
 import org.omegat.util.Language;
 
 /**
@@ -52,15 +52,33 @@ public class StarDictTest extends TestCore {
     private static final Language FRENCH = new Language(Locale.FRENCH);
 
     @Test
-    public void testReadFileDict() throws Exception {
-        StarDictBaseDict dict = (StarDictBaseDict) new StarDict().loadDict(new File("test/data/dicts/latin-francais.ifo"),
-                FRENCH);
-        assertEquals(11964, dict.data.size());
+    public void testStardict4j() throws Exception {
+        StarDictDictionary dict = StarDictDictionary.loadDictionary(
+                new File("test/data/dicts/latin-francais.ifo"));
+        assertEquals(10451, dict.getInformation().getWordCount());
 
         String word = "testudo";
-        List<Entry<String, StarDict.Entry>> data = dict.data.lookUp(word);
-        assertEquals(1, data.size());
+        List<StarDictDictionary.Entry> result = dict.readArticles(word);
+        assertEquals(1, result.size());
+        assertEquals(word, result.get(0).getWord());
+        assertEquals("dinis, f. : tortue", result.get(0).getArticle());
 
+        // Test prediction
+        word = "testu";
+        result = dict.readArticles(word);
+        assertTrue(result.isEmpty());
+        result = dict.readArticlesPredictive(word);
+        assertEquals(1, result.size());
+        assertEquals("testudo", result.get(0).getWord());
+        assertEquals("dinis, f. : tortue", result.get(0).getArticle());
+    }
+
+    @Test
+    public void testReadFileDict() throws Exception {
+        StarDict.StarDictDict dict = new StarDict.StarDictDict(
+                new File("test/data/dicts/latin-francais.ifo"), FRENCH);
+
+        String word = "testudo";
         List<DictionaryEntry> result = dict.readArticles(word);
         assertEquals(1, result.size());
         assertEquals(word, result.get(0).getWord());
@@ -85,13 +103,9 @@ public class StarDictTest extends TestCore {
 
     @Test
     public void testReadZipDict() throws Exception {
-        StarDictBaseDict dict = (StarDictBaseDict) new StarDict()
-                .loadDict(new File("test/data/dicts-zipped/latin-francais.ifo"), FRENCH);
-        assertEquals(11964, dict.data.size());
-
+        StarDict.StarDictDict dict = new StarDict.StarDictDict(
+                new File("test/data/dicts-zipped/latin-francais.ifo"), FRENCH);
         String word = "testudo";
-        List<Entry<String, StarDict.Entry>> data = dict.data.lookUp(word);
-        assertEquals(1, data.size());
         List<DictionaryEntry> result = dict.readArticles(word);
         assertEquals(1, result.size());
         assertFalse(result.isEmpty());


### PR DESCRIPTION
- Use stardict4j access library
  - Stardict4j is created from OmegaT stardict code. 
  - Stardict4j supports .dict and dict.dz, .idx and idx.gz, as same as current OmegaT does
  - It can handle .syn synonym file.
  - It can handle 64bit index file as same as 32bit index which OmegaT can handle.
  - It can handle entry type such as 'm', 'x' and 'h'. 
  - It has true LRU cache for articles expiry by number of items and  time (depends Caffeine) 
