### PR TITLE
missing menu properties in 5.8

### DIFF
--- a/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -14,6 +14,7 @@ projectCloseMenuItem=meta shift W
 projectSaveMenuItem=meta S
 #-separator-#
 projectCommitSourceFiles
+projectCommitTargetFiles
 #-separator-#
 projectCompileMenuItem=meta D
 projectSingleCompileMenuItem=meta shift D
@@ -29,12 +30,14 @@ viewFileListMenuItem=meta L
 #	projectAccessSourceMenuItem=
 #	projectAccessTargetMenuItem=
 #	projectAccessTMMenuItem=
+#	projectAccessExportTMMenuItem
 #-separator-#
 #	projectAccessCurrentSourceDocumentMenuItem=
 #	projectAccessCurrentTargetDocumentMenuItem=
 #	projectAccessWriteableGlossaryMenuItem=
 #<< End submenu <<#
 projectExitMenuItem=meta Q
+#	projectRestartMenuItem=
 
 #############
 # Edit menu #
@@ -66,6 +69,7 @@ editReplaceInProjectMenuItem=meta K
 #	lowerCaseMenuItem=
 #	upperCaseMenuItem=
 #	titleCaseMenuItem=
+#	sentenceCaseMenuItem=
 #-separator-#
 cycleSwitchCaseMenuItem=shift F3
 #<< End submenu <<#
@@ -85,6 +89,7 @@ editSelectFuzzy5MenuItem=meta 5
 #-separator-#
 #	insertCharsLRE=
 #	insertCharsRLE=
+#	insertCharsPDF=
 #<< End submenu <<#
 #-separator-#
 #	editMultipleDefault=
@@ -115,6 +120,7 @@ gotoHistoryBackMenuItem=meta shift P
 #############
 #	viewMarkTranslatedSegmentsCheckBoxMenuItem=
 #	viewMarkUntranslatedSegmentsCheckBoxMenuItem=
+#	viewMarkParagraphStartCheckBoxMenuItem=
 #	viewDisplaySegmentSourceCheckBoxMenuItem=
 #	viewMarkNonUniqueSegmentsCheckBoxMenuItem=
 #	viewMarkNotedSegmentsCheckBoxMenuItem=
@@ -122,6 +128,7 @@ gotoHistoryBackMenuItem=meta shift P
 #	viewMarkWhitespaceCheckBoxMenuItem=
 #	viewMarkBidiCheckBoxMenuItem=
 #	viewMarkAutoPopulatedCheckBoxMenuItem=
+#	viewMarkGlossaryMatchesCheckBoxMenuItem=
 #	viewMarkLanguageCheckerCheckBoxMenuItem=
 #	viewMarkFontFallbackCheckBoxMenuItem=
 #>> Modification Info submenu >>#
@@ -153,6 +160,7 @@ toolsCheckIssuesMenuItem=meta shift V
 #-separator-#
 #<< End submenu <<#
 #>> Glossary submenu >>#
+#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Dictionary submenu >>#
@@ -177,6 +185,7 @@ helpContentsMenuItem=F1
 #	helpAboutMenuItem=
 #	helpLastChangesMenuItem=
 #	helpLogMenuItem=
+#	helpUpdateCheckMenuItem
 
 #################
 # Search Window #

--- a/src/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -14,6 +14,7 @@ projectCloseMenuItem=ctrl shift W
 projectSaveMenuItem=ctrl S
 #-separator-#
 projectCommitSourceFiles
+projectCommitTargetFiles
 #-separator-#
 projectCompileMenuItem=ctrl D
 projectSingleCompileMenuItem=ctrl shift D
@@ -29,12 +30,14 @@ viewFileListMenuItem=ctrl L
 #	projectAccessSourceMenuItem=
 #	projectAccessTargetMenuItem=
 #	projectAccessTMMenuItem=
+#	projectAccessExportTMMenuItem
 #-separator-#
 #	projectAccessCurrentSourceDocumentMenuItem=
 #	projectAccessCurrentTargetDocumentMenuItem=
 #	projectAccessWriteableGlossaryMenuItem=
 #<< End submenu <<#
 projectExitMenuItem=ctrl Q
+#	projectRestartMenuItem=
 
 #############
 # Edit menu #
@@ -66,6 +69,7 @@ editReplaceInProjectMenuItem=ctrl K
 #	lowerCaseMenuItem=
 #	upperCaseMenuItem=
 #	titleCaseMenuItem=
+#	sentenceCaseMenuItem=
 #-separator-#
 cycleSwitchCaseMenuItem=shift F3
 #<< End submenu <<#
@@ -85,6 +89,7 @@ editSelectFuzzy5MenuItem=ctrl 5
 #-separator-#
 #	insertCharsLRE=
 #	insertCharsRLE=
+#	insertCharsPDF=
 #<< End submenu <<#
 #-separator-#
 #	editMultipleDefault=
@@ -115,6 +120,7 @@ gotoHistoryBackMenuItem=ctrl shift P
 #############
 #	viewMarkTranslatedSegmentsCheckBoxMenuItem=
 #	viewMarkUntranslatedSegmentsCheckBoxMenuItem=
+#	viewMarkParagraphStartCheckBoxMenuItem=
 #	viewDisplaySegmentSourceCheckBoxMenuItem=
 #	viewMarkNonUniqueSegmentsCheckBoxMenuItem=
 #	viewMarkNotedSegmentsCheckBoxMenuItem=
@@ -122,6 +128,7 @@ gotoHistoryBackMenuItem=ctrl shift P
 #	viewMarkWhitespaceCheckBoxMenuItem=
 #	viewMarkBidiCheckBoxMenuItem=
 #	viewMarkAutoPopulatedCheckBoxMenuItem=
+#	viewMarkGlossaryMatchesCheckBoxMenuItem=
 #	viewMarkLanguageCheckerCheckBoxMenuItem=
 #	viewMarkFontFallbackCheckBoxMenuItem=
 #>> Modification Info submenu >>#
@@ -153,6 +160,7 @@ toolsCheckIssuesMenuItem=ctrl shift V
 #-separator-#
 #<< End submenu <<#
 #>> Glossary submenu >>#
+#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Dictionary submenu >>#
@@ -177,6 +185,7 @@ helpContentsMenuItem=F1
 #	helpAboutMenuItem=
 #	helpLastChangesMenuItem=
 #	helpLogMenuItem=
+#	helpUpdateCheckMenuItem
 
 #################
 # Search Window #


### PR DESCRIPTION
The menu properties files are not up to date.

## Pull request type

- [X] Other (describe below)

Update

## Which ticket is resolved?

https://sourceforge.net/p/omegat/bugs/1121/

## What does this PR change?

Update the MainMenuShortcuts.properties and MainMenuShortcuts.mac.properties files
