### PR TITLE
Integration-test: support subversion test with docker

### DIFF
--- a/.docker-compose.yml
+++ b/.docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 services:
   server:
     build: test-integration/docker/server
-    expose:
-      - "22"
     volumes:
       - keygen:/keys
     tmpfs:
@@ -19,9 +17,6 @@ services:
       - /tmp
     environment:
       DURATION: ${DURATION:-2400}
-      REPO: "git@server:omegat-test.git"
-      ALTREPO: "https://git:gitpass@server/omegat-test.git"
-      MAPREPO: "http://server/"
-      MAPFILE: "README"
+      TYPE: ${TYPE:-GIT}
 volumes:
   keygen:

--- a/docs_devel/integration-test.md
+++ b/docs_devel/integration-test.md
@@ -40,10 +40,9 @@ git config receive.autogc false
 Docker and docker compose is popular to prepare a pragmatic test environment.
 You can find docker configurations `Dockerfile` in `test-integration/docker/`
 
-A test setup requires three containers.
-1. keygen: a docker container to create ssh key pair
-2. server: ssh+git server container to provide team repository
-3. client: omegat test instance container to run integration test.
+A test setup requires two containers.
+1. server: ssh+git and ssh+svn server container to provide team repository
+2. client: omegat test instance container to run integration test.
 
 OmegaT project provide `.docker-compose.yml` compose configuration that orchestrate
 test setup and execution in one line command.
