### PR TITLE
[#1106] CLI: expand tilde(~) in path arguments

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -71,6 +71,7 @@ import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.scripting.ConsoleBindings;
 import org.omegat.gui.scripting.ScriptItem;
 import org.omegat.gui.scripting.ScriptRunner;
+import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
@@ -131,7 +132,7 @@ public final class Main {
 
         String projectDir = PARAMS.get(CLIParameters.PROJECT_DIR);
         if (projectDir != null) {
-            projectLocation = new File(projectDir);
+            projectLocation = new File(FileUtil.expandTildeHomeDir(projectDir));
         }
         remoteProject = PARAMS.get(CLIParameters.REMOTE_PROJECT);
 
@@ -141,12 +142,12 @@ public final class Main {
 
         String resourceBundle = PARAMS.get(CLIParameters.RESOURCE_BUNDLE);
         if (resourceBundle != null) {
-            OStrings.loadBundle(resourceBundle);
+            OStrings.loadBundle(FileUtil.expandTildeHomeDir(resourceBundle));
         }
 
         String configDir = PARAMS.get(CLIParameters.CONFIG_DIR);
         if (configDir != null) {
-            RuntimePreferences.setConfigDir(configDir);
+            RuntimePreferences.setConfigDir(FileUtil.expandTildeHomeDir(configDir));
         }
 
         if (PARAMS.containsKey(CLIParameters.QUIET)) {
@@ -245,7 +246,7 @@ public final class Main {
         if (path == null) {
             return;
         }
-        File configFile = new File(path);
+        File configFile = new File(FileUtil.expandTildeHomeDir(path));
         if (!configFile.exists()) {
             return;
         }

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -494,7 +494,7 @@ public final class Main {
 
         try (TMXWriter2 wr = new TMXWriter2(new File(tmxFile), config.getSourceLanguage(), config.getTargetLanguage(),
                 config.isSentenceSegmentingEnabled(), false, false)) {
-            wr.writeEntries(p.align(p.getProjectProperties(), new File(dir)));
+            wr.writeEntries(p.align(p.getProjectProperties(), new File(FileUtil.expandTildeHomeDir(dir))));
         }
         p.closeProject();
         System.out.println(OStrings.getString("CONSOLE_FINISHED"));

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -39,6 +39,7 @@ import java.nio.charset.Charset;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -304,8 +305,21 @@ public final class FileUtil {
      * @return expanded path string
      */
     public static String expandTildeHomeDir(final String path){
-        String homedir = FileUtils.getUserDirectoryPath();
-        return path.replaceFirst("^~", Matcher.quoteReplacement(homedir));
+        if (path.startsWith("~+/") || path.equals("~+")) {
+            Path currentRelativePath = Paths.get("");
+            String pwd = currentRelativePath.toAbsolutePath().toString();
+            return path.replaceFirst("^~+", Matcher.quoteReplacement(pwd));
+        } else if (path.startsWith("~-/") || path.equals("~-")) {
+            String oldpwd = System.getenv("OLDPWD");
+            if (oldpwd != null) {
+                return path.replaceFirst("^~-", Matcher.quoteReplacement(oldpwd));
+            }
+        } else if (path.startsWith("~/") || path.equals("~")) {
+            String homedir = FileUtils.getUserDirectoryPath();
+            return path.replaceFirst("^~", Matcher.quoteReplacement(homedir));
+        }
+        // when all condition not passed, don't touch
+        return path;
     }
 
     public interface ICollisionCallback {

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -298,6 +298,16 @@ public final class FileUtil {
         }
     }
 
+    /**
+     * Expand tilde(~) in first character in path string.
+     * @param path path string
+     * @return expanded path string
+     */
+    public static String expandTildeHomeDir(final String path){
+        String homedir = FileUtils.getUserDirectoryPath();
+        return path.replaceFirst("^~", Matcher.quoteReplacement(homedir));
+    }
+
     public interface ICollisionCallback {
         boolean isCanceled();
 


### PR DESCRIPTION
This expand tilde(~) character at first character in path argument
into home directory.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## Pull request type

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?


- Ticket: [BUG#1106 CLI commands does not expand tilde(~) to home directory](https://sourceforge.net/p/omegat/bugs/1106/)

## discussed in dev ML.

- Link: https://sourceforge.net/p/omegat/mailman/omegat-development/thread/6581ad52-c5ef-4dc4-f5db-224bf65a8ef6%40northside.tokyo/#msg37693581
- Title: [[OmTdev] CLI path resolver (Was: CLI mode for stats)](https://sourceforge.net/p/omegat/mailman/message/37693581/)

## What does this PR change?

- Expand tilde(~) character in path related arguments;
  - config-dir
  - config-file
  - bundle
  - project path
  - alignDir
  
## Other information

related to PR #235