### PR TITLE
fix XMLStreamReader.java error message strings

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1120,9 +1120,7 @@ XSR_ERROR_EMPTY_TAG=(empty tag)
 
 XSR_ERROR_CLOSE_TAG=(close tag)
 
-XSR_ERROR_LOADED=loaded
-
-XSR_ERROR_ATTRIBUTES= attributes.
+XSR_ERROR_LOADED=loaded {0} attributes.
 
 XSR_ERROR_END_OF_STREAM=End of stream encountered without finding close block!
 

--- a/src/org/omegat/util/xml/XMLStreamReader.java
+++ b/src/org/omegat/util/xml/XMLStreamReader.java
@@ -119,8 +119,7 @@ public class XMLStreamReader implements Closeable {
             mHeadBlock = blk;
         } else {
             // not a valid XML file
-            throw new IOException(OStrings.getString("XSR_ERROR_NONVALID_XML") + "\n"
-                    + OStrings.getString("XSR_ERROR_NONVALID_XML"));
+            throw new IOException(OStrings.getString("XSR_ERROR_NONVALID_XML"));
         }
     }
 
@@ -657,8 +656,7 @@ public class XMLStreamReader implements Closeable {
             data += OStrings.getString("XSR_ERROR_CLOSE_TAG");
         }
         if (blk.numAttributes() > 0) {
-            data += OStrings.getString("XSR_ERROR_LOADED") + blk.numAttributes()
-                    + OStrings.getString("XSR_ERROR_ATTRIBUTES");
+            data += StringUtil.format(OStrings.getString("XSR_ERROR_LOADED"), String.valueOf(blk.numAttributes()));
         }
         throw new TranslationException(msg + data);
     }


### PR DESCRIPTION
The XMLStreamReader had 1 badly formatted error message and 1 redundant error message.
Both are fixed here.