### PR TITLE
Changing the flow of updating teamwork omegat.project

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -493,6 +493,7 @@ TF_COMMIT_TARGET_START=Committing target files
 TF_COMMIT_TARGET_DONE=Target files committed
 
 TF_PROJECT_PROPERTIES_ERROR=Failed to update project properties
+TF_REMOTE_PROJECT_LACKS_GIT_SETTING=Remote project file lacks git setting. This may be intentional, but likely an oversight.
 
 MW_PROMPT_SEG_NR_MSG=Enter the segment number:
 

--- a/src/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -260,6 +260,28 @@ public class RemoteRepositoryProvider {
     }
 
     /**
+     * Copy omegat.project from remote git server mapped to local
+     * directory under the name, omegat.project.NEW
+     *
+     * This is used only for that purpose, but follows the code of
+     * copyFilesFromReposToProject() because we have to go through the
+     * hoops of mapping to find out where the remote omegat.project
+     * file is.
+     *
+     * @param localPath
+     *            directory name or file name. This has to be "omegat.project".
+     */
+    public void copyFilesFromReposToProjectTempNew(String localPath) throws IOException {
+        String[] myForceExcludes = "".equals(localPath) ? forceExcludes : new String[]{};
+        for (Mapping m : getMappings(localPath, myForceExcludes)) {
+            m.copyFromRepoToProjectTempNew();
+            // if ("".equals(localPath)) {
+            //    m.propagateDeletes();
+            //}
+        }
+    }
+
+    /**
      * Copy all mappings that under specified directory path into repository directory.
      *
      * @param localPath
@@ -438,6 +460,40 @@ public class RemoteRepositoryProvider {
                 copyFile(from, to, null);
             }
         }
+      //
+      // This function is only used to copy remote omegat.project to local omegat.project.NEW
+      //
+        public void copyFromRepoToProjectTempNew() throws IOException {
+            if (!matches()) {
+                throw new RuntimeException("Path doesn't match with mapping");
+            }
+            // Remove leading slashes on child args to avoid doing `new
+            // File("foo", "/")` which treats the "/" as an actual child element
+            // name and prevents proper slash normalization later on.
+            File from = new File(getRepositoryDir(repoDefinition), withoutLeadingSlash(repoMapping.getRepository()));
+            // originally to was directory, but here we want to copy remote "omegat.project" to "omegat.project.NEW".
+            File to = new File(projectRoot, withoutLeadingSlash(repoMapping.getLocal()) + "omegat.project.NEW");
+
+
+            if (from.isDirectory()) {
+                // directory mapping
+                List<String> excludes = new ArrayList<>(repoMapping.getExcludes());
+                excludes.addAll(forceExcludes);
+                copyTempNew(from, to, filterPrefix, repoMapping.getIncludes(), excludes, null);
+            } else if (!from.exists()) {
+                //e.g. you opened an omegat.properties to download a team project, but it refers to a remote repo location that doesn't exist.
+                throw new RuntimeException("Location '"+withoutLeadingSlash(repoMapping.getRepository())+"' does not exist in repository "+repoDefinition.getUrl());
+            } else {
+                // file mapping
+                if (!filterPrefix.equals("/")) {
+                    throw new RuntimeException(
+                            "Filter prefix should have been / for file mapping, but was " + filterPrefix);
+                }
+                copyFile(from, to, null);
+            }
+        }
+
+
 
         public void copyFromProjectToRepo(String eolConversionCharset) throws Exception {
             if (!matches()) {
@@ -478,6 +534,37 @@ public class RemoteRepositoryProvider {
 
         public String getVersion() throws Exception {
             return repo.getFileVersion(new File(repoMapping.getRepository(), filterPrefix).getPath());
+        }
+
+
+        /**
+         * Specialized version of copy() to copy omegat.project in remote repository to
+         * omegat.project.NEW
+         *
+         * @return Relative paths of copied files, <em>with <code>/</code> at
+         *         start and end</em>
+         */
+        protected List<String> copyTempNew(File from, File to, String prefix, List<String> includes,
+                                    List<String> excludes, String eolConversionCharset) throws IOException {
+            prefix = withSlashes(prefix);
+            List<String> relativeFiles = FileUtil.buildRelativeFilesList(from, includes, excludes);
+            List<String> copied = new ArrayList<>();
+            for (String rf : relativeFiles) {
+                rf = withSlashes(rf);
+                if (rf.startsWith("/.repositories/")) {
+                    continue; // list from root - shouldn't travel to .repositories/
+                }
+                if (prefix.isEmpty() || prefix.equals("/") || rf.startsWith(prefix)) {
+                    // rf was /omegat.project/
+                    // from: /projectrootdir/.repositories/https_git.example.com_remote_repostory.git
+                    // to:   /projectrootdir/omegat.project.NEW
+                    // So the next line should be copyFile(new File(from, rf), new File(to, ""), eolConversionCharset);
+                    // Instead of copyFile(new File(from, rf), new File(to, rf), eolConversionCharset);
+                    copyFile(new File(from, rf), new File(to, ""), eolConversionCharset);
+                    copied.add(rf);
+                }
+            }
+            return copied;
         }
 
         /**

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -353,22 +353,6 @@ public final class ProjectUICommands {
                 }
                 // We write in all cases, because we might have added default excludes, for instance
                 ProjectFileStorage.writeProjectFile(props);
-
-                //String projectFileURL = dialog.txtRepositoryOrProjectFileURL.getText();
-                //File localDirectory = new File(dialog.txtDirectory.getText());
-//                try {
-//                    localDirectory.mkdirs();
-//                    byte[] projectFile = WikiGet.getURLasByteArray(projectFileURL);
-//                    FileUtils.writeByteArrayToFile(new File(localDirectory, OConsts.FILE_PROJECT), projectFile);
-//                } catch (Exception ex) {
-//                    ex.printStackTrace();
-//                    Core.getMainWindow().displayErrorRB(ex, "TEAM_CHECKOUT_ERROR");
-//                    mainWindow.setCursor(oldCursor);
-//                    return null;
-//                }
-
-//                projectOpen(localDirectory);
-
                 mainWindow.setCursor(oldCursor);
                 oldCursor=null;
                 return null;

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -455,6 +455,7 @@ public final class ProjectUICommands {
                 ProjectProperties props;
                 try {
                     props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
+                    // Here, 'props' is the current project setting read from local copy of omegat.project
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
@@ -467,10 +468,7 @@ public final class ProjectUICommands {
                     File projectFile = new File(projectRootFolder, OConsts.FILE_PROJECT);
                     boolean needToSaveProperties = false;
                     File rewriteOnSuccess = null;
-                    // Here, 'props' is the current project setting read from local copy of omegat.project
-                    if (props.hasRepositories()) {
-                        /*
-                         This is a remote project.
+                    if (props.hasRepositories()) {  /* This a remote project
                          Every time we reopen the project, we copy omegat.project from the remote project,
                          We take following strategy and procedure to open the project.
                          1. When opening a teamwork project as local only non-teamwork by passing 'no-team' to
@@ -478,7 +476,7 @@ public final class ProjectUICommands {
                          2. Save the currently effective repository mapping from LOCAL to variable 'repos'.
                          3. Update project.properties from REMOTE copy of omegat.project that has postfix .NEW
                             by calling loadPropertiesFile(... ) with "omegat.project.NEW".
-                            It respect local root repository URL than remote mapping configuration
+                            It respects a local root repository URL than remote mapping configuration
                          4. Handles mappings of four cases.
                              a. no mapping
                              b. no remote mapping, there are local mapping(s)
@@ -502,13 +500,14 @@ public final class ProjectUICommands {
                                 remoteRepositoryProvider.switchToVersion(OConsts.FILE_PROJECT, null);
                                 remoteRepositoryProvider.copyFilesFromReposToProject(OConsts.FILE_PROJECT,
                                          ".NEW", false);
-                                rewriteOnSuccess = new File(projectRootFolder.getAbsoluteFile(), OConsts.FILE_PROJECT + ".NEW");
+                                rewriteOnSuccess = new File(projectRootFolder.getAbsoluteFile(),
+                                        OConsts.FILE_PROJECT + ".NEW");
                                 props = ProjectFileStorage.loadPropertiesFile(projectRootFolder.getAbsoluteFile(),
                                         new File(projectRootFolder.getAbsoluteFile(), OConsts.FILE_PROJECT + ".NEW"));
-                                if (props.getRepositories() == null) {
-                                    Log.logWarningRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
-                                    Core.getMainWindow().displayWarningRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
-                                    props.setRepositories(repos); // restore the mapping we just lost
+                                // Here, 'props' is the REMOTE project setting read from the remote omegat.project
+                                if (props.getRepositories() == null) {  // We have a project without mapping
+                                    Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
+                                    props.setRepositories(repos); // So we restore the mapping we just lost
                                     needToSaveProperties = true;
                                 } else {
                                     // override repository URL when project URL is git type.

--- a/test/src/org/omegat/core/team2/RemoteRepositoryProviderTest.java
+++ b/test/src/org/omegat/core/team2/RemoteRepositoryProviderTest.java
@@ -280,6 +280,20 @@ public final class RemoteRepositoryProviderTest {
         checkCopyEnd();
     }
 
+    /**
+     * Test a case when remote omegat.project is removed, and OmegaT downloads team project.
+     * Only a few project files are copied.
+     * @throws Exception
+     */
+    @Test
+    public void testCopyAndDeletePropergateReposToProject() throws Exception {
+        createRemoteRepoFiles();
+        map_normalRemoteRepoAndExtraremoteRepoWithExcludesWithoutDirectorySeparatorPrefix();
+        provider.copyFilesFromReposToProject("omegat.project", ".NEW", false);
+        checkCopy(testProjectRepositoryDir + remoteSubdir + "omegat.project", testProjectRoot + "omegat.project.NEW");
+        checkCopyEnd();
+    }
+
     @Before
     public void setUp() throws Exception {
         File dir = new File("build/testdata/repotest");

--- a/test/src/org/omegat/core/team2/RemoteRepositoryProviderTest.java
+++ b/test/src/org/omegat/core/team2/RemoteRepositoryProviderTest.java
@@ -286,7 +286,7 @@ public final class RemoteRepositoryProviderTest {
      * @throws Exception
      */
     @Test
-    public void testCopyAndDeletePropergateReposToProject() throws Exception {
+    public void testCopyAndDeletePropagateReposToProject() throws Exception {
         createRemoteRepoFiles();
         map_normalRemoteRepoAndExtraremoteRepoWithExcludesWithoutDirectorySeparatorPrefix();
         provider.copyFilesFromReposToProject("omegat.project", ".NEW", false);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

This patch changes the flow of updating local teamwork "omegat.project" file with the content of remote copy of
"omegat.project" on the git server.

Before this patch, the content of remote copy overwrites the local copy first, and then if the content lacks the git setting, it was
added and then the "omegat.project" was updated to reflect the addition.

However, if OmegaT terminated early, such update may not happen and thus rendering the teamwork without proper git setting.  When the remote copy of "omegat.project" lacks git setting, on the next opening, the project may no longer be a teamwork project (!).  This confuses the end users to no end.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

## What does this PR change?


This patch changes the workflow of update as follows.

1. Content of the remote copy of "omegat.project" on the server is written to local file, "omegat.project.NEW".

2. The content of this file is parsed.

3. If git-setting is missing in the content, it is added from then current setting from the local copy of "omegat.project".
   In this case, rewriting from the content of the remote copy does not happen.
   
4. Only if the remote copy is good enough to replace the current local copy, then we create a backup copy of the old "omegat.project" in "omegat.project.TIMESTAMP.bak".  Then we RENAME "omegat.project.NEW"  to "omegat.project".

With this flow, there is always a working copy of `omegat.project` on the local computer even if OmegaT terminates early.  So we don't end up with incorrect non-teamwork copy even if the remote copy of "omegat.project" lacks git setting.

Also, this patch displays a warning dialog to warn the user when the remote copy of `omegat.project` on the git server lacks git setting. This should help end users to detect the wrong configuration early on.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

This PR is successor of PR #122  which has not been no response from original author.