### PR TITLE
Remove the DRAFT label from the title

### DIFF
--- a/doc_src/en/OmegaTUsersManual_xinclude full.xml
+++ b/doc_src/en/OmegaTUsersManual_xinclude full.xml
@@ -4,7 +4,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 <book lang="en" id="book.user.guide">
   <bookinfo>
-    <title id="book.user.guide.title">OmegaT &vernb; - User Guide <emphasis role="bold">DRAFT</emphasis></title>
+    <title id="book.user.guide.title">OmegaT &vernb; - User Guide</title>
     <pubdate>@timestamp@</pubdate>
 	<!-- TODO automate date insertion -->
     <abstract>


### PR DESCRIPTION
The manual is not a draft anymore :-)

## What does this PR change?

The PR removes the DRAFT label from the guide pages.