### PR TITLE
[6.1] Use Jackson XML dataformat for JAXB parser and replace TMX, TBX and omegat.prefs loader/saver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,9 @@ dependencies {
         // JSON parser
         implementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
         implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4"
+        implementation 'com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.14.0'
+
 
         implementation("com.github.ben-manes.caffeine:caffeine:2.9.3") {
             attributes {

--- a/src/org/omegat/convert/v20to21/Convert20to21.java
+++ b/src/org/omegat/convert/v20to21/Convert20to21.java
@@ -36,8 +36,8 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import gen.core.filters.Files;
 import gen.core.filters.Filter;
@@ -60,7 +60,6 @@ public final class Convert20to21 {
      *            old config file
      * @param toFile
      *            new config file
-     * @throws Exception
      */
     public static void convertFiltersConfig(final File fromFile, final File toFile) throws Exception {
         if (!fromFile.exists()) {
@@ -68,11 +67,9 @@ public final class Convert20to21 {
         }
         String c = read(fromFile);
         org.omegat.convert.v20to21.data.Filters filters;
-        XMLDecoder xmldec = new XMLDecoder(new ByteArrayInputStream(c.getBytes("UTF-8")));
-        try {
+        try (XMLDecoder xmldec = new XMLDecoder(
+                new ByteArrayInputStream(c.getBytes(StandardCharsets.UTF_8)))) {
             filters = (org.omegat.convert.v20to21.data.Filters) xmldec.readObject();
-        } finally {
-            xmldec.close();
         }
 
         Filters res = new Filters();
@@ -108,10 +105,9 @@ public final class Convert20to21 {
         convertTextFilter(res);
         convertHTMLFilter2(res);
 
-        JAXBContext ctx = JAXBContext.newInstance(Filters.class);
-        Marshaller m = ctx.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-        m.marshal(res, toFile);
+        XmlMapper mapper = new XmlMapper();
+        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.writeValue(toFile, res);
     }
 
     /**
@@ -133,8 +129,8 @@ public final class Convert20to21 {
         }
         String res = r.toString();
         res = res.replace("org.omegat.filters2.master.Filters", "org.omegat.convert.v20to21.data.Filters");
-        res = res
-                .replace("org.omegat.filters2.master.OneFilter", "org.omegat.convert.v20to21.data.OneFilter");
+        res = res.replace("org.omegat.filters2.master.OneFilter",
+                "org.omegat.convert.v20to21.data.OneFilter");
         res = res.replace("org.omegat.filters2.Instance", "org.omegat.convert.v20to21.data.Instance");
         res = res.replace("org.omegat.filters2.html2.HTMLOptions",
                 "org.omegat.convert.v20to21.data.HTMLOptions");

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -38,14 +38,17 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 
-import javax.xml.bind.JAXB;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.gui.TextUtil;
@@ -55,46 +58,36 @@ import org.omegat.util.gui.TextUtil;
  */
 @XmlRootElement(name = "omegat-stats")
 public class StatsResult {
-    public static final String[] HT_HEADERS = {
-        "",
-        OStrings.getString("CT_STATS_Segments"),
-        OStrings.getString("CT_STATS_Words"),
-        OStrings.getString("CT_STATS_Characters_NOSP"),
-        OStrings.getString("CT_STATS_Characters"),
-        OStrings.getString("CT_STATS_Files"),
-    };
+    public static final String[] HT_HEADERS = { "", OStrings.getString("CT_STATS_Segments"),
+            OStrings.getString("CT_STATS_Words"), OStrings.getString("CT_STATS_Characters_NOSP"),
+            OStrings.getString("CT_STATS_Characters"), OStrings.getString("CT_STATS_Files"), };
 
-    private static final String[] HT_ROWS = {
-        OStrings.getString("CT_STATS_Total"),
-        OStrings.getString("CT_STATS_Remaining"),
-        OStrings.getString("CT_STATS_Unique"),
-        OStrings.getString("CT_STATS_Unique_Remaining"),
-    };
+    private static final String[] HT_ROWS = { OStrings.getString("CT_STATS_Total"),
+            OStrings.getString("CT_STATS_Remaining"), OStrings.getString("CT_STATS_Unique"),
+            OStrings.getString("CT_STATS_Unique_Remaining"), };
 
     private static final boolean[] HT_ALIGN = new boolean[] { false, true, true, true, true, true };
 
-    public static final String[] FT_HEADERS = {
-        OStrings.getString("CT_STATS_FILE_Name"),
-        OStrings.getString("CT_STATS_FILE_Total_Segments"),
-        OStrings.getString("CT_STATS_FILE_Remaining_Segments"),
-        OStrings.getString("CT_STATS_FILE_Unique_Segments"),
-        OStrings.getString("CT_STATS_FILE_Unique_Remaining_Segments"),
-        OStrings.getString("CT_STATS_FILE_Total_Words"),
-        OStrings.getString("CT_STATS_FILE_Remaining_Words"),
-        OStrings.getString("CT_STATS_FILE_Unique_Words"),
-        OStrings.getString("CT_STATS_FILE_Unique_Remaining_Words"),
-        OStrings.getString("CT_STATS_FILE_Total_Characters_NOSP"),
-        OStrings.getString("CT_STATS_FILE_Remaining_Characters_NOSP"),
-        OStrings.getString("CT_STATS_FILE_Unique_Characters_NOSP"),
-        OStrings.getString("CT_STATS_FILE_Unique_Remaining_Characters_NOSP"),
-        OStrings.getString("CT_STATS_FILE_Total_Characters"),
-        OStrings.getString("CT_STATS_FILE_Remaining_Characters"),
-        OStrings.getString("CT_STATS_FILE_Unique_Characters"),
-        OStrings.getString("CT_STATS_FILE_Unique_Remaining_Characters"),
-    };
+    public static final String[] FT_HEADERS = { OStrings.getString("CT_STATS_FILE_Name"),
+            OStrings.getString("CT_STATS_FILE_Total_Segments"),
+            OStrings.getString("CT_STATS_FILE_Remaining_Segments"),
+            OStrings.getString("CT_STATS_FILE_Unique_Segments"),
+            OStrings.getString("CT_STATS_FILE_Unique_Remaining_Segments"),
+            OStrings.getString("CT_STATS_FILE_Total_Words"),
+            OStrings.getString("CT_STATS_FILE_Remaining_Words"),
+            OStrings.getString("CT_STATS_FILE_Unique_Words"),
+            OStrings.getString("CT_STATS_FILE_Unique_Remaining_Words"),
+            OStrings.getString("CT_STATS_FILE_Total_Characters_NOSP"),
+            OStrings.getString("CT_STATS_FILE_Remaining_Characters_NOSP"),
+            OStrings.getString("CT_STATS_FILE_Unique_Characters_NOSP"),
+            OStrings.getString("CT_STATS_FILE_Unique_Remaining_Characters_NOSP"),
+            OStrings.getString("CT_STATS_FILE_Total_Characters"),
+            OStrings.getString("CT_STATS_FILE_Remaining_Characters"),
+            OStrings.getString("CT_STATS_FILE_Unique_Characters"),
+            OStrings.getString("CT_STATS_FILE_Unique_Remaining_Characters"), };
 
-    private static final boolean[] FT_ALIGN = { false, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, };
+    private static final boolean[] FT_ALIGN = { false, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, };
 
     @JsonProperty("project")
     private StatProjectProperties props;
@@ -122,6 +115,7 @@ public class StatsResult {
 
     /**
      * Constructor.
+     * 
      * @param total
      * @param remaining
      * @param unique
@@ -143,7 +137,9 @@ public class StatsResult {
 
     /**
      * Update given hosStat with current stats data.
-     * @param hotStat StatisticsInfo data object.
+     * 
+     * @param hotStat
+     *            StatisticsInfo data object.
      */
     public void updateStatisticsInfo(StatisticsInfo hotStat) {
         hotStat.numberOfSegmentsTotal = total.segments;
@@ -167,6 +163,7 @@ public class StatsResult {
 
     /**
      * Return total number of segments.
+     * 
      * @return
      */
     @XmlElement(name = "total")
@@ -176,6 +173,7 @@ public class StatsResult {
 
     /**
      * Return remaining number of segments that needs translation.
+     * 
      * @return
      */
     @XmlElement(name = "remaining")
@@ -185,6 +183,7 @@ public class StatsResult {
 
     /**
      * Return a number of unique segments.
+     * 
      * @return
      */
     @XmlElement(name = "unique")
@@ -194,6 +193,7 @@ public class StatsResult {
 
     /**
      * Return a number of remaining unique segments.
+     * 
      * @return
      */
     @XmlElement(name = "unique-remaining")
@@ -203,6 +203,7 @@ public class StatsResult {
 
     /**
      * return a statistics of each source/target files.
+     * 
      * @return
      */
     @XmlElement(name = "files")
@@ -212,25 +213,25 @@ public class StatsResult {
 
     /**
      * Return pretty printed statistics data.
+     * 
      * @return pretty-printed string.
      */
     @JsonIgnore
     public String getTextData() {
-        return OStrings.getString("CT_STATS_Project_Statistics") +
-                "\n\n" +
-                TextUtil.showTextTable(HT_HEADERS, getHeaderTable(), HT_ALIGN) +
-                "\n\n" +
+        return OStrings.getString("CT_STATS_Project_Statistics") + "\n\n"
+                + TextUtil.showTextTable(HT_HEADERS, getHeaderTable(), HT_ALIGN) + "\n\n" +
 
                 // STATISTICS BY FILE
-                OStrings.getString("CT_STATS_FILE_Statistics") +
-                "\n\n" +
-                TextUtil.showTextTable(FT_HEADERS, getFilesTable(), FT_ALIGN);
+                OStrings.getString("CT_STATS_FILE_Statistics") + "\n\n"
+                + TextUtil.showTextTable(FT_HEADERS, getFilesTable(), FT_ALIGN);
     }
 
     /**
      * Return JSON expression of stats data.
+     * 
      * @return JSON string data.
-     * @throws IOException when export failed.
+     * @throws IOException
+     *             when export failed.
      */
     @JsonIgnore
     public String getJsonData() throws IOException {
@@ -245,14 +246,16 @@ public class StatsResult {
 
     /**
      * Return XML expression of Stats data.
+     * 
      * @return XML expression of stats data as String.
      */
     @JsonIgnore
-    public String getXmlData() {
+    public String getXmlData() throws JsonProcessingException {
         setDate();
-        StringWriter result = new StringWriter();
-        JAXB.marshal(this, result);
-        return result.toString();
+        XmlMapper mapper = XmlMapper.xmlBuilder().enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME)
+                .build();
+        mapper.registerModule(new JaxbAnnotationModule());
+        return mapper.writeValueAsString(this);
     }
 
     private void setDate() {

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -48,8 +48,8 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.apache.commons.io.FileUtils;
+
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.IAlignCallback;
@@ -58,6 +58,7 @@ import org.omegat.filters2.IParseCallback;
 import org.omegat.filters2.ITranslateCallback;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.TranslationException;
+import org.omegat.util.JaxbXmlMapper;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
@@ -434,7 +435,7 @@ public class FilterMaster {
         }
         Filters result;
         try {
-            XmlMapper mapper = new XmlMapper();
+            XmlMapper mapper = JaxbXmlMapper.getXmlMapper();
             result = mapper.readValue(configFile, Filters.class);
         } catch (Exception e) {
             Log.logErrorRB("FILTERMASTER_ERROR_LOADING_FILTERS_CONFIG");
@@ -460,8 +461,7 @@ public class FilterMaster {
             return;
         }
         try {
-            XmlMapper mapper = new XmlMapper();
-            mapper.registerModule(new JaxbAnnotationModule());
+            XmlMapper mapper = JaxbXmlMapper.getXmlMapper();
             mapper.writerWithDefaultPrettyPrinter().writeValue(configFile, config);
         } catch (Exception e) {
             Log.logErrorRB("FILTERMASTER_ERROR_SAVING_FILTERS_CONFIG");

--- a/src/org/omegat/util/JaxbXmlMapper.java
+++ b/src/org/omegat/util/JaxbXmlMapper.java
@@ -1,0 +1,53 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura.
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.omegat.util;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+public final class JaxbXmlMapper {
+
+    private static final XmlMapper mapper;
+
+    private JaxbXmlMapper() {
+    }
+
+    static {
+        JacksonXmlModule xmlModule = new JacksonXmlModule();
+        xmlModule.setDefaultUseWrapper(false);
+        mapper = new XmlMapper(xmlModule);
+        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    public static XmlMapper getXmlMapper() {
+        return mapper;
+    }
+}

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -50,11 +50,12 @@ import gen.core.filters.Filters;
 /**
  * Class to load & save global OmegaT preferences.
  * <p>
- * Initially this class was implemented with static members and methods directly implementing the interface, backed by
- * XML storage. However this was bad for testing and extensibility, or allowing different persistence formats.
+ * Initially this class was implemented with static members and methods directly
+ * implementing the interface, backed by XML storage. However, this was bad for
+ * testing and extensibility, or allowing different persistence formats.
  * <p>
- * This class's static methods remain for compatibility, but now they wrap a singleton instance of a concrete
- * implementation of {@link IPreferences}.
+ * This class's static methods remain for compatibility, but now they wrap a
+ * singleton instance of a concrete implementation of {@link IPreferences}.
  *
  * @author Keith Godfrey
  * @author Maxym Mykhalchuk
@@ -91,7 +92,9 @@ public final class Preferences {
 
     /** Whether to automatically perform MT requests on entering segment */
     public static final String MT_AUTO_FETCH = "mt_auto_fetch";
-    /** Whether to restrict automatic MT requests to only untranslated segments */
+    /**
+     * Whether to restrict automatic MT requests to only untranslated segments
+     */
     public static final String MT_ONLY_UNTRANSLATED = "mt_only_untranslated";
 
     public static final String GLOSSARY_TBX_DISPLAY_CONTEXT = "glossary_tbx_display_context";
@@ -119,7 +122,8 @@ public final class Preferences {
     public static final String PROJECT_FILES_WINDOW_GEOMETRY_PREFIX = "project_files_window";
     // Using the main font for the Project Files window
     public static final String PROJECT_FILES_USE_FONT = "project_files_use_font";
-    // Determines whether or not the Project Files window is shown on project load.
+    // Determines whether or not the Project Files window is shown on project
+    // load.
     // Currently not exposed in UI.
     public static final String PROJECT_FILES_SHOW_ON_LOAD = "project_files_show_on_load";
 
@@ -187,8 +191,8 @@ public final class Preferences {
     public static final String ALLOW_YANDEX_CLOUD_TRANSLATE = "allow_yandex_cloud_translate";
 
     /**
-     * Mark glossary matches. This feature used to be called "TransTips", and the prefs key remains unchanged for
-     * backwards-compatibility.
+     * Mark glossary matches. This feature used to be called "TransTips", and
+     * the prefs key remains unchanged for backwards-compatibility.
      */
     public static final String MARK_GLOSSARY_MATCHES = "transtips";
 
@@ -234,8 +238,8 @@ public final class Preferences {
     public static final int BEST_MATCH_MINIMAL_SIMILARITY_DEFAULT = 100;
 
     /**
-     * When a fuzzy match is displayed from a memory belonging to a language other than the target language, a penalty
-     * is applied.
+     * When a fuzzy match is displayed from a memory belonging to a language
+     * other than the target language, a penalty is applied.
      */
     public static final String PENALTY_FOR_FOREIGN_MATCHES = "penalty_foreign_matches";
     public static final int PENALTY_FOR_FOREIGN_MATCHES_DEFAULT = 30;
@@ -245,10 +249,13 @@ public final class Preferences {
     /** Workflow Option: Export current segment */
     public static final String EXPORT_CURRENT_SEGMENT = "wf_exportCurrentSegment";
     /**
-     * Workflow Option: Go To Next Untranslated Segment stops when there is at least one alternative translation
+     * Workflow Option: Go To Next Untranslated Segment stops when there is at
+     * least one alternative translation
      */
     public static final String STOP_ON_ALTERNATIVE_TRANSLATION = "wf_stopOnAlternativeTranslation";
-    /** Workflow Option: Attempt to convert numbers when inserting a fuzzy match */
+    /**
+     * Workflow Option: Attempt to convert numbers when inserting a fuzzy match
+     */
     public static final String CONVERT_NUMBERS = "wf_convertNumbers";
     /** Workflow Option: Save auto-populated status */
     public static final String SAVE_AUTO_STATUS = "save_auto_status";
@@ -269,7 +276,10 @@ public final class Preferences {
     public static final String CHECK_JAVA_PATTERN_TAGS = "tagValidation_javaMessageFormatSimplePatternCheck";
     /** Tag Validation Option: check user defined tags according to regexp. */
     public static final String CHECK_CUSTOM_PATTERN = "tagValidation_customPattern";
-    /** Tag Validation Option: check target for text that should have been removed according to regexp. */
+    /**
+     * Tag Validation Option: check target for text that should have been
+     * removed according to regexp.
+     */
     public static final String CHECK_REMOVE_PATTERN = "tagValidation_removePattern";
 
     /** Tag Validation Option: allow tag editing in editor. */
@@ -357,7 +367,10 @@ public final class Preferences {
     public static final String EXT_TMX_MATCH_TEMPLATE = "ext_tmx_match_template";
     /** External TMX options: Fuzzy match sort key **/
     public static final String EXT_TMX_SORT_KEY = "ext_tmx_sort_key";
-    /** External TMX options: Whether to show fuzzy matches from foreign (non-target language) matches. */
+    /**
+     * External TMX options: Whether to show fuzzy matches from foreign
+     * (non-target language) matches.
+     */
     public static final String EXT_TMX_KEEP_FOREIGN_MATCH = "keep_foreign_matches";
     /** External TMX options: Fuzzy Threshold **/
     public static final String EXT_TMX_FUZZY_MATCH_THRESHOLD = "ext_tmx_fuzzy_match_threshold";
@@ -524,7 +537,8 @@ public final class Preferences {
      * If the key is not found return false
      *
      * @param key
-     *            key of the key to look up, usually a static string from this class
+     *            key of the key to look up, usually a static string from this
+     *            class
      * @return true if preferences exists
      */
     public static boolean existsPreference(String key) {
@@ -615,9 +629,12 @@ public final class Preferences {
      */
     public static void setPreference(String name, Object value) {
         Object oldValue = preferences.setPreference(name, value);
-        // Manually compare retrieved new value to old value and check before firing.
-        // This is because the preferences store may only store the serialized (string) value
-        // so the regular equality check within PropertyChangeSupport will always fail
+        // Manually compare retrieved new value to old value and check before
+        // firing.
+        // This is because the preferences store may only store the serialized
+        // (string) value
+        // so the regular equality check within PropertyChangeSupport will
+        // always fail
         // (e.g. when value is Boolean but oldValue is "true"/"false").
         Object storedNewValue = preferences.getPreference(name);
         if (!Objects.equals(oldValue, storedNewValue)) {
@@ -628,9 +645,10 @@ public final class Preferences {
     /**
      * Register to receive notifications when preferences change.
      * <p>
-     * Note: The value returned by {@code PropertyChangeEvent#getNewValue()} will be of the "correct" type (Integer,
-     * Boolean, Enum, etc.) but the value returned by {@code PropertyChangeEvent#getOldValue()} will be the String
-     * equivalent for storing in XML.
+     * Note: The value returned by {@code PropertyChangeEvent#getNewValue()}
+     * will be of the "correct" type (Integer, Boolean, Enum, etc.) but the
+     * value returned by {@code PropertyChangeEvent#getOldValue()} will be the
+     * String equivalent for storing in XML.
      *
      * @param listener
      */
@@ -641,8 +659,9 @@ public final class Preferences {
     /**
      * Register to receive notifications when the specified preference changes.
      * <p>
-     * Note: The value returned by {@code getNewValue()} will be of the "correct" type (Integer, Boolean, Enum, etc.)
-     * but the value returned by {@code getOldValue()} will be the String equivalent for storing in XML.
+     * Note: The value returned by {@code getNewValue()} will be of the
+     * "correct" type (Integer, Boolean, Enum, etc.) but the value returned by
+     * {@code getOldValue()} will be the String equivalent for storing in XML.
      *
      * @param listener
      */
@@ -660,7 +679,8 @@ public final class Preferences {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
-        // Must manually check for equality (see FiltersUtil.filtersEqual() Javadoc)
+        // Must manually check for equality (see FiltersUtil.filtersEqual()
+        // Javadoc)
         if (!FiltersUtil.filtersEqual(oldValue, newFilters)) {
             PROP_CHANGE_SUPPORT.firePropertyChange(Preferences.PROPERTY_FILTERS, oldValue, newFilters);
         }
@@ -794,7 +814,8 @@ public final class Preferences {
         if (prefsFile.exists()) {
             return prefsFile;
         }
-        // If user prefs don't exist, fall back to defaults (possibly) bundled with OmegaT.
+        // If user prefs don't exist, fall back to defaults (possibly) bundled
+        // with OmegaT.
         prefsFile = new File(StaticUtils.installDir(), FILE_PREFERENCES);
         if (prefsFile.exists()) {
             return prefsFile;

--- a/src/org/omegat/util/PreferencesXML.java
+++ b/src/org/omegat/util/PreferencesXML.java
@@ -66,10 +66,12 @@ public class PreferencesXML implements IPrefsPersistence {
 
     private final File loadFile;
     private final File saveFile;
+    private final XmlMapper mapper;
 
     public PreferencesXML(File loadFile, File saveFile) {
         this.loadFile = loadFile;
         this.saveFile = saveFile;
+        mapper = JaxbXmlMapper.getXmlMapper();
     }
 
     @Override
@@ -86,7 +88,6 @@ public class PreferencesXML implements IPrefsPersistence {
     }
 
     private void loadXml(InputStream is, List<String> keys, List<String> values) throws IOException {
-        XmlMapper mapper = new XmlMapper();
         OmegaT rootComponent = mapper.readValue(is, OmegaT.class);
         rootComponent.preference.getRows().forEach((key, value) -> {
             keys.add(key);
@@ -96,7 +97,6 @@ public class PreferencesXML implements IPrefsPersistence {
 
     @Override
     public void save(final List<String> keys, final List<String> values) throws Exception {
-        XmlMapper mapper = new XmlMapper();
         OmegaT rootComponent = new OmegaT();
         for (int i = 0; i < keys.size(); i++) {
             rootComponent.preference.put(keys.get(i), values.get(i));

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -31,17 +31,16 @@
 
 package org.omegat.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters2.master.PluginUtils;
@@ -71,29 +70,24 @@ public final class ProjectFileStorage {
      */
     public static final String DEFAULT_FOLDER_MARKER = "__DEFAULT__";
 
-    private static final JAXBContext CONTEXT;
-    static {
-        try {
-            CONTEXT = JAXBContext.newInstance(Omegat.class);
-        } catch (Exception ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
-
     public static Omegat parseProjectFile(File file) throws Exception {
         return parseProjectFile(FileUtils.readFileToByteArray(file));
     }
 
     public static Omegat parseProjectFile(byte[] projectFile) throws Exception {
-        return (Omegat) CONTEXT.createUnmarshaller().unmarshal(new ByteArrayInputStream(projectFile));
+        XmlMapper mapper = new XmlMapper();
+        mapper.registerModule(new JaxbAnnotationModule());
+        return mapper.readValue(projectFile, Omegat.class);
     }
 
     /**
-     * Load the project properties file for the project at the specified directory. The properties file is
-     * assumed to exist at the root of the project and have the default name, {@link OConsts#FILE_PROJECT}.
-     * This is a convenience method for {@link #loadPropertiesFile(File, File)}.
+     * Load the project properties file for the project at the specified
+     * directory. The properties file is assumed to exist at the root of the
+     * project and have the default name, {@link OConsts#FILE_PROJECT}. This is
+     * a convenience method for {@link #loadPropertiesFile(File, File)}.
      * <p>
-     * If the supplied {@link File} is not a directory, an {@link IllegalArgumentException} will be thrown.
+     * If the supplied {@link File} is not a directory, an
+     * {@link IllegalArgumentException} will be thrown.
      *
      * @param projectDir
      *            The directory of the project
@@ -105,10 +99,11 @@ public final class ProjectFileStorage {
     }
 
     /**
-     * Load the specified project properties file for the project at the specified directory.
+     * Load the specified project properties file for the project at the
+     * specified directory.
      * <p>
-     * If <code>projectDir</code> is not a directory or <code>projectFile</code> is not a file, an
-     * {@link IllegalArgumentException} will be thrown.
+     * If <code>projectDir</code> is not a directory or <code>projectFile</code>
+     * is not a file, an {@link IllegalArgumentException} will be thrown.
      *
      * @param projectDir
      *            The directory of the project
@@ -119,7 +114,7 @@ public final class ProjectFileStorage {
      */
     public static ProjectProperties loadPropertiesFile(File projectDir, File projectFile) throws Exception {
         if (!projectFile.isFile()) {
-            throw new IllegalArgumentException("Project file "+projectFile+" was not a file");
+            throw new IllegalArgumentException("Project file " + projectFile + " was not a file");
         }
         Omegat om = parseProjectFile(projectFile);
         return loadPropertiesFile(projectDir, om);
@@ -132,10 +127,10 @@ public final class ProjectFileStorage {
 
         ProjectProperties result = new ProjectProperties(projectDir);
 
-        if (!OConsts.PROJ_CUR_VERSION.equals(om.getProject().getVersion())) {
-            throw new TranslationException(StringUtil.format(
-                    OStrings.getString("PFR_ERROR_UNSUPPORTED_PROJECT_VERSION"),
-                    om.getProject().getVersion()));
+        String curVersion = om.getProject().getVersion();
+        if (!OConsts.PROJ_CUR_VERSION.equals(curVersion)) {
+            throw new TranslationException(StringUtil
+                    .format(OStrings.getString("PFR_ERROR_UNSUPPORTED_PROJECT_VERSION"), curVersion));
         }
 
         result.setTargetRoot(normalizeLoadedPath(om.getProject().getTargetDir(), OConsts.DEFAULT_TARGET));
@@ -148,10 +143,13 @@ public final class ProjectFileStorage {
             result.getSourceRootExcludes().addAll(ProjectProperties.getDefaultExcludes());
         }
         result.setTMRoot(normalizeLoadedPath(om.getProject().getTmDir(), OConsts.DEFAULT_TM));
-        result.setExportTMRoot(normalizeLoadedPath(om.getProject().getExportTmDir(), OConsts.DEFAULT_EXPORT_TM));
-        result.setExportTmLevels(normalizeLoadedExportTmLevels(om.getProject().getExportTmLevels(), OConsts.DEFAULT_EXPORT_TM_LEVELS));
+        result.setExportTMRoot(
+                normalizeLoadedPath(om.getProject().getExportTmDir(), OConsts.DEFAULT_EXPORT_TM));
+        result.setExportTmLevels(normalizeLoadedExportTmLevels(om.getProject().getExportTmLevels(),
+                OConsts.DEFAULT_EXPORT_TM_LEVELS));
 
-        result.setGlossaryRoot(normalizeLoadedPath(om.getProject().getGlossaryDir(), OConsts.DEFAULT_GLOSSARY));
+        result.setGlossaryRoot(
+                normalizeLoadedPath(om.getProject().getGlossaryDir(), OConsts.DEFAULT_GLOSSARY));
 
         // Compute glossary file location
         String glossaryFile = om.getProject().getGlossaryFile();
@@ -165,8 +163,7 @@ public final class ProjectFileStorage {
         }
         result.setWriteableGlossary(glossaryFile);
 
-        result.setDictRoot(normalizeLoadedPath(om.getProject().getDictionaryDir(),
-                OConsts.DEFAULT_DICT));
+        result.setDictRoot(normalizeLoadedPath(om.getProject().getDictionaryDir(), OConsts.DEFAULT_DICT));
 
         result.setSourceLanguage(om.getProject().getSourceLang());
         result.setTargetLanguage(om.getProject().getTargetLang());
@@ -210,7 +207,8 @@ public final class ProjectFileStorage {
         om.getProject().getSourceDirExcludes().getMask().addAll(props.getSourceRootExcludes());
         om.getProject().setTargetDir(getPathForStoring(root, props.getTargetRoot(), OConsts.DEFAULT_TARGET));
         om.getProject().setTmDir(getPathForStoring(root, props.getTMRoot(), OConsts.DEFAULT_TM));
-        om.getProject().setExportTmDir(getPathForStoring(root, props.getExportTMRoot(), OConsts.DEFAULT_EXPORT_TM));
+        om.getProject()
+                .setExportTmDir(getPathForStoring(root, props.getExportTMRoot(), OConsts.DEFAULT_EXPORT_TM));
         om.getProject().setExportTmLevels(String.join(" ", props.getExportTmLevels()));
         String glossaryDir = getPathForStoring(root, props.getGlossaryRoot(), OConsts.DEFAULT_GLOSSARY);
         om.getProject().setGlossaryDir(glossaryDir);
@@ -238,9 +236,9 @@ public final class ProjectFileStorage {
             om.getProject().getRepositories().getRepository().addAll(props.getRepositories());
         }
 
-        Marshaller m = CONTEXT.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-        m.marshal(om, outFile);
+        XmlMapper mapper = new XmlMapper();
+        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.writeValue(outFile, om);
     }
 
     private static String normalizeLoadedPath(String path, String defaultValue) {
@@ -300,7 +298,8 @@ public final class ProjectFileStorage {
             // Path.normalize() will resolve any remaining "../"
             Path absPath = Paths.get(absolutePath).normalize();
             String rel = Paths.get(root).relativize(absPath).toString();
-            if (StringUtils.countMatches(rel, ".." + File.separatorChar) <= OConsts.MAX_PARENT_DIRECTORIES_ABS2REL) {
+            if (StringUtils.countMatches(rel,
+                    ".." + File.separatorChar) <= OConsts.MAX_PARENT_DIRECTORIES_ABS2REL) {
                 // Use the relativized path as it is "near" enough.
                 result = rel;
             } else {
@@ -314,9 +313,11 @@ public final class ProjectFileStorage {
 
     /**
      * Load a tokenizer class from its canonical name.
-     * @param className Name of tokenizer class
-     * @return Class object of specified tokenizer, or of fallback tokenizer
-     * if the specified one could not be loaded for whatever reason.
+     * 
+     * @param className
+     *            Name of tokenizer class
+     * @return Class object of specified tokenizer, or of fallback tokenizer if
+     *         the specified one could not be loaded for whatever reason.
      */
     private static Class<?> loadTokenizer(String className, Language fallback) {
         if (!StringUtil.isEmpty(className)) {

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -37,7 +37,6 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -75,8 +74,7 @@ public final class ProjectFileStorage {
     }
 
     public static Omegat parseProjectFile(byte[] projectFile) throws Exception {
-        XmlMapper mapper = new XmlMapper();
-        mapper.registerModule(new JaxbAnnotationModule());
+        XmlMapper mapper = JaxbXmlMapper.getXmlMapper();
         return mapper.readValue(projectFile, Omegat.class);
     }
 
@@ -236,8 +234,7 @@ public final class ProjectFileStorage {
             om.getProject().getRepositories().getRepository().addAll(props.getRepositories());
         }
 
-        XmlMapper mapper = new XmlMapper();
-        mapper.registerModule(new JaxbAnnotationModule());
+        XmlMapper mapper = JaxbXmlMapper.getXmlMapper();
         mapper.writeValue(outFile, om);
     }
 

--- a/src/org/omegat/util/TMXReader2.java
+++ b/src/org/omegat/util/TMXReader2.java
@@ -62,7 +62,6 @@ import javax.xml.stream.events.XMLEvent;
 import org.apache.commons.io.input.XmlStreamReader;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 /**
  * Helper for read TMX files, using StAX.
@@ -117,8 +116,7 @@ public class TMXReader2 {
         factory.setXMLReporter(new XMLReporter() {
             public void report(String message, String errorType, Object info, Location location)
                     throws XMLStreamException {
-                Log.logWarningRB("TMXR_WARNING_WHILE_PARSING",
-                        location.getLineNumber(),
+                Log.logWarningRB("TMXR_WARNING_WHILE_PARSING", location.getLineNumber(),
                         location.getColumnNumber());
                 Log.log(message + ": " + info);
                 warningsCount++;
@@ -163,7 +161,8 @@ public class TMXReader2 {
                         parseTu(eStart);
                         ParsedTuv origTuv = getTuvByLang(sourceLanguage);
                         ParsedTuv targetTuv = getTuvByLang(targetLanguage);
-                        allFound = callback.onEntry(currentTu, origTuv, targetTuv, isParagraphSegtype) && allFound;
+                        allFound = callback.onEntry(currentTu, origTuv, targetTuv, isParagraphSegtype)
+                                && allFound;
                     } else if ("header".equals(eStart.getName().getLocalPart())) {
                         parseHeader(eStart, sourceLanguage);
                     }
@@ -218,11 +217,11 @@ public class TMXReader2 {
         // different from the project source language
         String tmxSourceLanguage = getAttributeValue(element, "srclang");
         if (!sourceLanguage.getLanguage().equalsIgnoreCase(tmxSourceLanguage)) {
-            Log.logWarningRB("TMXR_WARNING_INCORRECT_SOURCE_LANG", tmxSourceLanguage,
-                    sourceLanguage);
+            Log.logWarningRB("TMXR_WARNING_INCORRECT_SOURCE_LANG", tmxSourceLanguage, sourceLanguage);
         }
 
-        // give a warning that TMX file will be upgraded to sentence segmentation
+        // give a warning that TMX file will be upgraded to sentence
+        // segmentation
         if (isSegmentingEnabled && isParagraphSegtype) {
             Log.logWarningRB("TMXR_WARNING_UPGRADE_SENTSEG");
         }
@@ -276,7 +275,7 @@ public class TMXReader2 {
         // find 'lang' or 'xml:lang' attribute
         for (Iterator<?> it = element.getAttributes(); it.hasNext();) {
             Attribute a = (Attribute) it.next();
-            if ("lang".equals(a.getName().getLocalPart())) {
+            if ("lang".equals(a.getName().getLocalPart()) || "xml:lang".equals(a.getName().getLocalPart())) {
                 tuv.lang = a.getValue();
                 break;
             }
@@ -543,8 +542,8 @@ public class TMXReader2 {
                 }
                 if (tagN == null) {
                     // check error of TMX reading
-                    Log.logErrorRB("TMX_ERROR_READING_LEVEL2", e.getLocation().getLineNumber(), e
-                            .getLocation().getColumnNumber());
+                    Log.logErrorRB("TMX_ERROR_READING_LEVEL2", e.getLocation().getLineNumber(),
+                            e.getLocation().getColumnNumber());
                     errorsCount++;
                     segContent.setLength(0);
                     return;
@@ -587,7 +586,8 @@ public class TMXReader2 {
      */
     protected ParsedTuv getTuvByLang(Language lang) {
         ParsedTuv tuvLC = null; // Tuv with the same language+country
-        ParsedTuv tuvL = null; // Tuv with the same language only, without country
+        ParsedTuv tuvL = null; // Tuv with the same language only, without
+                               // country
         ParsedTuv tuvLW = null; // Tuv with the same language+whatever country
         for (int i = 0; i < currentTu.tuvs.size(); i++) {
             ParsedTuv tuv = currentTu.tuvs.get(i);
@@ -604,7 +604,7 @@ public class TMXReader2 {
                 tuvLC = tuv;
             } else {
                 // other country
-                if (tuvLW == null) {  // take first occurrence
+                if (tuvLW == null) { // take first occurrence
                     tuvLW = tuv;
                 }
             }
@@ -665,7 +665,8 @@ public class TMXReader2 {
             changedate = 0;
             creationid = null;
             creationdate = 0;
-            props = new ArrayList<TMXProp>(); // do not CLEAR, because it may be shared
+            props = new ArrayList<TMXProp>(); // do not CLEAR, because it may be
+                                              // shared
             tuvs = new ArrayList<ParsedTuv>();
             note = null;
         }
@@ -681,7 +682,7 @@ public class TMXReader2 {
     }
 
     public static final EntityResolver TMX_DTD_RESOLVER = new EntityResolver() {
-        public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        public InputSource resolveEntity(String publicId, String systemId) {
             if (systemId.endsWith("tmx11.dtd")) {
                 return new InputSource(TMXReader2.class.getResourceAsStream("/schemas/tmx11.dtd"));
             } else if (systemId.endsWith("tmx14.dtd")) {

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -30,10 +30,10 @@ package org.omegat.util;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -66,7 +66,7 @@ public class TMXWriter2 implements AutoCloseable {
 
     public static final String PROP_ID = "id";
 
-    private static final XMLOutputFactory FACTORY;
+    private final XMLOutputFactory factory;
 
     private final OutputStream out;
     private final XMLStreamWriter xml;
@@ -76,33 +76,37 @@ public class TMXWriter2 implements AutoCloseable {
     private final boolean forceValidTMX;
 
     /**
-     * DateFormat with format YYYYMMDDThhmmssZ able to display a date in UTC time.
+     * DateFormat with format YYYYMMDDThhmmssZ able to display a date in UTC
+     * time.
      *
      * SimpleDateFormat IS NOT THREAD SAFE !!!
      */
     private final SimpleDateFormat tmxDateFormat;
 
-    static {
-        FACTORY = XMLOutputFactory.newInstance();
-    }
-
     /**
      *
-     * @param file to write TMX entries.
-     * @param sourceLanguage language of source.
-     * @param targetLanguage language of target.
-     * @param sentenceSegmentingEnabled true when sentence segmenting enabled, otherwise false.
+     * @param file
+     *            to write TMX entries.
+     * @param sourceLanguage
+     *            language of source.
+     * @param targetLanguage
+     *            language of target.
+     * @param sentenceSegmentingEnabled
+     *            true when sentence segmenting enabled, otherwise false.
      * @param levelTwo
-     *            When true, the tmx is made compatible with level 2 (TMX version 1.4)
-     * @throws Exception when error occurred.
+     *            When true, the tmx is made compatible with level 2 (TMX
+     *            version 1.4)
+     * @throws Exception
+     *             when error occurred.
      */
     public TMXWriter2(final File file, final Language sourceLanguage, final Language targetLanguage,
             boolean sentenceSegmentingEnabled, boolean levelTwo, boolean forceValidTMX) throws Exception {
         this.levelTwo = levelTwo;
         this.forceValidTMX = forceValidTMX;
+        factory = XMLOutputFactory.newInstance();
 
-        out = new BufferedOutputStream(new FileOutputStream(file));
-        xml = FACTORY.createXMLStreamWriter(out, StandardCharsets.UTF_8.name());
+        out = new BufferedOutputStream(Files.newOutputStream(file.toPath()));
+        xml = factory.createXMLStreamWriter(out, StandardCharsets.UTF_8.name());
 
         xml.writeStartDocument(StandardCharsets.UTF_8.name(), "1.0");
         xml.writeCharacters(lineSeparator);
@@ -156,10 +160,14 @@ public class TMXWriter2 implements AutoCloseable {
 
     /**
      * Write entries.
-     * @param entries Map of SourceTextEntry and TMXEntry to output.
-     * @throws Exception when i/o error or XMLStream error happened.
+     * 
+     * @param entries
+     *            Map of SourceTextEntry and TMXEntry to output.
+     * @throws Exception
+     *             when i/o error or XMLStream error happened.
      */
-    public void writeEntries(final Map<EntryKey, ? extends ITMXEntry> entries, boolean addProp) throws Exception {
+    public void writeEntries(final Map<EntryKey, ? extends ITMXEntry> entries, boolean addProp)
+            throws Exception {
         List<String> propList = new ArrayList<>();
         for (Map.Entry<EntryKey, ? extends ITMXEntry> en : entries.entrySet()) {
             EntryKey k = en.getKey();
@@ -179,15 +187,17 @@ public class TMXWriter2 implements AutoCloseable {
     /**
      * Write one entry.
      *
-     * @param source source text to write.
-     * @param translation translation text to write.
-     * @param entry that has interface ITMXEntry.
+     * @param source
+     *            source text to write.
+     * @param translation
+     *            translation text to write.
+     * @param entry
+     *            that has interface ITMXEntry.
      * @param propValues
      *            pairs with property name and values
      */
     public void writeEntry(final String source, final String translation, final ITMXEntry entry,
-                           final List<String> propValues)
-            throws Exception {
+            final List<String> propValues) throws Exception {
         writeEntry(source, translation, entry.getNote(), entry.getCreator(), entry.getCreationDate(),
                 entry.getChanger(), entry.getChangeDate(), propValues);
     }
@@ -428,7 +438,9 @@ public class TMXWriter2 implements AutoCloseable {
 
     /**
      * Replaces \n with platform specific end of lines
-     * @param text The string to be converted
+     * 
+     * @param text
+     *            The string to be converted
      * @return The converted string
      */
     private String platformLineSeparator(String text) {

--- a/src/org/omegat/util/xml/DefaultEntityFilter.java
+++ b/src/org/omegat/util/xml/DefaultEntityFilter.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
  * @author Keith Godfrey
  * @author Maxym Mykhalchuk
  */
+@Deprecated
 public class DefaultEntityFilter {
 
     private static final HashMap<Integer, String> CHAR_MAP;

--- a/src/org/omegat/util/xml/XMLAttribute.java
+++ b/src/org/omegat/util/xml/XMLAttribute.java
@@ -30,6 +30,7 @@ package org.omegat.util.xml;
  *
  * @author Keith Godfrey
  */
+@Deprecated
 public class XMLAttribute {
     public XMLAttribute(String n, String v) {
         name = n;

--- a/src/org/omegat/util/xml/XMLBlock.java
+++ b/src/org/omegat/util/xml/XMLBlock.java
@@ -35,6 +35,7 @@ import org.omegat.util.OConsts;
  *
  * @author Keith Godfrey
  */
+@Deprecated
 public class XMLBlock {
     public XMLBlock() {
         reset();

--- a/src/org/omegat/util/xml/XMLReader.java
+++ b/src/org/omegat/util/xml/XMLReader.java
@@ -51,6 +51,7 @@ import org.omegat.util.PatternConsts;
  *
  * @author Maxym Mykhalchuk
  */
+@Deprecated
 public class XMLReader extends Reader {
     /** Inner reader */
     private BufferedReader reader;

--- a/src/org/omegat/util/xml/XMLStreamReader.java
+++ b/src/org/omegat/util/xml/XMLStreamReader.java
@@ -46,6 +46,7 @@ import org.omegat.util.StringUtil;
  * @author Keith Godfrey
  * @author Maxym Mykhalchuk
  */
+@Deprecated
 public class XMLStreamReader implements Closeable {
     private DefaultEntityFilter entityFilter;
 

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -27,6 +27,7 @@
 package org.omegat.filters;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -40,8 +41,9 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,6 +52,8 @@ import org.omegat.core.data.IProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.statistics.StatCount;
 import org.omegat.core.statistics.StatisticsSettings;
+import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.IFilter;
 import org.omegat.filters2.ITranslateCallback;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters3.Tag;
@@ -60,10 +64,6 @@ import org.omegat.filters3.xml.xliff.XLIFFOptions;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
-import org.omegat.filters2.FilterContext;
-import org.omegat.filters2.IFilter;
-import org.omegat.util.xml.XMLBlock;
-import org.omegat.util.xml.XMLStreamReader;
 
 public class XLIFFFilterTest extends TestFilterBase {
     XLIFFFilter filter;
@@ -440,104 +440,94 @@ public class XLIFFFilterTest extends TestFilterBase {
             public void setPass(int pass) {
             }
         });
-        try (XMLStreamReader xml = new XMLStreamReader()) {
-            xml.setStream(outFile);
-            /*
-             * expect: <xliff version="1.2"
-             * xmlns="urn:oasis:names:tc:xliff:document:1.2">
-             */
-            XMLBlock xliffBlock = xml.advanceToTag("xliff");
-            assertEquals("1.2", xliffBlock.getAttribute("version"));
-            assertEquals("urn:oasis:names:tc:xliff:document:1.2", xliffBlock.getAttribute("xmlns"));
-            xml.advanceToTag("body");
-            /*
-             * expect: <trans-unit id="5078"> <source>1.0.1</source> <target
-             * state="needs-translation">1.0.1</target> </trans-unit>
-             */
-            XMLBlock block = xml.advanceToTag("trans-unit");
-            assertEquals("5078", block.getAttribute("id"));
-            xml.advanceToTag("source");
-            assertEquals("1.0.1", xml.getNextBlock().getText());
-            block = xml.advanceToTag("target");
-            assertEquals("needs-translation", block.getAttribute("state"));
-            assertEquals("1.0.1", xml.getNextBlock().getText());
-            block = xml.advanceToTag("trans-unit");
-            assertTrue(block.isClose());
-            /*
-             * expect: <trans-unit id="5086" approved="yes">
-             * <source>foo</source> <target state="final">bar</target>
-             * </trans-unit>
-             */
-            block = xml.advanceToTag("trans-unit");
-            assertEquals("5086", block.getAttribute("id"));
-            xml.advanceToTag("source");
-            assertEquals("foo", xml.getNextBlock().getText());
-            block = xml.advanceToTag("target");
-            assertEquals("final", block.getAttribute("state"));
-            assertEquals("bar", xml.getNextBlock().getText());
-            block = xml.advanceToTag("trans-unit");
-            assertTrue(block.isClose());
-            /*
-             * expect: <trans-unit id="5088" approved="yes">
-             * <source>Organization</source> <target
-             * state="needs-review-translation">&#x7D44;&#x7E54;</target>
-             * </trans-unit>
-             */
-            block = xml.advanceToTag("trans-unit");
-            assertEquals("5088", block.getAttribute("id"));
-            xml.advanceToTag("source");
-            assertEquals("Organization", xml.getNextBlock().getText());
-            block = xml.advanceToTag("target");
-            assertEquals("needs-review-translation", block.getAttribute("state"));
-            assertEquals("\u7D44\u7E54", xml.getNextBlock().getText());
-            block = xml.advanceToTag("trans-unit");
-            assertTrue(block.isClose());
-            /*
-             * expect in default: <trans-unit id="5090"> <source>Create</source>
-             * <target state="translated">&#x4F5C;&#x6210;</target>
-             * </trans-unit>
-             * 
-             * expect with option: <trans-unit id="5090">
-             * <source>Create</source> <target
-             * state="needs-review-translation">&#x4F5C;&#x6210;</target>
-             * </trans-unit>
-             */
-            block = xml.advanceToTag("trans-unit");
-            assertEquals("5090", block.getAttribute("id"));
-            xml.advanceToTag("source");
-            assertEquals("Create", xml.getNextBlock().getText());
-            block = xml.advanceToTag("target");
-            if (optionNeedsTranslate) {
-                assertEquals("needs-review-translation", block.getAttribute("state"));
-            } else {
-                assertEquals("translated", block.getAttribute("state"));
+        XmlMapper mapper = new XmlMapper();
+        JsonNode nodes = mapper.readTree(outFile);
+        assertNotNull(nodes);
+        /*
+         * expect: <xliff version="1.2"
+         * xmlns="urn:oasis:names:tc:xliff:document:1.2">
+         */
+        assertEquals("1.2", nodes.get("version").asText());
+        assertTrue(nodes.isContainerNode());
+        nodes = nodes.findPath("file");
+        assertEquals("92", nodes.get("id").asText());
+        assertEquals("/22.txt", nodes.get("original").asText());
+        assertEquals("en", nodes.get("source-language").asText());
+        nodes = nodes.findPath("body");
+        assertNotNull(nodes);
+        JsonNode transUnits = nodes.findPath("trans-unit");
+        assertNotNull(transUnits);
+        for (JsonNode transUnit : transUnits) {
+            String id = transUnit.get("id").asText();
+            switch (id) {
+            case "5078":
+                /*
+                 * expect: <trans-unit id="5078"> <source>1.0.1</source> <target
+                 * state="needs-translation">1.0.1</target> </trans-unit>
+                 */
+                assertEquals("1.0.1", transUnit.get("source").asText());
+                assertEquals("needs-translation", transUnit.get("target").get("state").asText());
+                assertEquals("1.0.1", transUnit.get("target").get("").asText());
+                break;
+            case "5086":
+                /*
+                 * expect: <trans-unit id="5086" approved="yes">
+                 * <source>foo</source> <target state="final">bar</target>
+                 * </trans-unit>
+                 */
+                assertEquals("yes", transUnit.get("approved").asText());
+                assertEquals("foo", transUnit.get("source").asText());
+                assertEquals("final", transUnit.get("target").get("state").asText());
+                assertEquals("bar", transUnit.get("target").get("").asText());
+                break;
+            case "5088":
+                /*
+                 * expect: <trans-unit id="5088" approved="yes">
+                 * <source>Organization</source> <target
+                 * state="needs-review-translation">&#x7D44;&#x7E54;</target>
+                 * </trans-unit>
+                 */
+                assertEquals("yes", transUnit.get("approved").asText());
+                assertEquals("Organization", transUnit.get("source").asText());
+                assertEquals("needs-review-translation", transUnit.get("target").get("state").asText());
+                assertEquals("\u7D44\u7E54", transUnit.get("target").get("").asText());
+                break;
+            case "5090":
+                /*
+                 * expect in default: <trans-unit id="5090">
+                 * <source>Create</source> <target
+                 * state="translated">&#x4F5C;&#x6210;</target> </trans-unit>
+                 *
+                 * expect with option: <trans-unit id="5090">
+                 * <source>Create</source> <target
+                 * state="needs-review-translation">&#x4F5C;&#x6210;</target>
+                 * </trans-unit>
+                 */
+                assertEquals("Create", transUnit.get("source").asText());
+                if (optionNeedsTranslate) {
+                    assertEquals("needs-review-translation", transUnit.get("target").get("state").asText());
+                } else {
+                    assertEquals("translated", transUnit.get("target").get("state").asText());
+                }
+                assertEquals("\u4F5C\u6210", transUnit.get("target").get("").asText());
+                break;
+            case "5128":
+                /*
+                 * expected: <trans-unit id="5128" approved="yes"> <source>
+                 * Emoji</source> <target
+                 * state="translated">&#x7D75;&#x6587;&#x5B57;</target>
+                 * </trans-unit>
+                 */
+                assertEquals("yes", transUnit.get("approved").asText());
+                assertEquals("Emoji", transUnit.get("source").asText());
+                if (optionNeedsTranslate) {
+                    assertEquals("needs-review-translation", transUnit.get("target").get("state").asText());
+                } else {
+                    assertEquals("translated", transUnit.get("target").get("state").asText());
+                }
+                assertEquals("\u7D75\u6587\u5B57", transUnit.get("target").get("").asText());
+                break;
             }
-            assertEquals("\u4F5C\u6210", xml.getNextBlock().getText());
-            block = xml.advanceToTag("trans-unit");
-            assertTrue(block.isClose());
-            /*
-             * expected: <trans-unit id="5128" approved="yes"> <source>-
-             * Emoji</source> <target
-             * state="final">&#x7D75;&#x6587;&#x5B57;</target> </trans-unit>
-             */
-            block = xml.advanceToTag("trans-unit");
-            assertEquals("5128", block.getAttribute("id"));
-            xml.advanceToTag("source");
-            assertEquals("Emoji", xml.getNextBlock().getText());
-            block = xml.advanceToTag("target");
-            if (optionNeedsTranslate) {
-                assertEquals("needs-review-translation", block.getAttribute("state"));
-            } else {
-                assertEquals("translated", block.getAttribute("state"));
-            }
-            assertEquals("\u7D75\u6587\u5B57", xml.getNextBlock().getText());
-            block = xml.advanceToTag("trans-unit");
-            assertTrue(block.isClose());
-            // here should be end of body block
-            block = xml.advanceToTag("body");
-            assertTrue(block.isClose());
-        } catch (TranslationException e) {
-            Assert.fail(String.format("Read error for filter output: %s", outFile.getPath()));
         }
     }
 

--- a/test/src/org/omegat/util/PreferencesTest.java
+++ b/test/src/org/omegat/util/PreferencesTest.java
@@ -62,8 +62,8 @@ public class PreferencesTest {
     }
 
     /**
-     * Test that if an error is encountered when loading the
-     * preferences file, the original file is backed up.
+     * Test that if an error is encountered when loading the preferences file,
+     * the original file is backed up.
      */
     @Test
     public void testPreferencesBackup() throws Exception {

--- a/test/src/org/omegat/util/XMLStreamReaderTest.java
+++ b/test/src/org/omegat/util/XMLStreamReaderTest.java
@@ -34,16 +34,19 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
+
 import org.omegat.filters2.TranslationException;
-import org.omegat.util.xml.XMLBlock;
-import org.omegat.util.xml.XMLStreamReader;
+import org.omegat.util.xml.*;
 
 /**
  * Test the XML reader used to read OmegaT preference files.
  *
  * @author Aaron Madlon-Kay
  */
+@Deprecated
+@Ignore
 public class XMLStreamReaderTest {
 
     @Test


### PR DESCRIPTION
## Which ticket is resolved?

- Use Jackson library as XML parser
    - https://sourceforge.net/p/omegat/feature-requests/1582/


- Improve TBX parsing
    - https://sourceforge.net/p/omegat/feature-requests/1268/


## What does this PR change?

- Replace JAXB parser with Jackson XML parser
- Patch generated definition of gen.core.project.Masks to add annotation of
  @JacksonXmlElementWrapper(useWrapping=false)
  because of known issue.
- Update TMXWriterTest to check with system line separator
  It is because XML parser can automatically change /r/n into
  XML entity `&#xD;/n` when `System.lineSeparator()` is /n
- Update `TMXReader2` to detect both "lang" and "xml:lang"
  some implementation return "lang" from "xml:lang" but
  other can return "xml:lang" as is.
- Drop JAXB parser from GlossaryReaderTBX class.
- Use jackson for TaasClient class
- Replace PreferencesXML parser with Jackson

## Other information
