### PR TITLE
Refactor tmx entry part2

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -61,6 +61,7 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.core.data.RealProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
@@ -496,9 +497,9 @@ public final class Main {
 
         System.out.println(StringUtil.format(OStrings.getString("CONSOLE_ALIGN_AGAINST"), dir));
 
-        Map<String, TMXEntry> data = p.align(p.getProjectProperties(), new File(dir));
+        Map<String, ProjectTMXEntry> data = p.align(p.getProjectProperties(), new File(dir));
         Map<String, PrepareTMXEntry> result = new TreeMap<>();
-        for (Map.Entry<String, TMXEntry> en : data.entrySet()) {
+        for (Map.Entry<String, ProjectTMXEntry> en : data.entrySet()) {
             result.put(en.getKey(), new PrepareTMXEntry(en.getValue()));
         }
 

--- a/src/org/omegat/core/data/AlternativeProjectTMXEntry.java
+++ b/src/org/omegat/core/data/AlternativeProjectTMXEntry.java
@@ -1,0 +1,138 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2010 Alex Buloichik
+               2012 Guido Leenders, Thomas Cordonnier
+               2013 Aaron Madlon-Kay
+               2014 Alex Buloichik, Aaron Madlon-Kay
+               2021-2022 Thomas Cordonnier
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.omegat.util.TMXProp;
+
+/**
+ * Storage for TMX entry for project memory
+ *
+ * Variables in this class can be changed only before store to ProjectTMX. After that, all values must be
+ * unchangeable.
+ *
+ * Only RealProject can create and change TMXEntry objects.
+ *
+ * @author Alex Buloichik (alex73mail@gmail.com)
+ * @author Guido Leenders
+ * @author Aaron Madlon-Kay
+ * @author Thomas Cordonnier
+ */
+public class AlternativeProjectTMXEntry extends ProjectTMXEntry {
+    private EntryKey key;
+
+    AlternativeProjectTMXEntry(ITMXEntry from, EntryKey key, ExternalLinked linked) {
+        super(from, linked);
+
+        if (key != null) {
+            this.key = key;
+        } else {
+            this.key = new EntryKey(from.getPropValue(ProjectTMX.PROP_FILE),
+                from.getSourceText(), from.getPropValue(ProjectTMX.PROP_ID),
+                from.getPropValue(ProjectTMX.PROP_PREV), from.getPropValue(ProjectTMX.PROP_NEXT),
+                from.getPropValue(ProjectTMX.PROP_PATH));
+        }
+    }
+    
+    @Override
+    public boolean isDefaultTranslation() {
+        return false;
+    }
+    
+    public String getSourceText() {
+        return key.sourceText;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (! super.equals(obj)) {
+            return false;
+        }
+        try {
+            ProjectTMXEntry other = (ProjectTMXEntry) obj;
+            if (other.isDefaultTranslation()) {
+                return false;
+            }
+            return true;
+        } catch (ClassCastException cc) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(changeDate / 1000, creationDate / 1000, translation, note, linked, changer, creator,
+                key);
+    }
+
+
+    public boolean hasProperties() {
+        return true; // will almost have properties from the key
+    }
+    
+    public String getPropValue(String propType) {
+        if (ProjectTMX.PROP_XAUTO.equals(propType)) {
+            switch (linked) {
+                case xAUTO: case xENFORCED: return "auto";
+                case xICE: case x100PC: return key.id;
+            }
+        }
+        return null; // for the moment internal entries do not store properties
+    }
+    
+    public boolean hasPropValue(String propType, String propValue) {
+        if (ProjectTMX.PROP_XAUTO.equals(propType)) {
+            switch (linked) {
+                case xAUTO: case xENFORCED: return "auto".equals(propValue);
+                case xICE: case x100PC: return key.id.equals(propValue);
+            }
+        }
+        return false; // for the moment internal entries do not store properties
+    }
+    
+    public List<TMXProp> getProperties() {
+        List<TMXProp> result = new ArrayList<>(key.toProperties());
+        switch (linked) {
+            case xAUTO: case xENFORCED: 
+                result.add(new TMXProp(ProjectTMX.PROP_XAUTO, "auto"));
+                break;
+            case xICE: 
+                result.add(new TMXProp(ProjectTMX.PROP_XICE, key.id));
+                break;
+            case x100PC: 
+                result.add(new TMXProp(ProjectTMX.PROP_X100PC, key.id));
+                break;
+        }
+        return result;
+    }    
+}

--- a/src/org/omegat/core/data/DataUtils.java
+++ b/src/org/omegat/core/data/DataUtils.java
@@ -30,7 +30,7 @@ public final class DataUtils {
     private DataUtils() {
     }
 
-    public static boolean isDuplicate(SourceTextEntry ste, TMXEntry te) {
+    public static boolean isDuplicate(SourceTextEntry ste, ProjectTMXEntry te) {
         return ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT && te.defaultTranslation;
     }
 }

--- a/src/org/omegat/core/data/DataUtils.java
+++ b/src/org/omegat/core/data/DataUtils.java
@@ -31,6 +31,6 @@ public final class DataUtils {
     }
 
     public static boolean isDuplicate(SourceTextEntry ste, ProjectTMXEntry te) {
-        return ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT && te.defaultTranslation;
+        return ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT && te.isDefaultTranslation();
     }
 }

--- a/src/org/omegat/core/data/EntryKey.java
+++ b/src/org/omegat/core/data/EntryKey.java
@@ -25,9 +25,12 @@
  **************************************************************************/
 package org.omegat.core.data;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 
 import org.omegat.util.StringUtil;
+import org.omegat.util.TMXProp;
 
 /**
  * Class for store full entry's identifier, including file, id, src, etc.
@@ -127,4 +130,14 @@ public class EntryKey implements Comparable<EntryKey> {
     public static boolean isIgnoreFileContext() {
         return ignoreFileContext;
     }
+    
+   public List<TMXProp> toProperties() {
+        return List.of(
+            new TMXProp(ProjectTMX.PROP_FILE, file),
+            new TMXProp(ProjectTMX.PROP_ID, id),
+            new TMXProp(ProjectTMX.PROP_PREV, prev),
+            new TMXProp(ProjectTMX.PROP_NEXT, next),
+            new TMXProp(ProjectTMX.PROP_PATH, path)
+        );
+   }    
 }

--- a/src/org/omegat/core/data/ExternalTMFactory.java
+++ b/src/org/omegat/core/data/ExternalTMFactory.java
@@ -181,7 +181,7 @@ public final class ExternalTMFactory {
                             te.otherProperties.add(new TMXProp(PROP_FOREIGN_MATCH, "true"));
                         }
 
-                        entries.add(new ExternalTMXEntry(te));
+                        entries.add(te.toExternalTMXEntry());
                     }
                 }
             };
@@ -336,7 +336,7 @@ public final class ExternalTMFactory {
             }
         }
         entry.otherProperties = tmxProps;
-        return new ExternalTMXEntry(entry);
+        return entry.toExternalTMXEntry();
     }
 
     private static List<TMXProp> propsToList(String[] props) {

--- a/src/org/omegat/core/data/ExternalTMFactory.java
+++ b/src/org/omegat/core/data/ExternalTMFactory.java
@@ -123,8 +123,8 @@ public final class ExternalTMFactory {
             return new ExternalTMX(file.getName(), loadImpl(sourceLang, targetLang));
         }
 
-        private List<PrepareTMXEntry> loadImpl(Language sourceLang, Language targetLang) throws Exception {
-            List<PrepareTMXEntry> entries = new ArrayList<>();
+        private List<? extends ITMXEntry> loadImpl(Language sourceLang, Language targetLang) throws Exception {
+            List<ExternalTMXEntry> entries = new ArrayList<ExternalTMXEntry>();
 
             TMXReader2.LoadCallback loader = new TMXReader2.LoadCallback() {
                 public boolean onEntry(TMXReader2.ParsedTu tu, TMXReader2.ParsedTuv tuvSource,
@@ -181,7 +181,7 @@ public final class ExternalTMFactory {
                             te.otherProperties.add(new TMXProp(PROP_FOREIGN_MATCH, "true"));
                         }
 
-                        entries.add(te);
+                        entries.add(new ExternalTMXEntry(te));
                     }
                 }
             };
@@ -231,8 +231,8 @@ public final class ExternalTMFactory {
             return new ExternalTMX(file.getName(), loadImpl(sourceLang, targetLang));
         }
 
-        private List<PrepareTMXEntry> loadImpl(Language sourceLang, Language targetLang) throws Exception {
-            List<PrepareTMXEntry> entries = new ArrayList<>();
+        private List<? extends ITMXEntry> loadImpl(Language sourceLang, Language targetLang) throws Exception {
+            List<ExternalTMXEntry> entries = new ArrayList<>();
             ParseEntryResult throwaway = new ParseEntryResult();
             Core.getFilterMaster().loadFile(file.getPath(),
                     new FilterContext(sourceLang, targetLang, true).setRemoveAllTags(removeTags),
@@ -299,7 +299,7 @@ public final class ExternalTMFactory {
 
     public static final class Builder {
         private final String name;
-        private final List<PrepareTMXEntry> entries = new ArrayList<>();
+        private final List<ExternalTMXEntry> entries = new ArrayList<>();
 
         public Builder(String name) {
             this.name = name;
@@ -316,7 +316,7 @@ public final class ExternalTMFactory {
         }
     }
 
-    private static PrepareTMXEntry makeEntry(String source, String target, String id, String comment, String path,
+    private static ExternalTMXEntry makeEntry(String source, String target, String id, String comment, String path,
             String[] props) {
         PrepareTMXEntry entry = new PrepareTMXEntry();
         entry.source = source;
@@ -336,7 +336,7 @@ public final class ExternalTMFactory {
             }
         }
         entry.otherProperties = tmxProps;
-        return entry;
+        return new ExternalTMXEntry(entry);
     }
 
     private static List<TMXProp> propsToList(String[] props) {

--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -43,7 +43,7 @@ public class ExternalTMX {
 
     private final String name;
 
-    private final List<PrepareTMXEntry> entries;
+    private final List<? extends ITMXEntry> entries;
 
     ExternalTMX(String name, List<PrepareTMXEntry> entries) {
         this.name = name;
@@ -54,7 +54,7 @@ public class ExternalTMX {
         return name;
     }
 
-    public List<PrepareTMXEntry> getEntries() {
+    public List<ITMXEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }
 }

--- a/src/org/omegat/core/data/ExternalTMX.java
+++ b/src/org/omegat/core/data/ExternalTMX.java
@@ -45,7 +45,7 @@ public class ExternalTMX {
 
     private final List<? extends ITMXEntry> entries;
 
-    ExternalTMX(String name, List<PrepareTMXEntry> entries) {
+    ExternalTMX(String name, List<? extends ITMXEntry> entries) {
         this.name = name;
         this.entries = entries;
     }

--- a/src/org/omegat/core/data/IProject.java
+++ b/src/org/omegat/core/data/IProject.java
@@ -150,7 +150,7 @@ public interface IProject {
      *            translation. It can't be null
      */
     void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked);
+            ProjectTMXEntry.ExternalLinked externalLinked);
 
     /**
      * Set translation for entry with optimistic lock checking: if previous translation is not the same like
@@ -163,7 +163,7 @@ public interface IProject {
      *            translation. It can't be null
      */
     void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked, AllTranslations previousTranslations)
+            ProjectTMXEntry.ExternalLinked externalLinked, AllTranslations previousTranslations)
             throws OptimisticLockingFail;
 
     /**
@@ -176,7 +176,7 @@ public interface IProject {
      * @param note
      *            note text
      */
-    void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note);
+    void setNote(SourceTextEntry entry, ProjectTMXEntry oldTrans, String note);
 
     /**
      * Get statistics for project.
@@ -195,7 +195,7 @@ public interface IProject {
      *            source entry
      * @return translation
      */
