### PR TITLE
Filter: ResourceBundleFilter: Add option to write in UTF-8

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1322,6 +1322,7 @@ RBFH_ERROR_ILLEGAL_U_SEQUENCE=Encountered illegal \\u sequence
 RB_FILTER_OPTIONS_TITLE=Java Resource Bundles Filter Options
 RB_FILTER_REMOVE_STRINGS_UNTRANSLATED=&Remove untranslated strings in the target files
 RB_FILTER_NOT_CONVERT_UNICODE_CHARACTERS=&Do not unescape Unicode literals (\\uXXXX)
+RB_FILTER_SUPPORT_JAVA8_ENCODING=Force escaping Unicode literals as compatible to Java 8 to write
 RB_FILTER_EXCEPTION=The Java Resource Bundles filter threw an exception:
 
 # XLIFFFilter.java

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.form
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.form
@@ -49,7 +49,7 @@
           </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="0" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+              <GridBagConstraints gridX="0" gridY="1" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -61,7 +61,19 @@
           </Properties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="1" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+              <GridBagConstraints gridX="0" gridY="2" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="supportJava8EncodingCB">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="RB_FILTER_SUPPORT_JAVA8_ENCODING" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
@@ -37,7 +37,7 @@ import org.omegat.util.gui.StaticUIUtils;
 
 /**
  * Modal dialog to edit the Java Resource Bundles filter options.
- *
+ *<p>
  * Code modified from the file: MozillaDTDOptionsDialog.java
  *
  * @author Enrique Estevez (keko.gl@gmail.com)
@@ -65,6 +65,9 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
 
         String notConvertCharacters = options.get(ResourceBundleFilter.OPTION_DONT_UNESCAPE_U_LITERALS);
         dontUnescapeULiteralsCB.setSelected("true".equalsIgnoreCase(notConvertCharacters));
+
+        String supportJava8Encoding = options.get(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE);
+        supportJava8EncodingCB.setSelected(!"false".equals(supportJava8Encoding));
 
         StaticUIUtils.setEscapeAction(this, new AbstractAction() {
             @Override
@@ -97,6 +100,7 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         jPanel1 = new javax.swing.JPanel();
         removeStringsUntranslatedCB = new javax.swing.JCheckBox();
         dontUnescapeULiteralsCB = new javax.swing.JCheckBox();
+        supportJava8EncodingCB = new javax.swing.JCheckBox();
         buttonPanel = new javax.swing.JPanel();
         okButton = new javax.swing.JButton();
         cancelButton = new javax.swing.JButton();
@@ -113,7 +117,7 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         org.openide.awt.Mnemonics.setLocalizedText(removeStringsUntranslatedCB, OStrings.getString("RB_FILTER_REMOVE_STRINGS_UNTRANSLATED")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridy = 1;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
@@ -124,12 +128,18 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         org.openide.awt.Mnemonics.setLocalizedText(dontUnescapeULiteralsCB, bundle.getString("RB_FILTER_NOT_CONVERT_UNICODE_CHARACTERS")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = 2;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
         jPanel1.add(dontUnescapeULiteralsCB, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(supportJava8EncodingCB, OStrings.getString("RB_FILTER_SUPPORT_JAVA8_ENCODING")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        jPanel1.add(supportJava8EncodingCB, gridBagConstraints);
 
         getContentPane().add(jPanel1, java.awt.BorderLayout.CENTER);
 
@@ -163,6 +173,7 @@ private void closeDialog(java.awt.event.WindowEvent evt) {//GEN-FIRST:event_clos
 private void okButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_okButtonActionPerformed
         options.put(ResourceBundleFilter.OPTION_REMOVE_STRINGS_UNTRANSLATED, Boolean.toString(removeStringsUntranslatedCB.isSelected()));
         options.put(ResourceBundleFilter.OPTION_DONT_UNESCAPE_U_LITERALS, Boolean.toString(dontUnescapeULiteralsCB.isSelected()));
+        options.put(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE, Boolean.toString(supportJava8EncodingCB.isSelected()));
         doClose(RET_OK);
 }//GEN-LAST:event_okButtonActionPerformed
 
@@ -183,6 +194,7 @@ private void cancelButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
     private javax.swing.JPanel jPanel1;
     private javax.swing.JButton okButton;
     private javax.swing.JCheckBox removeStringsUntranslatedCB;
+    private javax.swing.JCheckBox supportJava8EncodingCB;
     // End of variables declaration//GEN-END:variables
 
     private int returnStatus = RET_CANCEL;

--- a/test/data/filters/resourceBundle/.gitattributes
+++ b/test/data/filters/resourceBundle/.gitattributes
@@ -1,0 +1,1 @@
+file-ResourceBundleFilter-NonASCIIComments.properties text working-tree-encoding=UTF-8

--- a/test/data/filters/resourceBundle/file-ResourceBundleFilter-NonASCIIComments.properties
+++ b/test/data/filters/resourceBundle/file-ResourceBundleFilter-NonASCIIComments.properties
@@ -1,0 +1,26 @@
+#/**************************************************************************
+# OmegaT Plugin - OMT Package Manager
+#
+# Copyright (C) 2019 Briac Pilpré
+# Home page: http://www.omegat.org/
+# Support center: http://groups.yahoo.com/group/OmegaT/
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# **************************************************************************/
+omt.menu.import=Unpack project from OMT file...
+omt.menu.export=Pack project as OMT file...
+omt.menu.export.delete=Pack and delete project...
+omt.dialog.overwrite_project_save=The project already has an ongoing translation.\nDo you want to overwrite it with the translation from the package ?
+omt.status.delete_project=Deleting project...

