### PR TITLE
docgen: Specify uid:gid for docker run

### DIFF
--- a/doc_src/docgen
+++ b/doc_src/docgen
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec docker run -i --rm -v "$(dirname "$PWD")":/work/root omegatorg/docgen "$@"
+exec docker run -i --rm -u  `id -u`:`id -g` -v "$(dirname "$PWD")":/work/root omegatorg/docgen "$@"


### PR DESCRIPTION
When generating docs from gradle task, it failed with permission error on linux envionment.
This change solved the problem.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: https://sourceforge.net/p/omegat/bugs/1112/ <!-- Paste link here -->
- Title:  doc_src/docgen docker container should handle UID/GID properly

## What does this PR change?

- Update doc_src/docgen : add docker command option -u with host users uid:gid

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
