### PR TITLE
Fix NPE on team project conversion

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2365,7 +2365,10 @@ TEAM_26_to_37_CONVERTED_MESSAGE=The project was converted successfully.\n\
     \n\
     Please contact your project administrator to find out if any\n\
     additional steps need to be taken.
-
+TEAM_26_to_36_CONVERT_URL_NOT_DEFINED=Repository (type: {0}) URL not defined on path: {1}
+TEAM_26_to_36_CONVERT_FAILED=The project conversion was failed.\n\
+  Please check your repository has correct commits and files.\n\
+  Don't you forget a first commit?
 TEAM_USERPASS_TITLE=Authentication
 TEAM_USERPASS_FIRST=Please enter username/password for {0}
 TEAM_USERPASS_WRONG=Wrong username/password for {0}


### PR DESCRIPTION
When try to convert a project that is git repository but forget an initial commit of project files,
OmegaT crash with NPE.
This change to log warning and reason, and show
message dialog and continue to process.

Fix BUGS#1118


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

- Link: <!-- Paste link here --> https://sourceforge.net/p/omegat/bugs/1118/
- Title: <!-- Paste title here --> When converting git local-managed project, OmegaT raise NPE

## What does this PR change?

-  Check empty repository remote URL before try to get commit.HEAD
-  Log and show dialog instead of crash with exception
-  Avoid NPE

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
