### PR TITLE
Team(git): show message from credential manager on status area

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2342,6 +2342,7 @@ GIT_NO_CHANGES=Git '{0}' did nothing because there were no changes
 GIT_ERROR=Git '{0}' error: {1}
 GIT_CONFLICT=Push failed. Will be synchronized next time.
 GIT_SAVE_PLAINPASSWORD=Allow to save password as plain text
+GIT_CREDENTIAL_MESSAGE=Git notification: {0}
 VCS_OFFLINE=No connection available, the project is in offline mode.
 VCS_ONLINE=Connection available, the project is in team project mode.
 TEAM_26_TO_37_CONSOLE=The specified project is an OmegaT 3.6-style team project. It needs to be converted to a new team project, but this cannot be done in console mode. The project will be loaded as a local project without team functionality. To convert it into a new team project, open it in the OmegaT GUI.

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -281,7 +281,9 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 }
                 continue;
             } else if (i instanceof CredentialItem.InformationalMessage) {
-                Core.getMainWindow().showMessageDialog(i.getPromptText());
+                Log.logInfoRB("GIT_CREDENTIAL_MESSAGE", i.getPromptText());
+                Core.getMainWindow()
+                        .showTimedStatusMessageRB("GIT_CREDENTIAL_MESSAGE", i.getPromptText());
                 continue;
             }
             throw new UnsupportedCredentialItem(uri, i.getClass().getName() + ":" + i.getPromptText());


### PR DESCRIPTION
When enables gpg signing, omegat pop-up GPG key finger print on every push for team project.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?


- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

## What does this PR change?

-  Replace pop-up dialog for message only git credential request into display message on status area.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
