### PR TITLE
Preserve repo URL when team project creation

### DIFF
--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -345,6 +345,12 @@ public final class ProjectUICommands {
                 ProjectProperties props = ProjectFileStorage.loadProjectProperties(projectRoot);
                 if (props.getRepositories() == null) { // We assume it's a project with no repository mapping,
                     props.setRepositories(repos);      // so we add root repository mapping
+                } else {
+                    String remoteUrl = getRootGitRepositoryMapping(props.getRepositories());
+                    if (remoteUrl != null && !remoteUrl.equals(repo.getUrl())) {
+                        // when remote repository config is different with opening url, respect local one
+                        setRootGitRepositoryMapping(props.getRepositories(), repo.getUrl());
+                    }
                 }
                 // We write in all cases, because we might have added default excludes, for instance
                 ProjectFileStorage.writeProjectFile(props);

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -127,6 +127,10 @@ public final class TestTeamIntegrationChild {
             // load project
             ProjectProperties projectProperties = ProjectFileStorage.loadProjectProperties(new File(dir));
             projectProperties.autocreateDirectories();
+            String remoteRepoUrl = getRootGitRepositoryMapping(projectProperties.getRepositories());
+            if (!remoteRepoUrl.equals(repo)) {
+                setRootGitRepositoryMapping(projectProperties.getRepositories(), repo);
+            }
 
             Core.getAutoSave().disable();
             RealProject p = new TestRealProject(projectProperties);
@@ -189,6 +193,27 @@ public final class TestTeamIntegrationChild {
         }
         throw new RuntimeException("Wrong url in repository. expected: " + repo
                 + ": actual: " + prop.getRepositories().get(0).getUrl());
+    }
+
+    private static String getRootGitRepositoryMapping(List<RepositoryDefinition> repos) {
+        String repoUrl = null;
+        for (RepositoryDefinition definition : repos) {
+            if (definition.getMapping().get(0).getLocal().equals("/") && definition.getMapping().get(0).getRepository().equals("/") && definition.getType().equals("git")) {
+                repoUrl = definition.getUrl();
+                break;
+            }
+        }
+        return repoUrl;
+    }
+
+    private static void setRootGitRepositoryMapping(List<RepositoryDefinition> repos, String repoUrl) {
+        for (RepositoryDefinition definition : repos) {
+            if (definition.getMapping().get(0).getLocal().equals("/") && definition.getMapping().get(0).getRepository().equals("/") && definition.getType().equals("git")) {
+                definition.setUrl(repoUrl);
+                repos.set(0, definition);
+                break;
+            }
+        }
     }
 
 


### PR DESCRIPTION
OmegaT now keeps git/team repository URL configured in local working directory's omegat.project.
But when creating team project, it does not.

This change try to keep repository url set on dialog as repository url other than remote team project settings.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?


- Link: <!-- Paste link here -->  https://sourceforge.net/p/omegat/feature-requests/1629/
- Title: <!-- Paste title here --> Git/Team project should preserve access URL when download team

## What does this PR change?

- `ProjectUICommands#projectTeamCreate` check remote repository URL and if it is git type and differed with specified one, 
OmegaT respect local one and store it in local `omegat.project` file.

## Other information

If there has already modification in local `omegat.project` file, OmegaT has already respect it in next open.