### PR TITLE
Dictionary: bump stardict4j@0.3.2, dsl4j@0.5.2 and dictzip@0.12.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,9 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.1'
 
         // Dictionary
-        implementation 'io.github.dictzip:dictzip:0.11.2'
+        implementation 'io.github.dictzip:dictzip:0.12.1'
         implementation 'com.github.takawitter:trie4j:0.9.8'
-        implementation 'io.github.eb4j:dsl4j:0.4.5'
+        implementation 'io.github.eb4j:dsl4j:0.5.0'
         implementation 'io.github.eb4j:stardict4j:0.3.0'
 
         // Encoding dectection

--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,9 @@ dependencies {
         implementation 'net.loomchild:maligna:3.0.1'
 
         // Dictionary
-        implementation 'io.github.dictzip:dictzip:0.12.1'
+        implementation 'io.github.dictzip:dictzip:0.12.2'
         implementation 'com.github.takawitter:trie4j:0.9.8'
-        implementation 'io.github.eb4j:dsl4j:0.5.0'
+        implementation 'io.github.eb4j:dsl4j:0.5.1'
         implementation 'io.github.eb4j:stardict4j:0.3.0'
 
         // Encoding dectection

--- a/build.gradle
+++ b/build.gradle
@@ -134,8 +134,8 @@ dependencies {
         // Dictionary
         implementation 'io.github.dictzip:dictzip:0.12.2'
         implementation 'com.github.takawitter:trie4j:0.9.8'
-        implementation 'io.github.eb4j:dsl4j:0.5.1'
-        implementation 'io.github.eb4j:stardict4j:0.3.0'
+        implementation 'io.github.eb4j:dsl4j:0.5.2'
+        implementation 'io.github.eb4j:stardict4j:0.3.2'
 
         // Encoding dectection
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -294,7 +294,8 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
                 wasPrev = true;
             }
             txt.append("<div id=\"").append(i).append("\" class=\"entry\">");
-            txt.append("<b><span class=\"word\">").append(de.getWord()).append("</span></b>");
+            txt.append("<b><span class=\"word\">");
+            txt.append(de.getWord().replaceAll("\n", " ")).append("</span></b>");
             txt.append(" - <span class=\"article\">").append(de.getArticle()).append("</span>");
             txt.append("</div>");
             displayedWords.add(de.getQuery());

--- a/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
+++ b/test/src/org/omegat/core/dictionaries/LingvoDSLTest.java
@@ -50,6 +50,8 @@ import org.omegat.core.dictionaries.LingvoDSL.LingvoDSLDict;
  */
 public class LingvoDSLTest {
 
+    private final static String LINE_SEPARATOR = System.getProperty("line.separator");
+
     private static final File TEST_DICT = new File("test/data/dicts-lingvo/test.dsl");
     private static final File TEST_DICT_DZ = new File("test/data/dicts-lingvo-dz/test.dsl.dz");
     private static final Path TEST_DICT_IDX = Paths.get(Paths.get(TEST_DICT.toURI()) + ".idx");
@@ -74,7 +76,7 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<div style=\"text-indent: 30px\">Only a single white space on first character</div>\n",
+        assertEquals("<div style=\"text-indent: 30px\">Only a single white space on first character</div>",
                 result.get(0).getArticle());
     }
 
@@ -85,7 +87,8 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<div style=\"text-indent: 30px\">Translation line also can have a single TAB char</div>\n", result.get(0).getArticle());
+        assertEquals("<div style=\"text-indent: 30px\">Translation line also can have a single TAB char</div>",
+                result.get(0).getArticle());
     }
 
     @Test
@@ -95,7 +98,8 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<div style=\"text-indent: 30px\">\u0441\u0442\u0430\u043d\u043e\u043a</div>\n", result.get(0).getArticle());
+        assertEquals("<div style=\"text-indent: 30px\">\u0441\u0442\u0430\u043d\u043e\u043a</div>",
+                result.get(0).getArticle());
     }
 
     @Test
