### PR TITLE
[RFE#1624] new CLI mode to print or write the project stats in text, xml or json

### DIFF
--- a/src/org/omegat/CLIParameters.java
+++ b/src/org/omegat/CLIParameters.java
@@ -105,6 +105,10 @@ public final class CLIParameters {
     // CONSOLE_ALIGN mode
     public static final String ALIGNDIR = "alignDir";
 
+    // CONSOLE_STATS mode
+    public static final String STATS_OUTPUT = "output-file";
+    public static final String STATS_MODE = "stats-type";
+
     // Development
     public static final String DEV_MANIFESTS = "dev-manifests";
 
@@ -115,7 +119,7 @@ public final class CLIParameters {
      * Application execution mode. Value of {@link #MODE}.
      */
     enum RUN_MODE {
-        GUI, CONSOLE_TRANSLATE, CONSOLE_CREATEPSEUDOTRANSLATETMX, CONSOLE_ALIGN;
+        GUI, CONSOLE_TRANSLATE, CONSOLE_CREATEPSEUDOTRANSLATETMX, CONSOLE_ALIGN, CONSOLE_STATS;
 
         public static RUN_MODE parse(String s) {
             try {

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -414,15 +414,16 @@ public final class Main {
         try (OutputStreamWriter writer = new OutputStreamWriter(
                 Files.newOutputStream(outputXML, CREATE, TRUNCATE_EXISTING, WRITE),
                 StandardCharsets.UTF_8)) {
-            // no stats type specified.
-            if (statsMode == null) {
+            if (statsMode == null) { // no stats type specified. Assume XML.
                 writer.write(projectStats.getXmlData());
             } else if ("TXT".equalsIgnoreCase(statsMode) || "text".equalsIgnoreCase(statsMode)) {
                 writer.write(projectStats.getTextData());
             } else if ("JSON".equalsIgnoreCase(statsMode)) {
                 writer.write(projectStats.getJsonData());
-            } else {
+            } else if ("XML".equalsIgnoreCase(statsMode)){
                 writer.write(projectStats.getXmlData());
+            } else {
+                Log.log("Specified UNKNOWN file type for statistics. aborted.");
             }
         } catch (NoSuchFileException nsfe) {
             Log.log("Got directory/file open error. Does specified directory exist?");

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -401,22 +401,29 @@ public final class Main {
         ProjectProperties config = p.getProjectProperties();
         StatsResult projectStats = CalcStandardStatistics.buildProjectStats(p);
 
-        if (PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) {
-            Path outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT)).toPath();
-            try (OutputStreamWriter writer =
-                         new OutputStreamWriter(Files.newOutputStream(outputXML.toAbsolutePath(), CREATE_NEW,
-                                 TRUNCATE_EXISTING, WRITE), StandardCharsets.UTF_8)) {
-                if (PARAMS.containsKey(CLIParameters.STATS_MODE) &&
-                        "XML".equalsIgnoreCase(PARAMS.get(CLIParameters.STATS_MODE))) {
-                    writer.write(projectStats.getXmlData(config));
-                } else {
-                    writer.write(projectStats.getTextData(config));
-                }
-            } catch (NoSuchFileException nsfe) {
-                Log.log("Got directory/file open error. Does specified directory exist?");
-            }
-        } else {
+        if (!PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) { // no output file specified.
             System.out.println(projectStats.getTextData(config));
+            p.closeProject();
+            return 0;
+        }
+        String statsMode = null;
+        if (PARAMS.containsKey(CLIParameters.STATS_MODE)) {
+            statsMode = PARAMS.get(CLIParameters.STATS_MODE);
+        }
+        Path outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT)).toPath().toAbsolutePath();
+        try (OutputStreamWriter writer = new OutputStreamWriter(
+                Files.newOutputStream(outputXML, CREATE_NEW, TRUNCATE_EXISTING, WRITE),
+                StandardCharsets.UTF_8)) {
+            // no stats type specified.
+            if (statsMode == null) {
+                writer.write(projectStats.getXmlData(config));
+            } else if ("TXT".equalsIgnoreCase(statsMode) || "text".equalsIgnoreCase(statsMode)) {
+                writer.write(projectStats.getTextData(config));
+            } else {
+                writer.write(projectStats.getXmlData(config));
+            }
+        } catch (NoSuchFileException nsfe) {
+            Log.log("Got directory/file open error. Does specified directory exist?");
         }
         p.closeProject();
         return 0;

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -554,7 +554,7 @@ public final class Main {
      * @return the project.
      */
     private static RealProject selectProjectConsoleMode(boolean loadProject) {
-        Log.log(OStrings.getString("CONSOLE_LOADING_PROJECT"));
+        System.out.println(OStrings.getString("CONSOLE_LOADING_PROJECT"));
 
         // check if project okay
         ProjectProperties projectProperties = null;

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -29,7 +29,7 @@
 
 package org.omegat;
 
-import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
 
@@ -412,7 +412,7 @@ public final class Main {
         }
         Path outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT)).toPath().toAbsolutePath();
         try (OutputStreamWriter writer = new OutputStreamWriter(
-                Files.newOutputStream(outputXML, CREATE_NEW, TRUNCATE_EXISTING, WRITE),
+                Files.newOutputStream(outputXML, CREATE, TRUNCATE_EXISTING, WRITE),
                 StandardCharsets.UTF_8)) {
             // no stats type specified.
             if (statsMode == null) {

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -29,6 +29,10 @@
 
 package org.omegat;
 
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
 import java.awt.Toolkit;
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,6 +45,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -397,14 +402,17 @@ public final class Main {
 
         if (PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) {
             File outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT));
-            try (OutputStreamWriter writer = new OutputStreamWriter(Files.newOutputStream(outputXML.toPath()),
-                    StandardCharsets.UTF_8)) {
+            try (OutputStreamWriter writer =
+                         new OutputStreamWriter(Files.newOutputStream(outputXML.toPath(), CREATE_NEW,
+                                 TRUNCATE_EXISTING, WRITE), StandardCharsets.UTF_8)) {
                 if (PARAMS.containsKey(CLIParameters.STATS_MODE) &&
                         "XML".equalsIgnoreCase(PARAMS.get(CLIParameters.STATS_MODE))) {
                     writer.write(projectStats.getXmlData(config));
                 } else {
                     writer.write(projectStats.getTextData(config));
                 }
+            } catch (NoSuchFileException nsfe) {
+                Log.log("Got directory/file open error. Does specified directory exist?");
             }
         } else {
             System.out.println(projectStats.getTextData(config));

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -30,15 +30,13 @@
 package org.omegat;
 
 import java.awt.Toolkit;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -391,27 +389,22 @@ public final class Main {
 
         RealProject p = selectProjectConsoleMode(true);
         ProjectProperties config = p.getProjectProperties();
-        String outputMode = null;
-
-        if (PARAMS.containsKey(CLIParameters.STATS_MODE)) {
-            outputMode = PARAMS.get(CLIParameters.STATS_MODE).toUpperCase();
-        }
-
         StatsResult projectStats = CalcStandardStatistics.buildProjectStats(p);
 
         if (PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) {
             File outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT));
-            FileWriter fw = new FileWriter(outputXML);
-            if ("XML".equals(outputMode)) {
-                fw.write(projectStats.getXmlData(config));
-            } else {
-                fw.write(projectStats.getTextData(config));
+            try (OutputStreamWriter writer = new OutputStreamWriter(Files.newOutputStream(outputXML.toPath()),
+                    StandardCharsets.UTF_8)) {
+                if (PARAMS.containsKey(CLIParameters.STATS_MODE) &&
+                        "XML".equalsIgnoreCase(PARAMS.get(CLIParameters.STATS_MODE))) {
+                    writer.write(projectStats.getXmlData(config));
+                } else {
+                    writer.write(projectStats.getTextData(config));
+                }
             }
-            fw.close();
         } else {
             System.out.println(projectStats.getTextData(config));
         }
-
         p.closeProject();
         return 0;
     }

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -402,7 +402,7 @@ public final class Main {
         StatsResult projectStats = CalcStandardStatistics.buildProjectStats(p);
 
         if (!PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) { // no output file specified.
-            System.out.println(projectStats.getTextData(config));
+            System.out.println(projectStats.getTextData());
             p.closeProject();
             return 0;
         }
@@ -416,13 +416,13 @@ public final class Main {
                 StandardCharsets.UTF_8)) {
             // no stats type specified.
             if (statsMode == null) {
-                writer.write(projectStats.getXmlData(config));
+                writer.write(projectStats.getXmlData());
             } else if ("TXT".equalsIgnoreCase(statsMode) || "text".equalsIgnoreCase(statsMode)) {
-                writer.write(projectStats.getTextData(config));
+                writer.write(projectStats.getTextData());
             } else if ("JSON".equalsIgnoreCase(statsMode)) {
-                writer.write(projectStats.getJsonData(config));
+                writer.write(projectStats.getJsonData());
             } else {
-                writer.write(projectStats.getXmlData(config));
+                writer.write(projectStats.getXmlData());
             }
         } catch (NoSuchFileException nsfe) {
             Log.log("Got directory/file open error. Does specified directory exist?");

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -432,7 +432,8 @@ public final class Main {
             }
         }
         try (OutputStreamWriter writer = new OutputStreamWriter(
-                Files.newOutputStream(Paths.get(outputFilename), CREATE, TRUNCATE_EXISTING, WRITE),
+                Files.newOutputStream(Paths.get(FileUtil.expandTildeHomeDir(outputFilename)),
+                        CREATE, TRUNCATE_EXISTING, WRITE),
                 StandardCharsets.UTF_8)) {
             if ("TXT".equalsIgnoreCase(statsMode) || "text".equalsIgnoreCase(statsMode)) {
                 writer.write(projectStats.getTextData());

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -419,6 +419,8 @@ public final class Main {
                 writer.write(projectStats.getXmlData(config));
             } else if ("TXT".equalsIgnoreCase(statsMode) || "text".equalsIgnoreCase(statsMode)) {
                 writer.write(projectStats.getTextData(config));
+            } else if ("JSON".equalsIgnoreCase(statsMode)) {
+                writer.write(projectStats.getJsonData(config));
             } else {
                 writer.write(projectStats.getXmlData(config));
             }

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -46,6 +46,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -401,9 +402,9 @@ public final class Main {
         StatsResult projectStats = CalcStandardStatistics.buildProjectStats(p);
 
         if (PARAMS.containsKey(CLIParameters.STATS_OUTPUT)) {
-            File outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT));
+            Path outputXML = new File(PARAMS.get(CLIParameters.STATS_OUTPUT)).toPath();
             try (OutputStreamWriter writer =
-                         new OutputStreamWriter(Files.newOutputStream(outputXML.toPath(), CREATE_NEW,
+                         new OutputStreamWriter(Files.newOutputStream(outputXML.toAbsolutePath(), CREATE_NEW,
                                  TRUNCATE_EXISTING, WRITE), StandardCharsets.UTF_8)) {
                 if (PARAMS.containsKey(CLIParameters.STATS_MODE) &&
                         "XML".equalsIgnoreCase(PARAMS.get(CLIParameters.STATS_MODE))) {

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -30,7 +30,11 @@
 package org.omegat;
 
 import java.awt.Toolkit;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -380,7 +380,7 @@ public class RealProject implements IProject {
             StatsResult stat = CalcStandardStatistics.buildProjectStats(this);
             stat.updateStatisticsInfo(hotStat);
             String fn = config.getProjectInternal() + OConsts.STATS_FILENAME;
-            Statistics.writeStat(fn, stat.getTextData(config));
+            Statistics.writeStat(fn, stat.getTextData());
 
             loaded = true;
 
@@ -799,7 +799,7 @@ public class RealProject implements IProject {
                 StatsResult stat = CalcStandardStatistics.buildProjectStats(this);
                 stat.updateStatisticsInfo(hotStat);
                 String fn = config.getProjectInternal() + OConsts.STATS_FILENAME;
-                Statistics.writeStat(fn, stat.getTextData(config));
+                Statistics.writeStat(fn, stat.getTextData());
             } finally {
                 Core.getMainWindow().getMainMenu().getProjectMenu().setEnabled(true);
             }

--- a/src/org/omegat/core/statistics/CalcStandardStatistics.java
+++ b/src/org/omegat/core/statistics/CalcStandardStatistics.java
@@ -75,8 +75,8 @@ public class CalcStandardStatistics extends LongProcessThread {
         IProject p = Core.getProject();
         StatsResult result = buildProjectStats(p);
         callback.setProjectTableData(StatsResult.HT_HEADERS, result.getHeaderTable());
-        callback.setFilesTableData(StatsResult.FT_HEADERS, result.getFilesTable(p.getProjectProperties()));
-        callback.setTextData(result.getTextData(p.getProjectProperties()));
+        callback.setFilesTableData(StatsResult.FT_HEADERS, result.getFilesTable());
+        callback.setTextData(result.getTextData());
         callback.finishData();
 
         String internalDir = p.getProjectProperties().getProjectInternal();
@@ -91,7 +91,7 @@ public class CalcStandardStatistics extends LongProcessThread {
 
         // now dump file based word counts to disk
         String fn = internalDir + OConsts.STATS_FILENAME;
-        Statistics.writeStat(fn, result.getTextData(p.getProjectProperties()));
+        Statistics.writeStat(fn, result.getTextData());
         callback.setDataFile(fn);
     }
 

--- a/src/org/omegat/core/statistics/StatCount.java
+++ b/src/org/omegat/core/statistics/StatCount.java
@@ -25,6 +25,7 @@
 
 package org.omegat.core.statistics;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 
@@ -47,7 +48,16 @@ import org.omegat.core.data.SourceTextEntry;
  */
 public class StatCount {
 
-    public int segments, words, charsWithoutSpaces, charsWithSpaces, files;
+    @JsonProperty("segments")
+    public int segments;
+    @JsonProperty("words")
+    public int words;
+    @JsonProperty("characters-without-spaces")
+    public int charsWithoutSpaces;
+    @JsonProperty("characters")
+    public int charsWithSpaces;
+    @JsonProperty("files")
+    public int files;
 
     /**
      * Initialize counts with zeros.

--- a/src/org/omegat/core/statistics/StatCount.java
+++ b/src/org/omegat/core/statistics/StatCount.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 
+import javax.xml.bind.annotation.XmlAttribute;
+
 /**
  * Bean for store counts in statistics.
  * <p>
@@ -49,14 +51,19 @@ import org.omegat.core.data.SourceTextEntry;
 public class StatCount {
 
     @JsonProperty("segments")
+    @XmlAttribute(name="segments")
     public int segments;
     @JsonProperty("words")
+    @XmlAttribute(name="words")
     public int words;
     @JsonProperty("characters-without-spaces")
+    @XmlAttribute(name="characters-without-spaces")
     public int charsWithoutSpaces;
     @JsonProperty("characters")
+    @XmlAttribute(name="characters")
     public int charsWithSpaces;
     @JsonProperty("files")
+    @XmlAttribute(name="files")
     public int files;
 
     /**

--- a/src/org/omegat/core/statistics/StatProjectProperties.java
+++ b/src/org/omegat/core/statistics/StatProjectProperties.java
@@ -26,8 +26,11 @@
 package org.omegat.core.statistics;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProjectProperties;
+
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
  * Data class for statistics XML and JSON.
@@ -35,9 +38,13 @@ import org.omegat.core.data.ProjectProperties;
  */
 public final class StatProjectProperties {
 
+    @JsonProperty("name")
     private final String projectName;
+    @JsonProperty("root")
     private final String projectRoot;
+    @JsonProperty("source-langauge")
     private final String sourceLanguage;
+    @JsonProperty("target-language")
     private final String targetLanguage;
 
     @JsonIgnore
@@ -53,18 +60,22 @@ public final class StatProjectProperties {
 
     }
 
+    @XmlAttribute(name="name")
     public String getProjectName() {
         return projectName;
     }
 
+    @XmlAttribute(name="root")
     public String getProjectRoot() {
         return projectRoot;
     }
 
+    @XmlAttribute(name="source-language")
     public String getSourceLanguage() {
         return sourceLanguage;
     }
 
+    @XmlAttribute(name="target-language")
     public String getTargetLanguage() {
         return targetLanguage;
     }

--- a/src/org/omegat/core/statistics/StatProjectProperties.java
+++ b/src/org/omegat/core/statistics/StatProjectProperties.java
@@ -25,6 +25,7 @@
 
 package org.omegat.core.statistics;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProjectProperties;
 
@@ -32,12 +33,15 @@ import org.omegat.core.data.ProjectProperties;
  * Data class for statistics XML and JSON.
  * @author Hiroshi Miura
  */
-public class StatProjectProperties {
+public final class StatProjectProperties {
 
     private final String projectName;
     private final String projectRoot;
     private final String sourceLanguage;
     private final String targetLanguage;
+
+    @JsonIgnore
+    private final String sourceRoot;
 
     public StatProjectProperties() {
         ProjectProperties props = Core.getProject().getProjectProperties();
@@ -45,6 +49,8 @@ public class StatProjectProperties {
         this.projectRoot = props.getProjectRoot();
         this.sourceLanguage = props.getSourceLanguage().getLanguage();
         this.targetLanguage = props.getTargetLanguage().getLanguage();
+        this.sourceRoot = props.getSourceRoot();
+
     }
 
     public String getProjectName() {
@@ -61,5 +67,9 @@ public class StatProjectProperties {
 
     public String getTargetLanguage() {
         return targetLanguage;
+    }
+
+    public String getSourceRoot() {
+        return sourceRoot;
     }
 }

--- a/src/org/omegat/core/statistics/StatProjectProperties.java
+++ b/src/org/omegat/core/statistics/StatProjectProperties.java
@@ -3,9 +3,7 @@
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2009 Alex Buloichik
-               2010 Didier Briel
-               2020 Aaron Madlon-Kay
+ Copyright (C) 2022 Hiroshi Miura
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -27,24 +25,41 @@
 
 package org.omegat.core.statistics;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.omegat.core.Core;
+import org.omegat.core.data.ProjectProperties;
 
-public class FileData {
-    @JsonProperty("filename")
-    public String filename;
-    @JsonProperty("total")
-    public StatCount total;
-    @JsonProperty("unique")
-    public StatCount unique;
-    @JsonProperty("remaining")
-    public StatCount remaining;
-    @JsonProperty("unique-remaining")
-    public StatCount remainingUnique;
+/**
+ * Data class for statistics XML and JSON.
+ * @author Hiroshi Miura
+ */
+public class StatProjectProperties {
 
-    public FileData() {
-        total = new StatCount();
-        unique = new StatCount();
-        remaining = new StatCount();
-        remainingUnique = new StatCount();
+    private final String projectName;
+    private final String projectRoot;
+    private final String sourceLanguage;
+    private final String targetLanguage;
+
+    public StatProjectProperties() {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        this.projectName = props.getProjectName();
+        this.projectRoot = props.getProjectRoot();
+        this.sourceLanguage = props.getSourceLanguage().getLanguage();
+        this.targetLanguage = props.getTargetLanguage().getLanguage();
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public String getProjectRoot() {
+        return projectRoot;
+    }
+
+    public String getSourceLanguage() {
+        return sourceLanguage;
+    }
+
+    public String getTargetLanguage() {
+        return targetLanguage;
     }
 }

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -38,14 +38,14 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.gui.TextUtil;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 
 /**
  * @author Vladimir Bychkov
@@ -180,7 +180,7 @@ public class StatsResult {
 
         // Header stats
         String[][] headerTable = getHeaderTable();
-        String[] headers = { "segments", "words", "characters-nosp", "characters" };
+        String[] headers = { "segments", "words", "characters-nosp", "characters", "files" };
         String[] attrs = { "total", "remaining", "unique", "unique-remaining" };
 
         for (int h = 0; h < headers.length; h++) {

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -205,15 +205,15 @@ public class StatsResult {
                 "unique-remaining-characters" };
 
         String[][] filesTable = getFilesTable(props);
-        for (int f = 0; f < filesTable.length; f++) {
+        for (String[] strings : filesTable) {
             xml.writeStartElement("file");
-            xml.writeAttribute(fileAttrs[0], filesTable[f][0]); // name
+            xml.writeAttribute(fileAttrs[0], strings[0]); // name
             xml.writeCharacters(System.lineSeparator());
             for (int h = 0; h < headers.length; h++) {
                 xml.writeEmptyElement(headers[h]);
 
                 for (int a = 0; a < attrs.length; a++) {
-                    xml.writeAttribute(attrs[a], filesTable[f][1 + a + (h * attrs.length)]);
+                    xml.writeAttribute(attrs[a], strings[1 + a + (h * attrs.length)]);
                 }
                 xml.writeCharacters(System.lineSeparator());
             }

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -185,9 +185,8 @@ public class StatsResult {
 
         for (int h = 0; h < headers.length; h++) {
             xml.writeEmptyElement(headers[h]);
-
             for (int a = 1; a < attrs.length; a++) {
-                xml.writeAttribute(attrs[a], headerTable[h][a]);
+                xml.writeAttribute(attrs[a], headerTable[a][h + 1]);
             }
             xml.writeCharacters(System.lineSeparator());
         }
@@ -209,9 +208,8 @@ public class StatsResult {
             xml.writeStartElement("file");
             xml.writeAttribute(fileAttrs[0], strings[0]); // name
             xml.writeCharacters(System.lineSeparator());
-            for (int h = 0; h < headers.length; h++) {
+            for (int h = 0; h < headers.length - 1; h++) {
                 xml.writeEmptyElement(headers[h]);
-
                 for (int a = 0; a < attrs.length; a++) {
                     xml.writeAttribute(attrs[a], strings[1 + a + (h * attrs.length)]);
                 }


### PR DESCRIPTION
Pick ``topic/briacp/console-stats`` branch onto current master.

`--mode=CONSOLE_STATS [project_path] [--output-file=[stats-output-file] [--stats-type=[xml|text][txt][json]]] `

- When called without `--output-file` argument, it print text on console.
- When called without `--stats-type` argument but specify `--output-file` argument, detect from file extension, or  output xml.


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Tikcet: #1624 [CLI option to print the project stats to the console (text or xml)](https://sourceforge.net/p/omegat/feature-requests/1624/)

## What does this PR change?

- Output XML stat into file
- Output Text table to console

## Other information

related RFE#1287
