### PR TITLE
Fix inconsistency in use of periods in command line help

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -90,9 +90,9 @@ See Help > User Guide for details, including available Java options.\n\
 \n\
 OmegaT options:\n\
 \n\
-    \tNo option: Launch GUI\n\
+    \tNo option: Launch GUI.\n\
 \n\
-    \tProject path only: Launch GUI and load specified project\n\
+    \tProject path only: Launch GUI and load specified project.\n\
 \n\
     \t-h, --help\n\
     \t  Print this help message.\n\
@@ -127,7 +127,7 @@ OmegaT options:\n\
     \t  The directory used to read or write OmegaT configuration files.\n\
 \n\
     \t--resource-bundle=<path>\n\
-    \t  A Java .properties file to use for the interface text\n\
+    \t  A Java .properties file to use for the interface text.\n\
 \n\
     \t--mode=[console mode name]\n\
     \t  Specify a mode other than the GUI default. See below for details.\n\
@@ -150,7 +150,7 @@ Console mode names and their options:\n\
 \n\
     \t--mode=console-stats\n\
     \t  project_path\n\
-    \t    The path to the project\n\
+    \t    The path to the project.\n\
     \t  --output-file=[stats-output-file]\n\
     \t    Prints to the specified file, or to standard output\n\
     \t    if no file is given or the option is not used.\n\
@@ -175,7 +175,7 @@ Console only options:\n\
 {0}
 
 TEAM_TOOL_HELP=Usage: team init <source language> <target language>\n\
-    \tSee --help
+    \tSee --help.
 
 # 0: Source language ("en", etc.)
 # 1: Target language ("es", etc.)


### PR DESCRIPTION
[documentation]


## What does this PR change?

- Add missing periods at the end of sentences in command line help.