### PR TITLE
Make dictionary drivers as true plugin

### DIFF
--- a/Plugins.properties
+++ b/Plugins.properties
@@ -7,7 +7,9 @@ plugin=org.omegat.filters3.xml.xliff.XLIFFFilter \
     org.omegat.externalfinder.ExternalFinder \
     org.omegat.gui.theme.DefaultFlatTheme \
     org.omegat.gui.theme.DefaultClassicTheme \
-    org.omegat.util.gui.HtmlMediaSupport
+    org.omegat.util.gui.HtmlMediaSupport \
+    org.omegat.core.dictionaries.LingvoDSL \
+    org.omegat.core.dictionaries.StarDict
 filter=org.omegat.filters3.xml.android.AndroidFilter \
     org.omegat.filters2.latex.LatexFilter \
     org.omegat.filters2.po.PoFilter \

--- a/src/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/org/omegat/core/dictionaries/DictionariesManager.java
@@ -76,8 +76,6 @@ public class DictionariesManager implements DirectoryMonitor.Callback {
 
     public DictionariesManager(final IDictionaries pane) {
         this.pane = pane;
-        factories.add(new LingvoDSL());
-        factories.add(new StarDict());
         indexLanguage = new Language(Locale.getDefault());
         tokenizer = new DefaultTokenizer();
     }

--- a/src/org/omegat/core/dictionaries/LingvoDSL.java
+++ b/src/org/omegat/core/dictionaries/LingvoDSL.java
@@ -43,6 +43,9 @@ import io.github.eb4j.dsl.data.LanguageName;
 import io.github.eb4j.dsl.visitor.DslVisitor;
 import org.apache.commons.io.FilenameUtils;
 
+import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.util.Preferences;
 
 /**
@@ -60,6 +63,33 @@ import org.omegat.util.Preferences;
  * (Russian)</a>
  */
 public class LingvoDSL implements IDictionaryFactory {
+
+    /**
+     * Plugin loader.
+     */
+    public static void loadPlugins() {
+        CoreEvents.registerApplicationEventListener(new LingvoDSLApplicationEventListener());
+    }
+
+    /**
+     * Plugin unloader.
+     */
+    public static void unloadPlugins() {
+    }
+
+    /**
+     * registration of dictionary factory.
+     */
+    static class LingvoDSLApplicationEventListener implements IApplicationEventListener {
+        @Override
+        public void onApplicationStartup() {
+            Core.getDictionaries().addDictionaryFactory(new LingvoDSL());
+        }
+
+        @Override
+        public void onApplicationShutdown() {
+        }
+    }
 
     @Override
     public final boolean isSupportedFile(final File file) {

--- a/src/org/omegat/core/dictionaries/StarDict.java
+++ b/src/org/omegat/core/dictionaries/StarDict.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 
 import io.github.eb4j.stardict.StarDictDictionary;
 
+import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
@@ -62,6 +65,33 @@ import org.omegat.util.Preferences;
  * @author Suguru Oho
  */
 public class StarDict implements IDictionaryFactory {
+
+    /**
+     * Plugin loader.
+     */
+    public static void loadPlugins() {
+        CoreEvents.registerApplicationEventListener(new StarDictApplicationEventListener());
+    }
+
+    /**
+     * Plugin unloader.
+     */
+    public static void unloadPlugins() {
+    }
+
+    /**
+     * registration of dictionary factory.
+     */
+    static class StarDictApplicationEventListener implements IApplicationEventListener {
+        @Override
+        public void onApplicationStartup() {
+            Core.getDictionaries().addDictionaryFactory(new StarDict());
+        }
+
+        @Override
+        public void onApplicationShutdown() {
+        }
+    }
 
     @Override
     public boolean isSupportedFile(File file) {

--- a/test/src/org/omegat/core/dictionaries/DictionariesManagerTest.java
+++ b/test/src/org/omegat/core/dictionaries/DictionariesManagerTest.java
@@ -33,12 +33,14 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.omegat.gui.dictionaries.IDictionaries;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.util.Language;
@@ -96,6 +98,24 @@ public class DictionariesManagerTest {
         fw.println(IGNORE_WORD);
         fw.close();
         assertFalse(fw.checkError());
+
+        manager.addDictionaryFactory(new IDictionaryFactory() {
+            @Override
+            public boolean isSupportedFile(final File file) {
+                return true;
+            }
+            @Override
+            public IDictionary loadDict(final File file) throws Exception {
+                return new DummyDictionaryDriver();
+            }
+        });
+    }
+
+    static class DummyDictionaryDriver implements IDictionary {
+        @Override
+        public List<DictionaryEntry> readArticles(final String word) {
+            return Collections.singletonList(new DictionaryEntry(word, "result"));
+        }
     }
 
     @After
@@ -111,21 +131,21 @@ public class DictionariesManagerTest {
     public void testFileChanged() {
 
         // Nothing is loaded so there should be no result.
-        List<DictionaryEntry> result = manager.findWords(Arrays.asList(IGNORE_WORD));
+        List<DictionaryEntry> result = manager.findWords(Collections.singletonList(IGNORE_WORD));
         assertTrue(result.isEmpty());
 
         // Load sample dictionary.
         manager.fileChanged(DICT_FILE);
 
         // Now we find the result.
-        result = manager.findWords(Arrays.asList(IGNORE_WORD));
+        result = manager.findWords(Collections.singletonList(IGNORE_WORD));
         assertFalse(result.isEmpty());
 
         // Load ignore list.
         manager.fileChanged(IGNORE_FILE);
 
         // Now we should not find the result.
-        result = manager.findWords(Arrays.asList(IGNORE_WORD));
+        result = manager.findWords(Collections.singletonList(IGNORE_WORD));
         assertTrue(result.isEmpty());
     }
 
@@ -136,11 +156,11 @@ public class DictionariesManagerTest {
     public void testLoadIgnoreWords() throws Exception {
         manager.fileChanged(DICT_FILE);
 
-        List<DictionaryEntry> result = manager.findWords(Arrays.asList(IGNORE_WORD));
+        List<DictionaryEntry> result = manager.findWords(Collections.singletonList(IGNORE_WORD));
         assertFalse(result.isEmpty());
 
         manager.loadIgnoreWords(IGNORE_FILE);
-        result = manager.findWords(Arrays.asList(IGNORE_WORD));
+        result = manager.findWords(Collections.singletonList(IGNORE_WORD));
         assertTrue(result.isEmpty());
     }
 
@@ -153,11 +173,11 @@ public class DictionariesManagerTest {
 
         String word = "testudo";
 
-        List<DictionaryEntry> result = manager.findWords(Arrays.asList(word));
+        List<DictionaryEntry> result = manager.findWords(Collections.singletonList(word));
         assertFalse(result.isEmpty());
 
         manager.addIgnoreWord(word);
-        result = manager.findWords(Arrays.asList(word));
+        result = manager.findWords(Collections.singletonList(word));
         assertTrue(result.isEmpty());
     }
 


### PR DESCRIPTION
- Register dictionary drivers, LingvoDSL and StarDict through core API.
- Add class path to Plugins.properties.
- It allow clarify a core API, these drivers is not core.

## Pull request type

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

 Refactoring for future source tree management and clarify core API.

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
