### PR TITLE
[BUGS#1098,#1099] Searcher: show file path in relative

### DIFF
--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -356,9 +356,10 @@ public class Searcher {
             // Search TM entries, unless we search for date or author.
             // They are not loaded from external TM, so skip the search in
             // that case.
+            Path projectRoot = Paths.get(m_project.getProjectProperties().getProjectRoot());
             if (!searchExpression.searchAuthor && !searchExpression.searchDateAfter && !searchExpression.searchDateBefore) {
                 for (Map.Entry<String, ExternalTMX> tmEn : m_project.getTransMemories().entrySet()) {
-                    final String fileTM = tmEn.getKey();
+                    final String fileTM = searchExpression.fileNames ? projectRoot.relativize(Paths.get(tmEn.getKey())).toString() : null;
                     searchEntries(tmEn.getValue().getEntries(), ENTRY_ORIGIN_TRANSLATION_MEMORY, fileTM);
                     checkStop.checkInterrupted();
                 }


### PR DESCRIPTION



## Pull request type

Please check the type of change your PR introduces:

- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: <!-- Paste link here -->https://sourceforge.net/p/omegat/bugs/1099/
- Title: <!-- Paste title here -->Absolute paths used in search results from TMs

## What does this PR change?

- When filepath option is on in search dialog, a result pane will show
file paths in relative manner.
- Fix a behavior that TM search show paths even when filepath option is off.
- Address [BUGS#1098](https://sourceforge.net/p/omegat/bugs/1098/) and [BUGS#1099](https://sourceforge.net/p/omegat/bugs/1099/)

## Other information
