### PR TITLE
Don't run project team structure when --no-team CLI option is specified.

### DIFF
--- a/src/org/omegat/convert/ConvertProject26to37team.java
+++ b/src/org/omegat/convert/ConvertProject26to37team.java
@@ -37,6 +37,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.omegat.CLIParameters;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.team2.ProjectTeamSettings;
@@ -66,6 +67,12 @@ public class ConvertProject26to37team {
     public static void checkTeam(File projectRootFolder) throws Exception {
         if (isSVNDirectory(projectRootFolder) || isGITDirectory(projectRootFolder)) {
             // project is 2.6-style team project
+
+            // When --no-team option is given, we skip conversion silently.
+            if (Core.getParams().containsKey(CLIParameters.NO_TEAM)) {
+                return;
+            }
+
             if (isConsoleMode()) {
                 Core.getMainWindow().displayWarningRB("TEAM_26_TO_37_CONSOLE");
                 return;


### PR DESCRIPTION
- option no-team obviously means working project without team, so asking users a conversion to     4.0 style team is bad behavior.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?
 
- #1063 OmegaT --no-team does not complete 3.6 team project conversion
  * https://sourceforge.net/p/omegat/bugs/1063/


## What does this PR change?

- Skip conversion when `--no-team` specified.

## Other information

