### PR TITLE
Recreated PR for goto x

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -399,6 +399,11 @@ TF_MENU_GOTO_FORWARD_IN_HISTORY=&Forward in History
 TF_MENU_GOTO_BACK_IN_HISTORY=&Back in History
 
 # VIEW MENU
+TF_MENU_GOTO_X_SUBMENU=Segments with Automatic Translation
+TF_MENU_GOTO_NEXT_XAUTO=Next Segment with xAUTO
+TF_MENU_GOTO_PREV_XAUTO=Previous Segment with xAUTO
+TF_MENU_GOTO_NEXT_XENFORCED=Next Segment with xENFORCED
+TF_MENU_GOTO_PREV_XENFORCED=Previous Segment with xENFORCED
 
 MW_VIEW_MENU=&View
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -1456,6 +1456,40 @@ public class EditorController implements IEditor {
         nextTranslatedEntry(true);
     }
 
+    private void linkedEntry(boolean forward, String linked) {
+        iterateToEntry(forward, ste -> {
+                TMXEntry info = Core.getProject().getTranslationInfo(ste);
+                if (String.valueOf(info.linked) == linked) {
+                    return true;
+                }
+                return false;
+            });
+    }
+
+    /**
+     * Finds the next/previous x-auto translated entry
+     */
+
+    public void nextXAutoEntry() {
+        linkedEntry(true, "xAUTO");
+    }
+
+    public void prevXAutoEntry() {
+        linkedEntry(false, "xAUTO");
+    }
+
+    /**
+     * Finds the next/previous x-enforced translated entry
+     */
+
+    public void nextXEnforcedEntry() {
+        linkedEntry(true, "xENFORCED");
+    }
+
+    public void prevXEnforcedEntry() {
+        linkedEntry(false, "xENFORCED");
+    }
+
     private void entryWithNote(boolean forward) {
         iterateToEntry(forward, ste -> Core.getProject().getTranslationInfo(ste).hasNote());
     }

