### PR TITLE
Update PR template not to use checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,13 +12,13 @@ core contributor and the PR ticket will be closed. It will appear to have been
 <!-- Please try to limit your pull request to one type; submit multiple pull
 requests if needed. -->
 
-Please check the type of change your PR introduces:
+Please mark github LABEL of the type of change your PR introduces:
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Documentation
-- [ ] Build and release changes
-- [ ] Other (describe below)
+- Bug fix -> [bug]
+- Feature enhancement -> [enhancement]
+- Documentation -> [documentation]
+- Build and release changes -> [build/release]
+- Other (describe below)
 
 ## Which ticket is resolved?
 
@@ -28,10 +28,20 @@ Feature requests: https://sourceforge.net/p/omegat/feature-requests/
 
 Bugs: https://sourceforge.net/p/omegat/bugs/
 
-Documentation: https://sourceforge.net/p/omegat/documentation/ -->
+Documentation: https://sourceforge.net/p/omegat/documentation/ 
 
-- Link: <!-- Paste link here -->
-- Title: <!-- Paste title here -->
+ Plesae paste a ticket title and URL  
+-->
+
+- Title ex. fix...
+  * URL ex. https://...
+ 
+- Title
+  * URL
+
+<!-- 
+ Above block is used for changelog. 
+-->
 
 ## What does this PR change?
 


### PR DESCRIPTION
Update template not to use checklist but use Github labels

## Pull request type

- Other:  github template


## What does this PR change?

- Update template not to use checklist but use label
- Change order of ticket tiltle/url as same as change log format 

