### PR TITLE
[Java17] Replace modelToView and viewToModel with modelToView2D and viewToModel2D

### DIFF
--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -31,12 +31,12 @@ package org.omegat.gui.dictionaries;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.font.TextAttribute;
+import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -75,7 +75,6 @@ import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.ITokenizer.StemmingMode;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -230,17 +229,17 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
         int end = Math.max(el.getEndOffset() - 1, start);
         try {
             // Start position of article
-            Rectangle startRect = Java8Compat.modelToView(this, start);
+            Rectangle2D startRect = modelToView2D(start);
             // End position of article
-            Rectangle endRect = Java8Compat.modelToView(this, end);
+            Rectangle2D endRect = modelToView2D(end);
             // To show maximum extent possible, scroll to end and then to start.
             // Scrolling to startRect.union(endRect) will not show the start
             // when initiating scroll from below the target article.
             if (endRect != null) {
-                scrollRectToVisible(endRect);
+                scrollRectToVisible(endRect.getBounds());
             }
             if (startRect != null) {
-                scrollRectToVisible(startRect);
+                scrollRectToVisible(startRect.getBounds());
             }
         } catch (BadLocationException ex) {
             Log.log(ex);
@@ -347,7 +346,7 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
             UIThreadsUtil.mustBeSwingThread();
 
             JPopupMenu popup = new JPopupMenu();
-            int mousepos = Java8Compat.viewToModel(DictionariesTextArea.this, p);
+            int mousepos = DictionariesTextArea.this.viewToModel2D(p);
             final String word = getWordAtOffset(mousepos);
             if (word != null) {
                 JMenuItem item = popup.add(StringUtil.format(OStrings.getString("DICTIONARY_HIDE"), word));

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -50,6 +50,7 @@ import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -109,7 +110,6 @@ import org.omegat.gui.main.MainWindow;
 import org.omegat.gui.main.MainWindowUI;
 import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.help.Help;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
@@ -307,7 +307,7 @@ public class EditorController implements IEditor {
             int unitsPerSeg = (bar.getMaximum() - bar.getMinimum()) / (lastLoaded - firstLoaded + 1);
             if (firstLoaded > 0 && scrollPercent <= PAGE_LOAD_THRESHOLD) {
                 int docSize = editor.getDocument().getLength();
-                int visiblePos = Java8Compat.viewToModel(editor, scrollPane.getViewport().getViewPosition());
+                int visiblePos = editor.viewToModel2D(scrollPane.getViewport().getViewPosition());
                 // Try to load enough segments to restore scrollbar value to
                 // the range (PAGE_LOAD_THRESHOLD, 1 - PAGE_LOAD_THRESHOLD).
                 // Formula is obtained by solving the following equations for loadCount:
@@ -324,7 +324,7 @@ public class EditorController implements IEditor {
                 int sizeDelta = editor.getDocument().getLength() - docSize;
                 try {
                     scrollPane.getViewport()
-                            .setViewPosition(Java8Compat.modelToView(editor, visiblePos + sizeDelta).getLocation());
+                            .setViewPosition(editor.modelToView2D(visiblePos + sizeDelta).getBounds().getLocation());
                 } catch (BadLocationException ex) {
                     Log.log(ex);
                 }
@@ -987,20 +987,20 @@ public class EditorController implements IEditor {
         if (index < 0 || index >= m_docSegList.length) {
             return null;
         }
-        Rectangle result = null;
         try {
             SegmentBuilder sb = m_docSegList[index];
             if (sb.hasBeenCreated()) {
-                Rectangle start = Java8Compat.modelToView(editor, sb.getStartPosition());
-                Rectangle end = Java8Compat.modelToView(editor, sb.getEndPosition());
+                Rectangle2D start = editor.modelToView2D(sb.getStartPosition());
+                Rectangle2D end = editor.modelToView2D(sb.getEndPosition());
                 if (start != null && end != null) {
-                    result = start.union(end);
+                    Rectangle2D.union(start, end, start);
+                    return start.getBounds();
                 }
             }
         } catch (BadLocationException ex) {
             Log.log(ex);
         }
-        return result;
+        return null;
     }
 
     /**
@@ -2212,7 +2212,8 @@ public class EditorController implements IEditor {
                         continue;
                     }
                     try {
-                        Point location = Java8Compat.modelToView(editor, sb.getStartPosition()).getLocation();
+                        Point location =
+                                editor.modelToView2D(sb.getStartPosition()).getBounds().getLocation();
                         if (viewRect.contains(location)) { // location is viewable
                             int segmentNo = sb.segmentNumberInProject;
                             location.translate(0, -viewPosition.y); // adjust to vertically view position

--- a/src/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/org/omegat/gui/editor/EditorTextArea3.java
@@ -67,7 +67,6 @@ import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.StaticUIUtils;
@@ -235,7 +234,7 @@ public class EditorTextArea3 extends JEditorPane {
 
             // Handle double-click
             if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
-                int mousepos = Java8Compat.viewToModel(EditorTextArea3.this, e.getPoint());
+                int mousepos = EditorTextArea3.this.viewToModel2D(e.getPoint());
                 boolean changed = controller.goToSegmentAtLocation(getCaretPosition());
                 if (!changed) {
                     if (selectTag(mousepos)) {
@@ -260,7 +259,7 @@ public class EditorTextArea3 extends JEditorPane {
         }
 
         private void doPopup(Point p) {
-            int mousepos = Java8Compat.viewToModel(EditorTextArea3.this, p);
+            int mousepos = EditorTextArea3.this.viewToModel2D(p);
             JPopupMenu popup = makePopupMenu(mousepos);
             if (popup.getComponentCount() > 0) {
                 popup.show(EditorTextArea3.this, p.x, p.y);
@@ -509,7 +508,7 @@ public class EditorTextArea3 extends JEditorPane {
             // otherwise half of the caret is shown.
             try {
                 OvertypeCaret caret = (OvertypeCaret) getCaret();
-                Rectangle r = Java8Compat.modelToView(this, caret.getDot());
+                Rectangle r = modelToView2D(caret.getDot()).getBounds();
                 caret.damage(r);
             } catch (BadLocationException e) {
                 e.printStackTrace();
@@ -783,7 +782,7 @@ public class EditorTextArea3 extends JEditorPane {
 
     @Override
     public String getToolTipText(MouseEvent event) {
-        int pos = Java8Compat.viewToModel(EditorTextArea3.this, event.getPoint());
+        int pos = EditorTextArea3.this.viewToModel2D(event.getPoint());
         int s = controller.getSegmentIndexAtLocation(pos);
         return s < 0 ? null : controller.markerController.getToolTips(s, pos);
     }

--- a/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -43,6 +43,7 @@ import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Position;
 
 import org.omegat.gui.editor.EditorTextArea3;
 import org.omegat.gui.editor.TagAutoCompleterView;
@@ -51,7 +52,6 @@ import org.omegat.gui.editor.chartable.CharTableAutoCompleterView;
 import org.omegat.gui.editor.history.HistoryCompleter;
 import org.omegat.gui.editor.history.HistoryPredictor;
 import org.omegat.gui.glossary.GlossaryAutoCompleterView;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -243,8 +243,9 @@ public class AutoCompleter implements IAutoCompleter {
         int fontSize = editor.getFont().getSize();
         try {
             int pos = Math.min(editor.getCaret().getDot(), editor.getCaret().getMark());
-            x = Java8Compat.modelToView(editor.getUI(), editor, pos).x;
-            y = Java8Compat.modelToView(editor.getUI(), editor, editor.getCaret().getDot()).y + fontSize;
+            x = editor.getUI().modelToView2D(editor, pos, Position.Bias.Forward).getBounds().x;;
+            y = editor.getUI().modelToView2D(editor, editor.getCaret().getDot(),
+                    Position.Bias.Forward).getBounds().y + fontSize;
         } catch (BadLocationException e) {
             // this should never happen!!!
             Log.log(e);

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -73,7 +73,6 @@ import org.omegat.gui.editor.EditorUtils;
 import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
@@ -237,7 +236,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     @Override
     public String getToolTipText(MouseEvent event) {
         StyledDocument doc = getStyledDocument();
-        Element elem = doc.getCharacterElement(Java8Compat.viewToModel(this, event.getPoint()));
+        Element elem = doc.getCharacterElement(viewToModel2D(event.getPoint()));
         AttributeSet as = elem.getAttributes();
         Object attr = as.getAttribute(TooltipAttribute.ATTRIBUTE_KEY);
         if (attr instanceof TooltipAttribute) {

--- a/src/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/org/omegat/gui/matches/MatchesTextArea.java
@@ -76,7 +76,6 @@ import org.omegat.gui.preferences.PreferencesWindowController;
 import org.omegat.gui.preferences.view.TMMatchesPreferencesController;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
 import org.omegat.tokenizer.ITokenizer;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -537,7 +536,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
             int clickedItem = -1;
 
             // where did we click?
-            int mousepos = Java8Compat.viewToModel(MatchesTextArea.this, p);
+            int mousepos = MatchesTextArea.this.viewToModel2D(p);
 
             for (int i = 0; i < delimiters.size() - 1; i++) {
                 int start = delimiters.get(i);

--- a/src/org/omegat/gui/multtrans/MultipleTransPane.java
+++ b/src/org/omegat/gui/multtrans/MultipleTransPane.java
@@ -52,7 +52,6 @@ import org.omegat.gui.editor.SegmentBuilder;
 import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
-import org.omegat.util.Java8Compat;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
@@ -222,7 +221,7 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
                 return;
             }
             JPopupMenu popup = new JPopupMenu();
-            populateContextMenu(popup, Java8Compat.viewToModel(MultipleTransPane.this, p));
+            populateContextMenu(popup, MultipleTransPane.this.viewToModel2D(p));
             popup.show(MultipleTransPane.this, p.x, p.y);
         }
     };
@@ -278,7 +277,7 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
             JPopupMenu popup = new JPopupMenu();
             Caret caret = getCaret();
             Point p = caret == null ? getMousePosition() : caret.getMagicCaretPosition();
-            populateContextMenu(popup, Java8Compat.viewToModel(MultipleTransPane.this, p));
+            populateContextMenu(popup, MultipleTransPane.this.viewToModel2D(p));
             popup.show(this, (int) p.getX(), (int) p.getY());
             e.consume();
         }

--- a/src/org/omegat/gui/search/EntryListPane.java
+++ b/src/org/omegat/gui/search/EntryListPane.java
@@ -29,7 +29,6 @@
 
 package org.omegat.gui.search;
 
-import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
@@ -37,6 +36,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -582,8 +582,8 @@ class EntryListPane extends JTextPane {
                 beginPos = offsetList.get(index - 1) + ENTRY_SEPARATOR.length();
                 int endPos = offsetList.get(index);
                 try {
-                    Rectangle endRect = Java8Compat.modelToView(EntryListPane.this, endPos);
-                    scrollRectToVisible(endRect);
+                    Rectangle2D endRect = EntryListPane.this.modelToView2D(endPos);
+                    scrollRectToVisible(endRect.getBounds());
                 } catch (BadLocationException ex) {
                     // Eat exception silently
                 }

--- a/src/org/omegat/util/Java8Compat.java
+++ b/src/org/omegat/util/Java8Compat.java
@@ -25,14 +25,8 @@
 
 package org.omegat.util;
 
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-
-import javax.swing.plaf.TextUI;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.JTextComponent;
 
 @SuppressWarnings("deprecation")
 public class Java8Compat {
@@ -47,17 +41,5 @@ public class Java8Compat {
         default:
             return mask;
         }
-    }
-
-    public static Rectangle modelToView(JTextComponent comp, int pos) throws BadLocationException {
-        return comp.modelToView(pos);
-    }
-
-    public static Rectangle modelToView(TextUI ui, JTextComponent comp, int pos) throws BadLocationException {
-        return ui.modelToView(comp, pos);
-    }
-
-    public static int viewToModel(JTextComponent comp, Point pt) {
-        return comp.viewToModel(pt);
     }
 }

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -50,7 +50,6 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
-import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
@@ -118,7 +117,7 @@ public final class JTextPaneLinkifier {
             if (e.getButton() == MouseEvent.BUTTON1) {
                 final StyledDocument doc = jTextPane.getStyledDocument();
                 final Element characterElement = doc
-                        .getCharacterElement(Java8Compat.viewToModel(jTextPane, e.getPoint()));
+                        .getCharacterElement(jTextPane.viewToModel2D(e.getPoint()));
                 final AttributeSet as = characterElement.getAttributes();
                 final Object attr = as.getAttribute(ATTR_LINK);
                 if (attr instanceof IAttributeAction) {
@@ -132,7 +131,7 @@ public final class JTextPaneLinkifier {
         @Override
         public void mouseMoved(final MouseEvent e) {
             final StyledDocument doc = jTextPane.getStyledDocument();
-            final Element characterElement = doc.getCharacterElement(Java8Compat.viewToModel(jTextPane, e.getPoint()));
+            final Element characterElement = doc.getCharacterElement(jTextPane.viewToModel2D(e.getPoint()));
             final AttributeSet as = characterElement.getAttributes();
             final Object attr = as.getAttribute(ATTR_LINK);
             if (attr instanceof IAttributeAction) {


### PR DESCRIPTION
modelToView and viewToModel is deprecated from Java9.
This replace these with modelToView2D and viewToModel2D

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

Resolve a part of Java17 compatibility issues.

- Link: https://sourceforge.net/p/omegat/feature-requests/1525/
- Title: Java17 Compatibility

## What does this PR change?

- Deplicate `org.omegat.util.Java8Compat.modelToView` and `viewToMode` compat methods
- Use `modelToView2D` and `viewToModel2D` as replacement. These methods are introduced in Java 7

## Other information
