### PR TITLE
Highlight normalized

### DIFF
--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -666,8 +666,26 @@ public class Searcher {
                         start = find;
                     } else {
                         // If the string to search contains normalized characters, then we cannot find this match
-                        // Then this one will not be highlighted, but we continue to give a chance to other matches
-                        continue OUT_LOOP;
+                        // Try to find it using normalization of substrings
+                        boolean found = false;
+                        String foundText = text.substring(start, end);
+                        IN_LOOP:
+                        for (find = 0; find < origText.length(); find++) {
+                            if (StringUtil.normalizeWidth(origText.substring(find)).startsWith(foundText)) {
+                                start = end = find;
+                                while (end < origText.length()) {
+                                    end++;
+                                    if (StringUtil.normalizeWidth(origText.substring(start,end)).equals(foundText)) {
+                                        found = true;
+                                        break IN_LOOP;
+                                    }
+                                }
+                            }
+                        }
+                        if (! found) {
+                            // No way, we cannot find the match at all. Do not highlight but return true
+                            break OUT_LOOP;
+                        }
                     }
                 }
                 if (searchExpression.mode == SearchMode.REPLACE) {


### PR DESCRIPTION
## Pull request type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

From the discussion list: https://sourceforge.net/p/omegat/mailman/message/37682088/
(no ticket opened)

## What does this PR change?

The problem mentioned in the discussion comes from the option "Full/Half width insensitive" : when the option is activated, a normalization of the string occurs, and if this normalization changes the size of the string, actually highlights are unactivated.

Given the sample phrase 今の気温は20℃です。as we know that ℃ is the character which causes problems, 
For the solution I distinguish 3 cases
1. string before the normalized characters, like 気温
2. string after the normalized characters, like です
3. search containing the normalized characters, for example if you search "20°C"

First commit solves points 1 and 2: characters non-normalized may have been shifted, but that is all
Second patch solves point 3, which is more complicated: the found text is normalized and we don't have a method to "un-normalize" in order to find the equivalent in the original string. So, I do a search character per character until I find a piece of text whose normalized form looks like the searched text. 
