### PR TITLE
[Feature] team: preserve branch name for root mapping

### DIFF
--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -316,6 +316,9 @@ public class GITCredentialsProvider extends CredentialsProvider {
      * @return true when entered, false on cancel.
      */
     private Credentials askCredentials(URIish uri, Credentials credentials) {
+        if (Core.getMainWindow() == null) {
+            return null;
+        }
         GITUserPassDialog userPassDialog = new GITUserPassDialog(Core.getMainWindow().getApplicationFrame());
         userPassDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
         userPassDialog.descriptionTextArea.setText(OStrings


### PR DESCRIPTION
Support following senarios;

1. fork or make branch from translation team project repository
2. a project has root repository mapping that is as same as original
3. creating local working project with `branch` project.
4. works on branch team project

But OmegaT override local repository mapping with remote repository configuration, that can point to original team project.

This patch preserve branch name. 

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: <!-- Paste link here -->  https://sourceforge.net/p/omegat/feature-requests/1531/
- Title: <!-- Paste title here -->  Support using arbitrary git branch name

## What does this PR change?

- Keep branch name specified in Download team project dialog
- OmegaT to set branch name to local omegat.project's repository mapping as root repository configuration

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
