### PR TITLE
Remove messages.xml. It is not used in the DocBook build process.

### DIFF
--- a/doc_src/whc-toc.xsl
+++ b/doc_src/whc-toc.xsl
@@ -4,21 +4,6 @@
                 xmlns:htm="http://www.w3.org/1999/xhtml"
 		        version="1.1">
 
-    <xsl:param name="language">en</xsl:param>
-    <xsl:variable name="trfile" select="concat($language,'/messages.xml')"/>
-    <xsl:variable name="translations">
-        <xsl:choose>
-            <xsl:when test="count(document($trfile))">
-                <xsl:message>translations file : <xsl:value-of select="$trfile"/></xsl:message>
-                <xsl:copy-of select="document($trfile)/entries/entry"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:message>translations file : en/messages.xml</xsl:message>
-                <xsl:copy-of select="document('en/messages.xml')/entries/entry"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:variable>
-
     <xsl:template match="/">
         <whc:toc>
             <xsl:apply-templates select="//htm:div[@class='toc']/htm:ul"/>


### PR DESCRIPTION
## What does this PR change?

The message.xml file in not necessary anymore in the DocBook set. It was used to create an "Appendix" header for the HTML set, but the header is now created from the DocBook set itself.