--- a/src/org/omegat/gui/editor/IEditor.java
+++ b/src/org/omegat/gui/editor/IEditor.java
@@ -159,6 +159,34 @@ public interface IEditor {
     void prevEntry();
 
     /**
+     * Move to next x-auto translated entry
+     *
+     * Must be called only from UI thread.
+     */
+    void nextXAutoEntry();
+
+    /**
+     * Move to previous x-auto translated entry
+     *
+     * Must be called only from UI thread.
+     */
+    void prevXAutoEntry();
+
+    /**
+     * Move to next x-enforced translated entry
+     *
+     * Must be called only from UI thread.
+     */
+    void nextXEnforcedEntry();
+
+    /**
+     * Move to previous x-enforced translated entry
+     *
+     * Must be called only from UI thread.
+     */
+    void prevXEnforcedEntry();
+
+    /**
      * Move to next entry with a note.
      *
      * Must be called only from UI thread.

--- a/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -112,6 +112,11 @@ gotoSegmentMenuItem=meta J
 gotoNextUniqueMenuItem=meta shift Q
 gotoMatchSourceSegment=meta shift M
 #-separator-#
+#	gotoNextXAutoMenuItem=
+#	gotoPrevXAutoMenuItem=
+#	gotoNextXEnforcedMenuItem=
+#	gotoPrevXEnforcedMenuItem=
+#-separator-#
 gotoHistoryForwardMenuItem=meta shift N
 gotoHistoryBackMenuItem=meta shift P
 

--- a/src/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -112,6 +112,11 @@ gotoSegmentMenuItem=ctrl J
 gotoNextUniqueMenuItem=ctrl shift Q
 gotoMatchSourceSegment=ctrl shift M
 #-separator-#
+#	gotoNextXAutoMenuItem=
+#	gotoPrevXAutoMenuItem=
+#	gotoNextXEnforcedMenuItem=
+#	gotoPrevXEnforcedMenuItem=
+#-separator-#
 gotoHistoryForwardMenuItem=ctrl shift N
 gotoHistoryBackMenuItem=ctrl shift P
 

--- a/src/org/omegat/gui/main/MainWindowMenu.java
+++ b/src/org/omegat/gui/main/MainWindowMenu.java
@@ -369,8 +369,15 @@ public class MainWindowMenu implements ActionListener, MenuListener, IMainMenu {
         gotoMenu.add(gotoNextUniqueMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_UNIQUE"));
         gotoMenu.add(gotoMatchSourceSegment = createMenuItem("TF_MENU_GOTO_SELECTED_MATCH_SOURCE"));
         gotoMenu.addSeparator();
+        gotoMenu.add(gotoXEntrySubmenu = createMenu("TF_MENU_GOTO_X_SUBMENU"));
+        gotoMenu.addSeparator();
         gotoMenu.add(gotoHistoryForwardMenuItem = createMenuItem("TF_MENU_GOTO_FORWARD_IN_HISTORY"));
         gotoMenu.add(gotoHistoryBackMenuItem = createMenuItem("TF_MENU_GOTO_BACK_IN_HISTORY"));
+
+        gotoXEntrySubmenu.add(gotoNextXAutoMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_XAUTO"));
+        gotoXEntrySubmenu.add(gotoPrevXAutoMenuItem = createMenuItem("TF_MENU_GOTO_PREV_XAUTO"));
+        gotoXEntrySubmenu.add(gotoNextXEnforcedMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_XENFORCED"));
+        gotoXEntrySubmenu.add(gotoPrevXEnforcedMenuItem = createMenuItem("TF_MENU_GOTO_PREV_XENFORCED"));
 
         viewMenu.add(viewMarkTranslatedSegmentsCheckBoxMenuItem = createCheckboxMenuItem("TF_MENU_DISPLAY_MARK_TRANSLATED"));
         viewMenu.add(viewMarkUntranslatedSegmentsCheckBoxMenuItem = createCheckboxMenuItem("TF_MENU_DISPLAY_MARK_UNTRANSLATED"));
@@ -795,6 +802,11 @@ public class MainWindowMenu implements ActionListener, MenuListener, IMainMenu {
     JMenuItem gotoNextTranslatedMenuItem;
     JMenuItem gotoPreviousSegmentMenuItem;
     JMenuItem gotoSegmentMenuItem;
+    JMenu gotoXEntrySubmenu;
+    JMenuItem gotoNextXAutoMenuItem;
+    JMenuItem gotoPrevXAutoMenuItem;
+    JMenuItem gotoNextXEnforcedMenuItem;
+    JMenuItem gotoPrevXEnforcedMenuItem;
     JMenuItem gotoNextNoteMenuItem;
     JMenuItem gotoPreviousNoteMenuItem;
     JMenuItem gotoMatchSourceSegment;

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -727,6 +727,22 @@ public final class MainWindowMenuHandler {
         Core.getEditor().prevEntry();
     }
 
+    public void gotoNextXAutoMenuItemActionPerformed() {
+        Core.getEditor().nextXAutoEntry();
+    }
+
+    public void gotoPrevXAutoMenuItemActionPerformed() {
+        Core.getEditor().prevXAutoEntry();
+    }
+
+    public void gotoNextXEnforcedMenuItemActionPerformed() {
+        Core.getEditor().nextXEnforcedEntry();
+    }
+
+    public void gotoPrevXEnforcedMenuItemActionPerformed() {
+        Core.getEditor().prevXEnforcedEntry();
+    }
+
     public void gotoNextNoteMenuItemActionPerformed() {
         Core.getEditor().nextEntryWithNote();
     }

--- a/src/org/omegat/gui/scripting/ConsoleBindings.java
+++ b/src/org/omegat/gui/scripting/ConsoleBindings.java
@@ -99,6 +99,26 @@ public class ConsoleBindings implements IGlossaries, IEditor, IScriptLogger {
     }
 
     @Override
+    public void nextXAutoEntry() {
+
+    }
+
+    @Override
+    public void prevXAutoEntry() {
+
+    }
+
+    @Override
+    public void nextXEnforcedEntry() {
+
+    }
+
+    @Override
+    public void prevXEnforcedEntry() {
+
+    }
+
+    @Override
     public void nextEntryWithNote() {
 
     }

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -365,6 +365,22 @@ public final class TestTeamIntegrationChild {
         public void prevEntry() {
         }
 
+        @Override
+        public void nextXAutoEntry() {
+        }
+
+        @Override
+        public void prevXAutoEntry() {
+        }
+
+        @Override
+        public void nextXEnforcedEntry() {
+        }
+
+        @Override
+        public void prevXEnforcedEntry() {
+        }
+
         public void nextUntranslatedEntry() {
         }
 

--- a/test/src/org/omegat/core/TestCore.java
+++ b/test/src/org/omegat/core/TestCore.java
@@ -394,6 +394,22 @@ public abstract class TestCore {
             }
 
             @Override
+            public void nextXAutoEntry() {
+            }
+
+            @Override
+            public void prevXAutoEntry() {
+            }
+
+            @Override
+            public void nextXEnforcedEntry() {
+            }
+
+            @Override
+            public void prevXEnforcedEntry() {
+            }
+
+            @Override
             public void nextUntranslatedEntry() {
             }
 


### PR DESCRIPTION
Successor of #300

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Plesae paste a ticket title and URL  
-->

- #1641 Navigate between segments inserted from /tm/auto and /tm/enforce
  * https://sourceforge.net/p/omegat/feature-requests/1641/
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- It introduses 4 new Goto menu items (grouped in a submenu): goto next/prev xauto/xenforced.