@@ -120,6 +119,18 @@ docker-compose -f .docker-compose.yml down
 ```
 
 This clean up container resources.
+
+### Test svn setup
+
+When type environment is set to "GIT" then tested ssh+git configuration.
+If set it to SVN or other than "GIT", it test with ssh+svn setup.
+
+```console
+env DURATION=600 TYPE=SVN \
+  docker-compose -f .docker-compose.yml up \
+    --abort-on-container-exit --exit-code-from client
+```
+
 
 ## Manual execution
 

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -40,5 +40,7 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && git config --global http.sslVerify false \
   && echo "start test-integration" \
   && (cd /code \
-    && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
-     -Domegat.test.repo.alt=${ALTREPO} -Domegat.test.map.repo=${MAPREPO} -Domegat.test.map.file=${MAPFILE})
+    && [ "${TYPE}" = "GIT" ] && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=git@server:omegat-test.git \
+     -Domegat.test.repo.alt=https://git:gitpass@server/omegat-test.git -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README \
+    || ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=svn+ssh://git:gitpass@server/omegat-test/trunk \
+     -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README )

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -38,7 +38,7 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && touch /home/omegat/.ssh/known_hosts \
   && git config --global user.name example && git config --global user.email ex@example.com \
   && git config --global http.sslVerify false \
-  && [ "${TYPE}" = "SVN" ] && export REPO=svn+ssh://git:gitpass@server/omegat-test/trunk/ REPO2=http://git:gitpass@server/svn/omegat-test \
+  && [ "${TYPE}" = "SVN" ] && export REPO2=svn+ssh://git:gitpass@server/svn/omegat-test.svn REPO=http://git:gitpass@server/svn/omegat-test.svn \
      || export REPO=git@server:omegat-test.git REPO2=https://git:gitpass@server/omegat-test.git \
   && cd /code && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
        -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -38,7 +38,7 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && touch /home/omegat/.ssh/known_hosts \
   && git config --global user.name example && git config --global user.email ex@example.com \
   && git config --global http.sslVerify false \
-  && [ "${TYPE}" = "SVN" ] && export REPO=svn+ssh://git:gitpass@server/omegat-test/trunk/ \
+  && [ "${TYPE}" = "SVN" ] && export REPO=svn+ssh://git:gitpass@server/omegat-test/trunk/ REPO2=http://git:gitpass@server/svn/omegat-test \
      || export REPO=git@server:omegat-test.git REPO2=https://git:gitpass@server/omegat-test.git \
   && cd /code && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
        -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -38,7 +38,7 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && touch /home/omegat/.ssh/known_hosts \
   && git config --global user.name example && git config --global user.email ex@example.com \
   && git config --global http.sslVerify false \
-  && [ "${TYPE}" = "SVN" ] && export REPO2=svn+ssh://git:gitpass@server/svn/omegat-test.svn REPO=http://git:gitpass@server/svn/omegat-test.svn \
+  && [ "${TYPE}" = "SVN" ] && export REPO=svn+ssh://git:gitpass@server/home/git/svn/omegat-test.svn REPO2= \
      || export REPO=git@server:omegat-test.git REPO2=https://git:gitpass@server/omegat-test.git \
   && cd /code && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
        -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -38,9 +38,7 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && touch /home/omegat/.ssh/known_hosts \
   && git config --global user.name example && git config --global user.email ex@example.com \
   && git config --global http.sslVerify false \
-  && [ "${TYPE}" = "SVN" ] \
-     && (cd /code && echo "start test-integration for svn" &&./gradlew testIntegration -Domegat.test.duration=${DURATION} \
-       -Domegat.test.repo=svn+ssh://git:gitpass@server/omegat-test/trunk/ \
-       -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README) \
-     || (cd /code && echo "start test-integration for git" && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=git@server:omegat-test.git \
-       -Domegat.test.repo.alt=https://git:gitpass@server/omegat-test.git -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README)
+  && [ "${TYPE}" = "SVN" ] && export REPO=svn+ssh://git:gitpass@server/omegat-test/trunk/ \
+     || export REPO=git@server:omegat-test.git REPO2=https://git:gitpass@server/omegat-test.git \
+  && cd /code && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
+       -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -38,9 +38,9 @@ CMD ([ -f /keys/id_rsa ] || inotifywait -e attrib /keys ) \
   && touch /home/omegat/.ssh/known_hosts \
   && git config --global user.name example && git config --global user.email ex@example.com \
   && git config --global http.sslVerify false \
-  && echo "start test-integration" \
-  && (cd /code \
-    && [ "${TYPE}" = "GIT" ] && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=git@server:omegat-test.git \
-     -Domegat.test.repo.alt=https://git:gitpass@server/omegat-test.git -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README \
-    || ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=svn+ssh://git:gitpass@server/omegat-test/trunk \
-     -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README )
+  && [ "${TYPE}" = "SVN" ] \
+     && (cd /code && echo "start test-integration for svn" &&./gradlew testIntegration -Domegat.test.duration=${DURATION} \
+       -Domegat.test.repo=svn+ssh://git:gitpass@server/omegat-test/trunk/ \
+       -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README) \
+     || (cd /code && echo "start test-integration for git" && ./gradlew testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=git@server:omegat-test.git \
+       -Domegat.test.repo.alt=https://git:gitpass@server/omegat-test.git -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README)

--- a/test-integration/docker/client/ssh_config
+++ b/test-integration/docker/client/ssh_config
@@ -2,5 +2,4 @@ Host server
  Hostname server
  User git
  IdentityFile ~/.ssh/id_rsa
- IdentitiesOnly yes
  StrictHostKeyChecking no

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -36,9 +36,9 @@ COPY supervisord.conf /etc/supervisor/conf.d/
 COPY git-http-backend-wrapper.cgi /var/www/git/
 RUN chmod 755 /var/www/git/git-http-backend-wrapper.cgi \
     && touch /home/git/.ssh/authorized_keys && chmod 600 /home/git/.ssh/authorized_keys \
-    && mkdir -p /tmp/template && git init /tmp/template && echo "source content" > /tmp/template/README \
-    && (cd /home/git && svnadmin create omegat-test && svn import /tmp/template file:///home/git/omegat-test/trunk/ -m first ) \
-    && (cd /tmp/template && git config user.name git && git config user.email git@example.com \
+    && mkdir -p /tmp/template && echo "source content" > /tmp/template/README && mkdir -p /home/git/svn \
+    && (cd /home/git/svn && svnadmin create omegat-test.svn && svn import /tmp/template file:///home/git/svn/omegat-test.svn/trunk/ -m first ) \
+    && git init /tmp/template && (cd /tmp/template && git config user.name git && git config user.email git@example.com \
         && git config init.defaultBranch main && git add . && git commit -m first ) \
     && git clone /tmp/template /home/git/omegat-test.git --bare && (cd /home/git/omegat-test.git && git remote remove origin ) \
     && cp /tmp/template/README /var/www/html && chown -R www-data.www-data /var/www/html \

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -25,7 +25,7 @@
 #
 FROM debian:bullseye-slim
 RUN apt-get -y update && apt-get -y upgrade \
-    && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion \
+    && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion libapache2-mod-svn \
     && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) && mkdir -p /home/git/.ssh && chmod 700 /home/git/.ssh \
     && a2dissite default-ssl && a2enmod ssl cgi env alias suexec && htpasswd -b -c /home/git/htpasswd git gitpass \
     && mkdir -p /var/lock/apache2 /var/run/apache2 /var/run/sshd /var/log/supervisor \

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -25,8 +25,8 @@
 #
 FROM debian:bullseye-slim
 RUN apt-get -y update && apt-get -y upgrade \
-    && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine \
-    && adduser --system --group --shell /bin/bash git && mkdir -p /home/git/.ssh && chmod 700 /home/git/.ssh \
+    && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion \
+    && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) && mkdir -p /home/git/.ssh && chmod 700 /home/git/.ssh \
     && a2dissite default-ssl && a2enmod ssl cgi env alias suexec && htpasswd -b -c /home/git/htpasswd git gitpass \
     && mkdir -p /var/lock/apache2 /var/run/apache2 /var/run/sshd /var/log/supervisor \
     && mkdir -p /var/www/git /var/www/html && echo "AcceptEnv LANG LC_* GIT_PROTOCOL" >> /etc/ssh/sshd_config
@@ -36,9 +36,10 @@ COPY git-http-backend-wrapper.cgi /var/www/git/
 RUN chmod 755 /var/www/git/git-http-backend-wrapper.cgi \
     && touch /home/git/.ssh/authorized_keys && chmod 600 /home/git/.ssh/authorized_keys \
     && mkdir -p /tmp/template && git init /tmp/template && echo "source content" > /tmp/template/README \
+    && (cd /home/git && svnadmin create omegat-test && svn import /tmp/template file:///home/git/omegat-test/trunk/ -m first ) \
     && (cd /tmp/template && git config user.name git && git config user.email git@example.com \
         && git config init.defaultBranch main && git add . && git commit -m first ) \
-    && git clone /tmp/template /home/git/omegat-test.git --bare \
+    && git clone /tmp/template /home/git/omegat-test.git --bare && (cd /home/git/omegat-test.git && git remote remove origin ) \
     && cp /tmp/template/README /var/www/html && chown -R www-data.www-data /var/www/html \
     && chown -R git.git /home/git /var/www/git
 

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -y update && apt-get -y upgrade \
     && mkdir -p /var/lock/apache2 /var/run/apache2 /var/run/sshd /var/log/supervisor \
     && mkdir -p /var/www/git /var/www/html && echo "AcceptEnv LANG LC_* GIT_PROTOCOL" >> /etc/ssh/sshd_config
 COPY git-http.conf /etc/apache2/sites-enabled/
+COPY svn-http.conf /etc/apache2/mods-enabled/
 COPY supervisord.conf /etc/supervisor/conf.d/
 COPY git-http-backend-wrapper.cgi /var/www/git/
 RUN chmod 755 /var/www/git/git-http-backend-wrapper.cgi \

--- a/test-integration/docker/server/svn-http.conf
+++ b/test-integration/docker/server/svn-http.conf
@@ -1,10 +1,10 @@
 <Location /svn>
   DAV svn
-  SVNPath /usr/local/subversion/repos
+  SVNPath /home/git
   <LimitExcept GET PROPFIND OPTIONS REPORT>
     AuthType Basic
     AuthName "Subversion Repository"
-    AuthUserFile /etc/svn-auth-file
+    AuthUserFile /home/git/htpasswd
     Require valid-user
   </LimitExcept>
 </Location>

--- a/test-integration/docker/server/svn-http.conf
+++ b/test-integration/docker/server/svn-http.conf
@@ -1,0 +1,10 @@
+<Location /svn>
+  DAV svn
+  SVNPath /usr/local/subversion/repos
+  <LimitExcept GET PROPFIND OPTIONS REPORT>
+    AuthType Basic
+    AuthName "Subversion Repository"
+    AuthUserFile /etc/svn-auth-file
+    Require valid-user
+  </LimitExcept>
+</Location>

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -118,8 +118,9 @@ public final class TestTeamIntegration {
 
     private TestTeamIntegration() {
     }
-    private final static String regex = "http(s)?://(?<username>.+?)(:(?<password>.+?))?@.+";
-    private final static Pattern URL_PATTERN = Pattern.compile(regex);
+
+    private final static Pattern GIT_URL_PATTERN = Pattern.compile("http(s)?://(?<username>.+?)(:(?<password>.+?))?@.+");
+    private final static Pattern SVN_URL_PATTERN = Pattern.compile("svn(\\+ssh)?://(?<username>.+?)(:(?<password>.+?))?@.+");
 
     static final String DIR = "/tmp/teamtest";
     static final List<String> REPO = new ArrayList<>();
@@ -301,15 +302,15 @@ public final class TestTeamIntegration {
         config.setTargetLanguage(TRG_LANG);
         config.setRepositories(new ArrayList<>());
         if (MAP_REPO == null || MAP_FILE == null) {
-            config.getRepositories().add(getDef(repoUrl, predictMainTyep(repoUrl), "", ""));
+            config.getRepositories().add(getDef(repoUrl, predictMainType(repoUrl), "", ""));
         } else {
-            config.getRepositories().add(getDef(repoUrl, predictMainTyep(repoUrl), "/", "/"));
+            config.getRepositories().add(getDef(repoUrl, predictMainType(repoUrl), "/", "/"));
             config.getRepositories().add(getDef(MAP_REPO, MAP_REPO_TYPE, MAP_FILE, "source/" + MAP_FILE));
         }
         return config;
     }
 
-    static String predictMainTyep(String repoUrl) {
+    static String predictMainType(String repoUrl) {
         if (repoUrl.startsWith("git") || repoUrl.endsWith(".git")) {
             return "git";
         } else if (repoUrl.startsWith("svn") || repoUrl.startsWith("http") || repoUrl.endsWith(".svn")) {
@@ -324,7 +325,7 @@ public final class TestTeamIntegration {
         RepositoryMapping m = new RepositoryMapping();
         def.setType(type);
         if (type.equals("git") && repoUrl.contains("@")) {
-            Matcher matcher = URL_PATTERN.matcher(repoUrl);
+            Matcher matcher = GIT_URL_PATTERN.matcher(repoUrl);
             if (matcher.find()) {
                 String username = matcher.group("username");
                 if (!StringUtils.isEmpty(username)) {
@@ -333,6 +334,19 @@ public final class TestTeamIntegration {
                 String password = matcher.group("password");
                 if (!StringUtils.isEmpty(password)) {
                     def.getOtherAttributes().put(new QName("gitPassword"), password);
+                }
+            }
+        }
+        if (type.equals("svn") && repoUrl.contains("@")) {
+            Matcher matcher = SVN_URL_PATTERN.matcher(repoUrl);
+            if (matcher.find()) {
+                String username = matcher.group("username");
+                if (!StringUtils.isEmpty(username)) {
+                    def.getOtherAttributes().put(new QName("svnUsername"), username);
+                }
+                String password = matcher.group("password");
+                if (!StringUtils.isEmpty(password)) {
+                    def.getOtherAttributes().put(new QName("svnPassword"), password);
                 }
             }
         }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

## What does this PR change?

- Update integration test to accept username password for subversion URL
- Accept TYPE environment variable for docker-compose test
- Fix and update document

## Other information

Currently not finished when running svn test I got error

```
client_1  | start test-integration
server_1  | ssh-keygen: generating new host keys: DSA 
server_1  | start servers
client_1  | Downloading https://services.gradle.org/distributions/gradle-6.9-bin.zip
server_1  | /usr/lib/python3/dist-packages/supervisor/options.py:474: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
server_1  |   self.warnings.warn(
server_1  | 2022-09-03 08:38:16,220 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
server_1  | 2022-09-03 08:38:16,220 INFO Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
server_1  | 2022-09-03 08:38:16,224 INFO RPC interface 'supervisor' initialized
server_1  | 2022-09-03 08:38:16,224 CRIT Server 'unix_http_server' running without any HTTP authentication checking
server_1  | 2022-09-03 08:38:16,224 INFO supervisord started with pid 1
server_1  | 2022-09-03 08:38:17,226 INFO spawned: 'apache2' with pid 11
server_1  | 2022-09-03 08:38:17,227 INFO spawned: 'sshd' with pid 12
server_1  | 2022-09-03 08:38:18,256 INFO success: apache2 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
server_1  | 2022-09-03 08:38:18,256 INFO success: sshd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
client_1  | ..........10%..........20%..........30%...........40%..........50%..........60%...........70%..........80%..........90%...........100%
client_1  | 
client_1  | Welcome to Gradle 6.9!
client_1  | 
client_1  | Here are the highlights of this release:
client_1  |  - This is a small backport release.
client_1  |  - Java 16 can be used to compile when used with Java toolchains
client_1  |  - Dynamic versions can be used within plugin declarations
client_1  |  - Native support for Apple Silicon processors
client_1  | 
client_1  | For more details see https://docs.gradle.org/6.9/release-notes.html
client_1  | 
client_1  | Starting a Gradle Daemon (subsequent builds will be faster)
client_1  | > Task :compileJava UP-TO-DATE
client_1  | 
client_1  | > Task :processResources
client_1  | Detected revision 51a01a1c5
client_1  | 
client_1  | > Task :classes
client_1  | > Task :compileTestJava UP-TO-DATE
client_1  | > Task :processTestResources UP-TO-DATE
client_1  | > Task :testClasses UP-TO-DATE
client_1  | > Task :compileTestIntegrationJava
client_1  | > Task :processTestIntegrationResources NO-SOURCE
client_1  | > Task :testIntegrationClasses
server_1  | 2022-09-03 08:39:13,049 INFO reaped unknown pid 71 (exit status 255)
client_1  | 
client_1  | > Task :testIntegration FAILED
client_1  | 06703: Info: SVN 'checkout to null' execution start (SVN_START)
client_1  | 06703: Error: SVN 'checkout' error: svn: E210002: There was a problem while connecting to server:22 (SVN_ERROR)
client_1  | Exception in thread "main" org.omegat.core.team2.IRemoteRepository2$NetworkException: org.tmatesoft.svn.core.SVNException: svn: E210002: There was a problem while connecting to server:22
client_1  |     at org.omegat.core.team2.impl.SVNRemoteRepository2.checkNetworkException(SVNRemoteRepository2.java:246)
client_1  |     at org.omegat.core.team2.impl.SVNRemoteRepository2.switchToVersion(SVNRemoteRepository2.java:120)
client_1  |     at org.omegat.core.team2.RemoteRepositoryProvider.switchAllToLatest(RemoteRepositoryProvider.java:200)
client_1  |     at org.omegat.core.data.TestTeamIntegration.prepareRepo(TestTeamIntegration.java:282)
client_1  |     at org.omegat.core.data.TestTeamIntegration.main(TestTeamIntegration.java:153)
client_1  | Caused by: org.tmatesoft.svn.core.SVNException: svn: E210002: There was a problem while connecting to server:22
client_1  |     at org.tmatesoft.svn.core.internal.wc.SVNErrorManager.error(SVNErrorManager.java:70)
client_1  |     at org.tmatesoft.svn.core.internal.wc.SVNErrorManager.error(SVNErrorManager.java:57)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.SVNSSHConnector.open(SVNSSHConnector.java:145)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.SVNConnection.open(SVNConnection.java:77)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.SVNRepositoryImpl.openConnection(SVNRepositoryImpl.java:1273)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.SVNRepositoryImpl.getLatestRevision(SVNRepositoryImpl.java:172)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgRepositoryAccess.getRevisionNumber(SvnNgRepositoryAccess.java:119)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.SvnRepositoryAccess.getLocations(SvnRepositoryAccess.java:195)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgRepositoryAccess.createRepositoryFor(SvnNgRepositoryAccess.java:46)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgAbstractUpdate.checkout(SvnNgAbstractUpdate.java:815)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgCheckout.run(SvnNgCheckout.java:26)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgCheckout.run(SvnNgCheckout.java:11)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.ng.SvnNgOperationRunner.run(SvnNgOperationRunner.java:20)
client_1  |     at org.tmatesoft.svn.core.internal.wc2.SvnOperationRunner.run(SvnOperationRunner.java:21)
client_1  |     at org.tmatesoft.svn.core.wc2.SvnOperationFactory.run(SvnOperationFactory.java:1235)
client_1  |     at org.tmatesoft.svn.core.wc2.SvnOperation.run(SvnOperation.java:294)
client_1  |     at org.tmatesoft.svn.core.wc.SVNUpdateClient.doCheckout(SVNUpdateClient.java:777)
client_1  |     at org.omegat.core.team2.impl.SVNRemoteRepository2.switchToVersion(SVNRemoteRepository2.java:115)
client_1  |     ... 3 more
client_1  | Caused by: java.io.IOException: There was a problem while connecting to server:22
client_1  |     at com.trilead.ssh2.Connection.connect(Connection.java:817)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.ssh.SshHost.openConnection(SshHost.java:225)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.ssh.SshHost.openSession(SshHost.java:153)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.ssh.SshSessionPool.openSession(SshSessionPool.java:85)
client_1  |     at org.tmatesoft.svn.core.internal.io.svn.SVNSSHConnector.open(SVNSSHConnector.java:122)
client_1  |     ... 18 more
client_1  | Caused by: java.io.IOException: Key exchange was not finished, connection is closed.
client_1  |     at com.trilead.ssh2.transport.KexManager.getOrWaitForConnectionInfo(KexManager.java:92)
client_1  |     at com.trilead.ssh2.transport.TransportManager.getConnectionInfo(TransportManager.java:231)
client_1  |     at com.trilead.ssh2.Connection.connect(Connection.java:769)
client_1  |     ... 22 more
client_1  | Caused by: java.io.IOException: Cannot negotiate, proposals do not match.
client_1  |     at com.trilead.ssh2.transport.KexManager.handleMessage(KexManager.java:413)
client_1  |     at com.trilead.ssh2.transport.TransportManager.receiveLoop(TransportManager.java:765)
client_1  |     at com.trilead.ssh2.transport.TransportManager$1.run(TransportManager.java:480)
client_1  |     at java.base/java.lang.Thread.run(Thread.java:829)
client_1  | 
client_1  | FAILURE: Build failed with an exception.

```

