### PR TITLE
Update ProjectUICommands#projectOpen method

### DIFF
--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -579,6 +579,7 @@ public final class ProjectUICommands {
                                 if (!needToSavePropertiesFinal) {
                                     Log.logWarningRB("REMOTE_PROJECT_CONTENT_OVERRIDES_THE_CURRENT_PROJECT");
                                     FileUtil.backupFile(projectFile);
+                                    FileUtil.removeOldBackups(projectFile, OConsts.MAX_BACKUPS);
                                     // Rename omegat.project.NEW to omegat.project
                                     Files.move(rewriteOnSuccessFinal.toPath(), projectFile.toPath(),
                                             StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
- Limit number of backups when overriding local project.omegat

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

-  Link: https://sourceforge.net/p/omegat/bugs/1110/
- Title:  Team project pile upback up files of omegat.project

## What does this PR change?

- Insert `FileUtil#removeOldBackups` after `FileUtil.backupFile` in `ProjectUICommands#openProject`


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
