### PR TITLE
Show glossary comment on context menu candidate

### DIFF
--- a/src/org/omegat/gui/glossary/TransTipsPopup.java
+++ b/src/org/omegat/gui/glossary/TransTipsPopup.java
@@ -27,6 +27,8 @@
 
 package org.omegat.gui.glossary;
 
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -37,6 +39,7 @@ import javax.swing.text.JTextComponent;
 import org.omegat.core.Core;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
+import org.omegat.util.StringUtil;
 import org.omegat.util.Token;
 import org.omegat.util.gui.MenuItemPager;
 
@@ -78,6 +81,22 @@ public class TransTipsPopup implements IPopupMenuConstructor {
                             if (!added.contains(s)) {
                                 JMenuItem it = pager.add(new JMenuItem(s));
                                 it.addActionListener(e -> Core.getEditor().insertText(s));
+                                it.addMouseListener(new MouseAdapter() {
+                                    @Override
+                                    public void mouseEntered(final MouseEvent e) {
+                                        String comment = ge.getCommentText();
+                                        if (!StringUtil.isEmpty(comment)) {
+                                            it.setToolTipText(comment);
+                                        }
+                                    }
+
+                                    @Override
+                                    public void mouseReleased(MouseEvent e) {
+                                        if (it.getToolTipText(e) != null) {
+                                            it.setToolTipText(null);
+                                        }
+                                    }
+                                });
                                 added.add(s);
                             }
                         }


### PR DESCRIPTION
when context menu on glossary match on source text show replace candidate, and when mouse is hover on the candidate text, OmegaT show glossary comment as tooltip when it exist.


## Pull request type


- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Improving the right-click menu on underlined words
  * https://sourceforge.net/p/omegat/feature-requests/1515/

## What does this PR change?

- 

## Other information
![image](https://user-images.githubusercontent.com/123720/197320190-57a8cc02-7066-4519-a98e-061426c956e9.png)

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
