### PR TITLE
Gradle: use LanguageTools@5.7 and Lucene@5.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
         implementation fileTree(dir: providedLibsDir, include: '**/*.jar')
     } else {
         implementation 'commons-io:commons-io:2.11.0'
-        implementation 'commons-lang:commons-lang:2.6'
+        implementation 'org.apache.commons:commons-lang3:3.11'
         runtimeOnly 'org.slf4j:slf4j-jdk14:1.7.32'
 
         // macOS integration

--- a/build.gradle
+++ b/build.gradle
@@ -78,21 +78,16 @@ repositories {
 }
 
 configurations {
-    all {
-        // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/813/
-        exclude group: 'org.apache.lucene', module: 'lucene-core'
-    }
+    all
     [testRuntime, testCompile]*.exclude group: 'org.languagetool', module: 'language-all'
-
     testIntegrationImplementation.extendsFrom implementation
-
     jaxb
 }
 
 ext {
     providedLibsDir = file('lib/provided')
-    languageToolVersion = '3.5'
-    luceneVersion = '5.2.1'
+    languageToolVersion = '5.7'
+    luceneVersion = '5.5.5'
 }
 
 dependencies {
@@ -102,6 +97,7 @@ dependencies {
     } else {
         implementation 'commons-io:commons-io:2.11.0'
         implementation 'commons-lang:commons-lang:2.6'
+        runtimeOnly 'org.slf4j:slf4j-jdk14:1.7.32'
 
         // macOS integration
         implementation 'org.madlonkay:desktopsupport:0.6.0'
@@ -135,17 +131,19 @@ dependencies {
         implementation 'org.omegat:jmyspell-core:1.0.0-beta-2'
 
         // LanguageTool
-        implementation "org.languagetool:languagetool-core:${languageToolVersion}"
+        implementation("org.languagetool:languagetool-core:${languageToolVersion}") {
+            exclude module: 'guava'
+        }
+        // Exclicitly specify guava dependency for `jre` version rather than `-android`
+        implementation 'com.google.guava:guava:31.0.1-jre'
         runtimeOnly("org.languagetool:language-all:${languageToolVersion}") {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
             exclude module: 'lucene-gosen-ipadic'
         }
         runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0:ipadic'
-        runtimeOnly 'org.languagetool:hunspell-native-libs:2.9'
 
         // Lucene for tokenizers
-        // Temporary use of custom lucene-core; see https://sourceforge.net/p/omegat/bugs/813/
-        implementation "org.omegat.lucene:lucene-core:${luceneVersion}-1"
+        implementation "org.apache.lucene:lucene-core:${luceneVersion}"
         implementation "org.apache.lucene:lucene-analyzers-common:${luceneVersion}"
         implementation "org.apache.lucene:lucene-analyzers-kuromoji:${luceneVersion}"
         implementation "org.apache.lucene:lucene-analyzers-smartcn:${luceneVersion}"
@@ -224,6 +222,7 @@ dependencies {
         testImplementation "org.languagetool:language-${it}:${languageToolVersion}"
     }
     testRuntimeOnly "org.languagetool:language-pl:${languageToolVersion}"
+    testRuntimeOnly "org.slf4j:slf4j-jdk14:1.7.32"
     // http connection tests
     testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.35.0'
 
@@ -463,7 +462,7 @@ installMacDist {
 }
 
 def hunspellJar = configurations.runtimeClasspath.files.find {
-    it.name.startsWith('hunspell-native-libs')
+    it.name.startsWith('hunspell')
 }
 
 task hunspellJarSignedContents(type: Sync) {

--- a/build.gradle
+++ b/build.gradle
@@ -464,6 +464,9 @@ installMacDist {
 def hunspellJar = configurations.runtimeClasspath.files.find {
     it.name.startsWith('hunspell')
 }
+def bridjJar = configurations.runtimeClasspath.files.find {
+    it.name.startsWith('bridj')
+}
 
 task hunspellJarSignedContents(type: Sync) {
     onlyIf {
@@ -484,10 +487,33 @@ task hunspellJarSignedContents(type: Sync) {
         }
     }
 }
+task bridjJarSignedContents(type: Sync) {
+    onlyIf {
+        // Set this in e.g. local.properties
+        condition(project.hasProperty('macCodesignIdentity'), 'Code signing property not set')
+    }
+    from zipTree(bridjJar)
+    destinationDir = file("$buildDir/bridj")
+    doLast {
+        def jnilibs = fileTree(dir: destinationDir, include: '**/*.jnilib').files
+        exec {
+            commandLine('codesign', '--deep', '--force',
+                        '--sign', project.property('macCodesignIdentity'),
+                        '--timestamp',
+                        '--options', 'runtime',
+                        '--entitlements', file('release/mac-specific/java.entitlements'),
+                        *jnilibs.toList())
+        }
+    }
+}
 
 task hunspellSignedJar(type: Jar) {
     from hunspellJarSignedContents.outputs
     archiveFileName = hunspellJar.name
+}
+task bridjSignedJar(type: Jar) {
+    from bridjJarSignedContents.outputs
+    archiveFileName = bridjJar.name
 }
 
 task installMacSignedDist(type: Sync) {
@@ -499,6 +525,9 @@ task installMacSignedDist(type: Sync) {
     with distributions.mac.contents
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     from(hunspellSignedJar.outputs) {
+        into 'OmegaT.app/Contents/Java/lib'
+    }
+    from(bridjSignedJar.outputs) {
         into 'OmegaT.app/Contents/Java/lib'
     }
     destinationDir = file("${buildDir}/install/${applicationName}-macSigned")

--- a/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
+++ b/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
@@ -32,7 +32,7 @@ package org.omegat.core.machinetranslators;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import org.omegat.util.Language;
 import org.omegat.util.OStrings;
@@ -100,7 +100,7 @@ public final class MyMemoryMachineTranslate extends AbstractMyMemoryTranslate {
                 bestEntry = mtEntry;
             }
             assert bestEntry != null;
-            String translation = StringEscapeUtils.unescapeHtml(bestEntry.get("translation").asText());
+            String translation = StringEscapeUtils.unescapeHtml4(bestEntry.get("translation").asText());
             putToCache(sLang, tLang, text, translation);
             return translation;
         } catch (IOException e) {

--- a/src/org/omegat/core/spellchecker/SpellChecker.java
+++ b/src/org/omegat/core/spellchecker/SpellChecker.java
@@ -153,7 +153,6 @@ public class SpellChecker implements ISpellChecker {
         String dictionaryDir = Preferences.getPreferenceDefault(Preferences.SPELLCHECKER_DICTIONARY_DIRECTORY,
                 DEFAULT_DICTIONARY_DIR.getPath());
 
-        File dictBasename = new File(dictionaryDir, language);
         File affixName = new File(dictionaryDir, language + OConsts.SC_AFFIX_EXTENSION);
         File dictionaryName = new File(dictionaryDir, language + OConsts.SC_DICTIONARY_EXTENSION);
 

--- a/src/org/omegat/core/spellchecker/SpellChecker.java
+++ b/src/org/omegat/core/spellchecker/SpellChecker.java
@@ -173,7 +173,7 @@ public class SpellChecker implements ISpellChecker {
         }
 
         try {
-            ISpellCheckerProvider result = new SpellCheckerLangToolHunspell(dictBasename.getPath());
+            ISpellCheckerProvider result = new SpellCheckerLangToolHunspell(dictionaryName, affixName);
             Log.log("Initialized LanguageTool Hunspell spell checker for language '" + language
                     + "' dictionary " + dictionaryName);
             return Optional.of(result);

--- a/src/org/omegat/core/team2/RebaseAndCommit.java
+++ b/src/org/omegat/core/team2/RebaseAndCommit.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.omegat.util.Log;
 
 /**

--- a/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -33,7 +33,7 @@ import java.util.regex.Matcher;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Highlighter.HighlightPainter;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
@@ -130,7 +130,7 @@ public class ProtectedPartsMarker implements IMarker {
             // See if the tooltip contains an equiv-text attribute. If so, use just the value.
             m = PatternConsts.EQUIV_TEXT_ATTRIBUTE_DECOMPILE.matcher(s);
             if (m.find()) {
-                s = StringEscapeUtils.unescapeHtml(m.group(1));
+                s = StringEscapeUtils.unescapeHtml4(m.group(1));
             }
         }
         // standalone tag

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -50,7 +50,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import org.omegat.CLIParameters;
 import org.omegat.convert.ConvertProject;

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
@@ -73,6 +73,8 @@ import org.languagetool.rules.CategoryId;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.tools.Tools;
+import org.xml.sax.SAXException;
+
 import org.omegat.core.Core;
 import org.omegat.gui.preferences.BasePreferencesController;
 import org.omegat.languagetools.LanguageToolPrefs;
@@ -81,7 +83,6 @@ import org.omegat.languagetools.LanguageToolWrapper.BridgeType;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
-import org.xml.sax.SAXException;
 
 /**
  * @author Panagiotis Minos
@@ -539,10 +540,6 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
             throw new UnsupportedOperationException();
         }
 
-        @Override
-        public void reset() {
-            throw new UnsupportedOperationException();
-        }
     }
 
     /**

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -50,7 +50,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.EntryKey;

--- a/src/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -53,9 +53,9 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
         sourceLtLang = getLTLanguage(sourceLang);
         targetLtLang = getLTLanguage(targetLang);
         Log.log("Selected LanguageTool source language: "
-                + (sourceLtLang == null ? null : sourceLtLang.getShortNameWithCountryAndVariant()));
+                + (sourceLtLang == null ? null : sourceLtLang.getShortCodeWithCountryAndVariant()));
         Log.log("Selected LanguageTool target language: "
-                + (targetLtLang == null ? null : targetLtLang.getShortNameWithCountryAndVariant()));
+                + (targetLtLang == null ? null : targetLtLang.getShortCodeWithCountryAndVariant()));
         sourceLt = ThreadLocal.withInitial(
                 () -> sourceLtLang == null ? null : new JLanguageTool(sourceLtLang));
         targetLt = ThreadLocal.withInitial(
@@ -91,7 +91,7 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
         return ThreadLocal.withInitial(() -> {
             JLanguageTool lt = new JLanguageTool(lang);
             Tools.selectRules(lt, disabledCategories, Collections.emptySet(), disabledRules, enabledRules,
-                    false);
+                    false, false);
             return lt;
         });
     }
@@ -134,7 +134,7 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
         String omLang = lang.getLanguageCode();
         String omCountry = lang.getCountryCode();
         for (Language ltLang : ltLangs) {
-            if (omLang.equalsIgnoreCase(ltLang.getShortName())) {
+            if (omLang.equalsIgnoreCase(ltLang.getShortCode())) {
                 List<String> countries = Arrays.asList(ltLang.getCountries());
                 if (countries.contains(omCountry)) {
                     return ltLang;
@@ -144,7 +144,7 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
 
         // Search for just xx match
         for (Language ltLang : ltLangs) {
-            if (omLang.equalsIgnoreCase(ltLang.getShortName()) && ltLang.hasVariant()) {
+            if (omLang.equalsIgnoreCase(ltLang.getShortCode()) && ltLang.hasVariant()) {
                 Language defaultVariant = ltLang.getDefaultLanguageVariant();
                 if (defaultVariant != null) {
                     return ltLang;
@@ -152,7 +152,7 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
             }
         }
         for (Language ltLang : ltLangs) {
-            if (omLang.equalsIgnoreCase(ltLang.getShortName()) && !ltLang.hasVariant()) {
+            if (omLang.equalsIgnoreCase(ltLang.getShortCode()) && !ltLang.hasVariant()) {
                 return ltLang;
             }
         }

--- a/src/org/omegat/tokenizer/BaseTokenizer.java
+++ b/src/org/omegat/tokenizer/BaseTokenizer.java
@@ -34,7 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -38,8 +38,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-
+import org.apache.commons.lang3.StringUtils;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters2.master.PluginUtils;
@@ -310,7 +309,7 @@ public final class ProjectFileStorage {
 
     /**
      * Load a tokenizer class from its canonical name.
-     * 
+     *
      * @param className
      *            Name of tokenizer class
      * @return Class object of specified tokenizer, or of fallback tokenizer if

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.LogCommand;
 import org.eclipse.jgit.lib.Repository;

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -39,7 +39,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.languagetool.JLanguageTool;
 import org.languagetool.language.AmericanEnglish;
-import org.languagetool.language.Belarusian;
 import org.languagetool.language.CanadianEnglish;
 import org.languagetool.language.English;
 import org.languagetool.language.French;
@@ -48,6 +47,7 @@ import org.languagetool.rules.UppercaseSentenceStartRule;
 import org.languagetool.rules.patterns.PatternRule;
 import org.languagetool.rules.spelling.morfologik.MorfologikSpellerRule;
 import org.languagetool.server.HTTPServer;
+
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 import org.omegat.util.TestPreferencesInitializer;
@@ -55,6 +55,7 @@ import org.omegat.util.TestPreferencesInitializer;
 /**
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
+@SuppressWarnings("deprecation")
 public class LanguageToolTest {
     private static final Language SOURCE_LANG = new Language(Locale.FRENCH);
     private static final Language TARGET_LANG = new Language(Locale.ENGLISH);
@@ -66,7 +67,7 @@ public class LanguageToolTest {
 
     @Test
     public void testExecute() throws Exception {
-        JLanguageTool lt = new JLanguageTool(new Belarusian());
+        JLanguageTool lt = new JLanguageTool(new org.languagetool.language.Belarusian());
 
         // The test string is Belarusian; originally it was actual UTF-8,
         // but that causes the test to fail when environment encodings aren't set
@@ -136,7 +137,7 @@ public class LanguageToolTest {
         // We don't care about the actual content of the results as long as
         // there are some: we just want to make sure we are wrapping the result
         // correctly.
-        List<LanguageToolResult> results = bridge.getCheckResults("foo", "foo bar");
+        List<LanguageToolResult> results = bridge.getCheckResults("foo expertise", "foo bar expertise");
         assertFalse(results.isEmpty());
     }
 
@@ -174,12 +175,12 @@ public class LanguageToolTest {
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("be-BY"));
-            assertEquals(Belarusian.class, lang.getClass());
+            assertEquals(org.languagetool.language.Belarusian.class, lang.getClass());
         }
         {
             // Belarusian is offered in be-BY only; ensure hit with just "be"
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("be"));
-            assertEquals(Belarusian.class, lang.getClass());
+            assertEquals(org.languagetool.language.Belarusian.class, lang.getClass());
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("xyz"));

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -55,7 +55,6 @@ import org.omegat.util.TestPreferencesInitializer;
 /**
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
-@SuppressWarnings("deprecation")
 public class LanguageToolTest {
     private static final Language SOURCE_LANG = new Language(Locale.FRENCH);
     private static final Language TARGET_LANG = new Language(Locale.ENGLISH);
@@ -66,6 +65,7 @@ public class LanguageToolTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testExecute() throws Exception {
         JLanguageTool lt = new JLanguageTool(new org.languagetool.language.Belarusian());
 
@@ -156,6 +156,7 @@ public class LanguageToolTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testLanguageMapping() {
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-US"));

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -43,9 +43,7 @@ import org.languagetool.language.CanadianEnglish;
 import org.languagetool.language.English;
 import org.languagetool.language.French;
 import org.languagetool.rules.RuleMatch;
-import org.languagetool.rules.UppercaseSentenceStartRule;
 import org.languagetool.rules.patterns.PatternRule;
-import org.languagetool.rules.spelling.morfologik.MorfologikSpellerRule;
 import org.languagetool.server.HTTPServer;
 
 import org.omegat.util.Language;
@@ -66,17 +64,15 @@ public class LanguageToolTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testExecute() throws Exception {
+    public void testExecuteLanguageToolCheck() throws Exception {
         JLanguageTool lt = new JLanguageTool(new org.languagetool.language.Belarusian());
 
         // The test string is Belarusian; originally it was actual UTF-8,
         // but that causes the test to fail when environment encodings aren't set
         // correctly, so we are now using Unicode literals.
         List<RuleMatch> matches = lt.check("\u0441\u043F\u0440\u0430\u0443\u0434\u0437\u0456\u043C.");
-        assertEquals(3, matches.size());
-        assertTrue(matches.get(0).getRule() instanceof MorfologikSpellerRule);
-        assertTrue(matches.get(1).getRule() instanceof UppercaseSentenceStartRule);
-        assertTrue(matches.get(2).getRule() instanceof PatternRule);
+        assertEquals(1, matches.size());
+        assertTrue(matches.get(0).getRule() instanceof PatternRule);
     }
 
     @Test

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -83,7 +83,8 @@ public class LanguageToolTest {
     public void testFrench() throws Exception {
         JLanguageTool lt = new JLanguageTool(new French());
 
-        List<RuleMatch> matches = lt.check("Directeur production du groupe");
+        // example from https://github.com/languagetool-org/languagetool/issues/2852
+        List<RuleMatch> matches = lt.check("Il est par cons\u00E9quent perdue.");
         assertEquals(1, matches.size());
         assertTrue(matches.get(0).getRule() instanceof PatternRule);
     }

--- a/test/src/org/omegat/tokenizer/TokenizerTest.java
+++ b/test/src/org/omegat/tokenizer/TokenizerTest.java
@@ -27,7 +27,7 @@ package org.omegat.tokenizer;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.omegat.tokenizer.ITokenizer.StemmingMode;
 import org.omegat.util.Token;


### PR DESCRIPTION
## Pull request type

- Feature

## Which ticket is resolved?

- Upgrade to LanguageTool 3.6
    - https://sourceforge.net/p/omegat/feature-requests/1299/
- Lucene 5.2 does not work under WebStart
    - https://sourceforge.net/p/omegat/bugs/813/

## What does this PR change?

- Fix BUGS#813: The bug was fixed in Lucene 5.5.3 and later
- Bump LanguageTool@5.7
- Update LanguageToolTest expectations according to behavior changes on LanguageTool 3.5->5.7
-  Belarusian on LT@5.7 is deperecated, so I added suppresswarning for it.

## Other information

In RFE#1299 @amake said

> I have this 90% done locally:
> 
> Upgrade to LanguageTool 4.9
> Upgrade to Lucene 5.5.5
> The remaining issue is that LanguageTool switched Hunspell implementations, and the new one ([hunspell-java](https://gitlab.com/dumonts/hunspell-java)) has multiple JARs containing native binaries which complicates code signing for the Mac distribution.

TODO::
- [x] Update build.gradle to sign multiple jars
- [ ] Test distribution on macOS