### PR TITLE
Team: Improve a way to open team project and backup file creation

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -880,6 +880,8 @@ PP_MED_OPEN_FILTER=ZIP files
 PP_PROJECT_FILES_DESC=OmegaT Project Files
 
 PP_ERROR_UNABLE_TO_READ_PROJECT_FILE=Unable to read project file! \n
+PP_REMOTE_PROJECT_CONTENT_OVERRIDES_THE_CURRENT_PROJECT=Current project configuration will be override \
+  by the remote project configuration content. The original file is saved as backup: {0}
 
 PP_ERROR_UNABLE_TO_CONVERT_PROJECT=Unable to convert project!
 

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -52,8 +52,10 @@ import org.omegat.util.OStrings;
 import org.omegat.util.Platform;
 import org.omegat.util.StringUtil;
 
+import gen.core.filters.Filter;
 import gen.core.filters.Filters;
 import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
 
 /**
  * Storage for project properties. May read and write project from/to disk.
@@ -678,62 +680,12 @@ public class ProjectProperties {
 
         final ProjectProperties that = (ProjectProperties) o;
 
-        if (sentenceSegmentingEnabled != that.sentenceSegmentingEnabled) {
-            return false;
-        }
-        if (supportDefaultTranslations != that.supportDefaultTranslations) {
-            return false;
-        }
-        if (removeTags != that.removeTags) {
-            return false;
-        }
-        if (!projectName.equals(that.projectName)) {
-            return false;
-        }
         for (int i = 0; i < sourceRootExcludes.size(); i++) {
             if (!sourceRootExcludes.get(i).equals(that.sourceRootExcludes.get(i))) {
                 return false;
             }
         }
-        if (!sourceLanguage.getLocaleCode().equals(that.sourceLanguage.getLocaleCode())) {
-            return false;
-        }
-        if (!targetLanguage.getLocaleCode().equals(that.targetLanguage.getLocaleCode())) {
-            return false;
-        }
-        if (!sourceTokenizer.getCanonicalName().equals(that.sourceTokenizer.getCanonicalName())) {
-            return false;
-        }
-        if (!targetTokenizer.getCanonicalName().equals(that.targetTokenizer.getCanonicalName())) {
-            return false;
-        }
-        if (!exportTmLevels.equals(that.exportTmLevels)) {
-            return false;
-        }
-        if (!externalCommand.equals(that.externalCommand)) {
-            return false;
-        }
-        if (!projectRootDir.equals(that.projectRootDir)) {
-            return false;
-        }
-        if (!sourceDir.underRoot.equals(that.sourceDir.underRoot)) {
-            return false;
-        }
-        if (!targetDir.underRoot.equals(that.targetDir.underRoot)) {
-            return false;
-        }
-        if (!glossaryDir.underRoot.equals(that.glossaryDir.underRoot)) {
-            return false;
-        }
-        if (!writableGlossaryFile.underRoot.equals(that.writableGlossaryFile.underRoot)) {
-            return false;
-        }
-        if (!tmDir.underRoot.equals(that.tmDir.underRoot)) {
-            return false;
-        }
-        if (!exportTMDir.underRoot.equals(that.exportTMDir.underRoot)) {
-            return false;
-        }
+
         if (!new EqualsBuilder()
                 .append(projectFilters.isRemoveTags(), that.projectFilters.isRemoveTags())
                 .append(projectFilters.isRemoveSpacesNonseg(), that.projectFilters.isRemoveSpacesNonseg())
@@ -743,12 +695,12 @@ public class ProjectProperties {
             return false;
         }
         for (int i = 0; i < projectFilters.getFilters().size(); i++) {
+            Filter thisFilter = projectFilters.getFilters().get(i);
+            Filter thatFilter = that.projectFilters.getFilters().get(i);
             if (!new EqualsBuilder()
-                    .append(projectFilters.getFilters().get(i).getClassName(),
-                            that.projectFilters.getFilters().get(i).getClassName())
-                    .append(projectFilters.getFilters().get(i).isEnabled(),
-                            that.projectFilters.getFilters().get(i).isEnabled())
-            .isEquals())
+                    .append(thisFilter.getClassName(), thatFilter.getClassName())
+                    .append(thisFilter.isEnabled(), thatFilter)
+                    .isEquals())
                 return false;
         }
         for (int i = 0; i < repositories.size(); i++) {
@@ -762,15 +714,36 @@ public class ProjectProperties {
                 return false;
             }
             for (int j = 0; j < repositories.get(i).getMapping().size(); j ++) {
+                RepositoryMapping thisMap = repositories.get(i).getMapping().get(j);
+                RepositoryMapping thatMap = that.repositories.get(i).getMapping().get(j);
                 if (!new EqualsBuilder()
-                        .append(repositories.get(i).getMapping().get(j).getLocal(),
-                                that.repositories.get(i).getMapping().get(j).getLocal())
+                        .append(thisMap.getLocal(), thatMap.getLocal())
+                        .append(thisMap.getRepository(), thatMap.getRepository())
                         .isEquals()) {
                     return false;
                 }
             }
         }
-        return dictDir.underRoot.equals(that.dictDir.underRoot);
+        return new EqualsBuilder()
+                .append(sentenceSegmentingEnabled, that.sentenceSegmentingEnabled)
+                .append(supportDefaultTranslations, that.supportDefaultTranslations)
+                .append(removeTags, that.removeTags)
+                .append(projectName, that.projectName)
+                .append(sourceLanguage.getLocaleCode(), that.sourceLanguage.getLocaleCode())
+                .append(targetLanguage.getLocaleCode(), that.targetLanguage.getLocaleCode())
+                .append(sourceTokenizer.getCanonicalName(), that.sourceTokenizer.getCanonicalName())
+                .append(targetTokenizer.getCanonicalName(), that.targetTokenizer.getCanonicalName())
+                .append(exportTmLevels, that.exportTmLevels)
+                .append(externalCommand, that.externalCommand)
+                .append(projectRootDir, that.projectRootDir)
+                .append(sourceDir.underRoot, that.sourceDir.underRoot)
+                .append(targetDir.underRoot, that.targetDir.underRoot)
+                .append(glossaryDir.underRoot, that.glossaryDir.underRoot)
+                .append(writableGlossaryFile.underRoot, that.writableGlossaryFile.underRoot)
+                .append(tmDir.underRoot, that.tmDir.underRoot)
+                .append(exportTMDir.underRoot, that.exportTMDir.underRoot)
+                .append(dictDir.underRoot, that.dictDir.underRoot)
+                .isEquals();
     }
 
     @Override

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -39,6 +39,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+
 import org.omegat.core.segmentation.SRX;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
@@ -663,5 +665,138 @@ public class ProjectProperties {
         public String getUnderRoot() {
             return underRoot;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ProjectProperties that = (ProjectProperties) o;
+
+        if (sentenceSegmentingEnabled != that.sentenceSegmentingEnabled) {
+            return false;
+        }
+        if (supportDefaultTranslations != that.supportDefaultTranslations) {
+            return false;
+        }
+        if (removeTags != that.removeTags) {
+            return false;
+        }
+        if (!projectName.equals(that.projectName)) {
+            return false;
+        }
+        for (int i = 0; i < sourceRootExcludes.size(); i++) {
+            if (!sourceRootExcludes.get(i).equals(that.sourceRootExcludes.get(i))) {
+                return false;
+            }
+        }
+        if (!sourceLanguage.getLocaleCode().equals(that.sourceLanguage.getLocaleCode())) {
+            return false;
+        }
+        if (!targetLanguage.getLocaleCode().equals(that.targetLanguage.getLocaleCode())) {
+            return false;
+        }
+        if (!sourceTokenizer.getCanonicalName().equals(that.sourceTokenizer.getCanonicalName())) {
+            return false;
+        }
+        if (!targetTokenizer.getCanonicalName().equals(that.targetTokenizer.getCanonicalName())) {
+            return false;
+        }
+        if (!exportTmLevels.equals(that.exportTmLevels)) {
+            return false;
+        }
+        if (!externalCommand.equals(that.externalCommand)) {
+            return false;
+        }
+        if (!projectRootDir.equals(that.projectRootDir)) {
+            return false;
+        }
+        if (!sourceDir.underRoot.equals(that.sourceDir.underRoot)) {
+            return false;
+        }
+        if (!targetDir.underRoot.equals(that.targetDir.underRoot)) {
+            return false;
+        }
+        if (!glossaryDir.underRoot.equals(that.glossaryDir.underRoot)) {
+            return false;
+        }
+        if (!writableGlossaryFile.underRoot.equals(that.writableGlossaryFile.underRoot)) {
+            return false;
+        }
+        if (!tmDir.underRoot.equals(that.tmDir.underRoot)) {
+            return false;
+        }
+        if (!exportTMDir.underRoot.equals(that.exportTMDir.underRoot)) {
+            return false;
+        }
+        if (!new EqualsBuilder()
+                .append(projectFilters.isRemoveTags(), that.projectFilters.isRemoveTags())
+                .append(projectFilters.isRemoveSpacesNonseg(), that.projectFilters.isRemoveSpacesNonseg())
+                .append(projectFilters.isPreserveSpaces(), that.projectFilters.isPreserveSpaces())
+                .append(projectFilters.isIgnoreFileContext(), that.projectFilters.isIgnoreFileContext())
+                .isEquals()) {
+            return false;
+        }
+        for (int i = 0; i < projectFilters.getFilters().size(); i++) {
+            if (!new EqualsBuilder()
+                    .append(projectFilters.getFilters().get(i).getClassName(),
+                            that.projectFilters.getFilters().get(i).getClassName())
+                    .append(projectFilters.getFilters().get(i).isEnabled(),
+                            that.projectFilters.getFilters().get(i).isEnabled())
+            .isEquals())
+                return false;
+        }
+        for (int i = 0; i < repositories.size(); i++) {
+            if (!new EqualsBuilder()
+                    .append(repositories.get(i).getType(), that.repositories.get(i).getType())
+                    .append(repositories.get(i).getUrl(), that.repositories.get(i).getUrl())
+                    .append(repositories.get(i).getBranch(), that.repositories.get(i).getBranch())
+                    .append(repositories.get(i).getMapping().size(),
+                            that.repositories.get(i).getMapping().size())
+                    .isEquals()) {
+                return false;
+            }
+            for (int j = 0; j < repositories.get(i).getMapping().size(); j ++) {
+                if (!new EqualsBuilder()
+                        .append(repositories.get(i).getMapping().get(j).getLocal(),
+                                that.repositories.get(i).getMapping().get(j).getLocal())
+                        .isEquals()) {
+                    return false;
+                }
+            }
+        }
+        return dictDir.underRoot.equals(that.dictDir.underRoot);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = projectName.hashCode();
+        result = 31 * result + sourceRootExcludes.hashCode();
+        result = 31 * result + repositories.hashCode();
+        result = 31 * result + sourceLanguage.hashCode();
+        result = 31 * result + targetLanguage.hashCode();
+        result = 31 * result + sourceTokenizer.hashCode();
+        result = 31 * result + targetTokenizer.hashCode();
+        result = 31 * result + (sentenceSegmentingEnabled ? 1 : 0);
+        result = 31 * result + (supportDefaultTranslations ? 1 : 0);
+        result = 31 * result + (removeTags ? 1 : 0);
+        result = 31 * result + exportTmLevels.hashCode();
+        result = 31 * result + projectSRX.hashCode();
+        result = 31 * result + projectFilters.hashCode();
+        result = 31 * result + externalCommand.hashCode();
+        result = 31 * result + projectRootDir.hashCode();
+        result = 31 * result + sourceDir.hashCode();
+        result = 31 * result + targetDir.hashCode();
+        result = 31 * result + glossaryDir.hashCode();
+        result = 31 * result + writableGlossaryFile.hashCode();
+        result = 31 * result + tmDir.hashCode();
+        result = 31 * result + exportTMDir.hashCode();
+        result = 31 * result + dictDir.hashCode();
+        return result;
     }
 }

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -685,15 +685,6 @@ public class ProjectProperties {
                 return false;
             }
         }
-
-        if (!new EqualsBuilder()
-                .append(projectFilters.isRemoveTags(), that.projectFilters.isRemoveTags())
-                .append(projectFilters.isRemoveSpacesNonseg(), that.projectFilters.isRemoveSpacesNonseg())
-                .append(projectFilters.isPreserveSpaces(), that.projectFilters.isPreserveSpaces())
-                .append(projectFilters.isIgnoreFileContext(), that.projectFilters.isIgnoreFileContext())
-                .isEquals()) {
-            return false;
-        }
         for (int i = 0; i < projectFilters.getFilters().size(); i++) {
             Filter thisFilter = projectFilters.getFilters().get(i);
             Filter thatFilter = that.projectFilters.getFilters().get(i);
@@ -725,6 +716,10 @@ public class ProjectProperties {
             }
         }
         return new EqualsBuilder()
+                .append(projectFilters.isRemoveTags(), that.projectFilters.isRemoveTags())
+                .append(projectFilters.isRemoveSpacesNonseg(), that.projectFilters.isRemoveSpacesNonseg())
+                .append(projectFilters.isPreserveSpaces(), that.projectFilters.isPreserveSpaces())
+                .append(projectFilters.isIgnoreFileContext(), that.projectFilters.isIgnoreFileContext())
                 .append(sentenceSegmentingEnabled, that.sentenceSegmentingEnabled)
                 .append(supportDefaultTranslations, that.supportDefaultTranslations)
                 .append(removeTags, that.removeTags)

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -482,6 +482,7 @@ public final class ProjectUICommands {
                           the current mapping usage.
                         */
                         if (!Core.getParams().containsKey(CLIParameters.NO_TEAM)) {
+                            ProjectProperties localProps = props;
                             List<RepositoryDefinition> repos = props.getRepositories();
                             mainWindow.showStatusMessageRB("TEAM_OPEN");
                             try {
@@ -498,6 +499,7 @@ public final class ProjectUICommands {
                                 if (props.getRepositories() == null) {  // We have a project without mapping
                                     Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
                                     props.setRepositories(repos); // So we restore the mapping we just lost
+                                    requestSaveProjectProperties = !props.equals(localProps);
                                 } else {
                                     // use mapping from remote configuration but
                                     // override repository URL when project URL is git type
@@ -507,9 +509,9 @@ public final class ProjectUICommands {
                                     if (repoUrl != null && !repoUrl.equals(newUrl)) {
                                         setRootGitRepositoryMapping(props.getRepositories(), repoUrl);
                                     }
+                                    requestSaveProjectProperties = !props.equals(localProps);
                                 }
-                                requestSaveProjectProperties = true;
-                                requestBackup = true;
+                                requestBackup = requestSaveProjectProperties;
                             } catch (IRemoteRepository2.NetworkException ignore) {
                                 // Do nothing. Network errors are handled in RealProject.
                             } catch (Exception e) {


### PR DESCRIPTION
Improve a way to open team project

## Pull request type

<!-- Please try to limit your pull request to one tyhttps://sourceforge.net/p/omegat/bugs/1110/pe; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: https://sourceforge.net/p/omegat/bugs/1110/
- Title: <!-- Paste title here --> Team project pile upback up files of omegat.project

## What does this PR change?

- Update `ProjectUICommands#projectOpen` method
    - Simplify detection of condition whether override local or not.
    - add missing message entries in `Bundle.properties`
   - Detect remote omegat.project file is identical with local one and if identical it does not make backup
   
## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
