### PR TITLE
[Security] Bump Checkstyle@8.45.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -902,7 +902,7 @@ tasks.findAll { it.name =~ /^spotbugs.*/ }.each {
 }
 
 checkstyle {
-    toolVersion = '8.29'
+    toolVersion = '8.45.1'
 }
 checkstyleMain.exclude '**/gen/**'
 

--- a/build.gradle
+++ b/build.gradle
@@ -902,7 +902,7 @@ tasks.findAll { it.name =~ /^spotbugs.*/ }.each {
 }
 
 checkstyle {
-    toolVersion = '8.8'
+    toolVersion = '8.29'
 }
 checkstyleMain.exclude '**/gen/**'
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -53,6 +53,11 @@
         <property name="onCommentFormat" value="// End of variables declaration//GEN-END:variables"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
+    </module>
+
     <!-- Support default CHECKSTYLE:ON/OFF comments -->
     <module name="SuppressWithPlainTextCommentFilter"/>
 
@@ -134,10 +139,7 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^ *\* *[^ ]+$"/>
-        </module>
+
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 


### PR DESCRIPTION
- CheckStyle has a XXE  vulnerability that fixed in 8.29
- CVE-2019-9658
- CVE-2019-10782

## Pull request type

- Other (describe below)

Security
