### PR TITLE
Dictionary: DSL: compact line spacing for [m?]..[/m] entries

### DIFF
--- a/src/org/omegat/core/dictionaries/LingvoDSL.java
+++ b/src/org/omegat/core/dictionaries/LingvoDSL.java
@@ -185,25 +185,25 @@ public class LingvoDSL implements IDictionaryFactory {
             } else if (tag.isTagName("sub")) {
                 sb.append("<sub>");
             } else if (tag.isTagName("m")) {
-                sb.append("<p>");
+                sb.append("<div>");
             } else if (tag.isTagName("m1")) {
-                sb.append("<p style=\"text-indent: 30px\">");
+                sb.append("<div style=\"text-indent: 30px\">");
             } else if (tag.isTagName("m2")) {
-                sb.append("<p style=\"text-indent: 60px\">");
+                sb.append("<div style=\"text-indent: 60px\">");
             } else if (tag.isTagName("m3")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m4")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m5")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m6")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m7")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m8")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("m9")) {
-                sb.append("<p style=\"text-indent: 90px\">");
+                sb.append("<div style=\"text-indent: 90px\">");
             } else if (tag.isTagName("c")) {
                 if (tag.hasAttribute()) {
                     sb.append("<span style=\"color: ").append(tag.getAttribute().getValue()).append("\">");
@@ -274,7 +274,7 @@ public class LingvoDSL implements IDictionaryFactory {
             } else if (endTag.isTagName("sub")) {
                 sb.append("</sub>");
             } else if (endTag.isTagName("m")) {
-                sb.append("</p>");
+                sb.append("</div>");
             }
         }
 

--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -159,7 +159,9 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
                         : font.getStyle() == Font.ITALIC ? "italic" : "normal") + "; "
                 + " color: " + EditorColor.COLOR_FOREGROUND.toHex() + "; "
                 + " background: " + EditorColor.COLOR_BACKGROUND.toHex() + ";} "
-                + ".word {font-size: " + (2 + font.getSize()) + "; font-style: bold; }"
+                + ".word {font-size: " + (2 + font.getSize()) + "; font-style: bold;} "
+                + ".entry {line-height: 1.1;} "
+                + ".article {font-size: " + font.getSize() + ";}"
                 );
         htmlEditorKit.setStyleSheet(baseStyleSheet);
         setEditorKit(htmlEditorKit);
@@ -274,14 +276,13 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
         int i = 0;
         for (DictionaryEntry de : data) {
             if (wasPrev) {
-                txt.append("<br><hr>");
+                txt.append("<hr style=\"line-height: 1.3; color: #777\">");
             } else {
                 wasPrev = true;
             }
-            txt.append("<div id =\"").append(i).append("\"><b><span class=\"word\">");
-            txt.append(de.getWord());
-            txt.append("</span></b>");
-            txt.append(" - ").append(de.getArticle());
+            txt.append("<div id=\"").append(i).append("\" class=\"entry\">");
+            txt.append("<b><span class=\"word\">").append(de.getWord()).append("</span></b>");
+            txt.append(" - <span class=\"article\">").append(de.getArticle()).append("</span>");
             txt.append("</div>");
             displayedWords.add(de.getWord().toLowerCase());
             i++;

--- a/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
+++ b/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
@@ -55,7 +55,8 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<p style=\"text-indent: 30px\">Only a single white space on first character</p>\n", result.get(0).getArticle());
+        assertEquals("<div style=\"text-indent: 30px\">Only a single white space on first character</div>\n",
+                result.get(0).getArticle());
     }
 
     @Test
@@ -65,7 +66,7 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<p style=\"text-indent: 30px\">Translation line also can have a single TAB char</p>\n", result.get(0).getArticle());
+        assertEquals("<div style=\"text-indent: 30px\">Translation line also can have a single TAB char</div>\n", result.get(0).getArticle());
     }
 
     @Test
@@ -75,7 +76,7 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<p style=\"text-indent: 30px\">\u0441\u0442\u0430\u043d\u043e\u043a</p>\n", result.get(0).getArticle());
+        assertEquals("<div style=\"text-indent: 30px\">\u0441\u0442\u0430\u043d\u043e\u043a</div>\n", result.get(0).getArticle());
     }
 
     @Test
@@ -96,7 +97,7 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<p>Here is an <span style='font-style: italic'>italic</span> <strong>word</strong>.</p>\n",
+        assertEquals("<div>Here is an <span style='font-style: italic'>italic</span> <strong>word</strong>.</div>\n",
                 result.get(0).getArticle());
     }
 
@@ -107,19 +108,19 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<p style=\"text-indent: 30px\"><strong>1.</strong> \u043E\u0442\u043A\u0430\u0437\u044B\u0432\u0430\u0442\u044C\u0441\u044F" +
+        assertEquals("<div style=\"text-indent: 30px\"><strong>1.</strong> \u043E\u0442\u043A\u0430\u0437\u044B\u0432\u0430\u0442\u044C\u0441\u044F" +
                         " (<span style='font-style: italic'>\u043E\u0442 \u0447\u0435\u0433\u043E-\u043B.</span>)," +
                         " \u043F\u0440\u0435\u043A\u0440\u0430\u0449\u0430\u0442\u044C " +
                         "(<span style='font-style: italic'>\u043F\u043E\u043F\u044B\u0442\u043A\u0438 \u0438 \u0442." +
-                        " \u043F.</span>)</p>\n" +
-                        "<p style=\"text-indent: 30px\"><strong>2.</strong> \u043F\u043E\u043A\u0438\u0434\u0430\u0442\u044C," +
-                        " \u043E\u0441\u0442\u0430\u0432\u043B\u044F\u0442\u044C</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon attempts</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon a claim</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon convertibility</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon the [gold] standard</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon price control</p>\n" +
-                        "<p style=\"text-indent: 60px\">to abandon a right</p>\n",
+                        " \u043F.</span>)</div>\n" +
+                        "<div style=\"text-indent: 30px\"><strong>2.</strong> \u043F\u043E\u043A\u0438\u0434\u0430\u0442\u044C," +
+                        " \u043E\u0441\u0442\u0430\u0432\u043B\u044F\u0442\u044C</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon attempts</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon a claim</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon convertibility</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon the [gold] standard</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon price control</div>\n" +
+                        "<div style=\"text-indent: 60px\">to abandon a right</div>\n",
                 result.get(0).getArticle());
     }
 


### PR DESCRIPTION
This improves line spacing that is related to [omegat-users post](https://sourceforge.net/p/omegat/mailman/omegat-users/thread/595f0d78-6fcb-89b3-7934-10cc5c6f2f91%40gmail.com/#msg37597243) about dictionary UI.
 
Signed-off-by: Hiroshi Miura <miurahr@linux.com>