### PR TITLE
[BUGS#1075] Team: JGit@5.13.1 w/ mwiede/jsch@0.2.3 (Successor of #162)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,14 +165,21 @@ dependencies {
         implementation "org.apache.lucene:lucene-analyzers-stempel:${luceneVersion}"
 
         // Team project server support
-        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.11.1.202105131744-r'
-        implementation 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.1.202105131744-r'
-        implementation 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
-        // Specify the following two here just to make sure all jsch.agentproxy libs are the same version.
-        implementation 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'
-        implementation 'com.jcraft:jsch.agentproxy.svnkit-trilead-ssh2:0.0.9'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r'
+        // Original JSch is unmaintained and dead, so we use forked version, mwiede/jsch
+        // to fix BUGS#1075, and to support elliptic curve ciphers and improved ssh agent
+        implementation 'com.github.mwiede:jsch:0.2.3'
+        // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.ssh.jsch
+        implementation ('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.13.1.202206130422-r') {
+            exclude module: 'jsch'
+        }
+        // For ed25519 and ecdsa support of jsch, java16+ or BC
+        implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
+        // For ssh agent support of jsch, Java16+ or junixsocket
+        implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.4.0'
         // For gpg signing
         implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:5.11.1.202105131744-r'
+        // For subversion
         implementation 'org.tmatesoft.svnkit:svnkit:1.8.14'
 
         // Team project conflict resolution

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,12 +2,15 @@
  OmegaT 5.8.0
 ----------------------------------------------------------------------
   14 Enhancements
-  12 Bug fixes
+  14 Bug fixes
   0 Localisation updates
 ----------------------------------------------------------------------
 5.8.0 vs 5.7.1
 
   Bug fixes:
+
+  - OpenSSH new key format and ECDSA/ED25519 keys
+  https://sourceforge.net/p/omegat/bugs/1107/
 
   - CLI commands does not expand tilde(~) to home directory
   https://sourceforge.net/p/omegat/bugs/1106/
@@ -33,6 +36,9 @@
 
   - Team projects fail to commit with enabled signing
   https://sourceforge.net/p/omegat/bugs/1077/
+
+  - Unable to check-out or open/save team projects
+  https://sourceforge.net/p/omegat/bugs/1075/
 
   - Dictionary fails to jump to selected word
   https://sourceforge.net/p/omegat/bugs/1074/


### PR DESCRIPTION
- Fix BUG#1075: when ssh server reject environment variable GIT_PROTOCOL=version=2 that the fix is included in JGit@5.13.1
- Because JSch has been unmaintained and dead, we replace it with forked mwiede/jsch that supports ssh-agent native.
- Successor of PR #162

**THIS IS A CHANGE for OmegaT@5.8**

- Related PR #174 for OmegaT@6.1

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: https://sourceforge.net/p/omegat/bugs/1107/
- Title: OpenSSH new key format and ECDSA/ED25519 keys

- Link: https://sourceforge.net/p/omegat/bugs/1075/
- Title:  Unable to check-out or open/save team projects

## What does this PR change?

- Bump JGit@5.13.1
    - JGit@5.13.1 fixes the jgit bug that BUG#1075 reported.
- Replace dead JSch with forked  mwiede/jsch@0.2.3 that supports ssh-agent.

## Other information

- [x] Integration test (40min passed)
