### PR TITLE
Test: use ThreadLocalRandom for temp file name

### DIFF
--- a/test/src/org/omegat/core/team2/AbstractRemoteRepository2IT.java
+++ b/test/src/org/omegat/core/team2/AbstractRemoteRepository2IT.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -142,8 +142,7 @@ public abstract class AbstractRemoteRepository2IT {
      */
     @NotNull
     protected final String createFile(File basedir) throws IOException {
-        Random random = new Random();
-        String newFile = "file" + random.nextInt();
+        String newFile = "file" + ThreadLocalRandom.current().nextInt();
         File f = new File(basedir, newFile);
         FileUtils.writeStringToFile(f, "Files in Java might be tricky, but it is fun enough!", "UTF-8");
         return newFile;


### PR DESCRIPTION
It is bad practice to create Random instance and use only once.
This changes to use ThreadLocalRandom.current().nextInt().

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [x] Other (describe below)

Fix bad practice

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
