### PR TITLE
MT: fix conflict dialog when insert MT result

### DIFF
--- a/src/org/omegat/gui/editor/IEditor.java
+++ b/src/org/omegat/gui/editor/IEditor.java
@@ -278,11 +278,28 @@ public interface IEditor {
     void changeCase(CHANGE_CASE_TO newCase);
 
     /**
+     * Replaces the entire edit area with a given text which origin is origin.
+     * <p>
+     *     when manual edit and origin is unknown, origin will be null.
+     *
+     * Must be called only from UI thread.
+     */
+    void replaceEditText(String text, String origin);
+
+    /**
      * Replaces the entire edit area with a given text.
      *
      * Must be called only from UI thread.
      */
     void replaceEditText(String text);
+
+    /**
+     * Replace text and mark as to be changed by the translator from origin,
+     * i.e, background of segment should be marked
+     *
+     * Must be called only from UI thread.
+     */
+    void replaceEditTextAndMark(String text, String origin);
 
     /**
      * Inserts text at the cursor position and mark as to be changed

--- a/src/org/omegat/gui/main/MainWindow.java
+++ b/src/org/omegat/gui/main/MainWindow.java
@@ -282,9 +282,9 @@ public class MainWindow extends JFrame implements IMainWindow {
             if (near.comesFrom == NearString.MATCH_SOURCE.TM
                     && FileUtil.isInPath(new File(Core.getProject().getProjectProperties().getTMRoot(), "mt"),
                             new File(near.projs[0]))) {
-                Core.getEditor().replaceEditTextAndMark(translation);
+                Core.getEditor().replaceEditTextAndMark(translation, "TM:[tm/mt]");
             } else {
-                Core.getEditor().replaceEditText(translation);
+                Core.getEditor().replaceEditText(translation, "TM:[generic]");
             }
             Core.getEditor().requestFocus();
         }

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -39,7 +39,6 @@ package org.omegat.gui.main;
 import java.awt.Component;
 import java.awt.KeyboardFocusManager;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -51,7 +50,6 @@ import org.omegat.Main;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
-import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
@@ -89,7 +87,6 @@ import org.omegat.util.Preferences;
 import org.omegat.util.RecentProjects;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.StringUtil;
-import org.omegat.util.TMXProp;
 import org.omegat.util.TagUtil;
 import org.omegat.util.TagUtil.Tag;
 import org.omegat.util.gui.DesktopWrapper;
@@ -487,16 +484,7 @@ public final class MainWindowMenuHandler {
         if (tr == null) {
             Core.getMachineTranslatePane().forceLoad();
         } else if (!StringUtil.isEmpty(tr.result)) {
-            // set MachineTranslate result as target translation and record translation engine name as origin.
-            SourceTextEntry ste = Core.getEditor().getCurrentEntry();
-            PrepareTMXEntry prepareTMXEntry = new PrepareTMXEntry(Core.getProject().getTranslationInfo(ste));
-            prepareTMXEntry.translation = tr.result;
-            if (prepareTMXEntry.otherProperties == null) {
-                prepareTMXEntry.otherProperties = new ArrayList<>();
-            }
-            prepareTMXEntry.otherProperties.add(new TMXProp(PROP_ORIGIN, String.format("MT:[%s]", tr.translatorName)));
-            Core.getProject().setTranslation(ste, prepareTMXEntry,true, null);
-            Core.getEditor().replaceEditText(tr.result);
+            Core.getEditor().replaceEditText(tr.result, String.format("MT:[%s]", tr.translatorName));
         }
     }
 

--- a/src/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/org/omegat/gui/matches/MatchesTextArea.java
@@ -400,7 +400,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
                         translation =
                             substituteNumbers(currentEntry.getSrcText(), thebest.source, thebest.translation);
                     }
-                    Core.getEditor().replaceEditText(prefix + translation);
+                    Core.getEditor().replaceEditText(prefix + translation, "TM: auto");
                 }
             }
         }

--- a/src/org/omegat/gui/scripting/ConsoleBindings.java
+++ b/src/org/omegat/gui/scripting/ConsoleBindings.java
@@ -169,7 +169,17 @@ public class ConsoleBindings implements IGlossaries, IEditor, IScriptLogger {
     }
 
     @Override
+    public void replaceEditText(final String text, final String origin) {
+
+    }
+
+    @Override
     public void replaceEditText(String text) {
+
+    }
+
+    @Override
+    public void replaceEditTextAndMark(final String text, final String origin) {
 
     }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -288,6 +288,9 @@ public final class TestTeamIntegrationChild {
         public void replaceEditText(String text) {
         }
 
+        public void replaceEditTextAndMark(final String text, final String origin) {
+        }
+
         public void removeFilter() {
         }
 
@@ -402,6 +405,11 @@ public final class TestTeamIntegrationChild {
         }
 
         public void changeCase(CHANGE_CASE_TO newCase) {
+        }
+
+        @Override
+        public void replaceEditText(final String text, final String origin) {
+
         }
 
         public void activateEntry() {

--- a/test/src/org/omegat/core/TestCore.java
+++ b/test/src/org/omegat/core/TestCore.java
@@ -346,6 +346,10 @@ public abstract class TestCore {
             }
 
             @Override
+            public void replaceEditTextAndMark(final String text, final String origin) {
+            }
+
+            @Override
             public void removeFilter() {
             }
 
@@ -509,6 +513,11 @@ public abstract class TestCore {
 
             @Override
             public void changeCase(CHANGE_CASE_TO newCase) {
+            }
+
+            @Override
+            public void replaceEditText(final String text, final String origin) {
+
             }
 
             @Override

--- a/test/src/org/omegat/gui/glossary/GlossaryAutoCompleterViewTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryAutoCompleterViewTest.java
@@ -240,7 +240,16 @@ public class GlossaryAutoCompleterViewTest extends TestCore {
             }
 
             @Override
+            public void replaceEditText(final String text, final String origin) {
+
+            }
+
+            @Override
             public void replaceEditText(String text) {
+            }
+
+            @Override
+            public void replaceEditTextAndMark(final String text, final String origin) {
             }
 
             @Override


### PR DESCRIPTION
This fixes a degrade of 0961df01f2f97d9387b5e563bde84eda121fa61e that cause translation conflict dialog.

A design to hold origin is changed. Now EditorControll class keeps origin data of current edit entry, and write to TMX when commit.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: https://github.com/omegat-org/omegat/pull/205#issuecomment-1087391240
- Title: 

## What does this PR change?

- A commit   0961df01f2f97d9387b5e563bde84eda121fa61e from  Pull-Request #193 cause translation conflict dialog when insert MT result.
- This fix the issue.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
