### PR TITLE
Update .gitattributes to protect test data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 test/data/filters/pdf/file-PdfFilter-gold.txt text eol=lf
+test/data/tmx/TMXComplianceKit/*.rtf binary


### PR DESCRIPTION
set TMXComplianceKit RTF files as binary.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

Git configuration

## Which ticket is resolved?

## What does this PR change?

- update .gitattributes configuration

## Other information

RTF is windows binary file, so we should preserve its binary data.
Git convert line end of rtf files automatically in default.
