### PR TITLE
DictionaryTextArea: fix stylesheet

### DIFF
--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -156,8 +156,8 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
         Font font = getFont();
         baseStyleSheet.addRule("body { font-family: " + font.getName() + "; "
                 + " font-size: " + font.getSize() + "; "
-                + " font-style: " + (font.getStyle() == Font.BOLD ? "bold"
-                        : font.getStyle() == Font.ITALIC ? "italic" : "normal") + "; "
+                + (font.getStyle() == Font.BOLD ? "font-weight: bold; " : "")
+                + (font.getStyle() == Font.ITALIC ? "font-style: italic" : "font-style: normal") + "; "
                 + " color: " + EditorColor.COLOR_FOREGROUND.toHex() + "; "
                 + " background: " + EditorColor.COLOR_BACKGROUND.toHex() + ";} "
                 + ".word {font-size: " + (2 + font.getSize()) + "; font-style: bold;} "


### PR DESCRIPTION
- Use `font-weight` for bold font


## Pull request type

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- N/A

### Related isssue 

This problem found in another thread of code review

PR  #205

## What does this PR change?

- DictionaryTextArea set style with stylesheet, when set BOLD font, it uses `font-style` but it should be `font-weight`

## Other information

