### PR TITLE
Update JTextPaneLinkifier REGEX_URL

### DIFF
--- a/lib/licenses/Licenses.txt
+++ b/lib/licenses/Licenses.txt
@@ -67,6 +67,9 @@ are available in OmegaT sources, in the directory lib/sources.
 
 JTextPaneLinkifier uses a regex from dperini/regex-web.js
 (https://gist.github.com/dperini/729294) under the MIT License.
+and a resource regex from JetBrains/intellij-community
+(https://github.com/JetBrains/intellij-community/blob/master/platform/util/src/com/intellij/util/io/URLUtil.java)
+under Apache-2.0 License.
 
 dictzip is distributed under the GNU General Public License version
 2.0 and greater with classpath link exception.

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -938,6 +938,10 @@ NP_DICTDIR_DOESNT_EXIST=Dictionary files folder entered does not exist!
 # 0 - the error
 LD_ERROR=ERROR: {0}
 
+# JTextPaneLinkifier
+
+TPL_ERROR_URL=Wrong URL detected in Linkifier: {0}
+
 #ProjectFileChooser
 
 PFC_OMEGAT_PROJECT=OmegaT Project Folder

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -166,7 +166,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
 
         ToolTipManager.sharedInstance().registerComponent(this);
 
-        JTextPaneLinkifier.linkify(this);
+        JTextPaneLinkifier.linkify(this, true);
     }
 
     @Override

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -149,8 +149,20 @@ public final class JTextPaneLinkifier {
 
         // Regular Expression for URL validation
         // From https://gist.github.com/dperini/729294
-        // See lib/Licenses.txt
-        private static final String REGEX_URL = "(?:(?:https?|ftp):\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))\\.?)(?::\\d{2,5})?(?:[/?#]\\S*)?";
+        // and https://github.com/JetBrains/intellij-community
+        // See lib/licenses/Licenses.txt
+        private static final String REGEX_URL = "(?:https?|ftp)://"  // protocol
+                + "(?:\\S+(?::\\S*)?@)?(?:(?!"  // user:pass (optional)
+                + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
+                + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
+                + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
+                // IP addresses
+                + "|"
+                + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
+                + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
+                + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)"  // domain host
+                + "(?::\\d{2,5})?"  // port (optional)
+                + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?";  // resources
         private static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
         private static final AttributeSet DEFAULT_ATTRIBUTES = new SimpleAttributeSet();
         private static final AttributeSet LINK_ATTRIBUTES;
@@ -239,7 +251,7 @@ public final class JTextPaneLinkifier {
                         AttributeSet atts = makeAttributes(offset, new URI(matcher.group()));
                         doc.setCharacterAttributes(offset, targetLength, atts, true);
                     } catch (URISyntaxException ex) {
-                        Log.log(ex);
+                        Log.logWarningRB("TPL_ERROR_URL", matcher.group());
                     }
                 }
 


### PR DESCRIPTION
Previous match grab all characters with `\S*`.
This commit changes it with `(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?` That is taken from intellij-community (Apache-2.0).
This change also removes  unnecessary escape and capturing groups.
It also improve a warning message for URL capturing failure.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

### Bug fix

- Link: <!-- Paste link here --> https://sourceforge.net/p/omegat/bugs/1117/
- Title: <!-- Paste title here --> URL likifier raise exception when opening resource property file

### Feature request

- LInk: https://sourceforge.net/p/omegat/feature-requests/1604/
- Title: Hyperlinks to local files in the glossary

## What does this PR change?

- JTextPaneLinkifiler: previous match grab all characters with `\S*`.
- This  changes it with `(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?`
   from intellij-community (Apache-2.0) -
- Remove unnecessary escapes and capturing group brackets
- Improve warning message instead of showing stack dump
- Allow linkify file:// on glossary pane

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
