### PR TITLE
AbstractFilter,PoFilter,MozillaLangFilter: Refactoring createWriter createReader

### DIFF
--- a/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -31,13 +31,9 @@ import java.awt.Window;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -99,15 +95,13 @@ public class MozillaDTDFilter extends AbstractFilter {
     }
 
     @Override
-    protected BufferedReader createReader(File inFile, String inEncoding)
-            throws UnsupportedEncodingException, IOException {
-        return new BufferedReader(new InputStreamReader(new FileInputStream(inFile), StandardCharsets.UTF_8));
+    protected BufferedReader createReader(File inFile, String inEncoding) throws IOException {
+        return Files.newBufferedReader(inFile.toPath(), StandardCharsets.UTF_8);
     }
 
     @Override
-    protected BufferedWriter createWriter(File outFile, String outEncoding)
-            throws UnsupportedEncodingException, IOException {
-        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8));
+    protected BufferedWriter createWriter(File outFile, String outEncoding) throws IOException {
+        return Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8);
     }
 
     @Override
@@ -116,11 +110,7 @@ public class MozillaDTDFilter extends AbstractFilter {
 
         String removeStringsUntranslatedStr = processOptions.get(OPTION_REMOVE_STRINGS_UNTRANSLATED);
         // If the value is null the default is false
-        if ((removeStringsUntranslatedStr != null) && (removeStringsUntranslatedStr.equalsIgnoreCase("true"))) {
-            removeStringsUntranslated = true;
-        } else {
-            removeStringsUntranslated = false;
-        }
+        removeStringsUntranslated = "true".equalsIgnoreCase(removeStringsUntranslatedStr);
 
         StringBuilder block = new StringBuilder();
         boolean isInBlock = false;

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -29,12 +29,11 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -104,8 +103,11 @@ public class MozillaLangFilter extends AbstractFilter {
     @Override
     public BufferedWriter createWriter(File outfile, String encoding) throws UnsupportedEncodingException,
             IOException {
+        if (outfile == null) {
+            return null;
+        }
         // lang file use UTF8 encoding
-        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outfile), StandardCharsets.UTF_8));
+        return Files.newBufferedWriter(outfile.toPath(), StandardCharsets.UTF_8);
     }
 
     @Override