--- a/test/src/org/omegat/filters/ResourceBundleFilterTest.java
+++ b/test/src/org/omegat/filters/ResourceBundleFilterTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.IAlignCallback;
@@ -180,5 +181,48 @@ public class ResourceBundleFilterTest extends TestFilterBase {
         checkMultiEnd();
 
         translateText(filter, f);
+    }
+
+    @Test
+    public void testRegressionGithub227() throws Exception {
+        String f = "test/data/filters/resourceBundle/file-ResourceBundleFilter-NonASCIIComments.properties";
+        ResourceBundleFilter filter = new ResourceBundleFilter();
+
+        assertTrue(filter.isSourceEncodingVariable());
+        Map<String, String> config = new HashMap<>();
+        config.put(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE, "false");
+        IProject.FileInfo fi = loadSourceFiles(filter, f, config);
+        checkMultiStart(fi, f);
+        checkMulti("Unpack project from OMT file...", "omt.menu.import", null, null, null,
+                "#/**************************************************************************\n" +
+                        "# OmegaT Plugin - OMT Package Manager\n" +
+                        "#\n" +
+                        "# Copyright (C) 2019 Briac Pilpr\u00E9\n" +
+                        "# Home page: http://www.omegat.org/\n" +
+                        "# Support center: http://groups.yahoo.com/group/OmegaT/\n" +
+                        "#\n" +
+                        "# This program is free software: you can redistribute it and/or modify\n" +
+                        "# it under the terms of the GNU General Public License as published by\n" +
+                        "# the Free Software Foundation, either version 3 of the License, or\n" +
+                        "# (at your option) any later version.\n" +
+                        "#\n" +
+                        "# This program is distributed in the hope that it will be useful,\n" +
+                        "# but WITHOUT ANY WARRANTY; without even the implied warranty of\n" +
+                        "# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n" +
+                        "# GNU General Public License for more details.\n" +
+                        "#\n" +
+                        "# You should have received a copy of the GNU General Public License\n" +
+                        "# along with this program. If not, see <http://www.gnu.org/licenses/>.\n" +
+                        "#\n" +
+                        "# **************************************************************************/"
+        );
+        checkMulti("Pack project as OMT file...", "omt.menu.export", null, null, null, null);
+        checkMulti("Pack and delete project...", "omt.menu.export.delete", null, null, null, null);
+        checkMulti("The project already has an ongoing translation.\nDo you want to overwrite it with the translation from the package ?",
+                "omt.dialog.overwrite_project_save", null, null, null, null);
+        checkMulti("Deleting project..." ,"omt.status.delete_project", null, null, null, null);
+        checkMultiEnd();
+
+        translateText(filter, f, config);
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ -->

- Link: <!-- Paste link here --> https://sourceforge.net/p/omegat/bugs/1116/
- Title: <!-- Paste title here --> BundleProperties fIlter should accept UTF-8 properties file

- LInk: https://sourceforge.net/p/omegat/feature-requests/1634/
- Title: BundleProperties Filter: write properties file in UTF-8 w/o escape in default


## What does this PR change?

- Fix BUGS#1116 https://sourceforge.net/p/omegat/bugs/1116/
- Add preference option force to write Java 8 compatible escaped properties and set default to true, escaping.
- Accept UTF-8 encoded properties file in default.
- Add Regression test for ed5e7da83b5c Reproduce reported issue
	> 46573: Error: java.io.IOException: /Users/suzume/Documents/Repositories/OmegaT plugin FR/source/omt-package/omt-package.properties
	> 46573: Error: java.nio.charset.MalformedInputException: Input length = 1

## Other information

This PR add  option for resource bundle filter to force escape output file as compatible as Java 8.
In default, it set `true` and output will be escaped as same as previous OmegaT versions.
When set it false, OmegaT can output UTF-8 encoded properties file that is compatible with Java 9 and later.