@@ -104,9 +108,9 @@ public class LingvoDSLTest {
         String word = "\u4e00\u4e2a\u6837";
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
-        assertEquals(word, result.get(0).getWord());
+        assertEquals("\u4E00\u500B\u6A23"+ LINE_SEPARATOR + "\u4E00\u4E2A\u6837", result.get(0).getWord());
         assertEquals("[y\u012B ge y\u00E0ng]&nbsp;\nsame as \u4E00\u6A23|\u4E00\u6837 y\u012B " +
-                "y\u00E0ng&nbsp;, the same\n", result.get(0).getArticle());
+                "y\u00E0ng&nbsp;, the same", result.get(0).getArticle());
     }
 
     @Test
@@ -116,7 +120,7 @@ public class LingvoDSLTest {
         List<DictionaryEntry> result = dict.readArticles(word);
         assertFalse(result.isEmpty());
         assertEquals(word, result.get(0).getWord());
-        assertEquals("<div>Here is an <span style='font-style: italic'>italic</span> <strong>word</strong>.</div>\n",
+        assertEquals("<div>Here is an <span style='font-style: italic'>italic</span> <strong>word</strong>.</div>",
                 result.get(0).getArticle());
     }
 
@@ -139,7 +143,7 @@ public class LingvoDSLTest {
                         "<div style=\"text-indent: 60px\">to abandon convertibility</div>\n" +
                         "<div style=\"text-indent: 60px\">to abandon the [gold] standard</div>\n" +
                         "<div style=\"text-indent: 60px\">to abandon price control</div>\n" +
-                        "<div style=\"text-indent: 60px\">to abandon a right</div>\n",
+                        "<div style=\"text-indent: 60px\">to abandon a right</div>",
                 result.get(0).getArticle());
     }
 


### PR DESCRIPTION
## Changed

dictzip@0.12.2
- RandomAccessInputStream: buffering for dictionary access
- Fix bugs of RandomAccessInputStream in 0.12.0 and 0.12.1

stardict4j@0.3.2
- Depends on dictzip@0.12.2
- Fix NPE

dsl4j@0.5.2
- Support various DSL dictionary formats: UTF-16LE, UTF-8, UTF-16BE, BOM, LF/CR+LF,
   with or without empty line record separator
- {{ comment }} suppot on index entry
- Tested with many variations of dictionary data
- depends on dictzip@0.12.2
 
## DSL support matrix

|    | Encoding | BOM | Line/record terminators  | Note                     |
| -- | -------- | --- | ------------------------ | ------------------------ |
| ✓  | UTF-16LE | Yes | CR+LF / empty line       |                          |
| ✓  | UTF-16LE | Yes | CR+LF / single CR+LF     |    from v0.5.0            |
| ✓  | CP1251   | No  | CR+LF / empty line       | CODEPAGE header required |
| ✓  | CP1252   | No  | CR+LF / empty line       | CODEPAGE header required |
| ✓  | CP1253   | No  | CR+LF / empty line       | CODEPAGE header required |

#### Non standard combinations

|    | Encoding | BOM | Line/record terminators  | Note                     |
| -- | -------- | --- | ------------------------ | ------------------------ |
| ✓  | UTF-16LE | Yes | LF / empty line          |                          |
| ✓  | UTF-16LE | Yes | LF / single LF           |   from v0.5.0    |
| ✓  | UTF-16LE | No  | LF / empty line          |                          |
| ✓  | UTF-16LE | No  | LF / single LF           |  from v0.5.0    |
| ✓  | UTF-8    | Yes | LF / empty line          |                          |
| ✓  | UTF-8    | No  | LF / empty line          |                          |
| ✓  | UTF-8    | Yes | LF / single LF           |  From v0.5.0    |
| ✓  | UTF-8    | No  | LF / single LF           |  From v0.5.0      |
| ✓  | CP1251   | No  | LF / empty line          | CODEPAGE header required |
| ✓  | CP1252   | No  | LF / empty line          | CODEPAGE header required |
| ✓  | CP1253   | No  | LF / empty line          | CODEPAGE header required |
| ✓  | UTF-16BE | Yes | CR+LF / empty line       |    from v0.5.2        |
| ✓ | UTF-16BE | Yes | CR+LF / single CR+LF     |    from v0.5.2            |


Signed-off-by: Hiroshi Miura <miurahr@linux.com>