### PR TITLE
Backup project file to enable reuse in case of crash

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -898,6 +898,7 @@ PP_MED_OPEN_FILTER=ZIP files
 PP_PROJECT_FILES_DESC=OmegaT Project Files
 
 PP_ERROR_UNABLE_TO_READ_PROJECT_FILE=Unable to read project file! \n
+PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK=Unable to read project file! Trying with backup file\n
 PP_REMOTE_PROJECT_CONTENT_OVERRIDES_THE_CURRENT_PROJECT=Current project configuration will be override \
   by the remote project configuration content. The original file is saved as backup: {0}
 

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -39,6 +39,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -455,11 +457,25 @@ public final class ProjectUICommands {
                     props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
                     // Here, 'props' is the current project setting read from local copy of omegat.project
                 } catch (Exception ex) {
-                    Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
-                    Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
-                    mainWindow.setCursor(oldCursor);
-                    return null;
+                    Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK");
+                    Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK");
+                    // try with backup file
+                    try {
+                        Files.copy(Paths.get(projectRootFolder.getAbsoluteFile() + File.separator
+                            + OConsts.FILE_PROJECT + OConsts.BACKUP_EXTENSION),
+                            Paths.get(projectRootFolder.getAbsoluteFile() + File.separator + OConsts.FILE_PROJECT),
+                            StandardCopyOption.REPLACE_EXISTING);
+                        props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
+                    } catch (Exception ex2) {
+                        Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
+                        Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
+                        mainWindow.setCursor(oldCursor);
+                        return null;
+                    }
                 }
+                Files.copy(Paths.get(projectRootFolder.getAbsoluteFile() + File.separator + OConsts.FILE_PROJECT),
+                    Paths.get(projectRootFolder.getAbsoluteFile() + File.separator + OConsts.FILE_PROJECT + OConsts.BACKUP_EXTENSION),
+                    StandardCopyOption.REPLACE_EXISTING);
 
                 try {
                     // open LOCAL copy of "omegat.project"


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Build and release changes
- [ ] Other (describe below)

## Which ticket is resolved?

https://sourceforge.net/p/omegat/mailman/message/37715643/

This patch creates a backup of omegat.project; later, if OmegaT does not succeed to read the project file for any reason (usually because it was not correctly saved after a crash) it will re-use the backup file instead
