### PR TITLE
Remove filter check from ProjectUICommands#isIdenticalOmegatProjectProperties

### DIFF
--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -635,21 +635,6 @@ public final class ProjectUICommands {
                 }
             }
         }
-        if (my.getProjectFilters() != null && that.getProjectFilters() != null) {
-            if (!new EqualsBuilder()
-                    .append(my.getProjectFilters().isRemoveTags(), that.getProjectFilters().isRemoveTags())
-                    .append(my.getProjectFilters().isRemoveSpacesNonseg(),
-                            that.getProjectFilters().isRemoveSpacesNonseg())
-                    .append(my.getProjectFilters().isPreserveSpaces(), that.getProjectFilters().isPreserveSpaces())
-                    .append(my.getProjectFilters().isIgnoreFileContext(),
-                            that.getProjectFilters().isIgnoreFileContext()).isEquals()) {
-                return false;
-            }
-        } else {
-            if (my.getProjectFilters() != null || that.getProjectFilters() != null) {
-                return false;
-            }
-        }
         return new EqualsBuilder()
                 .append(my.isSentenceSegmentingEnabled(), that.isSentenceSegmentingEnabled())
                 .append(my.isSupportDefaultTranslations(), that.isSupportDefaultTranslations())


### PR DESCRIPTION
- Because a filter configuration is stored in filters.xml, remove a comparison from the ProjectUICommands#isIdenticalOmegatProjectProperties method.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: <!-- Paste link here -->
- Title: <!-- Paste title here -->

Pull request #274 is incomplete to remove a code which compare filters.

## What does this PR change?

- Remove a filter comparison from the ProjectUICommands#isIdenticalOmegatProjectProperties method.

## Other information

