### PR TITLE
PluginUtils: nullable getTypeByValue argument

### DIFF
--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -99,10 +99,12 @@ public final class PluginUtils {
         }
 
         public static PluginType getTypeByValue(String str) {
-            String sType = str.toLowerCase(Locale.ENGLISH);
-            for (PluginType v : values()) {
-                if (v.getTypeValue().equals(sType)) {
-                    return v;
+            if (!StringUtil.isEmpty(str)) {
+                String sType = str.toLowerCase(Locale.ENGLISH);
+                for (PluginType v : values()) {
+                    if (v.getTypeValue().equals(sType)) {
+                        return v;
+                    }
                 }
             }
             return UNKNOWN;


### PR DESCRIPTION
- Fix NPE introduced by commit ccbfe72
- Check whether PluginType.getTypeByValue argument is empty

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

N/A

## What does this PR change?

- Check null for PluginType.getTypeByValue argument.
- Fix NPE when plugin don't have category property.


