### PR TITLE
Dictionary: notify when search done but no data

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1849,6 +1849,7 @@ GUI_MATCHWINDOW_SUBWINDOWTITLE_Dictionary=Dictionary
 GUI_DICTIONARYWINDOW_explanation=Displays the dictionary entries found in the dictionary files located in the /dictionary/ folder if they are present in the source segment.
 
 GUI_DICTIONARYWINDOW_SETTINGS_NOTIFICATIONS=Notify Me When a Segment Has Dictionary Entries
+GUI_DICTIONARYWINDOW_SETTINGS_NOTIFICATION_NOHIT=Notify even When No Result found on Dictionary Search
 
 GUI_MATCHWINDOW_SUBWINDOWTITLE_MachineTranslate=Machine Translation
 

--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -283,12 +283,17 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
         clear();
 
         if (data == null) {
+            if (Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_NOHIT)) {
+                scrollPane.notify(false);
+            }
             return;
-        }
-
-        if (!data.isEmpty() && Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_HITS)) {
+        } else if (data.isEmpty() && Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_NOHIT)) {
+            scrollPane.notify(false);
+            return;
+        } else if (!data.isEmpty() && Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_HITS)) {
             scrollPane.notify(true);
         }
+        // otherwise, don't notify.
 
         StringBuilder txt = new StringBuilder("<html>");
         boolean wasPrev = false;
@@ -481,15 +486,17 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
 
     @Override
     public void populatePaneMenu(JPopupMenu menu) {
-        final JMenuItem notify = new JCheckBoxMenuItem(
+        final JMenuItem notifyHitMenuItem = new JCheckBoxMenuItem(
                 OStrings.getString("GUI_DICTIONARYWINDOW_SETTINGS_NOTIFICATIONS"));
-        notify.setSelected(Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_HITS));
-        notify.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                Preferences.setPreference(Preferences.NOTIFY_DICTIONARY_HITS, notify.isSelected());
-            }
-        });
-        menu.add(notify);
+        final JMenuItem notifyNoHitMenuItem = new JCheckBoxMenuItem(
+                OStrings.getString("GUI_DICTIONARYWINDOW_SETTINGS_NOTIFICATION_NOHIT"));
+        notifyHitMenuItem.setSelected(Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_HITS));
+        notifyNoHitMenuItem.setSelected(Preferences.isPreference(Preferences.NOTIFY_DICTIONARY_NOHIT));
+        notifyHitMenuItem.addActionListener(e -> Preferences.setPreference(Preferences.NOTIFY_DICTIONARY_HITS,
+                notifyHitMenuItem.isSelected()));
+        notifyNoHitMenuItem.addActionListener(e -> Preferences.setPreference(Preferences.NOTIFY_DICTIONARY_NOHIT,
+                notifyNoHitMenuItem.isSelected()));
+        menu.add(notifyHitMenuItem);
+        menu.add(notifyNoHitMenuItem);
     }
 }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -471,6 +471,7 @@ public final class Preferences {
     public static final String NOTIFY_GLOSSARY_HITS = "notify_glossary_hits";
     public static final String NOTIFY_COMMENTS = "notify_comments";
     public static final String NOTIFY_DICTIONARY_HITS = "notify_dictionary_hits";
+    public static final String NOTIFY_DICTIONARY_NOHIT = "notify_dictionary_nohit";
     public static final String NOTIFY_MULTIPLE_TRANSLATIONS = "notify_multiple_translations";
     public static final String NOTIFY_NOTES = "notify_notes";
 


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Plesae paste a ticket title and URL  
-->

- Title ex. fix...
  * URL ex. https://...
 
- Visual confirmation that dictionary was searched
  * https://sourceforge.net/p/omegat/feature-requests/1633/

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Introduce preference NOTIFY_DICTIONARY_NOHIT
- When set notify even when no search result, it notify with color


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