-    TMXEntry getTranslationInfo(SourceTextEntry ste);
+    ProjectTMXEntry getTranslationInfo(SourceTextEntry ste);
 
     /**
      * Get default and alternative translations for optimistic locking.
@@ -295,19 +295,19 @@ public interface IProject {
      * These translations can't be null. Only value or EMPTY_TRANSLATION.
      */
     class AllTranslations {
-        protected TMXEntry defaultTranslation;
-        protected TMXEntry alternativeTranslation;
-        protected TMXEntry currentTranslation;
+        protected ProjectTMXEntry defaultTranslation;
+        protected ProjectTMXEntry alternativeTranslation;
+        protected ProjectTMXEntry currentTranslation;
 
-        public TMXEntry getDefaultTranslation() {
+        public ProjectTMXEntry getDefaultTranslation() {
             return defaultTranslation;
         }
 
-        public TMXEntry getAlternativeTranslation() {
+        public ProjectTMXEntry getAlternativeTranslation() {
             return alternativeTranslation;
         }
 
-        public TMXEntry getCurrentTranslation() {
+        public ProjectTMXEntry getCurrentTranslation() {
             return currentTranslation;
         }
     }

--- a/src/org/omegat/core/data/ITMXEntry.java
+++ b/src/org/omegat/core/data/ITMXEntry.java
@@ -25,6 +25,9 @@
 
 package org.omegat.core.data;
 
+import java.util.List;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Common interface for any object storing a pair source / translation text
@@ -62,4 +65,14 @@ public interface ITMXEntry extends ITranslationEntry {
     default boolean hasNote() {
         return getNote() != null;
     }
+
+    /* --------------------- Properties ------------ */
+
+    boolean hasProperties();
+
+    String getPropValue(String propType);
+
+    boolean hasPropValue(String propType, String propValue);
+
+    List<TMXProp> getProperties();
 }

--- a/src/org/omegat/core/data/ITMXEntry.java
+++ b/src/org/omegat/core/data/ITMXEntry.java
@@ -1,0 +1,65 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Thomas Cordonnier
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+
+/**
+ * Common interface for any object storing a pair source / translation text
+ * with date and author
+ *
+ * @author Thomas Cordonnier
+ */
+public interface ITMXEntry extends ITranslationEntry {
+
+    /**
+     * Gets the initial creator of the entry
+     */
+    String getCreator();
+
+    /**
+     * Gets the initial creation date as an EPOCH timestamp
+     */
+    long getCreationDate();
+
+    /**
+     * Gets the author of last change in the entry
+     */
+    String getChanger();
+
+    /**
+     * Gets the EPOCH timestamp for last change in this entry
+     */
+    long getChangeDate();
+
+    /**
+     * Gets text note (markup &lt;note&gt; in TMX format)
+     */
+    String getNote();
+
+    default boolean hasNote() {
+        return getNote() != null;
+    }
+}

--- a/src/org/omegat/core/data/ITranslationEntry.java
+++ b/src/org/omegat/core/data/ITranslationEntry.java
@@ -1,0 +1,53 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021 Thomas Cordonnier
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+
+/**
+ * Common interface for any object storing a pair source / translation text
+ *
+ * @author Thomas Cordonnier
+ */
+public interface ITranslationEntry {
+
+    /**
+     * Gets the source text
+     */
+    String getSourceText();
+
+    /**
+     * Gets translation text
+     */
+    String getTranslationText();
+
+    /**
+     * Check whenever there is a translation
+     */
+    default boolean isTranslated() {
+        return getTranslationText() != null;
+    }
+
+}

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.omegat.util.StringUtil;
 import org.omegat.util.TMXProp;
 
 /**
@@ -66,8 +65,8 @@ public class ImportFromAutoTMX {
      */
     void process(ExternalTMX tmx, boolean isEnforcedTMX) {
 
-        for (PrepareTMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
-            List<SourceTextEntry> list = existEntries.get(e.source);
+        for (ITMXEntry e : tmx.getEntries()) { // iterate by all entries in TMX
+            List<SourceTextEntry> list = existEntries.get(e.getSourceText());
             if (list == null) {
                 continue; // there is no entries for this source
             }
@@ -113,13 +112,13 @@ public class ImportFromAutoTMX {
                             || existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
                         // already contains x-ice
                         if (hasICE
-                                && !Objects.equals(existTranslation.translation, e.translation)) {
+                                && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
                             setTranslation(ste, e, false, TMXEntry.ExternalLinked.xICE);
                         }
                     } else if (existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
                         // already contains x-100pc
                         if (has100PC
-                                && !Objects.equals(existTranslation.translation, e.translation)) {
+                                && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
                             setTranslation(ste, e, false, TMXEntry.ExternalLinked.x100PC);
                         }
                     }
@@ -128,13 +127,13 @@ public class ImportFromAutoTMX {
         }
     }
 
-    private boolean isAltTranslation(PrepareTMXEntry entry) {
-        if (entry.otherProperties == null) {
+    private boolean isAltTranslation(ITMXEntry entry) {
+        if (!entry.hasProperties()) {
             return false;
         }
         boolean hasFileProp = false;
         boolean hasOtherProp = false;
-        for (TMXProp p : entry.otherProperties) {
+        for (TMXProp p : entry.getProperties()) {
             if (p.getType().equals(ProjectTMX.PROP_FILE)) {
                 hasFileProp = true;
             } else if (p.getType().equals(ProjectTMX.PROP_ID)
@@ -148,12 +147,12 @@ public class ImportFromAutoTMX {
         return EntryKey.isIgnoreFileContext() ? hasOtherProp : hasFileProp;
     }
 
-    private boolean altTranslationMatches(PrepareTMXEntry entry, EntryKey key) {
-        if (entry.otherProperties == null) {
+    private boolean altTranslationMatches(ITMXEntry entry, EntryKey key) {
+        if (!entry.hasProperties()) {
             return false;
         }
         String file = null, id = null, next = null, prev = null, path = null;
-        for (TMXProp p : entry.otherProperties) {
+        for (TMXProp p : entry.getProperties()) {
             if (ProjectTMX.PROP_FILE.equals(p.getType())) {
                 file = p.getValue();
             } else if (ProjectTMX.PROP_ID.equals(p.getType())) {
@@ -169,20 +168,14 @@ public class ImportFromAutoTMX {
                 path = p.getValue();
             }
         }
-        return key.equals(new EntryKey(file, entry.source, id, prev, next, path));
+        return key.equals(new EntryKey(file, entry.getSourceText(), id, prev, next, path));
     }
 
-    private void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans, boolean defaultTranslation,
+    private void setTranslation(SourceTextEntry entry, ITMXEntry trans, boolean defaultTranslation,
             TMXEntry.ExternalLinked externalLinked) {
-        if (StringUtil.isEmpty(trans.note)) {
-            trans.note = null;
-        }
-
-        trans.source = entry.getSrcText();
-
         TMXEntry newTrEntry;
 
-        if (trans.translation == null && trans.note == null) {
+        if ((!trans.isTranslated()) && (!trans.hasNote())) {
             // no translation, no note
             newTrEntry = null;
         } else {

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -83,7 +83,7 @@ public class ImportFromAutoTMX {
                 }
                 if (!hasICE && !has100PC) { // TMXEntry without x-ids
                     boolean isDefaultTranslation = !isAltTranslation(e);
-                    if (!existTranslation.defaultTranslation && isDefaultTranslation) {
+                    if (!existTranslation.isDefaultTranslation() && isDefaultTranslation) {
                         // Existing translation is alt but the TMX entry is not.
                         continue;
                     }
@@ -101,7 +101,7 @@ public class ImportFromAutoTMX {
                         setTranslation(ste, e, isDefaultTranslation, ProjectTMXEntry.ExternalLinked.xAUTO);
                     }
                 } else { // TMXEntry with x-ids
-                    if (!existTranslation.isTranslated() || existTranslation.defaultTranslation) {
+                    if (!existTranslation.isTranslated() || existTranslation.isDefaultTranslation()) {
                         // need to update if id in xICE or x100PC
                         if (hasICE) {
                             setTranslation(ste, e, false, ProjectTMXEntry.ExternalLinked.xICE);
@@ -179,7 +179,11 @@ public class ImportFromAutoTMX {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new ProjectTMXEntry(trans, defaultTranslation, externalLinked);
+            if (defaultTranslation) {
+                newTrEntry = new DefaultProjectTMXEntry(trans, externalLinked);
+            } else {
+                newTrEntry = new AlternativeProjectTMXEntry(trans, entry.getKey(), externalLinked);            
+            }
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
     }

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -71,7 +71,7 @@ public class ImportFromAutoTMX {
                 continue; // there is no entries for this source
             }
             for (SourceTextEntry ste : list) { // for each TMX entry - get all sources in project
-                TMXEntry existTranslation = project.getTranslationInfo(ste);
+                ProjectTMXEntry existTranslation = project.getTranslationInfo(ste);
 
                 String id = ste.getKey().id;
                 boolean hasICE = id != null && e.hasPropValue(ProjectTMX.PROP_XICE, id);
@@ -92,34 +92,34 @@ public class ImportFromAutoTMX {
                         continue;
                     }
                     if (isEnforcedTMX && (!existTranslation.isTranslated()
-                            || existTranslation.linked != TMXEntry.ExternalLinked.xENFORCED)) {
+                            || existTranslation.linked != ProjectTMXEntry.ExternalLinked.xENFORCED)) {
                         // If there's no translation or if the existing translation doesn't
                         // come from an enforced TM.
-                        setTranslation(ste, e, isDefaultTranslation, TMXEntry.ExternalLinked.xENFORCED);
+                        setTranslation(ste, e, isDefaultTranslation, ProjectTMXEntry.ExternalLinked.xENFORCED);
                     } else if (!existTranslation.isTranslated()) {
                         // default translation not exist - use from auto tmx
-                        setTranslation(ste, e, isDefaultTranslation, TMXEntry.ExternalLinked.xAUTO);
+                        setTranslation(ste, e, isDefaultTranslation, ProjectTMXEntry.ExternalLinked.xAUTO);
                     }
                 } else { // TMXEntry with x-ids
                     if (!existTranslation.isTranslated() || existTranslation.defaultTranslation) {
                         // need to update if id in xICE or x100PC
                         if (hasICE) {
-                            setTranslation(ste, e, false, TMXEntry.ExternalLinked.xICE);
+                            setTranslation(ste, e, false, ProjectTMXEntry.ExternalLinked.xICE);
                         } else if (has100PC) {
-                            setTranslation(ste, e, false, TMXEntry.ExternalLinked.x100PC);
+                            setTranslation(ste, e, false, ProjectTMXEntry.ExternalLinked.x100PC);
                         }
-                    } else if (existTranslation.linked == TMXEntry.ExternalLinked.xICE
-                            || existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
+                    } else if (existTranslation.linked == ProjectTMXEntry.ExternalLinked.xICE
+                            || existTranslation.linked == ProjectTMXEntry.ExternalLinked.x100PC) {
                         // already contains x-ice
                         if (hasICE
                                 && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
-                            setTranslation(ste, e, false, TMXEntry.ExternalLinked.xICE);
+                            setTranslation(ste, e, false, ProjectTMXEntry.ExternalLinked.xICE);
                         }
-                    } else if (existTranslation.linked == TMXEntry.ExternalLinked.x100PC) {
+                    } else if (existTranslation.linked == ProjectTMXEntry.ExternalLinked.x100PC) {
                         // already contains x-100pc
                         if (has100PC
                                 && !Objects.equals(existTranslation.getTranslationText(), e.getTranslationText())) {
-                            setTranslation(ste, e, false, TMXEntry.ExternalLinked.x100PC);
+                            setTranslation(ste, e, false, ProjectTMXEntry.ExternalLinked.x100PC);
                         }
                     }
                 }
@@ -172,14 +172,14 @@ public class ImportFromAutoTMX {
     }
 
     private void setTranslation(SourceTextEntry entry, ITMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
-        TMXEntry newTrEntry;
+            ProjectTMXEntry.ExternalLinked externalLinked) {
+        ProjectTMXEntry newTrEntry;
 
         if ((!trans.isTranslated()) && (!trans.hasNote())) {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
+            newTrEntry = new ProjectTMXEntry(trans, defaultTranslation, externalLinked);
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
     }

--- a/src/org/omegat/core/data/NotLoadedProject.java
+++ b/src/org/omegat/core/data/NotLoadedProject.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.omegat.core.data.TMXEntry.ExternalLinked;
+import org.omegat.core.data.ProjectTMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.filters2.TranslationException;
 import org.omegat.tokenizer.ITokenizer;
@@ -77,7 +77,7 @@ public class NotLoadedProject implements IProject {
         return null;
     }
 
-    public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+    public ProjectTMXEntry getTranslationInfo(SourceTextEntry ste) {
         return null;
     }
 
@@ -91,7 +91,7 @@ public class NotLoadedProject implements IProject {
     public void iterateByMultipleTranslations(MultipleTranslationsIterator it) {
     }
 
-    public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
+    public void setNote(SourceTextEntry entry, ProjectTMXEntry oldTrans, String note) {
     }
 
     public boolean isOrphaned(String source) {

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -95,6 +95,14 @@ public class PrepareTMXEntry implements ITMXEntry {
         return note;
     }
 
+    public boolean hasProperties() {
+        return (otherProperties != null) && (otherProperties.size() > 0);
+    }
+
+    public List<TMXProp> getProperties() {
+        return otherProperties;
+    }
+
     public String getPropValue(String propType) {
         if (otherProperties == null) {
             return null;

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -28,6 +28,7 @@
 
 package org.omegat.core.data;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.omegat.util.TMXProp;
@@ -61,14 +62,15 @@ public class PrepareTMXEntry implements ITMXEntry {
     public PrepareTMXEntry() {
     }
 
-    public PrepareTMXEntry(TMXEntry e) {
-        source = e.source;
-        translation = e.translation;
-        changer = e.changer;
-        changeDate = e.changeDate;
-        creator = e.creator;
-        creationDate = e.creationDate;
-        note = e.note;
+    public PrepareTMXEntry(ITMXEntry e) {
+        source = e.getSourceText();
+        translation = e.getTranslationText();
+        changer = e.getChanger();
+        changeDate = e.getChangeDate();
+        creator = e.getCreator();
+        creationDate = e.getCreationDate();
+        note = e.getNote();
+        otherProperties = Collections.unmodifiableList(e.getProperties());
     }
 
     public String getSourceText() {
@@ -152,7 +154,11 @@ public class PrepareTMXEntry implements ITMXEntry {
         return new ExternalTMXEntry(this);
     }
 
-    ProjectTMXEntry toProjectTMXEntry(boolean defaultTranslation, ProjectTMXEntry.ExternalLinked linked) {
-        return new ProjectTMXEntry(this, defaultTranslation, linked);
+    ProjectTMXEntry toProjectTMXEntry(boolean defaultTranslation, EntryKey key, ProjectTMXEntry.ExternalLinked linked) {
+        if (defaultTranslation) {
+            return new DefaultProjectTMXEntry(this, linked);
+        } else {
+            return new AlternativeProjectTMXEntry(this, key, linked);        
+        }
     }
 }

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -33,7 +33,7 @@ import java.util.List;
 import org.omegat.util.TMXProp;
 
 /**
- * Class for prepare TMXEntry content before save unchangeable copy in the ProjectTMX. We can't use just
+ * Class for prepare TMXEntry content before save unchangeable copy anywhere. We can't use just
  * parameters in the setTranslation() method since count of parameters is too much. Structure of this class is
  * almost the save like TMXEntry.
  *

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -44,7 +44,7 @@ import org.omegat.util.TMXProp;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class PrepareTMXEntry {
+public class PrepareTMXEntry implements ITMXEntry {
     public String source;
     public String translation;
     public String changer;
@@ -65,6 +65,34 @@ public class PrepareTMXEntry {
         creator = e.creator;
         creationDate = e.creationDate;
         note = e.note;
+    }
+
+    public String getSourceText() {
+        return source;
+    }
+
+    public String getTranslationText() {
+        return translation;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    public String getChanger() {
+        return changer;
+    }
+
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    public String getNote() {
+        return note;
     }
 
     public String getPropValue(String propType) {

--- a/src/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/org/omegat/core/data/PrepareTMXEntry.java
@@ -147,5 +147,12 @@ public class PrepareTMXEntry implements ITMXEntry {
                 .append(", otherProperties=").append(otherProperties).append("]");
         return builder.toString();
     }
+    
+    ExternalTMXEntry toExternalTMXEntry() {
+        return new ExternalTMXEntry(this);
+    }
 
+    ProjectTMXEntry toProjectTMXEntry(boolean defaultTranslation, ProjectTMXEntry.ExternalLinked linked) {
+        return new ProjectTMXEntry(this, defaultTranslation, linked);
+    }
 }

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -72,22 +72,22 @@ public class ProjectTMX {
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<String, TMXEntry> defaults;
+    Map<String, ProjectTMXEntry> defaults;
 
     /**
      * Storage for alternative translations for current project.
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<EntryKey, TMXEntry> alternatives;
+    Map<EntryKey, ProjectTMXEntry> alternatives;
 
     final CheckOrphanedCallback checkOrphanedCallback;
 
     public ProjectTMX(Language sourceLanguage, Language targetLanguage, boolean isSentenceSegmentingEnabled,
             File file, CheckOrphanedCallback callback) throws Exception {
         this.checkOrphanedCallback = callback;
-        alternatives = new HashMap<EntryKey, TMXEntry>();
-        defaults = new HashMap<String, TMXEntry>();
+        alternatives = new HashMap<EntryKey, ProjectTMXEntry>();
+        defaults = new HashMap<String, ProjectTMXEntry>();
 
         if (file == null || !file.exists()) {
             // file not exist - new project
@@ -109,8 +109,8 @@ public class ProjectTMX {
      * Constructor for TMX delta.
      */
     public ProjectTMX() {
-        alternatives = new HashMap<EntryKey, TMXEntry>();
-        defaults = new HashMap<String, TMXEntry>();
+        alternatives = new HashMap<EntryKey, ProjectTMXEntry>();
+        defaults = new HashMap<String, ProjectTMXEntry>();
         checkOrphanedCallback = null;
     }
 
@@ -163,8 +163,8 @@ public class ProjectTMX {
         TMXWriter2 wr = new TMXWriter2(outFile, props.getSourceLanguage(), props.getTargetLanguage(),
                 props.isSentenceSegmentingEnabled(), levelTwo, forceValidTMX);
         try {
-            Map<String, TMXEntry> tempDefaults = new TreeMap<>();
-            Map<EntryKey, TMXEntry> tempAlternatives = new TreeMap<>();
+            Map<String, ProjectTMXEntry> tempDefaults = new TreeMap<>();
+            Map<EntryKey, ProjectTMXEntry> tempAlternatives = new TreeMap<>();
 
             synchronized (this) {
                 if (useOrphaned) {
@@ -173,12 +173,12 @@ public class ProjectTMX {
                     tempAlternatives.putAll(alternatives);
                 } else {
                     // slow call - copy non-orphaned only
-                    for (Map.Entry<String, TMXEntry> en : defaults.entrySet()) {
+                    for (Map.Entry<String, ProjectTMXEntry> en : defaults.entrySet()) {
                         if (checkOrphanedCallback.existSourceInProject(en.getKey())) {
                             tempDefaults.put(en.getKey(), en.getValue());
                         }
                     }
-                    for (Map.Entry<EntryKey, TMXEntry> en : alternatives.entrySet()) {
+                    for (Map.Entry<EntryKey, ProjectTMXEntry> en : alternatives.entrySet()) {
                         if (checkOrphanedCallback.existEntryInProject(en.getKey())) {
                             tempAlternatives.put(en.getKey(), en.getValue());
                         }
@@ -188,10 +188,10 @@ public class ProjectTMX {
 
             List<String> p = new ArrayList<>();
             wr.writeComment(" Default translations ");
-            for (Map.Entry<String, TMXEntry> en : new TreeMap<>(tempDefaults).entrySet()) {
+            for (Map.Entry<String, ProjectTMXEntry> en : new TreeMap<>(tempDefaults).entrySet()) {
                 p.clear();
                 if (Preferences.isPreferenceDefault(Preferences.SAVE_AUTO_STATUS, false)) {
-                    if (en.getValue().linked == TMXEntry.ExternalLinked.xAUTO) {
+                    if (en.getValue().linked == ProjectTMXEntry.ExternalLinked.xAUTO) {
                         p.add(PROP_XAUTO);
                         p.add("auto");
                     }
@@ -200,7 +200,7 @@ public class ProjectTMX {
             }
 
             wr.writeComment(" Alternative translations ");
-            for (Map.Entry<EntryKey, TMXEntry> en : new TreeMap<>(tempAlternatives).entrySet()) {
+            for (Map.Entry<EntryKey, ProjectTMXEntry> en : new TreeMap<>(tempAlternatives).entrySet()) {
                 EntryKey k = en.getKey();
                 p.clear();
                 p.add(PROP_FILE);
@@ -214,10 +214,10 @@ public class ProjectTMX {
                 p.add(PROP_PATH);
                 p.add(k.path);
                 if (Preferences.isPreferenceDefault(Preferences.SAVE_AUTO_STATUS, false)) {
-                    if (en.getValue().linked == TMXEntry.ExternalLinked.xICE) {
+                    if (en.getValue().linked == ProjectTMXEntry.ExternalLinked.xICE) {
                         p.add(PROP_XICE);
                         p.add(k.id);
-                    } else if (en.getValue().linked == TMXEntry.ExternalLinked.x100PC) {
+                    } else if (en.getValue().linked == ProjectTMXEntry.ExternalLinked.x100PC) {
                         p.add(PROP_X100PC);
                         p.add(k.id);
                     }
@@ -232,7 +232,7 @@ public class ProjectTMX {
     /**
      * Get default translation or null if not exist.
      */
-    public TMXEntry getDefaultTranslation(String source) {
+    public ProjectTMXEntry getDefaultTranslation(String source) {
         synchronized (this) {
             return defaults.get(source);
         }
@@ -241,7 +241,7 @@ public class ProjectTMX {
     /**
      * Get multiple translation or null if not exist.
      */
-    public TMXEntry getMultipleTranslation(EntryKey ek) {
+    public ProjectTMXEntry getMultipleTranslation(EntryKey ek) {
         synchronized (this) {
             return alternatives.get(ek);
         }
@@ -250,7 +250,7 @@ public class ProjectTMX {
     /**
      * Set new translation.
      */
-    public void setTranslation(SourceTextEntry ste, TMXEntry te, boolean isDefault) {
+    public void setTranslation(SourceTextEntry ste, ProjectTMXEntry te, boolean isDefault) {
         synchronized (this) {
             if (te == null) {
                 if (isDefault) {
@@ -338,7 +338,7 @@ public class ProjectTMX {
                             id, te.getPropValue(PROP_PREV), te.getPropValue(PROP_NEXT),
                             te.getPropValue(PROP_PATH));
 
-                    TMXEntry.ExternalLinked externalLinkedMode = calcExternalLinkedMode(te);
+                    ProjectTMXEntry.ExternalLinked externalLinkedMode = calcExternalLinkedMode(te);
 
                     boolean defaultTranslation = key.file == null;
                     if (te.otherProperties != null && te.otherProperties.isEmpty()) {
@@ -347,10 +347,10 @@ public class ProjectTMX {
 
                     if (defaultTranslation) {
                         // default translation
-                        defaults.put(segmentSource, new TMXEntry(te, true, externalLinkedMode));
+                        defaults.put(segmentSource, new ProjectTMXEntry(te, true, externalLinkedMode));
                     } else {
                         // multiple translation
-                        alternatives.put(key, new TMXEntry(te, false, externalLinkedMode));
+                        alternatives.put(key, new ProjectTMXEntry(te, false, externalLinkedMode));
                     }
                 }
             }
@@ -358,20 +358,20 @@ public class ProjectTMX {
         }
     };
 
-    private TMXEntry.ExternalLinked calcExternalLinkedMode(PrepareTMXEntry te) {
+    private ProjectTMXEntry.ExternalLinked calcExternalLinkedMode(PrepareTMXEntry te) {
         String id = te.getPropValue(PROP_ID);
         if (id == null) {
             id = te.getPropValue(ATTR_TUID);
         }
-        TMXEntry.ExternalLinked externalLinked = null;
+        ProjectTMXEntry.ExternalLinked externalLinked = null;
         if (externalLinked == null && te.hasPropValue(PROP_XICE, id)) {
-            externalLinked = TMXEntry.ExternalLinked.xICE;
+            externalLinked = ProjectTMXEntry.ExternalLinked.xICE;
         }
         if (externalLinked == null && te.hasPropValue(PROP_X100PC, id)) {
-            externalLinked = TMXEntry.ExternalLinked.x100PC;
+            externalLinked = ProjectTMXEntry.ExternalLinked.x100PC;
         }
         if (externalLinked == null && te.hasPropValue(PROP_XAUTO, null)) {
-            externalLinked = TMXEntry.ExternalLinked.xAUTO;
+            externalLinked = ProjectTMXEntry.ExternalLinked.xAUTO;
         }
         return externalLinked;
     }
@@ -379,14 +379,14 @@ public class ProjectTMX {
     /**
      * Returns the collection of TMX entries that have a default translation
      */
-    public Collection<TMXEntry> getDefaults() {
+    public Collection<ProjectTMXEntry> getDefaults() {
         return defaults.values();
     }
     /**
      * Returns the collection of TMX entries that have an alternative translation
      * @return
      */
-    public Collection<TMXEntry> getAlternatives() {
+    public Collection<ProjectTMXEntry> getAlternatives() {
         return alternatives.values();
     }
 

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -259,10 +259,10 @@ public class ProjectTMX {
                     alternatives.remove(ste.getKey());
                 }
             } else {
-                if (!ste.getSrcText().equals(te.source)) {
+                if (!ste.getSrcText().equals(te.getSourceText())) {
                     throw new IllegalArgumentException("Source must be the same as in SourceTextEntry");
                 }
-                if (isDefault != te.defaultTranslation) {
+                if (isDefault != te.isDefaultTranslation()) {
                     throw new IllegalArgumentException("Default/alternative must be the same");
                 }
                 if (isDefault) {
@@ -347,10 +347,10 @@ public class ProjectTMX {
 
                     if (defaultTranslation) {
                         // default translation
-                        defaults.put(segmentSource, new ProjectTMXEntry(te, true, externalLinkedMode));
+                        defaults.put(segmentSource, te.toProjectTMXEntry(true, null, externalLinkedMode));
                     } else {
                         // multiple translation
-                        alternatives.put(key, new ProjectTMXEntry(te, false, externalLinkedMode));
+                        alternatives.put(key, te.toProjectTMXEntry(false, key, externalLinkedMode));
                     }
                 }
             }

--- a/src/org/omegat/core/data/ProjectTMXEntry.java
+++ b/src/org/omegat/core/data/ProjectTMXEntry.java
@@ -1,0 +1,120 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2010 Alex Buloichik
+               2012 Guido Leenders, Thomas Cordonnier
+               2013 Aaron Madlon-Kay
+               2014 Alex Buloichik, Aaron Madlon-Kay
+               Home page: http://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.omegat.util.TMXProp;
+
+/**
+ * Storage for TMX entry for project memory
+ *
+ * Variables in this class can be changed only before store to ProjectTMX. After that, all values must be
+ * unchangeable.
+ *
+ * Only RealProject can create and change TMXEntry objects.
+ *
+ * @author Alex Buloichik (alex73mail@gmail.com)
+ * @author Guido Leenders
+ * @author Aaron Madlon-Kay
+ */
+public class ProjectTMXEntry extends TMXEntry {
+    public enum ExternalLinked {
+        // declares how this entry linked to external TMX in the tm/auto/
+        xICE, x100PC, xAUTO, xENFORCED
+    };
+
+    public final boolean defaultTranslation;
+    public final ExternalLinked linked;
+
+    ProjectTMXEntry(ITMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        super(from);
+
+        this.defaultTranslation = defaultTranslation;
+        this.linked = linked;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (! super.equals(obj)) {
+            return false;
+        }
+        try {
+            ProjectTMXEntry other = (ProjectTMXEntry) obj;
+            if (defaultTranslation != other.defaultTranslation) {
+                return false;
+            }
+            return true;
+        } catch (ClassCastException cc) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(changeDate / 1000, creationDate / 1000, translation, note, linked, changer, creator,
+                defaultTranslation, source);
+    }
+
+    /**
+     * Two TMXEntrys are considered interchangeable if this method returns true,
+     * even if equals() != true.
+     */
+    public boolean equalsTranslation(TMXEntry other) {
+        if (! super.equalsTranslation(other)) {
+            return false;
+        }
+        try {
+            ProjectTMXEntry pOther = (ProjectTMXEntry) other;
+            if (!Objects.equals(linked, pOther.linked)) {
+                return false;
+            }
+        } catch (ClassCastException cc) {
+            return false;
+        }
+        return true;
+    }
+    
+    public boolean hasProperties() {
+        return false;
+    }
+    
+    public String getPropValue(String propType) {
+        return null; // for the moment internal entries do not store properties
+    }
+    
+    public boolean hasPropValue(String propType, String propValue) {
+        return false; // for the moment internal entries do not store properties
+    }
+    
+    public List<TMXProp> getProperties() {
+        return null; // for the moment internal entries do not store properties
+    }
+}

--- a/src/org/omegat/core/data/ProjectTMXEntry.java
+++ b/src/org/omegat/core/data/ProjectTMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik, Aaron Madlon-Kay
+               2021-2022 Thomas Cordonnier
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -44,44 +45,23 @@ import org.omegat.util.TMXProp;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
+ * @author Thomas Cordonnier
  */
-public class ProjectTMXEntry extends TMXEntry {
+public abstract class ProjectTMXEntry extends TMXEntry {
     public enum ExternalLinked {
         // declares how this entry linked to external TMX in the tm/auto/
         xICE, x100PC, xAUTO, xENFORCED
     };
 
-    public final boolean defaultTranslation;
     public final ExternalLinked linked;
 
-    ProjectTMXEntry(ITMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+    ProjectTMXEntry(ITMXEntry from, ExternalLinked linked) {
         super(from);
 
-        this.defaultTranslation = defaultTranslation;
         this.linked = linked;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (! super.equals(obj)) {
-            return false;
-        }
-        try {
-            ProjectTMXEntry other = (ProjectTMXEntry) obj;
-            if (defaultTranslation != other.defaultTranslation) {
-                return false;
-            }
-            return true;
-        } catch (ClassCastException cc) {
-            return false;
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(changeDate / 1000, creationDate / 1000, translation, note, linked, changer, creator,
-                defaultTranslation, source);
-    }
+    
+    public abstract boolean isDefaultTranslation();
 
     /**
      * Two TMXEntrys are considered interchangeable if this method returns true,
@@ -103,18 +83,6 @@ public class ProjectTMXEntry extends TMXEntry {
     }
     
     public boolean hasProperties() {
-        return false;
-    }
-    
-    public String getPropValue(String propType) {
-        return null; // for the moment internal entries do not store properties
-    }
-    
-    public boolean hasPropValue(String propType, String propValue) {
-        return false; // for the moment internal entries do not store properties
-    }
-    
-    public List<TMXProp> getProperties() {
-        return null; // for the moment internal entries do not store properties
-    }
+        return linked != null;
+    }    
 }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -204,7 +204,7 @@ public class RealProject implements IProject {
     static {
         PrepareTMXEntry empty = new PrepareTMXEntry();
         empty.source = "";
-        EMPTY_TRANSLATION = new ProjectTMXEntry(empty, true, null);
+        EMPTY_TRANSLATION = empty.toProjectTMXEntry(true, null);
     }
 
     private final boolean allowTranslationEqualToSource = Preferences.isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
@@ -1240,7 +1240,7 @@ public class RealProject implements IProject {
                     if (enDefault == null) {
                         // default not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, true, null), true);
+                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(true, null), true);
                         allowToImport.put(ste.getSrcText(), ste.getSourceTranslation());
                     } else {
                         // default translation already exist - did we just
@@ -1251,7 +1251,7 @@ public class RealProject implements IProject {
                             // we just imported default and it doesn't equals to
                             // current - import as alternative
                             prepare.translation = ste.getSourceTranslation();
-                            projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, false, null), false);
+                            projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, null), false);
                         }
                     }
                 } else { // project without default translations
@@ -1259,7 +1259,7 @@ public class RealProject implements IProject {
                     if (en == null) {
                         // not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, false, null), false);
+                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, null), false);
                     }
                 }
             }
@@ -1494,7 +1494,7 @@ public class RealProject implements IProject {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new ProjectTMXEntry(trans, defaultTranslation, externalLinked);
+            newTrEntry = trans.toProjectTMXEntry(defaultTranslation, externalLinked);
         }
 
         setProjectModified(true);
@@ -1527,14 +1527,14 @@ public class RealProject implements IProject {
         if (prevTrEntry != null) {
             PrepareTMXEntry en = new PrepareTMXEntry(prevTrEntry);
             en.note = note;
-            projectTMX.setTranslation(entry, new ProjectTMXEntry(en, prevTrEntry.defaultTranslation,
+            projectTMX.setTranslation(entry, en.toProjectTMXEntry(prevTrEntry.defaultTranslation,
                     prevTrEntry.linked), prevTrEntry.defaultTranslation);
         } else {
             PrepareTMXEntry en = new PrepareTMXEntry();
             en.source = entry.getSrcText();
             en.note = note;
             en.translation = null;
-            projectTMX.setTranslation(entry, new ProjectTMXEntry(en, true, null), true);
+            projectTMX.setTranslation(entry, en.toProjectTMXEntry(true, null), true);
         }
 
         setProjectModified(true);
@@ -1838,7 +1838,7 @@ public class RealProject implements IProject {
                         }
                         tr.source = sourceS;
                         tr.translation = transS;
-                        data.put(sourceS, new ProjectTMXEntry(tr, true, null));
+                        data.put(sourceS, tr.toProjectTMXEntry(true, null));
                     } else {
                         for (short i = 0; i < segmentsSource.size(); i++) {
                             String oneSrc = segmentsSource.get(i);
@@ -1848,7 +1848,7 @@ public class RealProject implements IProject {
                             }
                             tr.source = oneSrc;
                             tr.translation = oneTrans;
-                            data.put(sourceS, new ProjectTMXEntry(tr, true, null));
+                            data.put(sourceS, tr.toProjectTMXEntry(true, null));
                         }
                     }
                 } else {
@@ -1857,7 +1857,7 @@ public class RealProject implements IProject {
                     }
                     tr.source = sourceS;
                     tr.translation = transS;
-                    data.put(sourceS, new ProjectTMXEntry(tr, true, null));
+                    data.put(sourceS, tr.toProjectTMXEntry(true, null));
                 }
             }
         }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -204,7 +204,7 @@ public class RealProject implements IProject {
     static {
         PrepareTMXEntry empty = new PrepareTMXEntry();
         empty.source = "";
-        EMPTY_TRANSLATION = empty.toProjectTMXEntry(true, null);
+        EMPTY_TRANSLATION = empty.toProjectTMXEntry(true, null, null);
     }
 
     private final boolean allowTranslationEqualToSource = Preferences.isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
@@ -1240,7 +1240,7 @@ public class RealProject implements IProject {
                     if (enDefault == null) {
                         // default not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(true, null), true);
+                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(true, ste.getKey(), null), true);
                         allowToImport.put(ste.getSrcText(), ste.getSourceTranslation());
                     } else {
                         // default translation already exist - did we just
@@ -1251,7 +1251,7 @@ public class RealProject implements IProject {
                             // we just imported default and it doesn't equals to
                             // current - import as alternative
                             prepare.translation = ste.getSourceTranslation();
-                            projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, null), false);
+                            projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, ste.getKey(), null), false);
                         }
                     }
                 } else { // project without default translations
@@ -1259,7 +1259,7 @@ public class RealProject implements IProject {
                     if (en == null) {
                         // not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, null), false);
+                        projectTMX.setTranslation(ste, prepare.toProjectTMXEntry(false, ste.getKey(), null), false);
                     }
                 }
             }
@@ -1494,7 +1494,7 @@ public class RealProject implements IProject {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = trans.toProjectTMXEntry(defaultTranslation, externalLinked);
+            newTrEntry = trans.toProjectTMXEntry(defaultTranslation, entry.getKey(), externalLinked);
         }
 
         setProjectModified(true);
@@ -1521,20 +1521,20 @@ public class RealProject implements IProject {
             note = null;
         }
 
-        ProjectTMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX
+        ProjectTMXEntry prevTrEntry = oldTE.isDefaultTranslation() ? projectTMX
                 .getDefaultTranslation(entry.getSrcText()) : projectTMX
                 .getMultipleTranslation(entry.getKey());
         if (prevTrEntry != null) {
             PrepareTMXEntry en = new PrepareTMXEntry(prevTrEntry);
             en.note = note;
-            projectTMX.setTranslation(entry, en.toProjectTMXEntry(prevTrEntry.defaultTranslation,
-                    prevTrEntry.linked), prevTrEntry.defaultTranslation);
+            projectTMX.setTranslation(entry, en.toProjectTMXEntry(prevTrEntry.isDefaultTranslation(),
+                    entry.getKey(), prevTrEntry.linked), prevTrEntry.isDefaultTranslation());
         } else {
             PrepareTMXEntry en = new PrepareTMXEntry();
             en.source = entry.getSrcText();
             en.note = note;
             en.translation = null;
-            projectTMX.setTranslation(entry, en.toProjectTMXEntry(true, null), true);
+            projectTMX.setTranslation(entry, en.toProjectTMXEntry(true, entry.getKey(), null), true);
         }
 
         setProjectModified(true);
@@ -1838,7 +1838,7 @@ public class RealProject implements IProject {
                         }
                         tr.source = sourceS;
                         tr.translation = transS;
-                        data.put(sourceS, tr.toProjectTMXEntry(true, null));
+                        data.put(sourceS, tr.toProjectTMXEntry(true, null, null));
                     } else {
                         for (short i = 0; i < segmentsSource.size(); i++) {
                             String oneSrc = segmentsSource.get(i);
@@ -1848,7 +1848,7 @@ public class RealProject implements IProject {
                             }
                             tr.source = oneSrc;
                             tr.translation = oneTrans;
-                            data.put(sourceS, tr.toProjectTMXEntry(true, null));
+                            data.put(sourceS, tr.toProjectTMXEntry(true, null, null));
                         }
                     }
                 } else {
@@ -1857,7 +1857,7 @@ public class RealProject implements IProject {
                     }
                     tr.source = sourceS;
                     tr.translation = transS;
-                    data.put(sourceS, tr.toProjectTMXEntry(true, null));
+                    data.put(sourceS, tr.toProjectTMXEntry(true, null, null));
                 }
             }
         }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -66,7 +66,7 @@ import org.omegat.CLIParameters;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
+import org.omegat.core.data.ProjectTMXEntry.ExternalLinked;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
@@ -200,11 +200,11 @@ public class RealProject implements IProject {
     protected List<FileInfo> projectFilesList = new ArrayList<>();
 
     /** This instance returned if translation not exist. */
-    private static final TMXEntry EMPTY_TRANSLATION;
+    private static final ProjectTMXEntry EMPTY_TRANSLATION;
     static {
         PrepareTMXEntry empty = new PrepareTMXEntry();
         empty.source = "";
-        EMPTY_TRANSLATION = new TMXEntry(empty, true, null);
+        EMPTY_TRANSLATION = new ProjectTMXEntry(empty, true, null);
     }
 
     private final boolean allowTranslationEqualToSource = Preferences.isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
@@ -443,7 +443,7 @@ public class RealProject implements IProject {
     /**
      * Align project.
      */
-    public Map<String, TMXEntry> align(final ProjectProperties props, final File translatedDir)
+    public Map<String, ProjectTMXEntry> align(final ProjectProperties props, final File translatedDir)
             throws Exception {
         FilterMaster fm = Core.getFilterMaster();
 
@@ -1226,7 +1226,7 @@ public class RealProject implements IProject {
                 PrepareTMXEntry prepare = new PrepareTMXEntry();
                 prepare.source = ste.getSrcText();
                 // project with default translations
-                TMXEntry en = projectTMX.getMultipleTranslation(ste.getKey());
+                ProjectTMXEntry en = projectTMX.getMultipleTranslation(ste.getKey());
                 if (config.isSupportDefaultTranslations()) {
                     // bug#969 - Alternative translations were not taken into account
                     // if no default translation is set.
@@ -1240,7 +1240,7 @@ public class RealProject implements IProject {
                     if (enDefault == null) {
                         // default not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new TMXEntry(prepare, true, null), true);
+                        projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, true, null), true);
                         allowToImport.put(ste.getSrcText(), ste.getSourceTranslation());
                     } else {
                         // default translation already exist - did we just
@@ -1251,7 +1251,7 @@ public class RealProject implements IProject {
                             // we just imported default and it doesn't equals to
                             // current - import as alternative
                             prepare.translation = ste.getSourceTranslation();
-                            projectTMX.setTranslation(ste, new TMXEntry(prepare, false, null), false);
+                            projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, false, null), false);
                         }
                     }
                 } else { // project without default translations
@@ -1259,7 +1259,7 @@ public class RealProject implements IProject {
                     if (en == null) {
                         // not exist yet - yes, we can
                         prepare.translation = ste.getSourceTranslation();
-                        projectTMX.setTranslation(ste, new TMXEntry(prepare, false, null), false);
+                        projectTMX.setTranslation(ste, new ProjectTMXEntry(prepare, false, null), false);
                     }
                 }
             }
@@ -1365,11 +1365,11 @@ public class RealProject implements IProject {
         return allProjectEntries;
     }
 
-    public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+    public ProjectTMXEntry getTranslationInfo(SourceTextEntry ste) {
         if (projectTMX == null) {
             return EMPTY_TRANSLATION;
         }
-        TMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
+        ProjectTMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
         if (r == null) {
             r = projectTMX.getDefaultTranslation(ste.getSrcText());
         }
@@ -1460,7 +1460,7 @@ public class RealProject implements IProject {
 
     @Override
     public void setTranslation(final SourceTextEntry entry, final PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
+            ProjectTMXEntry.ExternalLinked externalLinked) {
         if (trans == null) {
             throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
         }
@@ -1488,13 +1488,13 @@ public class RealProject implements IProject {
 
         trans.source = entry.getSrcText();
 
-        TMXEntry newTrEntry;
+        ProjectTMXEntry newTrEntry;
 
         if (trans.translation == null && trans.note == null) {
             // no translation, no note
             newTrEntry = null;
         } else {
-            newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
+            newTrEntry = new ProjectTMXEntry(trans, defaultTranslation, externalLinked);
         }
 
         setProjectModified(true);
@@ -1511,7 +1511,7 @@ public class RealProject implements IProject {
     }
 
     @Override
-    public void setNote(final SourceTextEntry entry, final TMXEntry oldTE, String note) {
+    public void setNote(final SourceTextEntry entry, final ProjectTMXEntry oldTE, String note) {
         if (oldTE == null) {
             throw new IllegalArgumentException("RealProject.setNote(tr) can't be null");
         }
@@ -1521,20 +1521,20 @@ public class RealProject implements IProject {
             note = null;
         }
 
-        TMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX
+        ProjectTMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX
                 .getDefaultTranslation(entry.getSrcText()) : projectTMX
                 .getMultipleTranslation(entry.getKey());
         if (prevTrEntry != null) {
             PrepareTMXEntry en = new PrepareTMXEntry(prevTrEntry);
             en.note = note;
-            projectTMX.setTranslation(entry, new TMXEntry(en, prevTrEntry.defaultTranslation,
+            projectTMX.setTranslation(entry, new ProjectTMXEntry(en, prevTrEntry.defaultTranslation,
                     prevTrEntry.linked), prevTrEntry.defaultTranslation);
         } else {
             PrepareTMXEntry en = new PrepareTMXEntry();
             en.source = entry.getSrcText();
             en.note = note;
             en.translation = null;
-            projectTMX.setTranslation(entry, new TMXEntry(en, true, null), true);
+            projectTMX.setTranslation(entry, new ProjectTMXEntry(en, true, null), true);
         }
 
         setProjectModified(true);
@@ -1544,11 +1544,11 @@ public class RealProject implements IProject {
         if (projectTMX == null) {
             return;
         }
-        Map.Entry<String, TMXEntry>[] entries;
+        Map.Entry<String, ProjectTMXEntry>[] entries;
         synchronized (projectTMX) {
             entries = entrySetToArray(projectTMX.defaults.entrySet());
         }
-        for (Map.Entry<String, TMXEntry> en : entries) {
+        for (Map.Entry<String, ProjectTMXEntry> en : entries) {
             it.iterate(en.getKey(), en.getValue());
         }
     }
@@ -1557,11 +1557,11 @@ public class RealProject implements IProject {
         if (projectTMX == null) {
             return;
         }
-        Map.Entry<EntryKey, TMXEntry>[] entries;
+        Map.Entry<EntryKey, ProjectTMXEntry>[] entries;
         synchronized (projectTMX) {
             entries = entrySetToArray(projectTMX.alternatives.entrySet());
         }
-        for (Map.Entry<EntryKey, TMXEntry> en : entries) {
+        for (Map.Entry<EntryKey, ProjectTMXEntry> en : entries) {
             it.iterate(en.getKey(), en.getValue());
         }
     }
@@ -1814,7 +1814,7 @@ public class RealProject implements IProject {
             this.config = props;
         }
 
-        Map<String, TMXEntry> data = new HashMap<>();
+        Map<String, ProjectTMXEntry> data = new HashMap<>();
         private ProjectProperties config;
 
         @Override
@@ -1838,7 +1838,7 @@ public class RealProject implements IProject {
                         }
                         tr.source = sourceS;
                         tr.translation = transS;
-                        data.put(sourceS, new TMXEntry(tr, true, null));
+                        data.put(sourceS, new ProjectTMXEntry(tr, true, null));
                     } else {
                         for (short i = 0; i < segmentsSource.size(); i++) {
                             String oneSrc = segmentsSource.get(i);
@@ -1848,7 +1848,7 @@ public class RealProject implements IProject {
                             }
                             tr.source = oneSrc;
                             tr.translation = oneTrans;
-                            data.put(sourceS, new TMXEntry(tr, true, null));
+                            data.put(sourceS, new ProjectTMXEntry(tr, true, null));
                         }
                     }
                 } else {
@@ -1857,7 +1857,7 @@ public class RealProject implements IProject {
                     }
                     tr.source = sourceS;
                     tr.translation = transS;
-                    data.put(sourceS, new TMXEntry(tr, true, null));
+                    data.put(sourceS, new ProjectTMXEntry(tr, true, null));
                 }
             }
         }

--- a/src/org/omegat/core/data/SyncTMX.java
+++ b/src/org/omegat/core/data/SyncTMX.java
@@ -85,7 +85,7 @@ public final class SyncTMX implements ITmx {
     }
 
     private Key makeKey(Object entryKey, ProjectTMXEntry tmxEntry) {
-        Key key = new Key(tmxEntry.source, entryKey);
+        Key key = new Key(tmxEntry.getSourceText(), entryKey);
         if (entryKey instanceof EntryKey) {
             EntryKey ek = (EntryKey) entryKey;
             key.addProp("file", ek.file);

--- a/src/org/omegat/core/data/SyncTMX.java
+++ b/src/org/omegat/core/data/SyncTMX.java
@@ -66,7 +66,7 @@ public final class SyncTMX implements ITmx {
     private void generateMaps() {
         tuvMap = new HashMap<Key, ITuv>();
         tuMap = new HashMap<Key, ITu>();
-        for (Entry<String, TMXEntry> e : tmx.defaults.entrySet()) {
+        for (Entry<String, ProjectTMXEntry> e : tmx.defaults.entrySet()) {
             ITu tu = new SyncTu(e.getValue(), targetLanguage);
             Key key = makeKey(e.getKey(), e.getValue());
             assert (!tuMap.containsKey(key));
@@ -74,7 +74,7 @@ public final class SyncTMX implements ITmx {
             tuMap.put(key, tu);
             tuvMap.put(key, tu.getTargetTuv());
         }
-        for (Entry<EntryKey, TMXEntry> e : tmx.alternatives.entrySet()) {
+        for (Entry<EntryKey, ProjectTMXEntry> e : tmx.alternatives.entrySet()) {
             ITu tu = new SyncTu(e.getValue(), targetLanguage);
             Key key = makeKey(e.getKey(), e.getValue());
             assert (!tuMap.containsKey(key));
@@ -84,7 +84,7 @@ public final class SyncTMX implements ITmx {
         }
     }
 
-    private Key makeKey(Object entryKey, TMXEntry tmxEntry) {
+    private Key makeKey(Object entryKey, ProjectTMXEntry tmxEntry) {
         Key key = new Key(tmxEntry.source, entryKey);
         if (entryKey instanceof EntryKey) {
             EntryKey ek = (EntryKey) entryKey;
@@ -125,10 +125,10 @@ public final class SyncTMX implements ITmx {
         }
         for (Entry<Key, ITuv> e : resolution.toReplace.entrySet()) {
             remove(e.getKey());
-            add(e.getKey(), (TMXEntry) e.getValue().getUnderlyingRepresentation());
+            add(e.getKey(), (ProjectTMXEntry) e.getValue().getUnderlyingRepresentation());
         }
         for (Entry<Key, ITu> e : resolution.toAdd.entrySet()) {
-            add(e.getKey(), (TMXEntry) e.getValue().getUnderlyingRepresentation());
+            add(e.getKey(), (ProjectTMXEntry) e.getValue().getUnderlyingRepresentation());
         }
         ProjectTMX modifiedData = tmx;
         this.tmx = originalData;
@@ -137,7 +137,7 @@ public final class SyncTMX implements ITmx {
         return new SyncTMX(modifiedData, this.name, this.sourceLanguage, this.targetLanguage);
     }
 
-    private void add(Key key, TMXEntry tuv) {
+    private void add(Key key, ProjectTMXEntry tuv) {
         if (key.foreignKey instanceof String) {
             tmx.defaults.put((String) key.foreignKey, tuv);
         } else if (key.foreignKey instanceof EntryKey) {
@@ -161,10 +161,10 @@ public final class SyncTMX implements ITmx {
 
     private static ProjectTMX clone(ProjectTMX tmx) {
         ProjectTMX newTmx = new ProjectTMX();
-        for (Entry<EntryKey, TMXEntry> e : tmx.alternatives.entrySet()) {
+        for (Entry<EntryKey, ProjectTMXEntry> e : tmx.alternatives.entrySet()) {
             newTmx.alternatives.put(e.getKey(), e.getValue());
         }
-        for (Entry<String, TMXEntry> e : tmx.defaults.entrySet()) {
+        for (Entry<String, ProjectTMXEntry> e : tmx.defaults.entrySet()) {
             newTmx.defaults.put(e.getKey(), e.getValue());
         }
         return newTmx;
@@ -247,10 +247,10 @@ public final class SyncTMX implements ITmx {
 
     private static class SyncTu implements ITu {
 
-        private final TMXEntry tmxEntry;
+        private final ProjectTMXEntry tmxEntry;
         private final String targetLanguage;
 
-        SyncTu(TMXEntry tmxEntry, String targetLanguage) {
+        SyncTu(ProjectTMXEntry tmxEntry, String targetLanguage) {
             this.tmxEntry = tmxEntry;
             this.targetLanguage = targetLanguage;
         }
@@ -269,11 +269,11 @@ public final class SyncTMX implements ITmx {
 
     private static class SyncTuv implements ITuv {
 
-        private final TMXEntry tmxEntry;
+        private final ProjectTMXEntry tmxEntry;
         private final String language;
         private Map<String, String> props;
 
-        SyncTuv(TMXEntry tmxEntry, String language) {
+        SyncTuv(ProjectTMXEntry tmxEntry, String language) {
             this.tmxEntry = tmxEntry;
             this.language = language;
         }

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -34,23 +34,16 @@ import java.util.Objects;
 import org.omegat.util.TMXProp;
 
 /**
- * Storage for TMX entry.
+ * Immutable storage for TMX entry.
  *
- * Variables in this class can be changed only before store to ProjectTMX. After that, all values must be
+ * Variables in this class can be changed only before they are stored. After that, all values must be
  * unchangeable.
- *
- * Only RealProject can create and change TMXEntry objects.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class TMXEntry implements ITMXEntry {
-    public enum ExternalLinked {
-        // declares how this entry linked to external TMX in the tm/auto/
-        xICE, x100PC, xAUTO, xENFORCED
-    };
-
+public abstract class TMXEntry implements ITMXEntry {
     public final String source;
     public final String translation;
     public final String changer;
@@ -58,10 +51,8 @@ public class TMXEntry implements ITMXEntry {
     public final String creator;
     public final long creationDate;
     public final String note;
-    public final boolean defaultTranslation;
-    public final ExternalLinked linked;
 
-    TMXEntry(ITMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+    TMXEntry(ITMXEntry from) {
         this.source = from.getSourceText();
         this.translation = from.getTranslationText();
         this.changer = from.getChanger();
@@ -69,9 +60,6 @@ public class TMXEntry implements ITMXEntry {
         this.creator = from.getCreator();
         this.creationDate = from.getCreationDate();
         this.note = from.getNote();
-
-        this.defaultTranslation = defaultTranslation;
-        this.linked = linked;
     }
 
     public String getSourceText() {
@@ -133,19 +121,10 @@ public class TMXEntry implements ITMXEntry {
         if (!Objects.equals(creator, other.creator)) {
             return false;
         }
-        if (defaultTranslation != other.defaultTranslation) {
-            return false;
-        }
         if (!Objects.equals(source, other.source)) {
             return false;
         }
         return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(changeDate / 1000, creationDate / 1000, translation, note, linked, changer, creator,
-                defaultTranslation, source);
     }
 
     /**
@@ -162,25 +141,6 @@ public class TMXEntry implements ITMXEntry {
         if (!Objects.equals(note, other.note)) {
             return false;
         }
-        if (!Objects.equals(linked, other.linked)) {
-            return false;
-        }
         return true;
-    }
-
-    public boolean hasProperties() {
-        return false;
-    }
-
-    public String getPropValue(String propType) {
-        return null; // for the moment internal entries do not store properties
-    }
-
-    public boolean hasPropValue(String propType, String propValue) {
-        return false; // for the moment internal entries do not store properties
-    }
-
-    public List<TMXProp> getProperties() {
-        return null; // for the moment internal entries do not store properties
     }
 }

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -28,7 +28,10 @@
 
 package org.omegat.core.data;
 
+import java.util.List;
 import java.util.Objects;
+
+import org.omegat.util.TMXProp;
 
 /**
  * Storage for TMX entry.
@@ -58,14 +61,14 @@ public class TMXEntry implements ITMXEntry {
     public final boolean defaultTranslation;
     public final ExternalLinked linked;
 
-    TMXEntry(PrepareTMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
-        this.source = from.source;
-        this.translation = from.translation;
-        this.changer = from.changer;
-        this.changeDate = from.changeDate;
-        this.creator = from.creator;
-        this.creationDate = from.creationDate;
-        this.note = from.note;
+    TMXEntry(ITMXEntry from, boolean defaultTranslation, ExternalLinked linked) {
+        this.source = from.getSourceText();
+        this.translation = from.getTranslationText();
+        this.changer = from.getChanger();
+        this.changeDate = from.getChangeDate();
+        this.creator = from.getCreator();
+        this.creationDate = from.getCreationDate();
+        this.note = from.getNote();
 
         this.defaultTranslation = defaultTranslation;
         this.linked = linked;
@@ -163,5 +166,21 @@ public class TMXEntry implements ITMXEntry {
             return false;
         }
         return true;
+    }
+
+    public boolean hasProperties() {
+        return false;
+    }
+
+    public String getPropValue(String propType) {
+        return null; // for the moment internal entries do not store properties
+    }
+
+    public boolean hasPropValue(String propType, String propValue) {
+        return false; // for the moment internal entries do not store properties
+    }
+
+    public List<TMXProp> getProperties() {
+        return null; // for the moment internal entries do not store properties
     }
 }

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -7,6 +7,7 @@
                2012 Guido Leenders, Thomas Cordonnier
                2013 Aaron Madlon-Kay
                2014 Alex Buloichik, Aaron Madlon-Kay
+               2021-2022 Thomas Cordonnier
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -42,9 +43,9 @@ import org.omegat.util.TMXProp;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
+ * @author Thomas Cordonnier
  */
 public abstract class TMXEntry implements ITMXEntry {
-    public final String source;
     public final String translation;
     public final String changer;
     public final long changeDate;
@@ -53,17 +54,12 @@ public abstract class TMXEntry implements ITMXEntry {
     public final String note;
 
     TMXEntry(ITMXEntry from) {
-        this.source = from.getSourceText();
         this.translation = from.getTranslationText();
         this.changer = from.getChanger();
         this.changeDate = from.getChangeDate();
         this.creator = from.getCreator();
         this.creationDate = from.getCreationDate();
         this.note = from.getNote();
-    }
-
-    public String getSourceText() {
-        return source;
     }
 
     public String getTranslationText() {
@@ -119,9 +115,6 @@ public abstract class TMXEntry implements ITMXEntry {
             return false;
         }
         if (!Objects.equals(creator, other.creator)) {
-            return false;
-        }
-        if (!Objects.equals(source, other.source)) {
             return false;
         }
         return true;

--- a/src/org/omegat/core/data/TMXEntry.java
+++ b/src/org/omegat/core/data/TMXEntry.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * @author Guido Leenders
  * @author Aaron Madlon-Kay
  */
-public class TMXEntry {
+public class TMXEntry implements ITMXEntry {
     public enum ExternalLinked {
         // declares how this entry linked to external TMX in the tm/auto/
         xICE, x100PC, xAUTO, xENFORCED
@@ -71,12 +71,32 @@ public class TMXEntry {
         this.linked = linked;
     }
 
-    public boolean isTranslated() {
-        return translation != null;
+    public String getSourceText() {
+        return source;
     }
 
-    public boolean hasNote() {
-        return note != null;
+    public String getTranslationText() {
+        return translation;
+    }
+    
+    public String getCreator() {
+        return creator;
+    }
+
+    public long getCreationDate() {
+        return creationDate;
+    }
+
+    public String getChanger() {
+        return changer;
+    }
+
+    public long getChangeDate() {
+        return changeDate;
+    }
+
+    public String getNote() {
+        return note;
     }
 
     @Override

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -402,7 +402,7 @@ public class Searcher {
                         }
                         checkStop.checkInterrupted();
                         if (m_project.isOrphaned(source)) {
-                            checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
+                            checkEntry(en.getSourceText(), en.getTranslationText(), en.getNote(), null, en, ENTRY_ORIGIN_ORPHAN, file);
                         }
                     }
                 });
@@ -417,7 +417,7 @@ public class Searcher {
                         }
                         checkStop.checkInterrupted();
                         if (m_project.isOrphaned(source)) {
-                            checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
+                            checkEntry(en.getSourceText(), en.getTranslationText(), en.getNote(), null, en, ENTRY_ORIGIN_ORPHAN, file);
                         }
                     }
                 });

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -44,7 +44,7 @@ import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.data.IProject.MultipleTranslationsIterator;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITMXEntry;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
@@ -227,13 +227,13 @@ public class FindMatches {
             if (matcher.find()) {
                 penalty = Integer.parseInt(matcher.group(1));
             }
-            for (PrepareTMXEntry tmen : en.getValue().getEntries()) {
+            for (ITMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
-                if (tmen.source == null) {
+                if (tmen.getSourceText() == null) {
                     // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.
                     continue;
                 }
-                if (requiresTranslation && tmen.translation == null) {
+                if (requiresTranslation && tmen.getTranslationText() == null) {
                     continue;
                 }
 
@@ -242,9 +242,9 @@ public class FindMatches {
                     tmenPenalty += foreignPenalty;
                 }
 
-                processEntry(null, tmen.source, tmen.translation, NearString.MATCH_SOURCE.TM, false, tmenPenalty,
-                        en.getKey(), tmen.creator, tmen.creationDate, tmen.changer, tmen.changeDate,
-                        tmen.otherProperties);
+                processEntry(null, tmen.getSourceText(), tmen.getTranslationText(), NearString.MATCH_SOURCE.TM, false, tmenPenalty,
+                        en.getKey(), tmen.getCreator(), tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(),
+                        tmen.getProperties());
             }
         }
 

--- a/src/org/omegat/core/tagvalidation/TagValidationTool.java
+++ b/src/org/omegat/core/tagvalidation/TagValidationTool.java
@@ -38,7 +38,7 @@ import org.omegat.core.Core;
 import org.omegat.core.data.DataUtils;
 import org.omegat.core.data.IProject.FileInfo;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.core.tagvalidation.ErrorReport.TagError;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.Preferences;
@@ -102,7 +102,7 @@ public class TagValidationTool implements ITagValidation {
         return Core.getProject().getProjectFiles().stream()
                 .filter(StreamUtil.patternFilter(sourcePattern, fi -> fi.filePath))
                 .flatMap(fi -> fi.entries.stream().map(ste -> {
-                    TMXEntry te = Core.getProject().getTranslationInfo(ste);
+                    ProjectTMXEntry te = Core.getProject().getTranslationInfo(ste);
                     if (sourcePattern.equals(ALL_FILES_PATTERN) && DataUtils.isDuplicate(ste, te)) {
                         return null;
                     } else {
@@ -128,7 +128,7 @@ public class TagValidationTool implements ITagValidation {
      * @return An {@link ErrorReport} summarizing the results (will be empty if
      *         no issues found)
      */
-    private ErrorReport checkEntry(FileInfo fi, SourceTextEntry ste, TMXEntry te) {
+    private ErrorReport checkEntry(FileInfo fi, SourceTextEntry ste, ProjectTMXEntry te) {
 
         ErrorReport report = new ErrorReport(ste, te);
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -1173,7 +1173,7 @@ public class EditorController implements IEditor {
                     newen.translation = newTrans;
                 } else {
                     // translation can't be equals to source
-                    if (oldTE.source.equals(oldTE.translation)) {
+                    if (oldTE.getSourceText().equals(oldTE.translation)) {
                         // but it was equals to source before
                         newen.translation = oldTE.translation;
                     } else {
@@ -1188,8 +1188,8 @@ public class EditorController implements IEditor {
         }
 
         boolean defaultTranslation = sb.isDefaultTranslation();
-        boolean isNewDefaultTrans = defaultTranslation && !oldTE.defaultTranslation;
-        boolean isNewAltTrans = !defaultTranslation && oldTE.defaultTranslation;
+        boolean isNewDefaultTrans = defaultTranslation && !oldTE.isDefaultTranslation();
+        boolean isNewAltTrans = !defaultTranslation && oldTE.isDefaultTranslation();
         boolean translationChanged = !Objects.equals(oldTE.translation, newen.translation);
         boolean noteChanged = !StringUtil.nvl(oldTE.note, "").equals(StringUtil.nvl(newen.note, ""));
 
@@ -1577,7 +1577,7 @@ public class EditorController implements IEditor {
             } else {
                 // default translation - multiple shouldn't exist for this entry
                 ProjectTMXEntry trans = Core.getProject().getTranslationInfo(entries.get(i));
-                if (!trans.isTranslated() || !trans.defaultTranslation) {
+                if (!trans.isTranslated() || !trans.isDefaultTranslation()) {
                     // we need exist alternative translation
                     continue;
                 }

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -95,6 +95,7 @@ import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.SourceTextEntry.DUPLICATE;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.statistics.StatisticsInfo;
@@ -855,7 +856,7 @@ public class EditorController implements IEditor {
         }
 
         previousTranslations = Core.getProject().getAllTranslations(ste);
-        TMXEntry currentTranslation = previousTranslations.getCurrentTranslation();
+        ProjectTMXEntry currentTranslation = previousTranslations.getCurrentTranslation();
         // forget about old marks
         builder.createSegmentElement(true, currentTranslation);
 
@@ -1141,7 +1142,7 @@ public class EditorController implements IEditor {
         SegmentBuilder sb = m_docSegList[displayedEntryIndex];
         SourceTextEntry entry = sb.ste;
 
-        TMXEntry oldTE = Core.getProject().getTranslationInfo(entry);
+        ProjectTMXEntry oldTE = Core.getProject().getTranslationInfo(entry);
 
         PrepareTMXEntry newen = new PrepareTMXEntry();
         newen.source = sb.ste.getSrcText();
@@ -1575,7 +1576,7 @@ public class EditorController implements IEditor {
                 }
             } else {
                 // default translation - multiple shouldn't exist for this entry
-                TMXEntry trans = Core.getProject().getTranslationInfo(entries.get(i));
+                ProjectTMXEntry trans = Core.getProject().getTranslationInfo(entries.get(i));
                 if (!trans.isTranslated() || !trans.defaultTranslation) {
                     // we need exist alternative translation
                     continue;

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -44,7 +44,7 @@ import javax.swing.text.Position;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.gui.editor.MarkerController.MarkInfo;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
@@ -166,19 +166,19 @@ public class SegmentBuilder {
      *            document
      * @return OmElementSegment
      */
-    public void createSegmentElement(final boolean isActive, TMXEntry trans) {
+    public void createSegmentElement(final boolean isActive, ProjectTMXEntry trans) {
         createSegmentElement(isActive, doc.getLength(), trans, trans.defaultTranslation);
     }
 
-    public void createSegmentElement(final boolean isActive, TMXEntry trans, final boolean defaultTranslation) {
+    public void createSegmentElement(final boolean isActive, ProjectTMXEntry trans, final boolean defaultTranslation) {
         createSegmentElement(isActive, doc.getLength(), trans, defaultTranslation);
     }
 
-    public void prependSegmentElement(final boolean isActive, TMXEntry trans) {
+    public void prependSegmentElement(final boolean isActive, ProjectTMXEntry trans) {
         createSegmentElement(isActive, 0, trans, trans.defaultTranslation);
     }
 
-    public void createSegmentElement(final boolean isActive, int initialOffset, TMXEntry trans, final boolean defaultTranslation) {
+    public void createSegmentElement(final boolean isActive, int initialOffset, ProjectTMXEntry trans, final boolean defaultTranslation) {
         UIThreadsUtil.mustBeSwingThread();
 
         displayVersion = globalVersions.incrementAndGet();
@@ -258,7 +258,7 @@ public class SegmentBuilder {
     /**
      * Create active segment for given entry
      */
-    private void createActiveSegmentElement(TMXEntry trans) throws BadLocationException {
+    private void createActiveSegmentElement(ProjectTMXEntry trans) throws BadLocationException {
         try {
             if (EditorSettings.DISPLAY_MODIFICATION_INFO_ALL.equals(settings.getDisplayModificationInfo())
                     || EditorSettings.DISPLAY_MODIFICATION_INFO_SELECTED.equals(settings
@@ -271,7 +271,7 @@ public class SegmentBuilder {
 
             Map<Language, ProjectTMX> otherLanguageTMs = Core.getProject().getOtherTargetLanguageTMs();
             for (Map.Entry<Language, ProjectTMX> entry : otherLanguageTMs.entrySet()) {
-                TMXEntry altTrans = entry.getValue().getDefaultTranslation(ste.getSrcText());
+                ProjectTMXEntry altTrans = entry.getValue().getDefaultTranslation(ste.getSrcText());
                 if (altTrans != null && altTrans.isTranslated()) {
                     Language language = entry.getKey();
                     addOtherLanguagePart(altTrans.translation, language);
@@ -333,7 +333,7 @@ public class SegmentBuilder {
      * @param trans TMX entry with translation
      * @throws BadLocationException
      */
-    private void createInactiveSegmentElement(TMXEntry trans) throws BadLocationException {
+    private void createInactiveSegmentElement(ProjectTMXEntry trans) throws BadLocationException {
         if (EditorSettings.DISPLAY_MODIFICATION_INFO_ALL.equals(settings.getDisplayModificationInfo())) {
             addModificationInfoPart(trans);
         }
@@ -518,7 +518,7 @@ public class SegmentBuilder {
      *            The translation entry (can be null)
      * @throws BadLocationException
      */
-    private void addModificationInfoPart(TMXEntry trans) throws BadLocationException {
+    private void addModificationInfoPart(ProjectTMXEntry trans) throws BadLocationException {
         if (!trans.isTranslated()) {
             return;
         }

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -167,7 +167,7 @@ public class SegmentBuilder {
      * @return OmElementSegment
      */
     public void createSegmentElement(final boolean isActive, ProjectTMXEntry trans) {
-        createSegmentElement(isActive, doc.getLength(), trans, trans.defaultTranslation);
+        createSegmentElement(isActive, doc.getLength(), trans, trans.isDefaultTranslation());
     }
 
     public void createSegmentElement(final boolean isActive, ProjectTMXEntry trans, final boolean defaultTranslation) {
@@ -175,7 +175,7 @@ public class SegmentBuilder {
     }
 
     public void prependSegmentElement(final boolean isActive, ProjectTMXEntry trans) {
-        createSegmentElement(isActive, 0, trans, trans.defaultTranslation);
+        createSegmentElement(isActive, 0, trans, trans.isDefaultTranslation());
     }
 
     public void createSegmentElement(final boolean isActive, int initialOffset, ProjectTMXEntry trans, final boolean defaultTranslation) {

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import org.omegat.core.Core;
 import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.core.search.SearchMatch;
 import org.omegat.core.search.Searcher;
 import org.omegat.gui.editor.EditorController;
@@ -102,7 +102,7 @@ public class ReplaceFilter implements IEditorFilter {
      */
     public void replaceAll() {
         for (SourceTextEntry ste : entries.values()) {
-            TMXEntry en = Core.getProject().getTranslationInfo(ste);
+            ProjectTMXEntry en = Core.getProject().getTranslationInfo(ste);
             String trans = getEntryText(ste, en);
             if (trans == null) {
                 continue;
@@ -172,7 +172,7 @@ public class ReplaceFilter implements IEditorFilter {
             if (ste == null) {
                 continue; // entry not filtered
             }
-            TMXEntry en = Core.getProject().getTranslationInfo(ste);
+            ProjectTMXEntry en = Core.getProject().getTranslationInfo(ste);
             String trans = getEntryText(ste, en);
             if (trans == null) {
                 continue;
@@ -193,7 +193,7 @@ public class ReplaceFilter implements IEditorFilter {
             if (ste == null) {
                 continue; // entry not filtered
             }
-            TMXEntry en = Core.getProject().getTranslationInfo(ste);
+            ProjectTMXEntry en = Core.getProject().getTranslationInfo(ste);
             String trans = getEntryText(ste, en);
             if (trans == null) {
                 continue;
@@ -236,7 +236,7 @@ public class ReplaceFilter implements IEditorFilter {
      * Returns text of entry where replacement should be found. It can be translation or source text depends
      * on settings, or null if entry should be skipped.
      */
-    private String getEntryText(SourceTextEntry ste, TMXEntry en) {
+    private String getEntryText(SourceTextEntry ste, ProjectTMXEntry en) {
         if (en.isTranslated()) {
             return en.translation;
         } else if (searcher.getExpression().replaceUntranslated) {

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -108,7 +108,7 @@ public class ReplaceFilter implements IEditorFilter {
                 continue;
             }
             // Avoid to replace more than once with variables when entries have duplicates
-            if ((en.defaultTranslation) && (ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT)) {
+            if ((en.isDefaultTranslation()) && (ste.getDuplicate() == SourceTextEntry.DUPLICATE.NEXT)) {
                 continue; // Already replaced when we parsed the first entry
             }
             List<SearchMatch> found = getReplacementsForEntry(trans);
@@ -121,7 +121,7 @@ public class ReplaceFilter implements IEditorFilter {
                 }
                 PrepareTMXEntry prepare = new PrepareTMXEntry(en);
                 prepare.translation = o.toString();
-                Core.getProject().setTranslation(ste, prepare, en.defaultTranslation, null);
+                Core.getProject().setTranslation(ste, prepare, en.isDefaultTranslation(), null);
             }
         }
         EditorController ec = (EditorController) Core.getEditor();

--- a/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -33,7 +33,7 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -57,7 +57,7 @@ public class ComesFromAutoTMMarker implements IMarker {
         if (!Core.getEditor().getSettings().isMarkAutoPopulated()) {
             return null;
         }
-        TMXEntry e = Core.getProject().getTranslationInfo(ste);
+        ProjectTMXEntry e = Core.getProject().getTranslationInfo(ste);
         if (e.linked == null) {
             return null;
         }

--- a/src/org/omegat/gui/glossary/GlossaryEntry.java
+++ b/src/org/omegat/gui/glossary/GlossaryEntry.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.omegat.core.data.ITranslationEntry;
 import org.omegat.util.StringUtil;
 
 /**
@@ -40,7 +41,7 @@ import org.omegat.util.StringUtil;
  * @author Aaron Madlon-Kay
  * @author Alex Buloichik
  */
-public class GlossaryEntry {
+public class GlossaryEntry implements ITranslationEntry {
     public GlossaryEntry(String src, String[] loc, String[] com, boolean[] fromPriorityGlossary, String[] origins) {
         mSource = StringUtil.normalizeUnicode(src);
         mTargets = loc;
@@ -60,6 +61,16 @@ public class GlossaryEntry {
         return mSource;
     }
 
+    /* Method for ITranslationEntry */
+    public String getSourceText() {
+        return mSource;
+    }
+    
+    /* Method for ITranslationEntry */
+    public String getTranslationText() {
+        return mTargets.length > 0 ? mTargets[0] : "";
+    }
+    
     /**
      * Return the first target-language term string.
      *

--- a/src/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/org/omegat/gui/issues/IssuesPanelController.java
@@ -87,7 +87,7 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.DataUtils;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Platform;
@@ -558,19 +558,19 @@ public class IssuesPanelController implements IIssues {
             return result;
         }
 
-        Map.Entry<SourceTextEntry, TMXEntry> makeEntryPair(SourceTextEntry ste) {
+        Map.Entry<SourceTextEntry, ProjectTMXEntry> makeEntryPair(SourceTextEntry ste) {
             IProject project = Core.getProject();
             if (!project.isProjectLoaded()) {
                 return null;
             }
-            TMXEntry tmxEntry = project.getTranslationInfo(ste);
+            ProjectTMXEntry tmxEntry = project.getTranslationInfo(ste);
             if (!tmxEntry.isTranslated()) {
                 return null;
             }
             if (isShowingAllFiles() && DataUtils.isDuplicate(ste, tmxEntry)) {
                 return null;
             }
-            return new AbstractMap.SimpleImmutableEntry<SourceTextEntry, TMXEntry>(ste, tmxEntry);
+            return new AbstractMap.SimpleImmutableEntry<SourceTextEntry, ProjectTMXEntry>(ste, tmxEntry);
         }
 
         boolean progressFilter(SourceTextEntry ste) {

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -57,7 +57,7 @@ import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.SourceTextEntry.DUPLICATE;
-import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.ProjectTMXEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.gui.main.DockableScrollPane;
@@ -310,7 +310,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
             setKeyProperties(ste.getKey());
             IProject project = Core.getProject();
             if (project.isProjectLoaded()) {
-                TMXEntry trg = project.getTranslationInfo(ste);
+                ProjectTMXEntry trg = project.getTranslationInfo(ste);
                 setTranslationProperties(trg);
             }
         }
@@ -325,7 +325,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
         setProperty(KEY_PATH, key.path);
     }
 
-    private void setTranslationProperties(TMXEntry entry) {
+    private void setTranslationProperties(ProjectTMXEntry entry) {
         if (entry == null) {
             return;
         }

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -345,7 +345,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
                     + timeFormat.format(new Date(entry.creationDate)));
         }
         setProperty(KEY_CREATOR, entry.creator);
-        if (!entry.defaultTranslation) {
+        if (!entry.isDefaultTranslation()) {
             setProperty(KEY_ISALT, true);
         }
         setProperty(KEY_LINKED, entry.linked);

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -211,7 +211,7 @@ public final class TestTeamIntegrationChild {
                 if (prev == null) {
                     prev = 0L;
                 }
-                long curr = Long.parseLong(trans.translation);
+                long curr = Long.parseLong(trans.getTranslationText());
                 if (curr < prev) {
                     throw new RuntimeException(source + ": Wrong value in " + source + ": current(" + curr
                             + ") less than previous(" + prev + ")");
@@ -222,7 +222,7 @@ public final class TestTeamIntegrationChild {
 
     static void checkTranslation(int index) {
         ProjectTMXEntry en = Core.getProject().getTranslationInfo(ste[index]);
-        String sv = en == null || !en.isTranslated() ? "" : en.translation;
+        String sv = en == null || !en.isTranslated() ? "" : en.getTranslationText();
         if (v[index] == 0 && sv.isEmpty()) {
             return;
         }
@@ -230,12 +230,12 @@ public final class TestTeamIntegrationChild {
             return;
         }
         throw new RuntimeException(source + ": Wrong value in " + source + "/" + index + ": expected "
-                + v[index] + " but contains " + en.translation);
+                + v[index] + " but contains " + en.getTranslationText());
     }
 
     static void checkTranslationFromFile(ProjectTMX tmx, int index) throws Exception {
         ProjectTMXEntry en = tmx.getDefaultTranslation(ste[index].getSrcText());
-        String sv = en == null || !en.isTranslated() ? "" : en.translation;
+        String sv = en == null || !en.isTranslated() ? "" : en.getTranslationText();
         if (v[index] == 0 && sv.isEmpty()) {
             return;
         }
@@ -563,7 +563,7 @@ public final class TestTeamIntegrationChild {
                                     .getUnderlyingRepresentation() : null;
                             String s = "Rebase " + src(enProject) + " base=" + tr(enBase) + " head="
                                     + tr(enHead) + " project=" + tr(enProject);
-                            if (enProject != null && CONCURRENT_NAME.equals(enProject.source)) {
+                            if (enProject != null && CONCURRENT_NAME.equals(enProject.getSourceText())) {
                                 if (v(enHead) < v(enBase)) {
                                     throw new RuntimeException("Rebase HEAD: wrong concurrent: " + s);
                                 }
@@ -626,13 +626,13 @@ public final class TestTeamIntegrationChild {
                 use(e);
             }
             for (ProjectTMXEntry e : headTMX.getDefaults()) {
-                ProjectTMXEntry eb = baseTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
+                ProjectTMXEntry eb = baseTMX.getDefaultTranslation(e.getSourceText());
+                if (CONCURRENT_NAME.equals(e.getSourceText())) { // concurrent
                     if (v(eb) > v(e)) {
                         throw new RuntimeException("Rebase HEAD: wrong concurrent" + s);
                     }
                     use(e);
-                } else if (e.source.startsWith(source + "/")) { // my segments
+                } else if (e.getSourceText().startsWith(source + "/")) { // my segments
                     if (v(eb) != v(e)) {
                         throw new RuntimeException("Rebase HEAD: not equals for current project" + s);
                     }
@@ -644,12 +644,12 @@ public final class TestTeamIntegrationChild {
                 }
             }
             for (ProjectTMXEntry e : projectTMX.getDefaults()) {
-                ProjectTMXEntry em = mergedTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
+                ProjectTMXEntry em = mergedTMX.getDefaultTranslation(e.getSourceText());
+                if (CONCURRENT_NAME.equals(e.getSourceText())) { // concurrent
                     if (v(e) > v(em)) {
                         use(e);
                     }
-                } else if (e.source.startsWith(source + "/")) { // my segments
+                } else if (e.getSourceText().startsWith(source + "/")) { // my segments
                     if (v(e) < v(em)) {
                         throw new RuntimeException("Rebase me: less value" + s);
                     }
@@ -663,8 +663,8 @@ public final class TestTeamIntegrationChild {
         }
 
         void use(ProjectTMXEntry en) {
-            EntryKey k = new EntryKey("file", en.source, null, null, null, null);
-            SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.source, Collections.emptyList());
+            EntryKey k = new EntryKey("file", en.getSourceText(), null, null, null, null);
+            SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.getSourceText(), Collections.emptyList());
             mergedTMX.setTranslation(ste, en, true);
         }
 
@@ -672,7 +672,7 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return 0;
             } else {
-                return Long.parseLong(e.translation);
+                return Long.parseLong(e.getTranslationText());
             }
         }
 
@@ -680,7 +680,7 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return "null";
             } else {
-                return e.source;
+                return e.getSourceText();
             }
         }
 
@@ -688,16 +688,16 @@ public final class TestTeamIntegrationChild {
             if (e == null) {
                 return "null";
             } else {
-                return e.translation;
+                return e.getTranslationText();
             }
         }
 
         String trans(ProjectTMX tmx, ProjectTMXEntry e) {
-            ProjectTMXEntry en = tmx.getDefaultTranslation(e.source);
+            ProjectTMXEntry en = tmx.getDefaultTranslation(e.getSourceText());
             if (en == null) {
                 return "null";
             } else {
-                return en.translation;
+                return en.getTranslationText();
             }
         }
     }

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -221,7 +221,7 @@ public final class TestTeamIntegrationChild {
     }
 
     static void checkTranslation(int index) {
-        TMXEntry en = Core.getProject().getTranslationInfo(ste[index]);
+        ProjectTMXEntry en = Core.getProject().getTranslationInfo(ste[index]);
         String sv = en == null || !en.isTranslated() ? "" : en.translation;
         if (v[index] == 0 && sv.isEmpty()) {
             return;
@@ -234,7 +234,7 @@ public final class TestTeamIntegrationChild {
     }
 
     static void checkTranslationFromFile(ProjectTMX tmx, int index) throws Exception {
-        TMXEntry en = tmx.getDefaultTranslation(ste[index].getSrcText());
+        ProjectTMXEntry en = tmx.getDefaultTranslation(ste[index].getSrcText());
         String sv = en == null || !en.isTranslated() ? "" : en.translation;
         if (v[index] == 0 && sv.isEmpty()) {
             return;
@@ -555,11 +555,11 @@ public final class TestTeamIntegrationChild {
                     .setResolutionStrategy(new ResolutionStrategy() {
                         @Override
                         public ITuv resolveConflict(Key key, ITuv baseTuv, ITuv projectTuv, ITuv headTuv) {
-                            TMXEntry enBase = baseTuv != null ? (TMXEntry) baseTuv
+                            ProjectTMXEntry enBase = baseTuv != null ? (ProjectTMXEntry) baseTuv
                                     .getUnderlyingRepresentation() : null;
-                            TMXEntry enProject = projectTuv != null ? (TMXEntry) projectTuv
+                            ProjectTMXEntry enProject = projectTuv != null ? (ProjectTMXEntry) projectTuv
                                     .getUnderlyingRepresentation() : null;
-                            TMXEntry enHead = headTuv != null ? (TMXEntry) headTuv
+                            ProjectTMXEntry enHead = headTuv != null ? (ProjectTMXEntry) headTuv
                                     .getUnderlyingRepresentation() : null;
                             String s = "Rebase " + src(enProject) + " base=" + tr(enBase) + " head="
                                     + tr(enHead) + " project=" + tr(enProject);
@@ -622,11 +622,11 @@ public final class TestTeamIntegrationChild {
             this.baseTMX = baseTMX;
             this.headTMX = headTMX;
             String s = "info";
-            for (TMXEntry e : baseTMX.getDefaults()) {
+            for (ProjectTMXEntry e : baseTMX.getDefaults()) {
                 use(e);
             }
-            for (TMXEntry e : headTMX.getDefaults()) {
-                TMXEntry eb = baseTMX.getDefaultTranslation(e.source);
+            for (ProjectTMXEntry e : headTMX.getDefaults()) {
+                ProjectTMXEntry eb = baseTMX.getDefaultTranslation(e.source);
                 if (CONCURRENT_NAME.equals(e.source)) { // concurrent
                     if (v(eb) > v(e)) {
                         throw new RuntimeException("Rebase HEAD: wrong concurrent" + s);
@@ -643,8 +643,8 @@ public final class TestTeamIntegrationChild {
                     use(e);
                 }
             }
-            for (TMXEntry e : projectTMX.getDefaults()) {
-                TMXEntry em = mergedTMX.getDefaultTranslation(e.source);
+            for (ProjectTMXEntry e : projectTMX.getDefaults()) {
+                ProjectTMXEntry em = mergedTMX.getDefaultTranslation(e.source);
                 if (CONCURRENT_NAME.equals(e.source)) { // concurrent
                     if (v(e) > v(em)) {
                         use(e);
@@ -662,13 +662,13 @@ public final class TestTeamIntegrationChild {
             projectTMX.replaceContent(mergedTMX);
         }
 
-        void use(TMXEntry en) {
+        void use(ProjectTMXEntry en) {
             EntryKey k = new EntryKey("file", en.source, null, null, null, null);
             SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.source, Collections.emptyList());
             mergedTMX.setTranslation(ste, en, true);
         }
 
-        long v(TMXEntry e) {
+        long v(ProjectTMXEntry e) {
             if (e == null) {
                 return 0;
             } else {
@@ -676,7 +676,7 @@ public final class TestTeamIntegrationChild {
             }
         }
 
-        String src(TMXEntry e) {
+        String src(ProjectTMXEntry e) {
             if (e == null) {
                 return "null";
             } else {
@@ -684,7 +684,7 @@ public final class TestTeamIntegrationChild {
             }
         }
 
-        String tr(TMXEntry e) {
+        String tr(ProjectTMXEntry e) {
             if (e == null) {
                 return "null";
             } else {
@@ -692,8 +692,8 @@ public final class TestTeamIntegrationChild {
             }
         }
 
-        String trans(ProjectTMX tmx, TMXEntry e) {
-            TMXEntry en = tmx.getDefaultTranslation(e.source);
+        String trans(ProjectTMX tmx, ProjectTMXEntry e) {
+            ProjectTMXEntry en = tmx.getDefaultTranslation(e.source);
             if (en == null) {
                 return "null";
             } else {

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -90,9 +90,9 @@ public class AutoTmxTest {
         p.allProjectEntries.add(ste12 = createSTE("12", "Edit"));
         p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
         p.appendFromAutoTMX(autoTMX, false);
-        checkTranslation(ste10, "Modifier", TMXEntry.ExternalLinked.x100PC);
-        checkTranslation(ste11, "Edition", TMXEntry.ExternalLinked.xICE);
-        checkTranslation(ste12, "Modifier", TMXEntry.ExternalLinked.xICE);
+        checkTranslation(ste10, "Modifier", ProjectTMXEntry.ExternalLinked.x100PC);
+        checkTranslation(ste11, "Edition", ProjectTMXEntry.ExternalLinked.xICE);
+        checkTranslation(ste12, "Modifier", ProjectTMXEntry.ExternalLinked.xICE);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class AutoTmxTest {
         checkTranslation(ste, "foobar", null);
         p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
         p.appendFromAutoTMX(enforceTMX, true);
-        checkTranslation(ste, "bizbaz", TMXEntry.ExternalLinked.xENFORCED);
+        checkTranslation(ste, "bizbaz", ProjectTMXEntry.ExternalLinked.xENFORCED);
     }
 
     SourceTextEntry createSTE(String id, String source) {
@@ -138,8 +138,8 @@ public class AutoTmxTest {
     }
 
     void checkTranslation(SourceTextEntry ste, String expectedTranslation,
-            TMXEntry.ExternalLinked expectedExternalLinked) {
-        TMXEntry e = p.getTranslationInfo(ste);
+            ProjectTMXEntry.ExternalLinked expectedExternalLinked) {
+        ProjectTMXEntry e = p.getTranslationInfo(ste);
         assertTrue(e.isTranslated());
         assertEquals(expectedTranslation, e.translation);
         assertEquals(expectedExternalLinked, e.linked);

--- a/test/src/org/omegat/core/data/AutoTmxTest.java
+++ b/test/src/org/omegat/core/data/AutoTmxTest.java
@@ -64,10 +64,10 @@ public class AutoTmxTest {
                 .setDoSegmenting(props.isSentenceSegmentingEnabled())
                 .load(props.getSourceLanguage(), props.getTargetLanguage());
 
-        PrepareTMXEntry e1 = autoTMX.getEntries().get(0);
+        ITMXEntry e1 = autoTMX.getEntries().get(0);
         checkListValues(e1, ProjectTMX.PROP_XICE, "11");
 
-        PrepareTMXEntry e2 = autoTMX.getEntries().get(1);
+        ITMXEntry e2 = autoTMX.getEntries().get(1);
         checkListValues(e2, ProjectTMX.PROP_XICE, "12");
         checkListValues(e2, ProjectTMX.PROP_X100PC, "10");
 
@@ -133,7 +133,7 @@ public class AutoTmxTest {
         return new SourceTextEntry(ek, 0, null, null, new ArrayList<ProtectedPart>());
     }
 
-    void checkListValues(PrepareTMXEntry en, String propType, String propValue) {
+    void checkListValues(ITMXEntry en, String propType, String propValue) {
         assertTrue(en.hasPropValue(propType, propValue));
     }
 

--- a/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/test/src/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -89,10 +89,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslationText());
     }
 
     @Test
@@ -106,15 +106,15 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(1013, tmx.getEntries().size());
-        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).source);
+        assertEquals("Choose syntax highlighting", tmx.getEntries().get(0).getSourceText());
         assertEquals(
                 "\u0412\u044B\u043B\u0443\u0447\u044D\u043D\u044C\u043D\u0435 "
                         + "&\u043A\u043E\u043B\u0435\u0440\u0430\u043C "
                         + "\u0441\u044B\u043D\u0442\u0430\u043A\u0441\u044B\u0441\u0443",
-                tmx.getEntries().get(0).translation);
-        assertEquals("< Auto >", tmx.getEntries().get(1).source);
+                tmx.getEntries().get(0).getTranslationText());
+        assertEquals("< Auto >", tmx.getEntries().get(1).getSourceText());
         assertEquals("\u041F\u0440\u0430 \u043F\u0440\u0430\u0433\u0440\u0430\u043C\u0443",
-                tmx.getEntries().get(1).translation);
+                tmx.getEntries().get(1).getTranslationText());
     }
 
     @Test
@@ -128,10 +128,10 @@ public class ExternalTMFactoryTest extends TestCore {
         ExternalTMX tmx = ExternalTMFactory.load(tmxFile);
 
         assertEquals(33, tmx.getEntries().size());
-        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).source);
-        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).translation);
-        assertEquals("Download %s in your language", tmx.getEntries().get(1).source);
-        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).translation);
+        assertEquals("Download %s for Android in your language", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Laden Sie %s f\u00FCr Android in Ihrer Sprache herunter", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Download %s in your language", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Laden Sie %s in Ihrer Sprache herunter", tmx.getEntries().get(1).getTranslationText());
     }
 
     /**
@@ -156,7 +156,7 @@ public class ExternalTMFactoryTest extends TestCore {
         // Only 5 FR translations
         assertEquals(5, tmx.getEntries().size());
 
-        List<PrepareTMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
+        List<ITMXEntry> matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("Hello World!"))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
         
@@ -167,15 +167,15 @@ public class ExternalTMFactoryTest extends TestCore {
         // All foreign translations are present
         assertEquals(14, tmx.getEntries().size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("Hello World!"))
+        matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("Hello World!"))
                 .collect(Collectors.toList());
         assertEquals(8, matchingEntries.size());
 
-        matchingEntries = tmx.getEntries().stream().filter(t -> t.source.equals("This is an english sentence."))
+        matchingEntries = tmx.getEntries().stream().filter(t -> t.getSourceText().equals("This is an english sentence."))
                 .collect(Collectors.toList());
         assertEquals(3, matchingEntries.size());
 
-        PrepareTMXEntry entry = matchingEntries.get(0);
+        ITMXEntry entry = matchingEntries.get(0);
         assertEquals("EN-US", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_TARGET_LANGUAGE));
         assertEquals("true", entry.getPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH));
 

--- a/test/src/org/omegat/core/data/MergeTest.java
+++ b/test/src/org/omegat/core/data/MergeTest.java
@@ -34,7 +34,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.junit.Test;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
+import org.omegat.core.data.ProjectTMXEntry.ExternalLinked;
 
 /**
  * Tests for merge in team project.
@@ -62,36 +62,36 @@ public class MergeTest {
         e2.changeDate = 123456999;
 
         // test equals
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertTrue(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
 
         e2.changeDate = 123456000;
         // test truncated time
-        assertTrue(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertTrue(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
 
         e2.changeDate = 123457000;
         // test other time
-        assertFalse(new TMXEntry(e1, true, null).equals(new TMXEntry(e2, true, null)));
+        assertFalse(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
         e2.changeDate = 123456999;
 
         e2.translation = "t";
         // test different translation
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
+        assertFalse(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
         e2.translation = "trans";
 
         e2.note = "n";
         // test different note
-        assertFalse(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
+        assertFalse(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
         e2.note = null;
 
         e2.changer = "c";
         // test different changer
-        assertTrue(new TMXEntry(e1, true, null).equalsTranslation(new TMXEntry(e2, true, null)));
+        assertTrue(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
         e2.changer = null;
 
         // test different linked
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE).equalsTranslation(new TMXEntry(e2, true,
+        assertFalse(new ProjectTMXEntry(e1, true, ExternalLinked.xICE).equalsTranslation(new ProjectTMXEntry(e2, true,
                 ExternalLinked.x100PC)));
-        assertFalse(new TMXEntry(e1, true, ExternalLinked.xICE)
-                .equalsTranslation(new TMXEntry(e2, true, null)));
+        assertFalse(new ProjectTMXEntry(e1, true, ExternalLinked.xICE)
+                .equalsTranslation(new ProjectTMXEntry(e2, true, null)));
     }
 }

--- a/test/src/org/omegat/core/data/MergeTest.java
+++ b/test/src/org/omegat/core/data/MergeTest.java
@@ -62,36 +62,36 @@ public class MergeTest {
         e2.changeDate = 123456999;
 
         // test equals
-        assertTrue(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
+        assertTrue(new DefaultProjectTMXEntry(e1, null).equals(new DefaultProjectTMXEntry(e2, null)));
 
         e2.changeDate = 123456000;
         // test truncated time
-        assertTrue(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
+        assertTrue(new DefaultProjectTMXEntry(e1, null).equals(new DefaultProjectTMXEntry(e2, null)));
 
         e2.changeDate = 123457000;
         // test other time
-        assertFalse(new ProjectTMXEntry(e1, true, null).equals(new ProjectTMXEntry(e2, true, null)));
+        assertFalse(new DefaultProjectTMXEntry(e1, null).equals(new DefaultProjectTMXEntry(e2, null)));
         e2.changeDate = 123456999;
 
         e2.translation = "t";
         // test different translation
-        assertFalse(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
+        assertFalse(new DefaultProjectTMXEntry(e1, null).equalsTranslation(new DefaultProjectTMXEntry(e2, null)));
         e2.translation = "trans";
 
         e2.note = "n";
         // test different note
-        assertFalse(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
+        assertFalse(new DefaultProjectTMXEntry(e1, null).equalsTranslation(new DefaultProjectTMXEntry(e2, null)));
         e2.note = null;
 
         e2.changer = "c";
         // test different changer
-        assertTrue(new ProjectTMXEntry(e1, true, null).equalsTranslation(new ProjectTMXEntry(e2, true, null)));
+        assertTrue(new DefaultProjectTMXEntry(e1, null).equalsTranslation(new DefaultProjectTMXEntry(e2, null)));
         e2.changer = null;
 
         // test different linked
-        assertFalse(new ProjectTMXEntry(e1, true, ExternalLinked.xICE).equalsTranslation(new ProjectTMXEntry(e2, true,
+        assertFalse(new DefaultProjectTMXEntry(e1, ExternalLinked.xICE).equalsTranslation(new DefaultProjectTMXEntry(e2, 
                 ExternalLinked.x100PC)));
-        assertFalse(new ProjectTMXEntry(e1, true, ExternalLinked.xICE)
-                .equalsTranslation(new ProjectTMXEntry(e2, true, null)));
+        assertFalse(new DefaultProjectTMXEntry(e1, ExternalLinked.xICE)
+                .equalsTranslation(new DefaultProjectTMXEntry(e2, null)));
     }
 }

--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -164,7 +164,7 @@ public class RealProjectTest {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        tmx.setTranslation(ste, new ProjectTMXEntry(tr, true, null), true);
+        tmx.setTranslation(ste, tr.toProjectTMXEntry(true, key, null), true);
     }
 
     private void setAlternative(String id, String source, String translation) {
@@ -173,7 +173,7 @@ public class RealProjectTest {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        tmx.setTranslation(ste, new ProjectTMXEntry(tr, false, null), false);
+        tmx.setTranslation(ste, tr.toProjectTMXEntry(false, key, null), false);
     }
 
     private void checkDefault(String source, String translation) {
@@ -220,6 +220,6 @@ public class RealProjectTest {
     }
 
     public static ProjectTMXEntry createEmptyTMXEntry() {
-        return new ProjectTMXEntry(new PrepareTMXEntry(), true, null);
+        return new DefaultProjectTMXEntry(new PrepareTMXEntry(), null);
     }
 }

--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -164,7 +164,7 @@ public class RealProjectTest {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, true, null), true);
+        tmx.setTranslation(ste, new ProjectTMXEntry(tr, true, null), true);
     }
 
     private void setAlternative(String id, String source, String translation) {
@@ -173,23 +173,23 @@ public class RealProjectTest {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        tmx.setTranslation(ste, new TMXEntry(tr, false, null), false);
+        tmx.setTranslation(ste, new ProjectTMXEntry(tr, false, null), false);
     }
 
     private void checkDefault(String source, String translation) {
-        TMXEntry tr = tmx.getDefaultTranslation(source);
+        ProjectTMXEntry tr = tmx.getDefaultTranslation(source);
         assertNotNull("Default translation of '" + source + "' not imported", tr);
         assertEquals("Default translation of '" + source + "' imported wrong", tr.translation, translation);
     }
 
     private void checkNoDefault(String source) {
-        TMXEntry tr = tmx.getDefaultTranslation(source);
+        ProjectTMXEntry tr = tmx.getDefaultTranslation(source);
         assertNull("Default translation of '" + source + "' imported, but shouldn't", tr);
     }
 
     private void checkAlternative(String id, String source, String translation) {
         EntryKey key = new EntryKey("test", source, id, null, null, null);
-        TMXEntry tr = tmx.getMultipleTranslation(key);
+        ProjectTMXEntry tr = tmx.getMultipleTranslation(key);
         assertNotNull("Alternative translation of '" + source + "' (id='" + id + "') not imported", tr);
         assertEquals("Alternative translation of '" + source + "' (id='" + id + "') imported wrong", tr.translation,
                 translation);
@@ -197,7 +197,7 @@ public class RealProjectTest {
 
     private void checkNoAlternative(String id, String source) {
         EntryKey key = new EntryKey("test", source, id, null, null, null);
-        TMXEntry tr = tmx.getMultipleTranslation(key);
+        ProjectTMXEntry tr = tmx.getMultipleTranslation(key);
         assertNull("Alternative translation of '" + source + "' (id='" + id + "') imported, but shouldn't", tr);
     }
 
@@ -219,7 +219,7 @@ public class RealProjectTest {
         }
     }
 
-    public static TMXEntry createEmptyTMXEntry() {
-        return new TMXEntry(new PrepareTMXEntry(), true, null);
+    public static ProjectTMXEntry createEmptyTMXEntry() {
+        return new ProjectTMXEntry(new PrepareTMXEntry(), true, null);
     }
 }

--- a/test/src/org/omegat/core/data/TmxComplianceBase.java
+++ b/test/src/org/omegat/core/data/TmxComplianceBase.java
@@ -121,7 +121,7 @@ public abstract class TmxComplianceBase {
 
     protected void translateAndCheckTextUsingTmx(String fileTextIn, String inCharset, String fileTMX,
             String fileTextOut, String outCharset, String sourceLang, String targetLang,
-            Map<String, TMXEntry> tmxPatch) throws Exception {
+            Map<String, ProjectTMXEntry> tmxPatch) throws Exception {
         TextFilter f = new TextFilter();
         Map<String, String> c = new TreeMap<String, String>();
         c.put(TextFilter.OPTION_SEGMENT_ON, TextFilter.SEGMENT_BREAKS);
@@ -134,7 +134,7 @@ public abstract class TmxComplianceBase {
 
     protected void translateUsingTmx(IFilter filter, Map<String, String> config, final String fileTextIn,
             String inCharset, String fileTMX, String outCharset, ProjectProperties props,
-            Map<String, TMXEntry> tmxPatch) throws Exception {
+            Map<String, ProjectTMXEntry> tmxPatch) throws Exception {
         final ProjectTMX tmx = new ProjectTMX(props.getSourceLanguage(), props.getTargetLanguage(),
                 props.isSentenceSegmentingEnabled(), new File("test/data/tmx/TMXComplianceKit/" + fileTMX),
                 orphanedCallback);
@@ -149,7 +149,7 @@ public abstract class TmxComplianceBase {
             @Override
             protected String getSegmentTranslation(String id, int segmentIndex, String segmentSource,
                     String prevSegment, String nextSegment, String path) {
-                TMXEntry e = tmx.getDefaultTranslation(segmentSource);
+                ProjectTMXEntry e = tmx.getDefaultTranslation(segmentSource);
                 assertNotNull(e);
                 return e.translation;
             }
@@ -207,7 +207,7 @@ public abstract class TmxComplianceBase {
         ProjectTMX tmx = new ProjectTMX(props.getSourceLanguage(), props.getTargetLanguage(),
                 props.isSentenceSegmentingEnabled(), outFile, orphanedCallback);
 
-        for (Map.Entry<String, TMXEntry> en : callback.data.entrySet()) {
+        for (Map.Entry<String, ProjectTMXEntry> en : callback.data.entrySet()) {
             tmx.defaults.put(en.getKey(), en.getValue());
         }
 

--- a/test/src/org/omegat/core/data/TmxComplianceTests.java
+++ b/test/src/org/omegat/core/data/TmxComplianceTests.java
@@ -283,7 +283,7 @@ public class TmxComplianceTests extends TmxComplianceBase {
         config.put(HTMLOptions.OPTION_TRANSLATE_SRC, "false");
         config.put(HTMLOptions.OPTION_SKIP_META, "true");
 
-        Map<String, TMXEntry> fix = new TreeMap<String, TMXEntry>();
+        Map<String, ProjectTMXEntry> fix = new TreeMap<String, ProjectTMXEntry>();
         fix.put("Picture:", createTMXEntry("Picture:", "Image:", true));
         translateUsingTmx(new HTMLFilter2(), config, "ImportTest2A.htm", "UTF-8", "ImportTest2A.tmx",
                 "windows-1252", props, fix);
@@ -312,7 +312,7 @@ public class TmxComplianceTests extends TmxComplianceBase {
         config.put(HTMLOptions.OPTION_TRANSLATE_SRC, "false");
         config.put(HTMLOptions.OPTION_SKIP_META, "true");
 
-        Map<String, TMXEntry> fix = new TreeMap<String, TMXEntry>();
+        Map<String, ProjectTMXEntry> fix = new TreeMap<String, ProjectTMXEntry>();
         fix.put("Picture:", createTMXEntry("Picture:", "Image:", true));
         translateUsingTmx(new HTMLFilter2(), config, "ImportTest2A.htm", "UTF-8", "ImportTest2A-0index.tmx",
                 "windows-1252", props, fix);
@@ -388,10 +388,10 @@ public class TmxComplianceTests extends TmxComplianceBase {
         compareTMX(tmxFile, outFile, 12);
     }
 
-    TMXEntry createTMXEntry(String source, String translation, boolean def) {
+    ProjectTMXEntry createTMXEntry(String source, String translation, boolean def) {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        return new TMXEntry(tr, def, null);
+        return new ProjectTMXEntry(tr, def, null);
     }
 }

--- a/test/src/org/omegat/core/data/TmxComplianceTests.java
+++ b/test/src/org/omegat/core/data/TmxComplianceTests.java
@@ -392,6 +392,6 @@ public class TmxComplianceTests extends TmxComplianceBase {
         PrepareTMXEntry tr = new PrepareTMXEntry();
         tr.source = source;
         tr.translation = translation;
-        return new ProjectTMXEntry(tr, def, null);
+        return tr.toProjectTMXEntry(def, null, null);
     }
 }

--- a/test/src/org/omegat/core/data/TmxSegmentationTest.java
+++ b/test/src/org/omegat/core/data/TmxSegmentationTest.java
@@ -64,8 +64,8 @@ public class TmxSegmentationTest {
                 });
 
         assertEquals(2, tmx.defaults.size());
-        assertEquals("Ceci est un test.", tmx.defaults.get("This is test.").translation);
-        assertEquals("Juste un test.", tmx.defaults.get("Just a test.").translation);
+        assertEquals("Ceci est un test.", tmx.defaults.get("This is test.").getTranslationText());
+        assertEquals("Juste un test.", tmx.defaults.get("Just a test.").getTranslationText());
     }
 
     @Test
@@ -74,9 +74,9 @@ public class TmxSegmentationTest {
                 .setDoSegmenting(true).load(new Language("en"), new Language("fr"));
 
         assertEquals(2, tmx.getEntries().size());
-        assertEquals("This is test.", tmx.getEntries().get(0).source);
-        assertEquals("Ceci est un test.", tmx.getEntries().get(0).translation);
-        assertEquals("Just a test.", tmx.getEntries().get(1).source);
-        assertEquals("Juste un test.", tmx.getEntries().get(1).translation);
+        assertEquals("This is test.", tmx.getEntries().get(0).getSourceText());
+        assertEquals("Ceci est un test.", tmx.getEntries().get(0).getTranslationText());
+        assertEquals("Just a test.", tmx.getEntries().get(1).getSourceText());
+        assertEquals("Juste un test.", tmx.getEntries().get(1).getTranslationText());
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 import org.junit.Test;
 import org.omegat.core.data.ExternalTMX;
-import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ITMXEntry;
 import org.omegat.filters2.po.PoFilter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -82,14 +82,14 @@ public class POFilterTest extends TestFilterBase {
         ExternalTMX tmEntries = fi.referenceEntries;
         assertEquals(2, tmEntries.getEntries().size());
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(0);
-            assertEquals("True fuzzy!", entry.source);
-            assertEquals("trans5", entry.translation);
+            ITMXEntry entry = tmEntries.getEntries().get(0);
+            assertEquals("True fuzzy!", entry.getSourceText());
+            assertEquals("trans5", entry.getTranslationText());
         }
         {
-            PrepareTMXEntry entry = tmEntries.getEntries().get(1);
-            assertEquals("True fuzzy 2!", entry.source);
-            assertEquals("trans6", entry.translation);
+            ITMXEntry entry = tmEntries.getEntries().get(1);
+            assertEquals("True fuzzy 2!", entry.getSourceText());
+            assertEquals("trans6", entry.getTranslationText());
         }
     }
 

--- a/test/src/org/omegat/languagetools/FalseFriendsTest.java
+++ b/test/src/org/omegat/languagetools/FalseFriendsTest.java
@@ -42,8 +42,8 @@ import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
-import org.omegat.core.data.TMXEntry.ExternalLinked;
+import org.omegat.core.data.ProjectTMXEntry;
+import org.omegat.core.data.ProjectTMXEntry.ExternalLinked;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.languagetools.LanguageToolWrapper.LanguageToolMarker;
@@ -68,7 +68,7 @@ public class FalseFriendsTest extends TestCore {
 
         Core.setProject(new IProject() {
             public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
-                    boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
+                    boolean defaultTranslation, ProjectTMXEntry.ExternalLinked externalLinked) {
             }
 
             public void setTranslation(SourceTextEntry entry, PrepareTMXEntry trans,
@@ -76,7 +76,7 @@ public class FalseFriendsTest extends TestCore {
                     AllTranslations previousTranslations) throws OptimisticLockingFail {
             }
 
-            public void setNote(SourceTextEntry entry, TMXEntry oldTrans, String note) {
+            public void setNote(SourceTextEntry entry, ProjectTMXEntry oldTrans, String note) {
             }
 
             public void saveProjectProperties() throws Exception {
@@ -107,7 +107,7 @@ public class FalseFriendsTest extends TestCore {
                 return false;
             }
 
-            public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+            public ProjectTMXEntry getTranslationInfo(SourceTextEntry ste) {
                 return null;
             }
 


### PR DESCRIPTION
This Pull Request is continuation of #185 

The role of these patches is to solve concerns mentioned by @miurahr about the role of PrepareTMXEntry class
This is of course one possible solution, not exclusive.

While patches from #185 were here for ensure plugins compatibility even in case of later changes inside OmegaT, the last patches here are known to break backward compatibility (see https://sourceforge.net/p/omegat/mailman/message/37593315/)
For that reason this pull request remains as a draft.