@@ -128,25 +130,9 @@ public class MozillaLangFilter extends AbstractFilter {
             TranslationException {
 
         inEncodingLastParsedFile = fc.getInEncoding();
-        BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
-        try {
-            BufferedWriter writer;
-
-            if (outFile != null) {
-                writer = createWriter(outFile, fc.getOutEncoding());
-            } else {
-                writer = null;
-            }
-
-            try {
-                processFile(reader, writer, fc);
-            } finally {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
-        } finally {
-            reader.close();
+        try (BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
+             BufferedWriter writer = createWriter(outFile, fc.getOutEncoding())) {
+            processFile(reader, writer, fc);
         }
     }
 

--- a/src/org/omegat/filters2/po/PoFilter.java
+++ b/src/org/omegat/filters2/po/PoFilter.java
@@ -36,7 +36,10 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +47,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SegmentProperties;
@@ -280,7 +286,7 @@ public class PoFilter extends AbstractFilter {
 
     enum MODE {
         MSGID, MSGSTR, MSGID_PLURAL, MSGSTR_PLURAL, MSGCTX
-    };
+    }
 
     private StringBuilder[] sources, targets;
     private StringBuilder translatorComments, extractedComments, references, sourceFuzzyTrue;
@@ -301,6 +307,46 @@ public class PoFilter extends AbstractFilter {
         return new Instance[]
         { new Instance("*.po", StandardCharsets.UTF_8.name(), StandardCharsets.UTF_8.name()),
                 new Instance("*.pot", StandardCharsets.UTF_8.name(), StandardCharsets.UTF_8.name()) };
+    }
+
+    /**
+     * return BufferdReader for PoFile reading.
+     * @param inFile
+     *            The source file.
+     * @param inEncoding
+     *            Encoding of the input file, if the filter supports it. Otherwise null.
+     * @return
+     * @throws IOException
+     */
+    @Override
+    protected BufferedReader createReader(File inFile, String inEncoding) throws IOException {
+        BOMInputStream bomInputStream = new BOMInputStream(Files.newInputStream(inFile.toPath()),
+                ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE);
+        ByteOrderMark bom = bomInputStream.getBOM();
+        String charset;
+        if (bom != null) {
+            charset = bom.getCharsetName();
+        } else if (inEncoding == null) {
+            charset = Charset.defaultCharset().name();
+        } else {
+            charset = inEncoding;
+        }
+        return new BufferedReader(new InputStreamReader(bomInputStream, charset));
+    }
+
+    @Override
+    protected BufferedWriter createWriter(File outFile, String outEncoding)
+            throws IOException {
+        if (outFile == null) {
+            return null;
+        }
+        Charset charset;
+        if (outEncoding != null) {
+            charset = Charset.forName(outEncoding);
+        } else {
+            charset = Charset.defaultCharset();
+        }
+        return Files.newBufferedWriter(outFile.toPath(), charset);
     }
 
     @Override
@@ -339,48 +385,20 @@ public class PoFilter extends AbstractFilter {
         formatMonolingual = "true".equalsIgnoreCase(formatMonolingualStr);
 
         inEncodingLastParsedFile = fc.getInEncoding();
-        BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
-        try {
-            BufferedWriter writer;
-
-            if (outFile != null) {
-                writer = createWriter(outFile, fc.getOutEncoding());
-            } else {
-                writer = null;
-            }
-
-            try {
-                processFile(reader, writer, fc);
-            } finally {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
-        } finally {
-            reader.close();
+        try (BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
+             BufferedWriter writer = createWriter(outFile, fc.getOutEncoding())) {
+            processFile(reader, writer, fc);
         }
     }
 
     @Override
     protected void alignFile(BufferedReader sourceFile, BufferedReader translatedFile, FilterContext fc) throws Exception {
-        // BOM (byte order mark) bugfix
-        translatedFile.mark(1);
-        int ch = translatedFile.read();
-        if (ch != 0xFEFF) {
-            translatedFile.reset();
-        }
         this.out = null;
         processPoFile(translatedFile, fc);
     }
 
     @Override
     public void processFile(BufferedReader in, BufferedWriter out, FilterContext fc) throws IOException {
-        // BOM (byte order mark) bugfix
-        in.mark(1);
-        int ch = in.read();
-        if (ch != 0xFEFF) {
-            in.reset();
-        }
         this.out = out;
         processPoFile(in, fc);
     }

--- a/test/data/filters/MozillaDTD/file-be.dtd
+++ b/test/data/filters/MozillaDTD/file-be.dtd
@@ -1,0 +1,3 @@
+<!ENTITY mainWindow.title "Title-be">
+<!ENTITY fileMenu.label "File-be">
+<!ENTITY editMenu.label 'Edit-be'>

--- a/test/data/filters/po/file-POFilter-fuzzyCtx-expected.po
+++ b/test/data/filters/po/file-POFilter-fuzzyCtx-expected.po
@@ -6,6 +6,8 @@ msgstr "POT-Creation-Date: 2005-08-23 10:06+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: be\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 msgid "source"
 msgstr "source"

--- a/test/data/filters/po/file-POFilter-fuzzyCtx-plural.po
+++ b/test/data/filters/po/file-POFilter-fuzzyCtx-plural.po
@@ -1,6 +1,5 @@
 msgid ""
-msgstr ""
-"POT-Creation-Date: 2005-08-23 10:06+0200\n"
+msgstr "POT-Creation-Date: 2005-08-23 10:06+0200\n"
 "PO-Revision-Date: 2002-08-25 16:15GMT+2\n"
 "Last-Translator: l10n team <team@example.org>\n"
 "Language-Team: l10n <i18n@example.org>\n"
@@ -8,16 +7,11 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: be\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#, fuzzy
-#| msgid "True fuzzy 2!"
 msgid "source"
-msgstr "translate"
+msgstr "source"
 
 #: path
-#, fuzzy
-#| msgctxt "context"
-#| msgid "old message ID"
 msgid "new message ID"
-msgstr "old message string"
+msgstr "new message ID"

--- a/test/src/org/omegat/filters/MozillaDTDFilterTest.java
+++ b/test/src/org/omegat/filters/MozillaDTDFilterTest.java
@@ -25,8 +25,13 @@
 
 package org.omegat.filters;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import org.omegat.core.data.IProject;
+import org.omegat.filters2.IAlignCallback;
+import org.omegat.filters2.IFilter;
 import org.omegat.filters2.mozdtd.MozillaDTDFilter;
 
 public class MozillaDTDFilterTest extends TestFilterBase {
@@ -40,5 +45,28 @@ public class MozillaDTDFilterTest extends TestFilterBase {
         checkMulti("File", "fileMenu.label", null, null, null, null);
         checkMulti("Edit", "editMenu.label", null, null, null, null);
         checkMultiEnd();
+    }
+
+    @Test
+    public void testTranslate() throws Exception {
+        translateText(new MozillaDTDFilter(), "test/data/filters/MozillaDTD/file.dtd");
+    }
+
+    public static class AlignResult {
+        boolean found = false;
+    }
+
+    @Test
+    public void testAlign() throws Exception {
+        final AlignResult ar = new AlignResult();
+        align(new MozillaDTDFilter(), "MozillaDTD/file.dtd",
+                "MozillaDTD/file-be.dtd",
+                new IAlignCallback() {
+                    @Override
+                    public void addTranslation(final String id, final String source, final String translation, final boolean isFuzzy, final String path, final IFilter filter) {
+                        ar.found |= id.equals("mainWindow.title") && source.equals("Title") && translation.equals("Title-be");
+                    }
+                });
+        assertTrue(ar.found);
     }
 }

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -26,7 +26,6 @@
 package org.omegat.filters;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
@@ -112,6 +111,14 @@ public class POFilterTest extends TestFilterBase {
     }
 
     @Test
+    public void testTranslateMonolingual() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(PoFilter.OPTION_FORMAT_MONOLINGUAL, "true");
+        translate(new PoFilter(), "test/data/filters/po/file-POFilter-Monolingual.po", options);
+        compareBinary(new File("test/data/filters/po/file-POFilter-Monolingual.po"), outFile);
+    }
+
+    @Test
     public void testTranslate() throws Exception {
         translate(new PoFilter(), "test/data/filters/po/file-POFilter-be.po");
         compareBinary(new File("test/data/filters/po/file-POFilter-be-expected.po"), outFile);
@@ -160,8 +167,15 @@ public class POFilterTest extends TestFilterBase {
     @Test
     public void testParseFuzzyCtx() throws Exception {
         translate(new PoFilter(), "test/data/filters/po/file-POFilter-fuzzyCtx.po");
-        assertTrue(outFile.canRead());
         compareBinary(new File("test/data/filters/po/file-POFilter-fuzzyCtx-expected.po"), outFile);
+    }
+
+    @Test
+    public void testAutoFillInPluralStatement() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(PoFilter.OPTION_AUTO_FILL_IN_PLURAL_STATEMENT, "true");
+        translate(new PoFilter(), "test/data/filters/po/file-POFilter-fuzzyCtx.po", options);
+        compareBinary(new File("test/data/filters/po/file-POFilter-fuzzyCtx-plural.po"), outFile);
     }
 
 }


### PR DESCRIPTION
Refactoring AbstractFilter and its children PoFilter, MozillaLangFilter and MozillaDTDFilter.
A main concern is to use try-resource-finally syntax for reader/writer objects.
Another concern is to clean a BOM workaround by using BOMInputStream in PoFilter.  

A side changes are 
1. Fix signature error in javadoc reference, 
2. Coding style: line length standard 
3. Adopt NIO style writer/reader object creation instead of old style

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [x] Other (describe below)

Refactoring to use try-resource-finally syntax for input/output to improve future maintenance.


## Which ticket is resolved?
N/A

## What does this PR change?

- PoFilter: MozillaLangFilter,MozDTDFilter: use try-resource-finally syntax for reader/writer
- PoFilter: MozillaLangFilter: Override createWriter/Reader method
- PoFilter: use BomInputStream for POFilter instead of hacky workaround
- AbstractFilter: use Files#newBufferedReader Files#newBufferedWriter for createReader/Writer
- AbstractFilter: fix javadoc method reference signature

## Other information

### Original authors' review requested

- PoFilter: @amake
- MozLang: @didierbr 
- MozDTD: @amake
- AbstractFilter: @amake

