### PR TITLE
Clarify link targets and add various missing parts

### DIFF
--- a/doc_src/en/App_ApplicationFolder.xml
+++ b/doc_src/en/App_ApplicationFolder.xml
@@ -3,30 +3,44 @@
 <section id="application.folder">
   <title id="application.folder.title">Application Folder</title>
 
-  <para>The application folder contains the <filename>OmegaT.jar</filename> application and a number of other important files.</para>
-  <note><para>The application folder location depends on your platform and on the way you have installed OmegaT. The recommended or default locations are the following:
+  <para>The application folder contains the <filename>OmegaT.jar</filename>
+  application and a number of other important files.</para>
 
-  <variablelist>
-	<varlistentry>
-	  <term>Windows</term>
-	  <listitem><para><filename>C:\Program Files\OmegaT\</filename></para></listitem>
-	</varlistentry>
-	
-	<varlistentry>
-	  <term>Linux</term>
-	  <listitem><para><filename>/opt/omegat/</filename></para></listitem>
-	</varlistentry>
-	
-	<varlistentry>
-	  <term>macOS</term>
-	  <listitem><para><filename>/Applications/OmegaT.app/Contents/Java/</filename></para></listitem>
-	</varlistentry>
-	
-	<varlistentry>
-	  <term>other platforms</term>
-	  <listitem><para><filename>/opt/omegat/</filename></para></listitem>
-	</varlistentry>
-  </variablelist></para></note>
+  <note>
+	<para>The application folder location depends on your platform and on the
+	way you have installed OmegaT. The recommended or default locations are the
+	following:</para>
+
+	<variablelist>
+	  <varlistentry>
+		<term>Windows</term>
+		<listitem>
+		  <para><filename>C:\Program Files\OmegaT\</filename></para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry>
+		<term>Linux</term>
+		<listitem>
+		  <para><filename>/opt/omegat/</filename></para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry>
+		<term>macOS</term>
+		<listitem>
+		  <para><filename>/Applications/OmegaT.app/Contents/Java/</filename></para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry>
+		<term>other platforms</term>
+		<listitem>
+		  <para><filename>/opt/omegat/</filename></para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </note>
   
   <variablelist>
 	<varlistentry id="application.folder.omegat.license">
@@ -39,14 +53,17 @@
 	<varlistentry id="application.folder.omegat.jar">
 	  <term id="application.folder.omegat.jar.title">OmegaT.jar</term>
 	  <listitem>
-		<para>OmegaT's executable. Used when launching OmegaT from the command line. See <link linkend="launch.with.command.line" endterm="launch.with.command.line.title"/> for details.</para>
+		<para>OmegaT's executable. Used when launching OmegaT from the command
+		line. See the <link linkend="launch.with.command.line"
+		endterm="launch.with.command.line.title"/> chapter for details.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.changes">
 	  <term id="application.folder.changes.title">changes.txt</term>
 	  <listitem>
-		<para>The list of improvements and bug fixes. Check it if you need information on OmegaT's evolution.</para>
+		<para>The list of improvements and bug fixes. Check it if you need
+		information on OmegaT's evolution.</para>
 	  </listitem>
 	</varlistentry>
 
@@ -60,7 +77,7 @@
 	<varlistentry id="application.folder.index.html">
 	  <term id="application.folder.index.html.title">index.html</term>
 	  <listitem>
-		<para>The index to the multilingual user guide.</para>
+		<para>The index to the multilingual user manual.</para>
 	  </listitem>
 	</varlistentry>
 
@@ -83,41 +100,40 @@
 	  <term id="application.folder.docs.title">docs/</term>
 	  <listitem>
 		<para>The documentation folder.
-		  <variablelist>
 
-			<varlistentry id="application.folder.docs.contributors">
-			  <term id="application.folder.docs.contributors.title">contributors.txt</term>
-			  <listitem>
-				<para>The list of individual contributors.</para>
-			  </listitem>
-			</varlistentry>
+		<variablelist>
+		  <varlistentry id="application.folder.docs.contributors">
+			<term id="application.folder.docs.contributors.title">contributors.txt</term>
+			<listitem>
+			  <para>The list of individual contributors.</para>
+			</listitem>
+		  </varlistentry>
 
-			<varlistentry id="application.folder.docs.en">
-			  <term id="application.folder.docs.en.title">en/</term>
-			  <listitem>
-				<para>Each translated user guide comes in a different language
-				folder.</para>
-			  </listitem>
-			</varlistentry>
+		  <varlistentry id="application.folder.docs.en">
+			<term id="application.folder.docs.en.title">en/</term>
+			<listitem>
+			  <para>Each translated user manual comes in a different language
+			  folder.</para>
+			</listitem>
+		  </varlistentry>
 
-			<varlistentry id="application.folder.docs.index.html">
-			  <term id="application.folder.docs.index.html.title">index.html</term>
-			  <listitem>
-				<para>The index to the multilingual user guide.</para>
-			  </listitem>
-			</varlistentry>
+		  <varlistentry id="application.folder.docs.index.html">
+			<term id="application.folder.docs.index.html.title">index.html</term>
+			<listitem>
+			  <para>The index to the multilingual user manual.</para>
+			</listitem>
+		  </varlistentry>
 
-			<varlistentry id="application.folder.docs.librairies.txt">
-			  <term id="application.folder.docs.librairies.txt.title">libraries.txt</term>
-			  <listitem>
-				<para>The list of libraries used by OmegaT.</para>
-			  </listitem>
-			</varlistentry>
-		  </variablelist>
+		  <varlistentry id="application.folder.docs.librairies.txt">
+			<term id="application.folder.docs.librairies.txt.title">libraries.txt</term>
+			<listitem>
+			  <para>The list of libraries used by OmegaT.</para>
+			</listitem>
+		  </varlistentry>
+		</variablelist>
 		</para>
 	  </listitem>
 	</varlistentry>
-
 
 	<varlistentry id="application.folder.images">
 	  <term id="application.folder.images.title">images/</term>
@@ -136,14 +152,19 @@
 	<varlistentry id="application.folder.plugins">
 	  <term id="application.folder.plugins.title">plugins/</term>
 	  <listitem>
-		<para>The folder where you can install external plugins. See <link linkend="dialogs.preferences.plugins" endterm="dialogs.preferences.plugins.title"/> for details.</para>
+		<para>The folder where you can install external plugins. See the <link
+		linkend="dialogs.preferences.plugins"
+		endterm="dialogs.preferences.plugins.title"/> preferences for
+		details.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.scripts">
 	  <term id="application.folder.scripts.title">scripts/</term>
 	  <listitem>
-		<para>The folder where distributed scripts are located. See <link linkend="windows.scripts" endterm="windows.scripts.title"/> for details.</para>
+		<para>The folder where distributed scripts are located. See the <link
+		linkend="windows.scripts" endterm="windows.scripts.title"/> window for
+		details.</para>
 	  </listitem>
 	</varlistentry>
   </variablelist>

--- a/doc_src/en/App_ConfigurationFolder.xml
+++ b/doc_src/en/App_ConfigurationFolder.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="configuration.folder">
   <title id="configuration.folder.title">Configuration Folder</title>
-  <para>The configuration folder stores the majority of the OmegaT options
-  and preferences for the user.</para>
-  	<para>You can always access it directly from <link linkend="menus.options.access.configuration.folder" endterm="menus.options.access.configuration.folder.title"/> in the <link linkend="menus.options" endterm="menus.options.title"/> menu.</para>
+  <para>The configuration folder stores the majority of the OmegaT options and
+  preferences for the user.</para>
+  
+  <para>Use <link linkend="menus.options" endterm="menus.options.title"/><link
+  linkend="menus.options.access.configuration.folder"
+  endterm="menus.options.access.configuration.folder.title"/> to access it
+  directly.</para>
 
   <section id="configuration.folder.location">
     <title id="configuration.folder.location.title">Location</title>	
@@ -12,9 +17,21 @@
 	  <varlistentry><term>Linux</term><listitem><para><filename>~/.omegat</filename></para></listitem></varlistentry>
 	  <varlistentry><term>macOS</term><listitem><para><filename>~/Library/Preferences/OmegaT</filename></para></listitem></varlistentry>
 	  <varlistentry><term>Windows</term><listitem><para><filename>~\AppData\Roaming\OmegaT</filename></para></listitem></varlistentry>
-	</variablelist>
-	</para>
-	<para>You can also use non default configuration folders by starting OmegaT from the command line. See <link linkend="launch.with.command.line" endterm="launch.with.command.line.title"/> for details.</para>
+	</variablelist></para>
+
+	<note>
+	  <para>You can specify a configuration folder other than the default when
+	  you start OmegaT from the command line. See the <link
+	  endterm="launch.with.command.line.title"
+	  linkend="launch.with.command.line"/> how-to for details.</para>
+
+	  <para>Modified preferences are stored in the configuration folder used by
+	  the project. If you do not use the default configuration folder, all
+	  modifications made in the <link
+	  linkend="chapter.dialogs.preferences">preferences</link> will be stored in
+	  the specified configuration folder and will not appear when you resume
+	  work with the default configuration folder.</para>
+	</note>
   </section>
   
   <section id="configuration.folder.default.contents">
@@ -22,117 +39,204 @@
 	<variablelist>
 	  <varlistentry id="configuration.folder.default.contents.omegat.prefs">
 		<term id="configuration.folder.default.contents.omegat.prefs.title">omegat.prefs</term>
-		<listitem><para>This file includes a number of important user
-		preferences.</para>
-		<para>Some preferences do not have an equivalent in the user interface. They must be modified manually.
-		<example id="no.source.file.display">
-		  <title id="no.source.file.display.title">Do not automatically display the Source Files list</title>
-		  <para>To prevent the Source Files list window from automatically opening when a project is loaded,  find <token>&lt;project_files_show_on_load></token> and replace <token>true</token> to <token>false</token>:</para>
-		  <para><programlisting>&lt;project_files_show_on_load><token>false</token>&lt;/project_files_show_on_load></programlisting>
-		  </para>
-		</example></para>
-	  <note><para>Only this preference currently requires manual modification.</para></note> </listitem></varlistentry>
+		<listitem>
+		  <para>This file includes a number of important user
+		  preferences.</para>
+
+		  <para>Some preferences do not have an equivalent in the user
+		  interface. They must be modified manually.</para>
+		  
+		  <example id="no.source.file.display">
+			<title id="no.source.file.display.title">Do not automatically
+			display the Source Files list</title>
+			<para>To prevent the Source Files list window from automatically
+			opening when a project is loaded, find
+			<token>&lt;project_files_show_on_load></token> and replace
+			<token>true</token> to <token>false</token>:</para>
+
+			<para><programlisting>&lt;project_files_show_on_load><token>false</token>&lt;/project_files_show_on_load></programlisting></para>
+		  </example>
+		  
+		  <note>
+			<para>Only this preference currently requires manual
+			modification.</para>
+		  </note>
+		</listitem>
+	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.uilayout">
 		<term id="configuration.folder.default.contents.uilayout.title">uiLayout.xml</term>
-		<listitem><para>This file describes the overall OmegaT layout.</para>
-	</listitem>
+		<listitem>
+		  <para>This file describes the overall OmegaT layout.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.logs">
 		<term id="configuration.folder.default.contents.logs.title">logs/</term>
-		<listitem><para>This folder contains a number of log files. The most current is <filename>OmegaT.log</filename>.</para>
-		<para>These files record various internal state and program event messages generated while OmegaT is running. If OmegaT behaves erratically, include this file, or the relevant part thereof, to your report.</para>
-		<para>The contents of the file can also be viewed using the <link linkend="menus.help.log" endterm="menus.help.log.title"/> option in the <link linkend="menus.help" endterm="menus.help.title"/> menu.</para>
+		<listitem>
+		  <para>This folder contains a number of log files. The most current is
+		  <filename>OmegaT.log</filename>.</para>
+
+		  <para>These files record various internal state and program event
+		  messages generated while OmegaT is running. If OmegaT behaves
+		  erratically, include this file, or the relevant part thereof, to your
+		  report.</para>
+
+		  <para>Use <link linkend="menus.help" endterm="menus.help.title"/><link
+		  linkend="menus.help.log" endterm="menus.help.log.title"/> to view the
+		  contents of the file.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.default.contents.script">
 		<term id="configuration.folder.default.contents.script.title">script/</term>
-		<listitem><para>If the applicable functions are used, this folder can contain up to three text files:<variablelist>
-		  <varlistentry id="configuration.folder.default.contents.script.selection">
-			<term id="configuration.folder.default.contents.script.selection.title">selection.txt</term>
-			<listitem><para>This file stores the currently selected text when the <link linkend="menus.edit.export.selection" endterm="menus.edit.export.selection.title"/> command in the <link linkend="menus.edit" endterm="menus.edit.title"/> menu is used. The text in the file is replaced each time this function is called.</para></listitem>
-		  </varlistentry>
+		<listitem>
+		  <para>If the applicable functions are used, this folder can contain up
+		  to three text files:</para>
+
+		  <variablelist>
+			<varlistentry id="configuration.folder.default.contents.script.selection">
+			  <term id="configuration.folder.default.contents.script.selection.title">selection.txt</term>
+			  <listitem>
+				<para>This file stores the currently selected text when <link
+				linkend="menus.edit" endterm="menus.edit.title"/><link
+				linkend="menus.edit.export.selection"
+				endterm="menus.edit.export.selection.title"/> is used. The text
+				in the file is replaced each time this function is
+				called.</para>
+			  </listitem>
+			</varlistentry>
 		  
-		  <varlistentry id="configuration.folder.default.contents.script.source">
-			<term id="configuration.folder.default.contents.script.source.title">source.txt</term>
-			<listitem><para>This file contains the <emphasis>original text</emphasis> from of the current segment when <link linkend="dialogs.preferences.editor.export.the.segment.to.text.files" endterm="dialogs.preferences.editor.export.the.segment.to.text.files.title"/> is active. The text in the file is replaced each time a new segment is entered.</para></listitem>
-		  </varlistentry>
-		  <varlistentry id="configuration.folder.default.contents.script.target">
-			<term id="configuration.folder.default.contents.script.target.title">target.txt</term>
-			<listitem><para>This file contains the <emphasis>translated text</emphasis>  from the current segment when <link linkend="dialogs.preferences.editor.export.the.segment.to.text.files" endterm="dialogs.preferences.editor.export.the.segment.to.text.files.title"/> is active. The text in the file is replaced each time a new segment is entered.</para>
-			</listitem>
-		  </varlistentry>
-	  </variablelist>Those three files provide as a simple way to access some OmegaT content and process it with local programs such as shell scripts.</para></listitem></varlistentry>
+			<varlistentry id="configuration.folder.default.contents.script.source">
+			  <term id="configuration.folder.default.contents.script.source.title">source.txt</term>
+			  <listitem>
+				<para>This file contains the <emphasis>original text</emphasis>
+				from of the current segment when the <link
+				linkend="dialogs.preferences.editor.export.the.segment.to.text.files"
+				endterm="dialogs.preferences.editor.export.the.segment.to.text.files.title"/>
+				preference is enabled. The text in the file is replaced each
+				time a new segment is entered.</para>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry id="configuration.folder.default.contents.script.target">
+			  <term id="configuration.folder.default.contents.script.target.title">target.txt</term>
+			  <listitem>
+				<para>This file contains the <emphasis>translated
+				text</emphasis> from the current segment when the <link
+				linkend="dialogs.preferences.editor.export.the.segment.to.text.files"
+				endterm="dialogs.preferences.editor.export.the.segment.to.text.files.title"/>
+				preference is enabled. The text in the file is replaced each
+				time a new segment is entered.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+
+		  <para>Those three files provide as a simple way to access some OmegaT
+		  content and process it with local programs such as shell
+		  scripts.</para>
+		</listitem>
+	  </varlistentry>
 	</variablelist>
   </section>
   
-    <section id="configuration.folder.extra.contents">
+  <section id="configuration.folder.extra.contents">
     <title id="configuration.folder.extra.contents.title">Additional contents</title>
 
 	<variablelist>
-	<varlistentry id="configuration.folder.extra.contents.editorshortcuts">
-	  <term id="configuration.folder.extra.contents.editorshortcuts.title">EditorShortcuts.properties</term>
-	  <listitem><para>This parameter file  contains customized editor shortcuts. See <link linkend="app.shortcuts.customization" endterm="app.shortcuts.customization.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.editorshortcuts">
+		<term id="configuration.folder.extra.contents.editorshortcuts.title">EditorShortcuts.properties</term>
+		<listitem>
+		  <para>This parameter file contains customized editor shortcuts. See
+		  the <link linkend="app.shortcuts.customization"
+		  endterm="app.shortcuts.customization.title"/> appendix for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
 	
-	<varlistentry id="configuration.folder.extra.contents.maninmenushortcut">
-	  <term id="configuration.folder.extra.contents.maninmenushortcut.title">MainMenuShortcuts.properties</term>
-	  <listitem><para>This parameter file  contains customized user interface shortcuts. See <link linkend="app.shortcuts.customization" endterm="app.shortcuts.customization.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.maninmenushortcut">
+		<term id="configuration.folder.extra.contents.maninmenushortcut.title">MainMenuShortcuts.properties</term>
+		<listitem>
+		  <para>This parameter file contains customized user interface
+		  shortcuts. See the <link linkend="app.shortcuts.customization"
+		  endterm="app.shortcuts.customization.title"/> appendix for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
 	
-	<varlistentry id="configuration.folder.extra.contents.filters">
-	  <term id="configuration.folder.extra.contents.filters.title">filters.xml</term>
-	  <listitem><para>This parameter file contains customized file filters. See <link linkend="dialogs.preferences.file.filters" endterm="dialogs.preferences.file.filters.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.filters">
+		<term id="configuration.folder.extra.contents.filters.title">filters.xml</term>
+		<listitem>
+		  <para>This parameter file contains customized file filters. See the
+		  <link linkend="dialogs.preferences.file.filters"
+		  endterm="dialogs.preferences.file.filters.title"/> preferences for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="configuration.folder.extra.contents.finder">
-	  <term id="configuration.folder.extra.contents.finder.title">finder.xml</term>
-	  <listitem><para>This parameter file contains customized external search parameters. See <link linkend="dialogs.preferences.external.searches" endterm="dialogs.preferences.external.searches.title"/> for details.</para>
-	  </listitem>
+	  <varlistentry id="configuration.folder.extra.contents.finder">
+		<term id="configuration.folder.extra.contents.finder.title">finder.xml</term>
+		<listitem>
+		  <para>This parameter file contains customized external search
+		  parameters. See the <link
+		  linkend="dialogs.preferences.external.searches"
+		  endterm="dialogs.preferences.external.searches.title"/> preferences
+		  for details.</para>
+		</listitem>
 	</varlistentry>
 	
 	<varlistentry id="configuration.folder.extra.contents.omegat.autotext">
 	  <term id="configuration.folder.extra.contents.omegat.autotext.title">omegat.autotext</term>
-	  <listitem><para>This parameter file contains customized autotext parameters. See <link linkend="dialog.preferences.auto.completion" endterm="dialog.preferences.auto.completion.title"/> for details.</para>
+	  <listitem>
+		<para>This parameter file contains customized autotext parameters. See
+		the <link linkend="dialog.preferences.auto.completion"
+		endterm="dialog.preferences.auto.completion.title"/> preferences for
+		details.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="configuration.folder.extra.contents.repositories">
 	  <term id="configuration.folder.extra.contents.repositories.title">repositories.properties</term>
-	  <listitem><para>This file contains the login information for your team project repositories.<warning><para>The file contents are not encrypted.</para></warning>See <link linkend="how.to.setup.team.project" endterm="how.to.setup.team.project.title"/> for details.</para>
+	  <listitem>
+		<para>This file contains the login information for your team project
+		repositories.<warning><para>The file contents are not
+		encrypted.</para></warning>See the <link
+		linkend="how.to.setup.team.project"
+		endterm="how.to.setup.team.project.title"/> how-to for details.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="configuration.folder.extra.contents.segmentation">
 	  <term id="configuration.folder.extra.contents.segmentation.title">segmentation.conf</term>
-	  <listitem><para>This parameter file contains customized segmentation parameters. See <link linkend="dialogs.preferences.segmentation.setup" endterm="dialogs.preferences.segmentation.setup.title"/> for details.</para>
+	  <listitem>
+		<para>This parameter file contains customized segmentation
+		parameters. See the <link
+		linkend="dialogs.preferences.segmentation.setup"
+		endterm="dialogs.preferences.segmentation.setup.title"/> preferences for
+		details.</para>
 	  </listitem>
 	</varlistentry>
 	
 	<varlistentry id="configuration.folder.extra.contents.plugin">
 	  <term id="configuration.folder.extra.contents.plugin.title">plugins/</term>
-	  <listitem><para>This folder provides an alternative location for manually installed OmegaT extension plugins. See <link linkend="dialogs.preferences.plugins" endterm="dialogs.preferences.plugins.title"/> for details.</para>
+	  <listitem>
+		<para>This folder provides an alternative location for manually
+		installed OmegaT extension plugins. See the <link
+		linkend="dialogs.preferences.plugins"
+		endterm="dialogs.preferences.plugins.title"/> preference for
+		details.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="configuration.folder.extra.contents.spelling">
 	  <term id="configuration.folder.extra.contents.spelling.title">spelling/</term>
-	  <listitem><para>This folder contains your spelling dictionaries. See <link linkend="dialog.preferences.spellchecker" endterm="dialog.preferences.spellchecker.title"/> for details.</para>
+	  <listitem>
+		<para>This folder contains your spelling dictionaries. See the <link
+		linkend="dialog.preferences.spellchecker"
+		endterm="dialog.preferences.spellchecker.title"/> preferences for
+		details.</para>
 	  </listitem>
 	</varlistentry>
-  </variablelist>
-	</section>
-	
-	<note><para>You can specify a configuration folder other than the default when you
-	start OmegaT from the command line. See <link
-	endterm="launch.with.command.line.title"
-	linkend="launch.with.command.line"/> for details.</para>
-
-	<para>Modified preferences are stored in the configuration folder used by the project. If
-	you do not use the default configuration folder, all modifications made in <link linkend="dialogs.preferences" endterm="dialogs.preferences.title"/> will be stored in the specified configuration folder and will not appear when you resume work with the default configuration folder.</para></note>
+	</variablelist>
+  </section>
 </section>

--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -5,465 +5,482 @@
 <section id="file.filters">
   <title id="file.filters.title">File Filters</title>
 
-  <warning><para>File filters are either local and specific to a given project, or global and available to all the projects that share a configuration folder.</para>
-  <para>See:
-  <itemizedlist>
-	<listitem>
-	  <para><link linkend="dialogs.project.properties.filters" endterm="dialogs.project.properties.filters.title"/></para>
-	</listitem>
-	<listitem>
-	  <para><link linkend="dialogs.preferences.file.filters" endterm="dialogs.preferences.file.filters.title"/></para>
-	</listitem>
-	<listitem>
-	  <para><link linkend="configuration.folder" endterm="configuration.folder.title"/></para>
-	</listitem>
-  </itemizedlist>
-  for details.</para></warning>
+  <warning>
+	<para>File filters are either local and specific to a given project, or
+	global and available to all the projects that share a configuration
+	folder.</para>
+
+	<para>For details, see:</para>
+	<itemizedlist>
+	  <listitem>
+		<para><link linkend="dialogs.project.properties.filters" endterm="dialogs.project.properties.filters.title"/></para>
+	  </listitem>
+	  <listitem>
+		<para><link linkend="dialogs.preferences.file.filters" endterm="dialogs.preferences.file.filters.title"/></para>
+	  </listitem>
+	  <listitem>
+		<para><link linkend="configuration.folder" endterm="configuration.folder.title"/></para>
+	  </listitem>
+	</itemizedlist>
+  </warning>
   
-  	<para>Filters in bold are used in the current project.</para>
-	<para>Disable a filter by unchecking its box if you prefer not to translate
-	the files that are associated to it. Their contents will not be displayed
-	for translation.</para>
+  <para>Filters in bold are used in the current project.</para>
 
-	<para>To modify the file extensions, target file name 
-	and encodings associated to a filter, select  it in the list and
-	click the <guibutton>Edit...</guibutton> button.</para>
+  <para>Disable a filter by unchecking its box if you prefer not to translate
+  the files that are associated to it. Their contents will not be displayed for
+  translation.</para>
 
-	<para>Some filters provide a <guibutton>Options...</guibutton> button to
-	further customize their settings.</para>
+  <para>To modify the file extensions, target file name and encodings associated
+  to a filter, select it in the list and click the
+  <guibutton>Edit...</guibutton> button.</para>
+
+  <para>Some filters provide a <guibutton>Options...</guibutton> button to
+  further customize their settings.</para>
 	
-	<para>Click the <guibutton>Restore Defaults</guibutton> button to
-	reset the file filters to their default settings.</para>
+  <para>Click the <guibutton>Restore Defaults</guibutton> button to reset the
+  file filters to their default settings.</para>
 
-	<para>Modified global file filter preferences are saved in <link
-	linkend="configuration.folder.extra.contents.filters"
-	endterm="configuration.folder.extra.contents.filters.title"/>, in the
-	configuration folder. See <link linkend="configuration.folder"
-	endterm="configuration.folder.title"/> for details. Deleting that file also
-	resets the filter preferences.</para>
+  <para>Modified global file filter preferences are saved in <link
+  linkend="configuration.folder.extra.contents.filters"
+  endterm="configuration.folder.extra.contents.filters.title"/>, in the
+  configuration folder. See <link linkend="configuration.folder"
+  endterm="configuration.folder.title"/> for details. Deleting that file also
+  resets the filter preferences.</para>
 
-	<para>Modified local file filters are saved in <link
-	linkend="configuration.folder.extra.contents.filters"
-	endterm="configuration.folder.extra.contents.filters.title"/>, in the
-	project folder. See <link linkend="project.folder"
-	endterm="project.folder.title"/> for details. Deleting that file also resets
-	the filter preferences and reverts the project to global file
-	filters.</para>
+  <para>Modified local file filters are saved in the <link
+  linkend="configuration.folder.extra.contents.filters"
+  endterm="configuration.folder.extra.contents.filters.title"/> file, located in
+  the project folder. See the <link linkend="chapter.project.folder"
+  endterm="chapter.project.folder.title"/> chapter for details. Deleting that
+  file also resets the filter preferences and reverts the project to global file
+  filters.</para>
 
-	<section id="file.filters.general">
-	  <title id="file.filters.general.title">Common preferences</title>
+  <section id="file.filters.general">
+	<title id="file.filters.general.title">Common preferences</title>
 	  
-	  <variablelist>
-		<varlistentry>
-		  <term>Remove leading and trailing tags</term>
-		  <listitem>
-			<para>Leading and trailing tags are generally required by OmegaT to
-			properly recreate the translated segment. Removing them from the
-			translatable contents ensures that you will not erase or modify them
-			by mistake.</para>
-			<para>If you keep the leading and trailing tags, make sure that
-			they are leading and trailing as well in the translation.</para>
-		  </listitem>
-		</varlistentry>
-		<varlistentry>
-		  <term>Remove leading and trailing whitespace in non-segmented
-		  projects</term>
-		  <listitem>
-			<para> By default, OmegaT removes any leading and trailing
-			whitespace from the translatable contents. In non-segmented
-			projects, disable this option to make leading and trailing
-			whitespace modifiable in the translation.</para>
-		  </listitem>
-		</varlistentry>
-		<varlistentry>
-		  <term>Preserve spaces for all tags</term>
-		  <listitem>
-			<para>If the source documents contain whitespace used to control the
-			layout, the whitespace that must be will retained in the
-			translated document.</para>
-		  </listitem>
-		</varlistentry>
-		<varlistentry>
-		  <term>Do not use the file name to identify alternate translations</term>
-		  <listitem>
-			<para>The source file name is one of the elements that characterize
-			an alternative translation. If this option is checked, only the
-			previous/next segments or a segment identifier will be used to
-			characterize an alternative translation.</para>
-			<para>Segments with the same characteristics located in other files
-			will be translated the same way.</para>
-		  </listitem>
-		</varlistentry>
-	  </variablelist>
-	</section>
+	<variablelist>
+	  <varlistentry>
+		<term>Remove leading and trailing tags</term>
+		<listitem>
+		  <para>Leading and trailing tags are generally required by OmegaT to
+		  properly recreate the translated segment. Removing them from the
+		  translatable contents ensures that you will not erase or modify them
+		  by mistake.</para>
+
+		  <para>If you keep the leading and trailing tags, make sure that they
+		  are leading and trailing as well in the translation.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Remove leading and trailing whitespace in non-segmented
+		projects</term>
+		<listitem>
+		  <para> By default, OmegaT removes any leading and trailing whitespace
+		  from the translatable contents. In non-segmented projects, disable
+		  this option to make leading and trailing whitespace modifiable in the
+		  translation.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Preserve spaces for all tags</term>
+		<listitem>
+		  <para>If the source documents contain whitespace used to control the
+		  layout, the whitespace that must be will retained in the translated
+		  document.</para>
+		</listitem>
+	  </varlistentry>
+	  <varlistentry>
+		<term>Do not use the file name to identify alternate translations</term>
+		<listitem>
+		  <para>The source file name is one of the elements that characterize an
+		  alternative translation. If this option is checked, only the
+		  previous/next segments or a segment identifier will be used to
+		  characterize an alternative translation.</para>
+
+		  <para>Segments with the same characteristics located in other files
+		  will be translated the same way.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 	
-	<section id="edit.filter.dialog">
-      <title id="edit.filter.dialog.title">Edit</title>
+  <section id="edit.filter.dialog">
+    <title id="edit.filter.dialog.title">Edit</title>
+	
+    <para>Double-click the editable fields to make simple modifications or click
+    on the <guibutton>Edit...</guibutton> button to access the modification
+    dialog.</para>
 
-      <para>Double-click the editable fields to make simple modifications or
-      click on the <guibutton>Edit...</guibutton> button to access the
-      modification dialog.</para>
+	<para>To add a filter pattern, click on <guibutton>Add...</guibutton> to
+	open a similar dialog.</para>
 
-	  <para>To add a filter pattern, click on <guibutton>Add...</guibutton> to
-	  open a similar dialog.</para>
+	<para>Both dialogs allow you to customize the filename patterns for the
+	source and target files associated to this the filter, and select their
+	respective encoding.</para>
 
-	  <para>Both dialogs allow you to customize the filename patterns for the
-	  source and target files associated to this the filter, and select their
-	  respective encoding.</para>
+	<para>Use the <guilabel>Filename Variables</guilabel> drop-down menu to
+	customize the target file name.</para>
 
-	  <para>Use the <guilabel>Filename Variables</guilabel> drop-down menu to
-	  customize the target file name.</para>
+    <section id="source.filetype.and.filename.pattern">
+	  <title id="source.filetype.and.filename.pattern.title">Source filename
+	  pattern</title>
 
-      <section id="source.filetype.and.filename.pattern">
-		<title id="source.filetype.and.filename.pattern.title">Source filename
-		pattern</title>
+	  <para> To associate a filter to a file, OmegaT checks its file extension
+	  and attempts to match it to a source filename patterns in a filter.</para>
 
-		<para> To associate a filter to a file, OmegaT checks its file  extension and attempts
-		to match it to a source filename patterns in a filter.</para>
+	  <para>For example, the pattern <literal>.xhtml</literal> registered in the
+	  XHTML filter matches any file with the <filename>xhtml</filename>
+	  extension. If such a file is found in the <link
+	  linkend="project.folder.source" endterm="project.folder.source.title"/>
+	  folder, the file will be handled by the XHTML filter.</para>
 
-		<para>For example, the pattern <literal>.xhtml</literal> registered in
-		the XHTML filter matches any file with the <filename>xhtml</filename>
-		extension. If such a file is found in the <link linkend="project.folder.source" endterm="project.folder.source.title"/> folder, the file will be handled by the
-		XHTML filter.</para>
-
-		<para>You can change or add filename patterns to associate different
-		files to a filter.</para>
+	  <para>You can change or add filename patterns to associate different files
+	  to a filter.</para>
 		
-		<warning><para>Associating a file extension to a filter is not
-		sufficient to have the filter properly handle the file. The file
-		structure must also be compatible with the filter: even if you associate
+	  <warning>
+		<para>Associating a file extension to a filter is not sufficient to have
+		the filter properly handle the file. The file structure must also be
+		compatible with the filter: even if you associate
 		<literal>.odt</literal> to the XHMTL filter, the filter will not be able
 		to understand the contents of a LibreOffice Writer
-		file.</para></warning>
-		
-		
-		<para>Source filename patterns use wild card characters : The
-		<literal>*</literal> character matches zero or more characters, while
-		the <literal>?</literal> character matches exactly one character.</para>
-
-		<para>For example, use the pattern
-		<literal>read*</literal> if you want to have
-		the text filter handle readme files (<literal>readme, read.me</literal>,
-		or <literal>readme.txt</literal>).</para>
-      </section>
-
-      <section id="source.and.target.files.encoding">
-		<title id="source.and.target.files.encoding.title">Source and translated
-		file encoding</title>
-
-		<para>Most file formats allow various possible encodings. By default,
-		the encoding of the translated file is the same as that of the source
 		file.</para>
-
-		<para>The source and target encoding fields use drop-down menus listing
-		all supported encodings. Selecting the <guilabel>&lt;auto&gt;</guilabel>
-		option leaves the choice of encoding to OmegaT, based on the following
-		criteria:</para>
-
-		<itemizedlist>
-          <listitem>
-			<para>OmegaT uses the encoding declaration in the source file, if
-			present, to identify the encoding (HTML or XML based files).</para>
-          </listitem>
-		</itemizedlist>
-
-		<itemizedlist>
-          <listitem>
-			<para>OmegaT is instructed to use a mandatory encoding for certain
-			file formats (Java properties, for example).</para>
-          </listitem>
-		</itemizedlist>
-
-		<itemizedlist>
-          <listitem>
-			<para>OmegaT uses the default encoding of the operating system for
-			text files.</para>
-          </listitem>
-		</itemizedlist>
-      </section>
-
-      <section id="target.name">
-		<title id="target.name.title">Translated filename</title>
-
-		<para>Files in the <link linkend="project.folder.target"
-		endterm="project.folder.target.title"/> folder are overwritten every time
-		you create them if they are created with the same name.</para>
-
-		<para>OmegaT can automatically create new file names for the files you
-		create, by adding a language code or a time stamp, for example.</para>
-
-		<para>The target
-		filename pattern uses a special syntax. The easiest way to modify it is to  use the
-		<guilabel>Edit Pattern</guilabel> dialog. The  dialog
-		offers various options:</para>
-
-		<variablelist>
-          <varlistentry>
-        <term>${filename}</term>
-        <listitem><para>The default pattern. It
-			represents the complete filename of the source file, including the
-			extension. Using this pattern assigns the translated file the exact
-			same name as the source file.</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${nameOnly}</term>
-        <listitem><para>name of the source file,
-			without the extension</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${extension} </term>
-        <listitem><para>original file
-			extension</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${targetLocale}</term>
-        <listitem><para>target language+region
-			code (xx_YY)</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${targetLanguage}</term>
-        <listitem><para>target
-			language+region (xx-YY)</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${targetLanguageCode}</term>
-        <listitem><para>
-			target language code (xx)</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${targetCountryCode}</term>
-        <listitem><para> 
-			target region code (YY)</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${timestamp-????}</term>
-        <listitem><para>system time when the file was created</para>
-		<para>See the <ulink url="&javadate;">Oracle documentation</ulink> for
-		examples.</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${system-os-name}</term>
-        <listitem><para>name of
-			the operating system</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${system-user-name}</term>
-        <listitem><para>user’s
-			login name</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${system-host-name}</term>
-        <listitem><para>host name on the
-			system</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${file-source-encoding}</term>
-        <listitem><para>
-          encoding of the source file</para> </listitem>
-		  </varlistentry>
-		  
-          <varlistentry>
-        <term>${file-target-encoding}</term>
-        <listitem><para>encoding of the target file</para>
-          </listitem>
-		</varlistentry>
-
-          <varlistentry>
-        <term>${targetLocaleLCID}</term>
-        <listitem><para>Microsoft target locale</para>
-          </listitem>
-		</varlistentry>
-		</variablelist>
+	  </warning>
 		
-		<para>Additional variants are available for
-		<literal>${nameOnly}</literal> and <literal>${Extension}</literal>.</para>
 		
-		<para>If the file name is ambiguous, variables of the form
-		<literal>${nameonly-</literal><emphasis>extension number</emphasis>}
-		and <literal>${extension-</literal><emphasis>extension number}
-		</emphasis> can be used.</para>
+	  <para>Source filename patterns use wild card characters : The
+	  <literal>*</literal> character matches zero or more characters, while the
+	  <literal>?</literal> character matches exactly one character.</para>
 
-		<example id="target.name.example">
-		  <title id="target.name.example.title">Target file names</title>
-		<para>For a source file named Document.xx.docx, using
-		the variable variants below will produce the following results:</para>
+	  <para>For example, use the pattern <literal>read*</literal> if you want to
+	  have the text filter handle readme files (<literal>readme,
+	  read.me</literal>, or <literal>readme.txt</literal>).</para>
+    </section>
 
-		<itemizedlist>
-          <listitem>
-			<para><literal>${nameOnly-0}</literal>:
-			<filename>Document</filename></para>
-          </listitem>
+    <section id="source.and.target.files.encoding">
+	  <title id="source.and.target.files.encoding.title">Source and translated
+	  file encoding</title>
 
-          <listitem>
-			<para><literal>${nameOnly-1}</literal>:
-			<filename>Document.xx</filename></para>
-          </listitem>
+	  <para>Most file formats allow various possible encodings. By default, the
+	  encoding of the translated file is the same as that of the source
+	  file.</para>
 
-          <listitem>
-			<para><literal>${nameOnly-2}</literal>:
-			<filename>Document.xx.docx</filename></para>
-          </listitem>
+	  <para>The source and target encoding fields use drop-down menus listing
+	  all supported encodings. Selecting the <guilabel>&lt;auto&gt;</guilabel>
+	  option leaves the choice of encoding to OmegaT, based on the following
+	  criteria:</para>
 
-          <listitem>
-			<para><literal>${extension-0}</literal>:
-			<filename>docx</filename></para>
-          </listitem>
+	  <itemizedlist>
+        <listitem>
+		  <para>OmegaT uses the encoding declaration in the source file, if
+		  present, to identify the encoding (HTML or XML based files).</para>
+        </listitem>
+	  </itemizedlist>
 
-          <listitem>
-			<para><literal>${extension-1}</literal>:
-			<filename>xx.docx</filename></para>
-          </listitem>
+	  <itemizedlist>
+        <listitem>
+		  <para>OmegaT is instructed to use a mandatory encoding for certain
+		  file formats (Java properties, for example).</para>
+        </listitem>
+	  </itemizedlist>
 
-          <listitem>
-			<para><literal>${extension-2}</literal>:
-			<filename>Document.xx.docx</filename></para>
-          </listitem>
-		</itemizedlist>
-		</example>
-      </section>
-	</section>
-	
-	<section id="filters.options">
-      <title id="filters.options.title">Options</title>
+	  <itemizedlist>
+        <listitem>
+		  <para>OmegaT uses the default encoding of the operating system for
+		  text files.</para>
+        </listitem>
+	  </itemizedlist>
+    </section>
 
-      <para>Several filters offer options. Select the filter in the list and
-      click <guibutton>Options...</guibutton> to modify them. </para>
+    <section id="target.name">
+	  <title id="target.name.title">Translated filename</title>
+	  
+	  <para>Files in the <link linkend="project.folder.target"
+	  endterm="project.folder.target.title"/> folder are overwritten every time
+	  you create them if they are created with the same name.</para>
 
-	  <para>The available options are:</para>
+	  <para>OmegaT can automatically create new file names for the files you
+	  create, by adding a language code or a time stamp, for example.</para>
+
+	  <para>The target filename pattern uses a special syntax. The easiest way
+	  to modify it is to use the <guilabel>Edit Pattern</guilabel> dialog. The
+	  dialog offers various options:</para>
 
 	  <variablelist>
-		<varlistentry  id="file.filters.xliff">
-		  <term id="file.filters.xliff.title">Monolingual XLIFF</term>
-		  <listitem>
-			<para>
-			  <variablelist>
-				<varlistentry>
-				  <term>Compatibility with OmegaT 2.6</term>
-				  <listitem>
-					<para>Enable this option if you need to work with XLIFF
-					files created with OmegaT 2.6.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry>
-				  <term>Identifier used for alternative
-				  translations</term>
-				  <listitem>
-					<para>User can select from three options,
-					Previous and next paragraphs, &lt;trans unit&gt;
-					ID, or &lt;trans-unit&gt; resname attribute
-					when available, when unavailable, the ID will be
-					used as a fallback.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry>
-				  <term>Tag shortcuts</term>
-				  <listitem>
-					<para>These option specify the way OmegaT creates tags from
-					the XLIFF contents.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry>
-				  <term>Target segment status</term>
-				  <listitem>
-					<para>if checked, OmegaT changes the state of the XLIFF
-					target part to "needs-review-translation" instead of
-					"translated"</para>
-				  </listitem>
-				</varlistentry>
-			  </variablelist>
-			</para>
+        <varlistentry>
+          <term>${filename}</term>
+          <listitem>
+			<para>The default pattern. It represents the complete filename of
+			the source file, including the extension. Using this pattern assigns
+			the translated file the exact same name as the source file.</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${nameOnly}</term>
+          <listitem>
+			<para>name of the source file, without the extension</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${extension} </term>
+          <listitem>
+			<para>original file extension</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${targetLocale}</term>
+          <listitem>
+			<para>target language+region code (xx_YY)</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${targetLanguage}</term>
+          <listitem>
+			<para>target language+region (xx-YY)</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${targetLanguageCode}</term>
+          <listitem>
+			<para>target language code (xx)</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${targetCountryCode}</term>
+          <listitem>
+			<para>target region code (YY)</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${timestamp-????}</term>
+          <listitem>
+			<para>system time when the file was created</para>
+
+			<para>See the <ulink url="&javadate;">Oracle documentation</ulink>
+			for examples.</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${system-os-name}</term>
+          <listitem>
+			<para>name of the operating system</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${system-user-name}</term>
+          <listitem>
+			<para>user’s login name</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${system-host-name}</term>
+          <listitem>
+			<para>host name on the system</para>
+          </listitem>
+		</varlistentry>
+
+        <varlistentry>
+          <term>${file-source-encoding}</term>
+          <listitem>
+			<para>encoding of the source file</para>
 		  </listitem>
 		</varlistentry>
-		
-		<varlistentry id="file.filters.text">
-		  <term id="file.filters.text.title">Text files</term>
-		  <listitem>
-			<para>
-			  <variablelist>
-				<varlistentry>
-				  <term>Create paragraphs on:</term>
-				  <listitem>
-					<para>Text files do not have generic paragraph markers. Choose here the way OmegaT creates paragraphs in your
-					text files.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry>
-				  <term>Line length in target files (0
-				  = no limit)</term>
-				  <listitem>
-					<para>
-					  <variablelist>
-						<varlistentry>
-						  <term>Line length</term>
-						  <listitem>
-							<para>specifies the maximum number of characters before breaking a long line. A value of 0 sets no limits.</para>
-						  </listitem>
-						</varlistentry>
-						<varlistentry>
-						  <term>Maximum line length</term>
-						  <listitem>
-							<para>specifies the maximum number of characters before cutting a line and ignoring the rest. A value of 0 sets no limits.</para>
-						  </listitem>
-						</varlistentry>
-					  </variablelist>
-					</para>
-				  </listitem>
-				</varlistentry>
-			  </variablelist>
-			</para>
-		  </listitem>
+		  
+        <varlistentry>
+          <term>${file-target-encoding}</term>
+          <listitem>
+			<para>encoding of the target file</para>
+          </listitem>
 		</varlistentry>
+
+        <varlistentry>
+          <term>${targetLocaleLCID}</term>
+          <listitem>
+			<para>Microsoft target locale</para>
+          </listitem>
+		</varlistentry>
+	  </variablelist>
 		
-		<varlistentry id="file.filter.microsoft">
-		  <term id="file.filter.microsoft.title">Microsoft Office Open XML files</term>
-		  <listitem>
-			<para>You can choose additional document elements to
-			translate. They will appear as separate segments in the
-			editor.</para>
+	  <para>Additional variants are available for <literal>${nameOnly}</literal>
+	  and <literal>${Extension}</literal>.</para>
+		
+	  <para>If the file name is ambiguous, variables of the form
+	  <literal>${nameonly-</literal><emphasis>extension number</emphasis>} and
+	  <literal>${extension-</literal><emphasis>extension number} </emphasis> can
+	  be used.</para>
+
+	  <example id="target.name.example">
+		<title id="target.name.example.title">Target file names</title>
+		<para>For a source file named Document.xx.docx, using the variable
+		variants below will produce the following results:</para>
+
+		<itemizedlist>
+          <listitem>
+			<para><literal>${nameOnly-0}</literal>: <filename>Document</filename></para>
+          </listitem>
+
+          <listitem>
+			<para><literal>${nameOnly-1}</literal>: <filename>Document.xx</filename></para>
+          </listitem>
+
+          <listitem>
+			<para><literal>${nameOnly-2}</literal>: <filename>Document.xx.docx</filename></para>
+          </listitem>
+
+          <listitem>
+			<para><literal>${extension-0}</literal>: <filename>docx</filename></para>
+          </listitem>
+
+          <listitem>
+			<para><literal>${extension-1}</literal>: <filename>xx.docx</filename></para>
+          </listitem>
+
+          <listitem>
+			<para><literal>${extension-2}</literal>: <filename>Document.xx.docx</filename></para>
+          </listitem>
+		</itemizedlist>
+	  </example>
+    </section>
+  </section>
+	
+  <section id="filters.options">
+    <title id="filters.options.title">Options</title>
+
+    <para>Several filters offer options. Select the filter in the list and click
+    <guibutton>Options...</guibutton> to modify them. </para>
+
+	<para>The available options are:</para>
+
+	<variablelist>
+	  <varlistentry  id="file.filters.xliff">
+		<term id="file.filters.xliff.title">Monolingual XLIFF</term>
+		<listitem>
+		  <para>
 			<variablelist>
 			  <varlistentry>
-				<term>Word</term>
+				<term>Compatibility with OmegaT 2.6</term>
 				<listitem>
-				  <para>Non-visible instruction text, comments, footnotes,
-				  endnotes, footers, duplicate fallback text, and document
-				  properties.</para>
+				  <para>Enable this option if you need to work with XLIFF files
+				  created with OmegaT 2.6.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
-				<term>Excel</term>
+				<term>Identifier used for alternative translations</term>
 				<listitem>
-				  <para>Comments and sheet names.</para>
+				  <para>User can select from three options, Previous and next
+				  paragraphs, &lt;trans unit&gt; ID, or &lt;trans-unit&gt;
+				  resname attribute when available, when unavailable, the ID
+				  will be used as a fallback.</para>
 				</listitem>
 			  </varlistentry>
+			  
+			  <varlistentry>
+				<term>Tag shortcuts</term>
+				<listitem>
+				  <para>These option specify the way OmegaT creates tags from
+				  the XLIFF contents.</para>
+				</listitem>
+			  </varlistentry>
+
+			  <varlistentry>
+				<term>Target segment status</term>
+				<listitem>
+				  <para>if checked, OmegaT changes the state of the XLIFF target
+				  part to "needs-review-translation" instead of
+				  "translated"</para>
+				</listitem>
+			  </varlistentry>
+			</variablelist>
+		  </para>
+		</listitem>
+	  </varlistentry>
+		
+	  <varlistentry id="file.filters.text">
+		<term id="file.filters.text.title">Text files</term>
+		<listitem>
+		  <para>
+			<variablelist>
+			  <varlistentry>
+				<term>Create paragraphs on:</term>
+				<listitem>
+				  <para>Text files do not have generic paragraph markers. Choose
+				  here the way OmegaT creates paragraphs in your text
+				  files.</para>
+				</listitem>
+			  </varlistentry>
+
+			  <varlistentry>
+				<term>Line length in target files (0 = no limit)</term>
+				<listitem>
+				  <para>
+					<variablelist>
+					  <varlistentry>
+						<term>Line length</term>
+						<listitem>
+						  <para>specifies the maximum number of characters
+						  before breaking a long line. A value of 0 sets no
+						  limits.</para>
+						</listitem>
+					  </varlistentry>
+
+					  <varlistentry>
+						<term>Maximum line length</term>
+						<listitem>
+						  <para>specifies the maximum number of characters
+						  before cutting a line and ignoring the rest. A value
+						  of 0 sets no limits.</para>
+						</listitem>
+					  </varlistentry>
+					</variablelist>
+				  </para>
+				</listitem>
+			  </varlistentry>
+			</variablelist>
+		  </para>
+		</listitem>
+	  </varlistentry>
+		
+	  <varlistentry id="file.filter.microsoft">
+		<term id="file.filter.microsoft.title">Microsoft Office Open XML files</term>
+		<listitem>
+		  <para>You can choose additional document elements to translate. They
+		  will appear as separate segments in the editor.</para>
+		  <variablelist>
+			<varlistentry>
+			  <term>Word</term>
+			  <listitem>
+				<para>Non-visible instruction text, comments, footnotes,
+				endnotes, footers, duplicate fallback text, and document
+				properties.</para>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>Excel</term>
+			  <listitem>
+				<para>Comments and sheet names.</para>
+			  </listitem>
+			  </varlistentry>
+
 			  <varlistentry>
 				<term>Power Point</term>
 				<listitem>
-				  <para>Slide comments, slide masters, and slide
-				  layouts.</para>
+				  <para>Slide comments, slide masters, and slide layouts.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
 				<term>Global</term>
 				<listitem>
@@ -471,206 +488,231 @@
 				  WordArt.</para>
 				</listitem>
 			  </varlistentry>
+			  
 			  <varlistentry>
 				<term>Other Options:</term>
-				<listitem><para>
+				<listitem>
 				  <variablelist>
 					<varlistentry>
 					  <term>Aggregate tags</term>
 					  <listitem>
-						<para>Tags that do not enclose
-						translatable text will be aggregated into a single
-						tag.</para>
+						<para>Tags that do not enclose translatable text will be
+						aggregated into a single tag.</para>
 					  </listitem>
 					</varlistentry>
+
 					<varlistentry>
 					  <term>Preserve spaces for all tags</term>
 					  <listitem>
-						<para>Whitespace (i.e., spaces and
-						newlines) will be preserved, even if this option
-						is not defined in the document.</para>
+						<para>Whitespace (i.e., spaces and newlines) will be
+						preserved, even if this option is not defined in the
+						document.</para>
 					  </listitem>
 					</varlistentry>
+
 					<varlistentry>
 					  <term>Start a new paragraph on Word soft-returns</term>
 					  <listitem>
-						<para>Enable this option if soft-returns are intended to be
-						paragraph starters.</para>
+						<para>Enable this option if soft-returns are intended to
+						be paragraph starters.</para>
 					  </listitem>
 					</varlistentry>
 				  </variablelist>
-				</para>
 				</listitem>
 			  </varlistentry>
-			</variablelist>
-		  </listitem>
-		</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
 
-		<varlistentry id="file.filters.xhtml">
-		  <term id="file.filters.xhtml.title">XHTML Files</term>
-		  <listitem><para>
-			<variablelist>
-			  <varlistentry>
-				<term>Translate the following attributes</term>
-				<listitem>
-				  <para>The selected attributes will appear as translatable segments in the
-				  <guilabel>Editor</guilabel> pane.</para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Start a new paragraph on</term>
-				<listitem>
-				  <para>The &lt;br&gt; HTML tag will constitute a paragraph
-				  break for segmentation purposes.</para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Ignored paragraphs at loading (regular expression)</term>
-				<listitem>
-				  <para>At loading, any paragraph
-				  matching the regular expression will be ignored and
-				  will not be displayed for translation.</para>
-				  <para>This option is convenient when dealing with HTML
-				  parts that only contain non translatable text.</para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Ignored &lt;meta&gt; tags "content" attribute</term>
-				<listitem>
-				  <para>Define the &lt;meta&gt; tag attribute values for which
-				  the associated "content" attribute will not be
-				  translated.</para>
-				  <para>Do not add quotation marks and separate the
-				  values with a comma.
-				  <example id="file.filters.xhtml.example">
-					<title id="file.filters.xhtml.example.title">Ignore the content part of &lt;meta name="robots"
-					content="index, follow"&gt;</title>
-					<para>To ignore this content:</para>
-					<para><code>&lt;meta name="robots" content="index,
-					follow"&gt;</code></para>
-					<para>use:</para>
-					<para><literal>name=robots</literal></para>					
-				  </example>
-				  </para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Ignored tags (attribute=value)</term>
-				<listitem>
-				  <para>Define the attribute values that make a tag
-				  non-translatable.</para>
-				  <para>Do not add quotation marks and separate the
-				  values with a comma.
-				  <example id="file.filters.xhtml.ignore.translate.no">
-					<title id="file.filters.xhtml.ignore.translate.no.title">Ignore tags that contain translate=&quot;no&quot;</title>
-					<para>To ignore this content:</para>
-					<para><code>&lt;span translate=&quot;no&quot;&gt;This
-					content is not translatable&lt;/span&gt;</code></para>
-					<para>use: <literal>translate=no</literal>.</para>
-					<para>All the tags that are marked with
-					<code>translate=&quot;no&quot;</code> will be ignored.</para>
-				  </example>
-				  </para>
-				</listitem>
-			  </varlistentry>
-			</variablelist>
-		  </para>
-		  </listitem>
-		</varlistentry>
+	  <varlistentry id="file.filters.xhtml">
+		<term id="file.filters.xhtml.title">XHTML Files</term>
+		<listitem>
+		  <variablelist>
+			<varlistentry>
+			  <term>Translate the following attributes</term>
+			  <listitem>
+				<para>The selected attributes will appear as translatable
+				segments in the <guilabel>Editor</guilabel> pane.</para>
+			  </listitem>
+			</varlistentry>
+			<varlistentry>
+			  <term>Start a new paragraph on</term>
+			  <listitem>
+				<para>The &lt;br&gt; HTML tag will constitute a paragraph break
+				for segmentation purposes.</para>
+			  </listitem>
+			</varlistentry>
+			<varlistentry>
+			  <term>Ignored paragraphs at loading (regular expression)</term>
+			  <listitem>
+				  <para>At loading, any paragraph matching the regular
+				  expression will be ignored and will not be displayed for
+				  translation.</para>
 
-		<varlistentry>
-		  <term>HTML and XHTML files</term>
-		  <listitem>
-			<para>Only the options not available under the XHTML files filter
-			(see above) are described here.</para>
-			<variablelist>
-			  <varlistentry>
-				<term>Modify encoding declaration</term>
-				<listitem>
-				  <para>The encoding of an HTML document is generally declared
-				  within a &lt;meta&gt; element situated in the &lt;head&gt;
-				  element.</para>
-				  <para>Source and target files
-				  sometimes require a different encoding.</para>
-				  <para>Here, you can decide whether to add or modify the
-				  declaration of the target file
-				  <itemizedlist>
-					<listitem>
-					  <para>always, based on the file filter settings,</para>
-					</listitem>
-					<listitem>
-					  <para>only  if the file already has a &lt;head&gt; tag,</para>
-					</listitem>
-					<listitem>
-					  <para>only if the file already has a declaration,</para>
-					</listitem>
-					<listitem>
-					  <para>or never and only save the target file in the
-					  encoding specified in the file filter settings.</para>
-					</listitem>
-				  </itemizedlist>
-				  </para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Compress whitespace in translated file</term>
-				<listitem>
-				  <para>Whitespace outside the tags is considered non
-				  significant in HTML/XHTML.</para>
-				  <para>This option converts such multiple continuous whitespace
-				  characters into a single space in the translated
-				  document.</para>
-				</listitem>
-			  </varlistentry>
-			  <varlistentry>
-				<term>Remove HTML comments in translated file</term>
-				<listitem>
-				  <para>Comments within an HTML file are generally addressed to
-				  developers.</para>
-				  <para>Text in HTML comments (between <literal>&lt;!--</literal>
-				  and <literal>--&gt;</literal>) will not be copied into the
-				  translated document.</para>
-				</listitem>
-			  </varlistentry>
-			</variablelist>
-		  </listitem>
-		</varlistentry>
+				  <para>This option is convenient when dealing with HTML parts
+				  that only contain non translatable text.</para>
+			  </listitem>
+			</varlistentry>
+			<varlistentry>
+			  <term>Ignored &lt;meta&gt; tags "content" attribute</term>
+			  <listitem>
+				<para>Define the &lt;meta&gt; tag attribute values for which the
+				associated "content" attribute will not be translated.</para>
 
+				<para>Do not add quotation marks and separate the values with a
+				comma.</para>
+				
+				<example id="file.filters.xhtml.example">
+				  <title id="file.filters.xhtml.example.title">Ignore the
+				  content part of &lt;meta name="robots" content="index,
+				  follow"&gt;</title>
+				  <para>To ignore this content:</para>
 
-		<varlistentry id="file.filters.mozilla.ftl">
-		  <term id="file.filters.mozilla.ftl.title">Mozilla FTL</term>
-		  <listitem><para>
-			<variablelist>
-			  <varlistentry>
-				<term>Remove untranslated strings in the target
-				files</term>
-				<listitem>
+				  <para><code>&lt;meta name="robots" content="index,
+				  follow"&gt;</code></para>
+
+				  <para>use:</para>
+
+				  <para><literal>name=robots</literal></para>					
+				</example>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>Ignored tags (attribute=value)</term>
+			  <listitem>
+				<para>Define the attribute values that make a tag
+				non-translatable.</para>
+
+				<para>Do not add quotation marks and separate the values with a
+				comma.</para>
+
+				<example id="file.filters.xhtml.ignore.translate.no">
+				  <title
+				  id="file.filters.xhtml.ignore.translate.no.title">Ignore tags
+				  that contain translate=&quot;no&quot;</title>
+				  <para>To ignore this content:</para>
+
+				  <para><code>&lt;span translate=&quot;no&quot;&gt;This content
+				  is not translatable&lt;/span&gt;</code></para>
+
+				  <para>use: <literal>translate=no</literal>.</para>
+
+				  <para>All the tags that are marked with
+				  <code>translate=&quot;no&quot;</code> will be ignored.</para>
+				</example>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>HTML and XHTML files</term>
+		<listitem>
+		  <para>Only the options not available under the XHTML files filter (see
+		  above) are described here.</para>
+
+		  <variablelist>
+			<varlistentry>
+			  <term>Modify encoding declaration</term>
+			  <listitem>
+				<para>The encoding of an HTML document is generally declared
+				within a &lt;meta&gt; element situated in the &lt;head&gt;
+				element.</para>
+
+				<para>Source and target files sometimes require a different
+				encoding.</para>
+
+				<para>Here, you can decide whether to add or modify the
+				declaration of the target file</para>
+				
+				<itemizedlist>
+				  <listitem>
+					<para>always, based on the file filter settings,</para>
+				  </listitem>
+
+				  <listitem>
+					<para>only  if the file already has a &lt;head&gt; tag,</para>
+				  </listitem>
+
+				  <listitem>
+					<para>only if the file already has a declaration,</para>
+				  </listitem>
+
+				  <listitem>
+					<para>or never and only save the target file in the encoding
+					specified in the file filter settings.</para>
+				  </listitem>
+				</itemizedlist>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>Compress whitespace in translated file</term>
+			  <listitem>
+				<para>Whitespace outside the tags is considered non significant
+				in HTML/XHTML.</para>
+
+				<para>This option converts such multiple continuous whitespace
+				characters into a single space in the translated
+				document.</para>
+			  </listitem>
+			</varlistentry>
+			<varlistentry>
+			  <term>Remove HTML comments in translated file</term>
+			  <listitem>
+				<para>Comments within an HTML file are generally addressed to
+				developers.</para>
+
+				<para>Text in HTML comments (between <literal>&lt;!--</literal>
+				and <literal>--&gt;</literal>) will not be copied into the
+				translated document.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="file.filters.mozilla.ftl">
+		<term id="file.filters.mozilla.ftl.title">Mozilla FTL</term>
+		<listitem>
+		  <variablelist>
+			<varlistentry>
+			  <term>Remove untranslated strings in the target files</term>
+			  <listitem>
+				<para>Having untranslated contents in the translated files
+				sometimes create compatibility issues.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="file.filters.mozilla.dtd">
+		<term id="file.filters.mozilla.dtd.title">Mozilla DTD</term>
+		<listitem>
+		  <variablelist>
+			<varlistentry>
+			  <term>Remove untranslated strings in the target files</term>
+			  <listitem>
 				  <para>Having untranslated contents in the translated files
 				  sometimes create compatibility issues.</para>
-				</listitem>
-			  </varlistentry>
-		  </variablelist></para></listitem>
-		</varlistentry>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
 
-		<varlistentry id="file.filters.mozilla.dtd">
-		  <term id="file.filters.mozilla.dtd.title">Mozilla DTD</term>
-		  <listitem><para>
-			<variablelist>
-			  <varlistentry>
-				<term>Remove untranslated strings in the target
-				files</term>
-				<listitem>
-				  <para>Having untranslated contents in the translated files
-				  sometimes create compatibility issues.</para>
-				</listitem>
-			  </varlistentry>
-		  </variablelist></para></listitem>
-		</varlistentry>
+	  <varlistentry id="file.filters.po">
+		<term id="file.filters.po.title">PO files</term>
+		<listitem>
+			<para>The filter checks printf variables ('%s', etc.) by
+			default. See the <link
+			linkend="dialogs.preferences.tag.processing.programming.variables"
+			endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
+			preference for details.</para>
 
-		<varlistentry id="file.filters.po">
-		  <term id="file.filters.po.title">PO files</term>
-		  <listitem>
-			<para>The filter checks printf variables ('%s', etc.) by default. See <link linkend="dialogs.preferences.tag.processing.programming.variables" endterm="dialogs.preferences.tag.processing.programming.variables.title"/> for details.</para>
 			<variablelist>
 			  <varlistentry>
 				<term>Allow blank target segments</term>
@@ -680,6 +722,7 @@
 				  translated segment blank.</para>
 				</listitem>
 			  </varlistentry>
+			  
 			  <varlistentry>
 				<term>Translate blank source segments</term>
 				<listitem>
@@ -689,12 +732,14 @@
 				  translation based on the associated comments.</para>
 				</listitem>
 			  </varlistentry>
+			  
 			  <varlistentry>
 				<term>Ignore PO header</term>
 				<listitem>
 				  <para>The PO header will not be displayed for translation.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
 				<term>Auto replace plural specification</term>
 				<listitem>
@@ -702,55 +747,61 @@
 				  the target language default.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
 				<term>Format:</term>
 				<listitem>
-				  <para>
-					<variablelist>
-					  <varlistentry>
-						<term>Standard</term>
-						<listitem>
-						  <para>PO files that use <literal>msgid</literal> as
-						  the source container and expect the translation to be
-						  put in <literal>msgstr</literal></para>
-						</listitem>
-					  </varlistentry>
-					  <varlistentry>
-						<term>Monolingual</term>
-						<listitem>
-						  <para>PO files that use <literal>msgid</literal> as an
-						  ID code, use <literal>msgstr</literal> as the source
-						  container and expect the translation to overwrite
-						  <literal>msgstr</literal></para>
-						</listitem>
-					  </varlistentry>
-					</variablelist>
-				  </para>
+				  <variablelist>
+					<varlistentry>
+					  <term>Standard</term>
+					  <listitem>
+						<para>PO files that use <literal>msgid</literal> as the
+						source container and expect the translation to be put in
+						<literal>msgstr</literal></para>
+					  </listitem>
+					</varlistentry>
+					
+					<varlistentry>
+					  <term>Monolingual</term>
+					  <listitem>
+						<para>PO files that use <literal>msgid</literal> as an
+						ID code, use <literal>msgstr</literal> as the source
+						container and expect the translation to overwrite
+						<literal>msgstr</literal></para>
+					  </listitem>
+					</varlistentry>
+				  </variablelist>
 				</listitem>
 			  </varlistentry>
 			</variablelist>
 		  </listitem>
-		</varlistentry>
+	  </varlistentry>
 
-		<varlistentry id="file.filters.moodle.php">
-		  <term id="file.filters.moodle.php.title">Moodle PHP</term>
-		  <listitem><para>
-			<variablelist>
-			  <varlistentry>
-				<term>Remove untranslated strings in the target
-				files</term>
-				<listitem>
-				  <para>Having untranslated contents in the translated files
-				  sometimes create compatibility issues.</para>
-				</listitem>
-			  </varlistentry>
-		  </variablelist></para></listitem>
-		</varlistentry>
+	  <varlistentry id="file.filters.moodle.php">
+		<term id="file.filters.moodle.php.title">Moodle PHP</term>
+		<listitem>
+		  <variablelist>
+			<varlistentry>
+			  <term>Remove untranslated strings in the target
+			  files</term>
+			  <listitem>
+				<para>Having untranslated contents in the translated files
+				sometimes create compatibility issues.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
 
-		<varlistentry id="file.filter.java.bundle">
-		  <term id="file.filter.java.bundle.title">Java Resource bundle</term>
-		  <listitem>
-			<para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by default. See <link linkend="dialogs.preferences.tag.processing.programming.variables" endterm="dialogs.preferences.tag.processing.programming.variables.title"/> for details.</para>
+	  <varlistentry id="file.filter.java.bundle">
+		<term id="file.filter.java.bundle.title">Java Resource bundle</term>
+		<listitem>
+			<para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by
+			default. See the <link
+			linkend="dialogs.preferences.tag.processing.programming.variables"
+			endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
+			preference for details.</para>
+
 			<variablelist>
 			  <varlistentry>
 				<term>Force Unicode literals compatibility with Java 8</term>
@@ -761,6 +812,7 @@
 				  compatibility.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
 				<term>Remove untranslated strings in the target files</term>
 				<listitem>
@@ -768,6 +820,7 @@
 				  sometimes create compatibility issues.</para>
 				</listitem>
 			  </varlistentry>
+
 			  <varlistentry>
 				<term>Keep Unicode literals (\\uXXXX)</term>
 				<listitem>
@@ -776,29 +829,24 @@
 				</listitem>
 			  </varlistentry>
 			</variablelist>
-		  </listitem>
-		</varlistentry>
+		</listitem>
+	  </varlistentry>
 
-<varlistentry id="file.filters.odf">
-  <term id="file.filters.odf.title">Open Document Format (ODF) files</term>
-  <listitem>
-	<para>
-	  <variablelist>
-		<varlistentry>
-		  <term>Translate the following elements</term>
-		  <listitem>
-			<para>Index entries, bookmarks, bookmark
-			references, notes, comments, presentation notes,
-			links (URL), and sheet names.</para>
-		  </listitem>
-		</varlistentry>
-	  </variablelist>
-	</para>
-  </listitem>
-</varlistentry>
-
-
-</variablelist>
-</section>
-
+	  <varlistentry id="file.filters.odf">
+		<term id="file.filters.odf.title">Open Document Format (ODF) files</term>
+		<listitem>
+		  <variablelist>
+			<varlistentry>
+			  <term>Translate the following elements</term>
+			  <listitem>
+				<para>Index entries, bookmarks, bookmark references, notes,
+				comments, presentation notes, links (URL), and sheet
+				names.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 </section>

--- a/doc_src/en/App_Glossaries.xml
+++ b/doc_src/en/App_Glossaries.xml
@@ -4,72 +4,87 @@
 <section id="app.glossaries">
   <title id="app.glossaries.title">Glossaries</title>
 
-  <para>Glossaries are terminology files stored in the <link linkend="project.folder.glossary" endterm="project.folder.glossary.title"/> folder.</para>
+  <para>Glossaries are terminology files stored in the <link
+  linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
+  folder.</para>
 
-  <para>All terms in a segment with a match in <emphasis>any</emphasis> of
-  the glossaries will be displayed in the <link
-  linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
+  <para>All terms in a segment with a match in <emphasis>any</emphasis> of the
+  glossaries will be displayed in the <link linkend="panes.glossary"
+  endterm="panes.glossary.title"/> pane.</para>
 
   <para>Source terms can be multi-word expressions.</para>
 
-  <para>There are 2 kinds of glossary files:
+  <para>There are 2 kinds of glossary files:</para>
 
   <variablelist>
 	<varlistentry>
 	  <term>The project glossary</term>
 	  <listitem>
-		<para>You can use <link linkend="menus.edit.create.glossary.entry"
-          endterm="menus.edit.create.glossary.entry.title"/> to enter new terms in this glossary. It is called the <emphasis>writable</emphasis> glossary for this reason.</para>
-		  <para>You can also access it with <link
-		  linkend="menus.project.access.project.contents.title"
-		  endterm="menus.project.access.project.contents.title"/>, open it in a
-		  text editor and modify it.</para>
-		  <para>You do not need to prepare the file in advance.</para>
-		  <para>It will be created the first time you add an entry to the
-		  glossary.</para>
+		<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+		linkend="menus.edit.create.glossary.entry"
+		endterm="menus.edit.create.glossary.entry.title"/> to enter new terms in
+		this glossary. It is called the <emphasis>writable</emphasis> glossary
+		for this reason.</para>
+		
+		<para>Use <link linkend="menus.project"
+		endterm="menus.project.title"/><link
+		linkend="menus.project.access.project.contents.title"
+		endterm="menus.project.access.project.contents.title"/> to directly
+		access it. You can then open it in a text editor and modify it.</para>
 
-		  <note>
-        <para>If you choose to use an existing file as the default
-		  glossary, all new entries will be recorded in tab-separated format and
-		  saved in UTF-8 by default.</para>
-        <para>If you want to specify a different encoding, you can do so by
-        adding a “magic” comment that takes the following form:
-          <simplelist>
+		<para>You do not need to prepare the file in advance.</para>
+
+		<para>It will be created the first time you add an entry to the
+		glossary.</para>
+
+		<note>
+          <para>If you choose to use an existing file as the default glossary,
+          all new entries will be recorded in tab-separated format and saved in
+          UTF-8 by default.</para>
+
+		  <para>If you want to specify a different encoding, you can do so by
+		  adding a “magic” comment that takes the following form:</para>
+
+		  <simplelist>
             <member>
-              <code># -*- coding: <parameter>&lt;charset&gt;</parameter>
-              -*-</code>,
+              <code># -*- coding: &lt;charset&gt; -*-</code>,
             </member>
           </simplelist>
-        where <parameter>&lt;charset&gt;</parameter> is typically one of the sets listed in the <ulink
-        url="http://www.iana.org/assignments/character-sets/character-sets.xhtml">IANA
-        Charset Registry</ulink>. To specify a glossary in the latin encoding, for
-        example, use:
-          <informalexample>
-            <para><code># -*- coding: ISO-8859-1 -*-</code></para>
-          </informalexample>
-        (or any of the ISO-8859-1 to ISO-8859-10 character sets).</para>
-      </note>
+		  
+          <para>where <parameter>&lt;charset&gt;</parameter> is typically one of
+          the sets listed in the <ulink
+          url="http://www.iana.org/assignments/character-sets/character-sets.xhtml">IANA
+          Charset Registry</ulink>.</para>
+		</note>
 	  </listitem>
 	</varlistentry>
 	
 	<varlistentry>
 	  <term>Reference glossaries</term>
-	  <listitem><para>They are terminology files in a format recognized by 
-    OmegaT. You cannot modify them from the OmegaT interface like the
-	  project glossary, but you can do so in a text editor.</para></listitem>
+	  <listitem>
+		<para>They are terminology files in a format recognized by OmegaT. You
+		cannot modify them from the OmegaT interface like the project glossary,
+		but you can do so in a text editor.</para>
+	  </listitem>
 	</varlistentry>
   </variablelist>
-</para>
 
-<note>
-  <para>Modifications made to any glossary are immediately recognized by OmegaT displayed in the <link
-  linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
-</note>
+  <note>
+	<para>Modifications made to any glossary are immediately recognized by
+	OmegaT displayed in the <link linkend="panes.glossary"
+	endterm="panes.glossary.title"/> pane.</para>
+  </note>
 
   <section id="glossaries.glossary.folder">
     <title id="glossaries.glossary.folder.title">The glossaries folder</title>
 
-    <para>By default, each project contains a <link linkend="project.folder.glossary" endterm="project.folder.glossary.title"/> folder to store the writable glossary and any reference glossaries you want to add to the project. See <link linkend="dialogs.project.properties.file.locations.glossaries" endterm="dialogs.project.properties.file.locations.glossaries.title"/> for details.</para>
+    <para>By default, each project contains a <link
+    linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
+    folder to store the writable glossary and any reference glossaries you want
+    to add to the project. See the <link
+    linkend="dialogs.project.properties.file.locations.glossaries"
+    endterm="dialogs.project.properties.file.locations.glossaries.title"/>
+    project property for details.</para>
 
     <para>All glossaries must be located in the <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -79,11 +94,11 @@
     terminology subfolders organized by topic, client, or any other category
     that suits your workflow.</para>
     <para>Use the <link
-    linkend="dialogs.project.properties.file.locations.glossaries">option</link>
-    to set the location of the reference glossaries folder. This folder can be
-    set outside the project, enabling you to use it, or one of the specific
-    subfolders, in other projects.</para>
-		
+    linkend="dialogs.project.properties.file.locations.glossaries"
+    endterm="dialogs.project.properties.file.locations.glossaries.title"/> project
+    property to set the location of the reference glossaries folder. This folder
+    can be set outside the project, enabling you to use it, or one of the
+    specific subfolders, in other projects.</para>
   </section>
 
   <section id="glossaries.default.glossary">
@@ -101,7 +116,6 @@
     <filename>.utf8</filename> extension, and store it within the <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
     folder or in one of its subfolders.</para>
-
   </section>
 
   <section id="glossaries.fileformat">

--- a/doc_src/en/App_PostProcessingCommands.xml
+++ b/doc_src/en/App_PostProcessingCommands.xml
@@ -3,24 +3,30 @@
 <section id="post.processing.commands">
   <title id="post.processing.commands.title">Post-Processing Commands</title>
 
-  <para>See <link linkend="dialogs.project.properties.external.processing.command" endterm="dialogs.project.properties.external.processing.command.title"/> for project specific commands.</para>
-  <para>See <link linkend="dialogs.preferences.saving.and.output.external.post-processing.command" endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/> for global commands.</para>
+  <para>See the <link
+  linkend="dialogs.project.properties.external.processing.command"
+  endterm="dialogs.project.properties.external.processing.command.title"/>
+  projet property for project specific commands.</para>
+
+  <para>See the <link
+  linkend="dialogs.preferences.saving.and.output.external.post-processing.command"
+  endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/>
+  preference for global commands.</para>
 	
 
   <section id="post.processing.commands.template.variables">
     <title id="post.processing.commands.template.variables.title">Template Variables</title>
-    <para>
-      The command is passed to Java runtime exec as a string with the
-      template values expanded. All the arguments should be quoted,
-      e.g. <literal>&quot;${fileName}&quot;</literal>.
-    </para>
-    <para>
-      The following template variables are always available. The other
-      items on the template list are environment variables for your
-      system.
-    </para>
+    <para>The command is passed to Java runtime exec as a string with the
+    template values expanded. All the arguments should be quoted,
+    e.g. <literal>&quot;${fileName}&quot;</literal>.</para>
+
+    <para>The following template variables are always available. The other items
+    on the template list are environment variables for your system.</para>
+	
     <table id="post.processing.commands.template.variables.table">
-      <title id="post.processing.commands.template.variables.table.title">Template Variables</title>
+      <title
+      id="post.processing.commands.template.variables.table.title">Template
+      Variables</title>
       <tgroup cols="2" colsep="1">
         <colspec align="left" colname="1" colnum="1"/>
         <colspec align="left" colname="2" colnum="2"/>
@@ -33,52 +39,71 @@
 
         <tbody>
 		  <row>
-			<entry>${projectName}</entry><entry>The name of the project directory</entry>
+			<entry>${projectName}</entry>
+			<entry>The name of the project directory</entry>
 		  </row>
 		  <row>
-			<entry>${projectRoot}</entry><entry>Full path to the project folder</entry>
+			<entry>${projectRoot}</entry>
+			<entry>Full path to the project folder</entry>
 		  </row>
 		  <row>
-			<entry>${sourceRoot}</entry><entry>Full path to the source folder</entry>
+			<entry>${sourceRoot}</entry>
+			<entry>Full path to the source folder</entry>
 		  </row>
 		  <row>
-			<entry>${targetRoot}</entry><entry>Full path to the target folder</entry>
+			<entry>${targetRoot}</entry>
+			<entry>Full path to the target folder</entry>
 		  </row>
 		  <row>
-			<entry>${glossaryRoot}</entry><entry>Full path to the glossary folder</entry>
+			<entry>${glossaryRoot}</entry>
+			<entry>Full path to the glossary folder</entry>
 		  </row>
 		  <row>
-			<entry>${tmRoot}</entry><entry>Full path to the TM root folder</entry>
+			<entry>${tmRoot}</entry>
+			<entry>Full path to the TM root folder</entry>
 		  </row>
 		  <row>
-			<entry>${tmAutoRoot}</entry><entry>Full path to the TM auto folder</entry>
+			<entry>${tmAutoRoot}</entry>
+			<entry>Full path to the TM auto folder</entry>
 		  </row>
 		  <row>
-			<entry>${dictRoot}</entry><entry>Full path to the dictionary folder</entry>
+			<entry>${dictRoot}</entry>
+			<entry>Full path to the dictionary folder</entry>
 		  </row>
 		  <row>
-			<entry>${tmOtherLangRoot}</entry><entry>TM Root + tmx2source (See <link linkend="how.to.tm.bridge.two.languages" endterm="how.to.tm.bridge.two.languages.title"/> for details.)</entry>
+			<entry>${tmOtherLangRoot}</entry>
+			<entry>TM Root + tmx2source (See the <link
+			linkend="how.to.tm.bridge.two.languages"
+			endterm="how.to.tm.bridge.two.languages.title"/> how-to for
+			details.)</entry>
 		  </row>
 		  <row>
-			<entry>${sourceLang}</entry><entry>Source language</entry>
+			<entry>${sourceLang}</entry>
+			<entry>Source language</entry>
 		  </row>
 		  <row>
-			<entry>${targetLang}</entry><entry>Target language</entry>
+			<entry>${targetLang}</entry>
+			<entry>Target language</entry>
 		  </row>
 		  <row>
-			<entry>${filePath}</entry><entry>Full path to source file</entry>
+			<entry>${filePath}</entry>
+			<entry>Full path to source file</entry>
 		  </row>
 		  <row>
-			<entry>${fileShortPath}</entry><entry>Source file name relative to given root</entry>
+			<entry>${fileShortPath}</entry>
+			<entry>Source file name relative to given root</entry>
 		  </row>
 		  <row>
-			<entry>${fileName}</entry><entry>Full name of source file</entry>
+			<entry>${fileName}</entry>
+			<entry>Full name of source file</entry>
 		  </row>
 		  <row>
-			<entry>${fileNameOnly}</entry><entry>Name of source file without extension</entry>
+			<entry>${fileNameOnly}</entry>
+			<entry>Name of source file without extension</entry>
 		  </row>
 		  <row>
-			<entry>${fileExtension}</entry><entry>Extension of source file without a dot</entry>
+			<entry>${fileExtension}</entry>
+			<entry>Extension of source file without a dot</entry>
 		  </row>
         </tbody>
       </tgroup>
@@ -86,7 +111,8 @@
   </section>
   
   <section id="post.processing.commands.user.defined.scripts">
-    <title id="post.processing.commands.user.defined.scripts.title">User Defined Scripts</title>
+    <title id="post.processing.commands.user.defined.scripts.title">User Defined
+    Scripts</title>
     <para>
       In addition to a regular command, you can call a script. Never run
       post-processing scripts from untrusted sources. For security reasons,
@@ -106,7 +132,8 @@
   </section>
 
   <section id="post.processing.commands.linux.and.macos">
-    <title id="post.processing.commands.linux.and.macos.title">Linux and macOS</title>
+    <title id="post.processing.commands.linux.and.macos.title">Linux and
+    macOS</title>
     <para>
       You should use a shebang, e.g. <literal>#! /bin/bash</literal> or
       <literal>#! /usr/bin/env python3</literal>. And the script must be
@@ -115,23 +142,24 @@
     </para>
   </section>
   
-	<example id="post.processing.commands.example">
-	  <title
-		  id="post.processing.commands.example.title">Simple
-	  example of a post-processing commands:</title>
+  <example id="post.processing.commands.example">
+	  <title id="post.processing.commands.example.title">Simple example of a
+	  post-processing commands:</title>
 	  <variablelist>
 		<varlistentry>
 		  <term>Open the target folder in Linux</term>
 		  <listitem>
 			<programlisting>xdg-open ${targetRoot}</programlisting>
 		  </listitem>
-		</varlistentry>
+		</varlistentry
+		>
 		<varlistentry>
 		  <term>Open the target folder in macOS</term>
 		  <listitem>
 			<programlisting>open ${targetRoot}</programlisting>
 		  </listitem>
 		</varlistentry>
+
 		<varlistentry>
 		  <term>Open the target folder in Windows Powershell</term>
 		  <listitem>

--- a/doc_src/en/App_Regex.xml
+++ b/doc_src/en/App_Regex.xml
@@ -10,34 +10,39 @@
   way to boost their productivity. Although seen as daunting and complex, even
   the simplest regular expressions (often abbreviated <emphasis>regex</emphasis>
   or <emphasis>regexp</emphasis>) are extremely useful, not only in OmegaT, but
-  in many other applications you might use on a
-  day-to-day basis, with some variations.</para>
+  in many other applications you might use on a day-to-day basis, with some
+  variations.</para>
 
   <para>Only the fundamentals most useful to translators are covered. The
   <link linkend="app.regex.tools" endterm="app.regex.tools.title"/>
-  section at the end of this appendix provides a few starting points to
-  explore advanced or complex uses beyond the scope of this guide. If you need help for a specific case, you can also ask questions in the various support channels.</para>
+  section at the end of this appendix provides a few starting points to explore
+  advanced or complex uses beyond the scope of this manual. If you need help for
+  a specific case, you can also ask questions in the various support
+  channels.</para>
   
-  <para>Regular expressions use a combination of letters,
-  digits, and symbols (collectively known as <emphasis>characters</emphasis>)
-  to define an <emphasis>expression</emphasis> that represents a specific text
+  <para>Regular expressions use a combination of letters, digits, and symbols
+  (collectively known as <emphasis>characters</emphasis>) to define an
+  <emphasis>expression</emphasis> that represents a specific text
   pattern.</para>
 
-  <para>Here are a few examples.
+  <para>Here are a few examples.</para>
+  
   <variablelist>
     <varlistentry>
       <term>[0-9]</term>
       <listitem><para>Any single digit from 0 to 9.</para>
       </listitem>
     </varlistentry>
-    <varlistentry>
+
+	<varlistentry>
       <term>\w+</term>
       <listitem><para>Represents one or more “word characters”, namely
       the letters of the alphabet, digits, and
       underscore symbols.</para>
       </listitem>
     </varlistentry>
-    <varlistentry>
+
+	<varlistentry>
       <term>\h?</term>
       <listitem><para>Represents zero or one horizontal whitespace
       character (this includes regular and non-breaking spaces as well as
@@ -46,10 +51,9 @@
       </listitem>
     </varlistentry>
   </variablelist>    
-  </para>
   
-  <para>Many OmegaT functions rely on regular expressions or make them
-  available as an option:
+  <para>Many OmegaT functions rely on regular expressions or make them available
+  as an option:</para>
 
   <variablelist>
     <varlistentry>
@@ -60,6 +64,7 @@
         endterm="windows.text.search.methods.regex.title"/> option that
         allows you to make extremely powerful searches across your
         files.</para>
+
         <para>The same option in the <link linkend="windows.text.replace"
         endterm="windows.text.replace.title"/> dialog allows you to apply
         regular expressions to both the search and replaced text.</para>
@@ -69,58 +74,74 @@
     <varlistentry>
       <term>Custom tags</term>
       <listitem>
-        <para>Custom tags are tags defined with regular expressions that 
-        are handled exactly like native OmegaT tags. See <link
+        <para>Custom tags are tags defined with regular expressions that are
+        handled exactly like native OmegaT tags. See the <link
         linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"
-        endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/> 
-        for details.</para>
-        <para>Use the <code>|</code> (OR) character to separate individual
+        endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/>
+        preference for details.</para>
+
+		<para>Use the <code>|</code> (OR) character to separate individual
         tag definitions.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry>
-      <term>Flagged fragments</term>
+      <term>Flagged text</term>
       <listitem>
-        <para><link
+        <para>The <link
         linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
         endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/>
-        allow you to define strings that OmegaT will mark in red by
-        default, and treat as extraneous tags for validation
-        purposes.</para>
-        <para>Use the <code>|</code> (OR) character to separate individual
+        preference allows you to define strings that OmegaT will mark in red by
+        default, and treat as extraneous tags for validation purposes.</para>
+
+		<para>Use the <code>|</code> (OR) character to separate individual
         fragment definitions.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry>
+      <term>Text highlighting in alignments</term>
+      <listitem>
+        <para>Visual cues can help verifying that your alignment is correct. The
+        <link linkend="windows.aligner.adjust.highlight"
+        endterm="windows.aligner.adjust.highlight.title"/> setting allows you to
+        define strings that OmegaT will highlight in the aligned
+        documents.</para>
+
+		<para>Use the <code>|</code> (OR) character to separate individual
+        expressions.</para>
+      </listitem>
+    </varlistentry>	
+
+    <varlistentry>
       <term>Segmentation</term>
       <listitem>
-        <para>Segmentation rules and language patterns are defined with
-        regular expressions. You can modify them freely to improve the
-        segmentation of a document or add additional general rules. See
-        <link linkend="app.segmentation"
-			  endterm="app.segmentation.title"/> for
+        <para>Segmentation rules and language patterns are defined with regular
+        expressions. You can modify them freely to improve the segmentation of a
+        document or add additional general rules. See the <link
+        linkend="app.segmentation" endterm="app.segmentation.title"/> appendix for
         details.</para>
+
         <para>Segmentation or exception rules define the position in a
         segment where a split will, or will not, be made. Two regular
         expressions are required to define that position: a “before”
         expression to define the text pattern ahead of where the rule
         should apply, and an “after” expression to define the text 
         pattern following that position.</para>
-        <para>A language pattern that matches the source language of the project will apply to that project.</para></listitem>
+
+		<para>A language pattern that matches the source language of the project
+		will apply to that project.</para>
+	  </listitem>
     </varlistentry>
   </variablelist>
-  </para>
 
   <section id="app.regex.four.rules">
     <title id="app.regex.four.rules.title">The 4 rules</title>
 
-    <para>Regular expressions are used to find text, including
-    characters that are not visible on the screen or when printed out, such as
-    spaces, tabs, or line breaks. Any given expression either
-    <emphasis>matches</emphasis>, or <emphasis>does
-    <emphasis role="bold">not</emphasis> match</emphasis> a word,
+    <para>Regular expressions are used to find text, including characters that
+    are not visible on the screen or when printed out, such as spaces, tabs, or
+    line breaks. Any given expression either <emphasis>matches</emphasis>, or
+    <emphasis>does <emphasis role="bold">not</emphasis> match</emphasis> a word,
     phrase, or other sequence of text.</para>
     
     <para>Each and every character in the expression is relevant when
@@ -143,11 +164,11 @@
           <para>The majority of characters in a regular expression simply
           <emphasis>look for themselves</emphasis> in the text
           sequence.</para>
-          <para>For example, the seven letters spelling out the word
-          “<emphasis>example</emphasis>” simply tell the search function
-          to match exactly those letters, in that order. Simply put, the
-          search just looks for the word
-          “<emphasis>example</emphasis>”.</para>
+
+		  <para>For example, the seven letters spelling out the word
+		  “<emphasis>example</emphasis>” simply tell the search function to
+		  match exactly those letters, in that order. Simply put, the search
+		  just looks for the word “<emphasis>example</emphasis>”.</para>
         </listitem>
       </varlistentry>
 
@@ -155,25 +176,27 @@
         <term>Letters of the alphabet preceded by a backslash
         (<literal>\</literal>) take on a special meaning</term>
         <listitem>
-          <para>Unlike a letter on its own, which simply represents itself
-          as noted above, a letter preceded by a <literal>\</literal> has a
-          special function in a regular expression.</para>
-          <para>For example, <emphasis>r</emphasis> is just a normal
-          character but preceding it with <literal>\</literal> to make it
-          <literal>\r</literal> turns it into a special combination that
-          matches a <emphasis>carriage return character</emphasis>.
-          Similarly, <literal>\R</literal> matches <emphasis>any line
-          break character</emphasis>.</para>
+          <para>Unlike a letter on its own, which simply represents itself as
+          noted above, a letter preceded by a <literal>\</literal> has a special
+          function in a regular expression.</para>
+
+		  <para>For example, <emphasis>r</emphasis> is just a normal character
+		  but preceding it with <literal>\</literal> to make it
+		  <literal>\r</literal> turns it into a special combination that matches
+		  a <emphasis>carriage return character</emphasis>.  Similarly,
+		  <literal>\R</literal> matches <emphasis>any line break
+		  character</emphasis>.</para>
+		  
           <note>
             <para>Only the letters <emphasis>i j l m o</emphasis>, and
             <emphasis>y</emphasis>, in both lower- and uppercase, have no
-            special meaning when preceded by a backslash. This guide
-            only describes a small subset of letters that take on a special
+            special meaning when preceded by a backslash. This manual only
+            describes a small subset of letters that take on a special
             meaning.</para>
-            <para>Consult the sites in the <link
-            linkend="app.regex.tools" endterm="app.regex.tools.title"/>
-            section below for information on combinations not covered
-            here.</para>
+
+			<para>Consult the sites in the <link linkend="app.regex.tools"
+			endterm="app.regex.tools.title"/> section below for information on
+			combinations not covered here.</para>
           </note>
         </listitem>
       </varlistentry>
@@ -181,16 +204,17 @@
       <varlistentry>
       <term>Twelve characters have a special meaning by default</term>
         <listitem>
-          <para>That special meaning has to be cancelled by another
-          character to match the character itself.</para>
+          <para>That special meaning has to be cancelled by another character to
+          match the character itself.</para>
+
           <para>The full list of characters is presented <link
-          linkend="app.regex.twelve.characters">below</link>. One
-          example is <literal>.</literal>: on its own, it has the
-          special meaning of matching <emphasis>any single
-          character</emphasis>.</para>
-          <para>To find a normal period, that meaning has to be cancelled
-          using the <literal>\</literal>, to make the expression
-          <literal>\.</literal>, which just matches a period.</para>
+          linkend="app.regex.twelve.characters">below</link>. One example is
+          <literal>.</literal>: on its own, it has the special meaning of
+          matching <emphasis>any single character</emphasis>.</para>
+
+		  <para>To find a normal period, that meaning has to be cancelled using
+		  the <literal>\</literal>, to make the expression
+		  <literal>\.</literal>, which just matches a period.</para>
         </listitem>
       </varlistentry>
 
@@ -198,15 +222,15 @@
         <term>The <literal>\</literal> character is a very special
         character</term>
         <listitem>
-          <para>As stated above, the <literal>\</literal> character has
-          the default special meaning of either cancelling or activating
-          the special meaning of other characters. It has no effect if
-          placed before a character with no special meaning (either by
-          default or by addition).</para>
-          <para>The <literal>\</literal> can cancel its own special
-          meaning by doubling up to form <literal>\\</literal>, which
-          simply matches the <emphasis>backslash</emphasis> character
-          itself.</para>
+          <para>As stated above, the <literal>\</literal> character has the
+          default special meaning of either cancelling or activating the special
+          meaning of other characters. It has no effect if placed before a
+          character with no special meaning (either by default or by
+          addition).</para>
+
+          <para>The <literal>\</literal> can cancel its own special meaning by
+          doubling up to form <literal>\\</literal>, which simply matches the
+          <emphasis>backslash</emphasis> character itself.</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -215,13 +239,11 @@
   <section id="app.regex.twelve.characters">
     <title id="app.regex.twelve.characters.title">The 12 characters</title>
   
-    <para>The twelve special characters are the
-    <emphasis>backslash</emphasis> <literal>\</literal>, the
-    <emphasis>caret</emphasis> <literal>^</literal>, the
-    <emphasis>dollar sign</emphasis> <literal>$</literal>, the
+    <para>The twelve special characters are the <emphasis>backslash</emphasis>
+    <literal>\</literal>, the <emphasis>caret</emphasis> <literal>^</literal>,
+    the <emphasis>dollar sign</emphasis> <literal>$</literal>, the
     <emphasis>period</emphasis> (or <emphasis>dot</emphasis>)
-    <literal>.</literal>, the
-    <emphasis>vertical bar</emphasis> (or
+    <literal>.</literal>, the <emphasis>vertical bar</emphasis> (or
     <emphasis>pipe symbol</emphasis>) <literal>|</literal>, the
     <emphasis>question mark</emphasis> <literal>?</literal>, the
     <emphasis>asterisk</emphasis> (or <emphasis>star</emphasis>)
@@ -229,12 +251,12 @@
     <literal>+</literal>, the opening <emphasis>parenthesis</emphasis>
     <literal>(</literal>, the closing <emphasis>parenthesis</emphasis>,
     <literal>)</literal>, the opening <emphasis>square bracket</emphasis>
-    <literal>[</literal>, and the opening
-    <emphasis>curly brace</emphasis> <literal>{</literal>.</para>
+    <literal>[</literal>, and the opening <emphasis>curly brace</emphasis>
+    <literal>{</literal>.</para>
 
-    <para>Each character is briefly described below with examples
-    of regular expressions that rely on the character as well as
-    of text that they do, or do not, match.
+    <para>Each character is briefly described below with examples of regular
+    expressions that rely on the character as well as of text that they do, or
+    do not, match.</para>
     
       <variablelist>
         <varlistentry>
@@ -260,11 +282,12 @@
                       <emphasis>0.9</emphasis>, or just the final
                       <emphasis>0.5</emphasis> in numbers such as 10.5 or
                       560.5.</para>
+
                       <para>The <literal>\.</literal> cancels the “any
                       character” meaning of the period to match the decimal
                       point, while the <literal>\d</literal> turns the
-                      ordinarily lowercase “d” letter into an expression
-                      that matches any digit between 0 and 9.</para>
+                      ordinarily lowercase “d” letter into an expression that
+                      matches any digit between 0 and 9.</para>
                     </entry>
                   </row>
 
@@ -272,7 +295,8 @@
                     <entry>Does not match</entry>
                     <entry>
                       <para>Sequences such as 0,1, 0-3, or the first three
-                      characters of 0x002E, which would be matched if the expression was just <literal>0.[0-9]</literal>, with no
+                      characters of 0x002E, which would be matched if the
+                      expression was just <literal>0.[0-9]</literal>, with no
                       backslash before the period</para>
                     </entry>
                   </row>
@@ -285,13 +309,14 @@
         <varlistentry>
           <term>The CARET: <literal>^</literal></term>
           <listitem>
-            <para>When it is the first character in the expression, the 
+            <para>When it is the first character in the expression, the
             <emphasis>caret</emphasis> character matches the beginning of a
             line.</para>
+
             <para>When it is the first character in <link
             linkend="app.regex.types.of.expressions.classes">a character class
-            enclosed in brackets</link>, it excludes the characters in that
-            class from the match.</para>
+            enclosed in brackets</link>, it matches all the characters that are
+            not part of that class.</para>
 
             <informaltable>
               <tgroup cols="2">
@@ -319,9 +344,8 @@
                     <entry>
                       <orderedlist>
                         <listitem>
-                          <para>The uppercase “A” in the following sentence:
-                          “A long, but exciting journey was about to
-                          begin”.</para>
+                          <para>The uppercase “A” in the following sentence: “A
+                          long, but exciting journey was about to begin”.</para>
                         </listitem>
 
                         <listitem>
@@ -338,9 +362,9 @@
                     <entry>
                       <orderedlist>
                         <listitem>
-                          <para>The uppercase “A” in the following sentence:
-                          “My friend is writing a book called <emphasis>A Long
-                            Journey</emphasis>”.</para>
+                          <para>The uppercase “A” in the following sentence: “My
+                          friend is writing a book called <emphasis>A Long
+                          Journey</emphasis>”.</para>
                         </listitem>
                       
                         <listitem>
@@ -551,8 +575,8 @@
         <varlistentry>
           <term>The ASTERISK: <literal>*</literal></term>
           <listitem>
-            <para>This character specifies that zero or more instances of
-            the preceding character or expression should be matched.</para>
+            <para>This character specifies that zero or more instances of the
+            preceding character or expression should be matched.</para>
 
             <informaltable>
               <tgroup cols="2">
@@ -569,12 +593,12 @@
                     <entry>Matches</entry>
                     <entry>
                       <para>The word “run”, as well as “runs”, “runner”,
-                      “runway”, “runt” in “grunt” or “brunt”, and any other
-                      word or sequence of characters containing “run” followed
-                      by zero or more “<emphasis>word characters</emphasis>”
-                      (which include digits and the underscore, so the part
-                      before the “@” in an email address such as
-                      run_123@example.email.org is also a match).</para>
+                      “runway”, “runt” in “grunt” or “brunt”, and any other word
+                      or sequence of characters containing “run” followed by
+                      zero or more “<emphasis>word characters</emphasis>” (which
+                      include digits and the underscore, so the part before the
+                      “@” in an email address such as run_123@example.email.org
+                      is also a match).</para>
                     </entry>
                   </row>
 
@@ -638,18 +662,19 @@
 
           <listitem>
             <para>This character starts a <emphasis>group</emphasis>, which is a
-            set of characters treated as a single unit. Groups are numbered,
-            and their contents group are stored in memory. They can be reused
-            later in the search expression using
-            <literal>\<option>n</option></literal>, where
-            <option>n</option> is the number of the group.</para>
+            set of characters treated as a single unit. Groups are numbered, and
+            their contents group are stored in memory. They can be reused later
+            in the search expression using
+            <literal>\<option>n</option></literal>, where <option>n</option> is
+            the number of the group.</para>
+
             <note>
               <para>The content of the group can also be used in the <link
-              linkend="windows.text.replace">replacement text</link>. In Java,
-              the syntax for doing so is
-              <literal>$<option>n</option></literal> instead of
-              <literal>\<option>n</option></literal>.</para>
+              linkend="windows.text.replace">replacement text</link>. Use
+              <literal>$<option>n</option></literal>, where <option>n</option>
+              is the number of the group defined in the search.</para>
             </note>
+
             <para>Parentheses are always used in opening and closing pairs.
             Trying to use only the opening or closing parenthesis on its own
             will cause an error.</para>
@@ -670,7 +695,8 @@
                     <entry>
                       <para>Doubled up words separated by a space, such as the
                       consecutive “an” in the following sentence:</para>
-                      <para>“I bought an an apple.”</para>
+
+					  <para>“I bought an an apple.”</para>
                     </entry>
                   </row>
 
@@ -678,7 +704,8 @@
                     <entry>Does not match</entry>
                     <entry>
                       <para>The “that, that” in the following sentence:</para>
-                      <para>“But that, that is just unbelievable”, because the
+
+					  <para>“But that, that is just unbelievable”, because the
                       first “that” is followed by both a comma and a space
                       rather than only a space.</para>
                     </entry>
@@ -713,13 +740,13 @@
                     <entry>Matches</entry>
                     <entry>
                       <para>The sequence number (including the parenthesis) at
-                      the beginning of each line in a list such as:
-                        <simplelist>
-                          <member>1) Apples</member>
-                          <member>2) Oranges</member>
-                          <member>3) Pears</member>
-                        </simplelist>
-                      </para>
+                      the beginning of each line in a list such as:</para>
+
+                      <simplelist>
+                        <member>1) Apples</member>
+                        <member>2) Oranges</member>
+                        <member>3) Pears</member>
+                      </simplelist>
                     </entry>
                   </row>
 
@@ -728,12 +755,12 @@
                     <entry>
                       <para>Sequence numbers that are not at the beginning of a
                       line.</para>
-                      <para>Follow these steps:
-                        <simplelist>
-                          <member>Step 1) Preparation</member>
-                          <member>Step 2) …</member>
-                        </simplelist>
-                      </para>
+
+                      <para>Follow these steps:</para>
+                      <simplelist>
+                        <member>Step 1) Preparation</member>
+                        <member>Step 2) …</member>
+                      </simplelist>
                     </entry>
                   </row>
                 </tbody>
@@ -752,9 +779,9 @@
 
             <para>Only the opening bracket is special and needs to be preceded
             by a backslash to search for the bracket character itself. If you
-            only want to match the closing bracket as itself, you do not need
-            to precede it with a backslash. (You can still add it, but it will
-            have no effect on the expression or the result.)</para>
+            only want to match the closing bracket as itself, you do not need to
+            precede it with a backslash. (You can still add it, but it will have
+            no effect on the expression or the result.)</para>
 
             <informaltable>
               <tgroup cols="2">
@@ -845,7 +872,6 @@
           </listitem>
         </varlistentry>
       </variablelist>
-    </para>
   </section>
 
   <section id="app.regex.types.of.expressions">
@@ -895,19 +921,22 @@
             <row>
               <entry><literal>\t</literal></entry>
               <entry>
-                <para>The tab character, not the letter “t”.</para></entry>
+                <para>The tab character, not the letter “t”.</para>
+			  </entry>
             </row>
 
             <row>
               <entry><literal>\n</literal></entry>
-              <entry>The newline (line feed) character, not the letter “n”.</entry>
+              <entry>The newline (line feed) character, not the letter
+              “n”.</entry>
             </row>
 
             <row>
               <entry><literal>\r</literal></entry>
               <entry>
                 <para>The carriage-return character, not the letter “r”.</para>
-                <para>similarly, <literal>\R</literal> is any line break character.</para></entry>
+                <para>similarly, <literal>\R</literal> is any line break character.</para>
+			  </entry>
             </row>
           </tbody>
         </tgroup>
@@ -920,18 +949,21 @@
       
       <para>Ordinary OmegaT searches are case insensitive by default: they match
       both uppercase and lowercase characters, unless you choose to enable the
-      <link linkend="windows.text.search.options">case sensitive option</link>.
-      Doing so makes the entire search expression case sensitive.</para>
+      <link linkend="windows.text.search.options"
+      endterm="windows.text.search.options.title"/> option. Doing so makes the
+      entire search expression case sensitive.</para>
+
       <para>In contrast, Regular expressions are case sensitive by default. This
       means that a regular expression search for “OmegaT”, for example, will not
       match “omegat”. However, regular expressions also provide special modifiers
-      to specify case sensitivity within the expression:
+      to specify case sensitivity within the expression:</para>
 
       <variablelist>
         <varlistentry>
           <term><literal>(?i)</literal></term>
           <listitem>
-            <para>Makes the part of the expression to the right of the modifier case insensitive.</para>
+            <para>Makes the part of the expression to the right of the modifier
+            case insensitive.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -941,12 +973,12 @@
             case sensitive.</para>
           </listitem>
         </varlistentry>
-      </variablelist> </para>
-
+      </variablelist>
+	  
       <para>You can take advantage of this to apply a fine degree of control to
       case sensitivity in searches. Suppose, for example, that you want to find
-      instances of “OmegaT” and “omegat”, but not “OMEGAT”. You can do so with the
-      following expression:
+      instances of “OmegaT” and “omegat”, but not “OMEGAT”. You can do so with
+      the following expression:
       <literal>(?i)o</literal><literal>(?-i)mega</literal>
       <literal>(?i)t</literal>, which represents a case insensitive “o” followed
       by a case sensitive “mega”, followed by a case insensitive “t”.</para>
@@ -958,33 +990,36 @@
       <para>Regular expressions allow you to create sets of characters—known as
       <emphasis>classes</emphasis>. Searches will match any of the characters in
       the set.</para>
-      <para>Classes are defined by enclosing the desired characters in square
+
+	  <para>Classes are defined by enclosing the desired characters in square
       brackets, and can be specified either by listing each individual character
       to include, or by specifying a range of characters. For example, you could
       create the <literal>[£€$]</literal> class to find any of those three
-      currency symbols in the text, or [1-3] to find the number 1, 2 or 3.
-        <note>
-          <para>Inside a class, only the backslash (<literal>\</literal>), 
-          caret (<literal>^</literal>), closing bracket (<literal>]</literal>)
-          and hyphen (<literal>-</literal>) are special. The rest of the twelve
-          characters are normal, and do not have to be preceded by a backslash if
-          you want to search for those characters themselves.</para>
-          <para>You can search for any of the four class special characters as
-          normal characters by preceding them with a backslash. You can also
-          search for the caret, closing bracket, and hyphen as themselves by
-          placing them at a position that does not trigger their special meaning:
-          anywhere except right after the opening bracket for the caret,
-          immediately after either opening bracket or the caret following it for
-          the closing bracket, and either just after the opening bracket or just
-          before the closing bracket for the hyphen.</para>
-        </note>
-      </para>
-      <para>Many frequently used sets have a shorthand form consisting of a
-      backslash followed by a letter of the alphabet. For example,
-      <literal>\d</literal> is a shorthand for <literal>[0-9]</literal>, which
-      matches any digit between 0 and 9. In many cases, the corresponding
-      uppercase later is used to negate the class: <literal>\D</literal> matches
-      any character that is <emphasis role="bold">not</emphasis> a digit.</para>
+      currency symbols in the text, or [1-3] to find the number 1, 2 or 3.</para>
+
+      <note>
+        <para>Inside a class, only the backslash (<literal>\</literal>), caret
+        (<literal>^</literal>), closing bracket (<literal>]</literal>) and
+        hyphen (<literal>-</literal>) are special. The rest of the twelve
+        characters are normal, and do not have to be preceded by a backslash if
+        you want to search for those characters themselves.</para>
+
+		<para>You can search for any of the four class special characters as
+		normal characters by preceding them with a backslash. You can also
+		search for the caret, closing bracket, and hyphen as themselves by
+		placing them at a position that does not trigger their special meaning:
+		anywhere except right after the opening bracket for the caret,
+		immediately after either opening bracket or the caret following it for
+		the closing bracket, and either just after the opening bracket or just
+		before the closing bracket for the hyphen.</para>
+      </note>
+
+	  <para>Many frequently used sets have a shorthand form consisting of a
+	  backslash followed by a letter of the alphabet. For example,
+	  <literal>\d</literal> is a shorthand for <literal>[0-9]</literal>, which
+	  matches any digit between 0 and 9. In many cases, the corresponding
+	  uppercase later is used to negate the class: <literal>\D</literal> matches
+	  any character that is <emphasis role="bold">not</emphasis> a digit.</para>
       <para>The table below provides various additional examples. These
       classes never represent only the actual letter used to form the
       shorthand.</para>
@@ -1008,7 +1043,8 @@
               <entry><literal>[abc]</literal></entry>
               <entry>
                 <para>The letter “a”, “b”, or “c”.</para>
-                <para>A simple class consists of any number of characters
+
+				<para>A simple class consists of any number of characters
                 enclosed by <literal>[</literal> and <literal>]</literal>.</para>
               </entry>
             </row>
@@ -1018,15 +1054,16 @@
               <entry>
                 <para>A character in the range of letters from “C” through
                 “X”.</para>
-                <para>A range is defined by the first character in a series,
-                followed by a hyphen, followed by last character in the
-                series. Any number of ranges can be defined:
-                <literal>[a-zA-Z0-9]</literal> means any lowercase character from
-                “a” to “z”, or any uppercase character from “A” to “Z”, or any
-                digit from “0” to “9”.
-                A hyphen placed outside the series is just a hyphen:
-                <literal>[a-z-]</literal> means any lowercase character from
-                “a” to “z”, or the hyphen character itself.</para>
+
+				<para>A range is defined by the first character in a series,
+				followed by a hyphen, followed by last character in the
+				series. Any number of ranges can be defined:
+				<literal>[a-zA-Z0-9]</literal> means any lowercase character
+				from “a” to “z”, or any uppercase character from “A” to “Z”, or
+				any digit from “0” to “9”.  A hyphen placed outside the series
+				is just a hyphen: <literal>[a-z-]</literal> means any lowercase
+				character from “a” to “z”, or the hyphen character
+				itself.</para>
               </entry>
             </row>
             
@@ -1034,6 +1071,7 @@
               <entry><literal>[^\n\r\t]</literal></entry>
               <entry>
                 <para>Any character <emphasis>except</emphasis> a newline, a carriage return, or tab.</para>
+
                 <para>The caret placed immediately after the opening square
                 bracket excludes the rest of the characters in the class.</para>
               </entry>
@@ -1044,6 +1082,7 @@
               <entry>
                 <para>A word character, generally defined as
                 <literal>[A-Za-z0-9_]</literal>.</para>
+
                 <para><literal>\W</literal> is any character that is
                 <emphasis role="bold">not</emphasis> a word character
                 (<literal>[^\w]</literal>).</para>
@@ -1055,6 +1094,7 @@
               <entry>
                 <para>A whitespace character, including the space and tab
                 characters, as well as line breaks.</para>
+
                 <para><literal>\S</literal> is any character that is
                 <emphasis role="bold">not</emphasis> a whitespace character
                 (<literal>[^\s]</literal>).</para>
@@ -1062,15 +1102,21 @@
             </row>
 
             <row>
-              <entry><literal>\h</literal> and <literal>\v</literal></entry>
-              <entry>Horizontal and vertical whitespace (generally preferred to
-              <literal>\s</literal>).
-              <para><literal>\H </literal> is any character that is
-              <emphasis role="bold">not</emphasis> a horizontal white space, and
-              <literal>\V</literal> any character that is
-              <emphasis role="bold">not</emphasis> a vertical white space
-              (<literal>[^\h]</literal> and <literal>[^\v]</literal>,
-              respectively).</para></entry>
+              <entry>
+				<literal>\h</literal> and <literal>\v</literal>
+			  </entry>
+
+              <entry>
+				<para>Horizontal and vertical whitespace (generally preferred to
+				<literal>\s</literal>).</para>
+
+				<para><literal>\H </literal> is any character that is <emphasis
+				role="bold">not</emphasis> a horizontal white space, and
+				<literal>\V</literal> any character that is <emphasis
+				role="bold">not</emphasis> a vertical white space
+				(<literal>[^\h]</literal> and <literal>[^\v]</literal>,
+				respectively).</para>
+			  </entry>
             </row>
           </tbody>
         </tgroup>
@@ -1103,9 +1149,10 @@
             <row>
               <entry><literal>\p{InGreek}</literal></entry>
               <entry>
-                <para>A character in the Greek block
-                (<ulink url="https://unicode.org/reports/tr18/#Blocks">Unicode
+                <para>A character in the Greek block (<ulink
+                url="https://unicode.org/reports/tr18/#Blocks">Unicode
                 block</ulink>)</para>
+				
                 <para><literal>\P{InGreek}</literal> is any character that is
                 <emphasis role="bold">not</emphasis> in the Greek block.</para>
               </entry>
@@ -1200,9 +1247,10 @@
               <entry><literal>(?=u)</literal></entry>
               <entry>
                 <para>A character followed by a “u”.</para>
+				
                 <para>For example, <literal>q(?=u)</literal> matches the letter
-                “q” when it is followed by a “u”. It therefore matches the
-                “q” in “equal” or “question”, but <emphasis>not</emphasis> the one
+                “q” when it is followed by a “u”. It therefore matches the “q”
+                in “equal” or “question”, but <emphasis>not</emphasis> the one
                 in “qigong” or “Iraq”.</para>
               </entry>
             </row>
@@ -1212,6 +1260,7 @@
               <entry>
                 <para>A character that is <emphasis>not</emphasis> followed by the
                 letter “u”.</para>
+				
                 <para>For example, <literal>q(?!u)</literal> matches the letter
                 “q” when it is <emphasis>not</emphasis> followed by a “u”. It
                 therefore matches the “q” in “qigong” or “Iraq”, but
@@ -1223,6 +1272,7 @@
               <entry><literal>(?&lt;=q)</literal></entry>
               <entry>
                 <para>A character preceded by the letter “q”.</para>
+				
                 <para>For example, <literal>(?&lt;=q)u</literal> matches the
                 letter “u” if it comes after “q”. It therefore matches the “u”
                 in “quick”, but not the one in “run”.</para>
@@ -1234,6 +1284,7 @@
               <entry>
                 <para>A character that is <emphasis>not</emphasis> preceded
                 by the letter “q”.</para>
+				
                 <para>For example, <literal>(?&lt;!q)u</literal> matches the
                 letter “u” if it does <emphasis>not</emphasis> come after “q”.
                 It therefore matches the “u” in “run”, but
@@ -1250,11 +1301,12 @@
     <title id="app.regex.more.examples.title">More examples</title>
 
     <para>This section presents a few examples demonstrating how the various
-    expressions described above can be combined to perform powerful searches in OmegaT.</para>
+    expressions described above can be combined to perform powerful searches in
+    OmegaT.</para>
     
     <table id="regex.examples">
-      <title id="regex.examples.title">Examples of regular expressions
-    that use the above expressions</title>
+      <title id="regex.examples.title">Examples of regular expressions that use
+      the above expressions</title>
 
       <tgroup align="left" cols="2" rowsep="1">
         <colspec align="left" colnum="1"/>
@@ -1313,7 +1365,8 @@
             <entry>
               <para>Find numerical dates in year, month, and day order with the
               month and day separated by a slash, period, or hyphen, such
-              as:
+              as:</para>
+			  
                 <itemizedlist>
                   <listitem>
                     <para>2002/11/8</para>
@@ -1325,12 +1378,12 @@
                     <para>2022-10-31</para>
                   </listitem>
                 </itemizedlist>
-              </para>
-              <note>
-                <para>This expression finds number and separator patterns
-                matching possible dates, but does not validate them. It will also
-                find patterns such as “5136/36/71”.</para>
-              </note>
+
+				<note>
+                  <para>This expression finds number and separator patterns
+                  matching possible dates, but does not validate them. It will
+                  also find patterns such as “5136/36/71”.</para>
+				</note>
             </entry>
           </row>
 
@@ -1369,9 +1422,9 @@
     <title id="app.regex.tools.title">References</title>
 
     <para>Although OmegaT does not offer fancy colouring for your regular
-    expressions, you can get a lot of practice by using the <link linkend="windows.text.search"
-    endterm="windows.text.search.title"/> window since OmegaT does colour the
-    matching results.</para>
+    expressions, you can get a lot of practice by using the <link
+    linkend="windows.text.search" endterm="windows.text.search.title"/> window
+    since OmegaT does colour the matching results.</para>
     
     <para>A few additional resources are presented below.</para>
 
@@ -1393,15 +1446,18 @@
 
       <variablelist>
         <varlistentry id="app.regex.tools.regex101">
-          <term id="app.regex.tools.regex101.title"><ulink url="https://regex101.com">https://regex101.com</ulink></term>
+          <term id="app.regex.tools.regex101.title"><ulink
+          url="https://regex101.com">https://regex101.com</ulink></term>
           <listitem>
             <para>An online regular expression matcher that lets you enter the
-            text you want to search and the regular expressions you want to test.</para>
+            text you want to search and the regular expressions you want to
+            test.</para>
           </listitem>
         </varlistentry>
 
         <varlistentry id="app.regex.tools.regular.expression.info">
-          <term id="app.regex.tools.regular.expression.info.title"><ulink url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
+          <term id="app.regex.tools.regular.expression.info.title"><ulink
+          url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
           <listitem>
             <para>One of the most thorough regular expression tutorial and
             reference on the web.</para>

--- a/doc_src/en/App_Segmentation.xml
+++ b/doc_src/en/App_Segmentation.xml
@@ -8,19 +8,15 @@
 	<title id="dialog.preferences.segmentation.setup.type.title">Paragraph or
 	sentence?</title>
 	
-	<para>Translation memory tools work with textual units called
-	segments. When a translation is entered, the segment containing the source
-	text is stored with its translation in the project memory, and
-	subsequently used to match other source segments in the project.</para>
+	<para>Translation memory tools work with textual units called segments. When
+	a translation is entered, the segment containing the source text is stored
+	with its translation in the project memory, and subsequently used to match
+	other source segments in the project.</para>
 
-	<para>Select the type of segmentation by clicking <link
-	linkend="menus.project.properties"
-	endterm="menus.project.properties.title"/> in the <link
-	linkend="menus.project" endterm="menus.project.title"/> menu and checking or
-	unchecking the <link
+	<para>Use the <link
 	linkend="dialogs.project.properties.options.segmentation"
-	endterm="dialogs.project.properties.options.segmentation.title"/>
-	box.</para>
+	endterm="dialogs.project.properties.options.segmentation.title"/> project
+	property to select the type of segmentation.</para>
 
 	<para>Segments are by default <emphasis role="bold">paragraphs</emphasis>
 	defined by the file format itself.</para>
@@ -50,14 +46,14 @@
 
 		<listitem>
 		  <para>OmegaT first parses the text for paragraph-level
-		  segmentation. This process relies only on the structure of the
-		  source file to produce segments.</para>
+		  segmentation. This process relies only on the structure of the source
+		  file to produce segments.</para>
 
 		  <para>For example, text files may be segmented on line breaks, empty
-		  lines, or not at all. Files containing formatting (ODF, HTML, or
-		  other documents) are divided at block-level (paragraph)
-		  tags. Translatable object attributes in XHTML or HTML files can be
-		  extracted as separate "paragraphs".</para>
+		  lines, or not at all. Files containing formatting (ODF, HTML, or other
+		  documents) are divided at block-level (paragraph) tags. Translatable
+		  object attributes in XHTML or HTML files can be extracted as separate
+		  "paragraphs".</para>
 		</listitem>
 	  </varlistentry>
 
@@ -75,19 +71,21 @@
 		  position where a break will occur, or where a break will not be
 		  allowed.</para>
 
-		  <para>Each time the cursor
-		  moves to the next character, OmegaT checks whether:
+		  <para>Each time the cursor moves to the next character, OmegaT checks
+		  whether:</para>
+		  
 		  <itemizedlist>
 			<listitem>
 			  <para>the text before the location corresponds to a <emphasis
-		  role="bold">Before</emphasis> rule,</para>
+			  role="bold">Before</emphasis> rule,</para>
 			</listitem>
+			
 			<listitem>
 			  <para>and the text after the location corresponds to the associated <emphasis
 			  role="bold">After</emphasis> rule.</para>
 			</listitem>
 		  </itemizedlist>
-		  </para>
+
 		  <para>If the location matches both rules, it is considered either as a
 		  break, or as a non-break, depending on what the rule defined.</para>
         </listitem>
@@ -99,19 +97,22 @@
 	<title id="dialog.preferences.segmentation.setup.scope.title">Global or
 	local?</title>
 
-	<note><para>The same mechanisms and dialogs are used to define global and
-	local segmentation rules.</para></note>
+	<note>
+	  <para>The same mechanisms and dialogs are used to define global and local
+	  segmentation rules.</para>
+	</note>
 
-	<para>By default, segmentation settings are global and shared by all projects.</para>
+	<para>By default, segmentation settings are global and shared by all
+	projects.</para>
 
-	<para>You can limit the segmentation rules used by the project to that
-	project by either setting local rules with <link
-	linkend="dialogs.project.properties.local.segmentation"
-	endterm="dialogs.project.properties.local.segmentation.title"/>, in <link
-	linkend="dialogs.project.properties"
-	endterm="dialogs.project.properties.title"/>, or by starting OmegaT from
-	the command line. See <link linkend="launch.with.command.line"
-	endterm="launch.with.command.line.title"/> for details.</para>
+	<para>Use the <link linkend="dialogs.project.properties.local.segmentation"
+	endterm="dialogs.project.properties.local.segmentation.title"/> project
+	property to limit the scope of the segmentation rules to the current
+	project.</para>
+
+	<para>You can achieve a similar result by starting OmegaT from the command
+	line. See the <link linkend="launch.with.command.line"
+	endterm="launch.with.command.line.title"/> how-to for details.</para>
 	
 	<para>If you use local rules, you can still access the global rules, but
 	modifying them will have no effect on your project.</para>
@@ -121,9 +122,8 @@
   <section id="dialog.preferences.segmentation.setup.rules.based.segmentation">
 	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">Rules</title>
 	<para>OmegaT provides predefined segmentation rules, and the translator can
-	use regular expressions to modify them. See <link
-	linkend="app.regex" endterm="app.regex.title"/> for
-	details.</para>
+	use regular expressions to modify them. See the <link linkend="app.regex"
+	endterm="app.regex.title"/> appendix for details.</para>
 
 	<para>As a reminder, rules work the following way: when a rule matches,
 	OmegaT puts a marker at the match location so that rules that come after
@@ -138,54 +138,58 @@
 	  translation will still be in the project memory.</para>
 	</warning>
 
-		<table id="segmentation.simple.examples">
-		<title id="segmentation.simple.examples.title">A few simple examples</title>
-          <tgroup cols="5">
-			<colspec align="left" colnum="1"/>
-			<colspec align="left" colnum="2"/>
-			<colspec align="center" colnum="3"/>
-			<colspec align="center" colnum="4"/>
-			<colspec align="left" colnum="5"/>
-			<thead>
-              <row>
-				<entry>Category</entry>
-				<entry>Intention</entry>
-				<entry align="center">Before</entry>
-				<entry align="center">After</entry>
-				<entry>Explanation</entry>
-              </row>
-			</thead>
-			<tbody>
-			  <row>
-				<entry>Exception rule, box unchecked, higher in the list</entry>
-				<entry>Do not segment after Ms.</entry>
-				<entry align="center">Ms\.</entry>
-				<entry align="center">\s</entry>
-				<entry>Ms, followed by a period, followed by a whitespace.</entry>
-			  </row>
-			  <row>
-				<entry>Exception rule, box unchecked, higher in the list</entry>
-				<entry>Excel cells with lines breaks that do not represent segments</entry>
-				<entry align="center">\n</entry>
-				<entry align="center">.</entry>
-				<entry>Line break, followed by anything.</entry>
-			  </row>
-			  <row>
-				<entry>Break rule, box checked, lower in the list</entry>
-				<entry>Start a new segment start after a period followed by a space, tab, or other whitespace.</entry>
-				<entry align="center">\.</entry>
-				<entry align="center">\s</entry>
-				<entry>A period followed by a whitespace</entry>
-			  </row>
-			  <row>
-				<entry>Break rule, box checked, lower in the list</entry>
-				<entry>Start a new segment after “。” (Japanese period).</entry>
-				<entry align="center">。</entry>
-				<entry align="center"/>
-				<entry>Note that the <literal>Pattern After</literal> field can be empty.</entry>
-			  </row>
-			</tbody>
-		  </tgroup>
-		</table>
-	  </section>
+	<table id="segmentation.simple.examples">
+	  <title id="segmentation.simple.examples.title">A few simple examples</title>
+      <tgroup cols="5">
+		<colspec align="left" colnum="1"/>
+		<colspec align="left" colnum="2"/>
+		<colspec align="center" colnum="3"/>
+		<colspec align="center" colnum="4"/>
+		<colspec align="left" colnum="5"/>
+		<thead>
+          <row>
+			<entry>Category</entry>
+			<entry>Intention</entry>
+			<entry align="center">Before</entry>
+			<entry align="center">After</entry>
+			<entry>Explanation</entry>
+          </row>
+		</thead>
+		<tbody>
+		  <row>
+			<entry>Exception rule, box unchecked, higher in the list</entry>
+			<entry>Do not segment after Ms.</entry>
+			<entry align="center">Ms\.</entry>
+			<entry align="center">\s</entry>
+			<entry>Ms, followed by a period, followed by a
+			whitespace.</entry>
+		  </row>
+		  <row>
+			<entry>Exception rule, box unchecked, higher in the list</entry>
+			<entry>Excel cells with lines breaks that do not represent
+			segments</entry>
+			<entry align="center">\n</entry>
+			<entry align="center">.</entry>
+			<entry>Line break, followed by anything.</entry>
+		  </row>
+		  <row>
+			<entry>Break rule, box checked, lower in the list</entry>
+			<entry>Start a new segment start after a period followed by a
+			space, tab, or other whitespace.</entry>
+			<entry align="center">\.</entry>
+			<entry align="center">\s</entry>
+			<entry>A period followed by a whitespace</entry>
+		  </row>
+		  <row>
+			<entry>Break rule, box checked, lower in the list</entry>
+			<entry>Start a new segment after “。” (Japanese period).</entry>
+			<entry align="center">。</entry>
+			<entry align="center"/>
+			<entry>Note that the <literal>Pattern After</literal> field can
+			be empty.</entry>
+		  </row>
+		</tbody>
+	  </tgroup>
+	</table>
+  </section>
 </section>

--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -7,22 +7,25 @@
   <section id="app.shortcuts.description">
     <title id="app.shortcuts.description.title">Description</title>
 
-    <para>The OmegaT interface generally does not rely on buttons to give
-    access to its functions. Instead, they are called from the menus or, for the
+    <para>The OmegaT interface generally does not rely on buttons to give access
+    to its functions. Instead, they are called from the menus or, for the
     majority of functions, from their assigned default shortcut.</para>
   
-    <para>Learning the most frequent shortcuts will not take long once you
-    start working with OmegaT. The shortcuts are indicated next to each menu
-    item, allowing them to learn new shortcuts gradually as you use the software.</para>
+    <para>Learning the most frequent shortcuts will not take long once you start
+    working with OmegaT. The shortcuts are indicated next to each menu item,
+    allowing them to learn new shortcuts gradually as you use the
+    software.</para>
 
-    <para>You can customize the majority of the shortcuts in OmegaT. See <link
-    endterm="app.shortcuts.customization.title"
-    linkend="app.shortcuts.customization"/> for details.</para>
+    <para>You can customize the majority of the shortcuts in OmegaT. See the
+    <link endterm="app.shortcuts.customization.title"
+    linkend="app.shortcuts.customization"/> section for details.</para>
 
     <para>OmegaT runs on any platform that runs a Java Runtime Environment
     (Windows, macOS, and Linux being the most mainstream). The modifier keys
     that form the shortcuts vary slightly depending between platforms. To make
-    reading easier we have adopted the following convention for modifier keys:
+    reading easier we have adopted the following convention for modifier
+    keys:</para>
+	
     <table id="app.shortcut.description">
       <title id="app.shortcut.description.title">Modifier key identifiers</title>
 
@@ -62,138 +65,156 @@
           </row>
         </tbody>
       </tgroup>
-      </table></para>
-      
-      <para>The <emphasis role="bold">Key identifiers</emphasis> above enable us
-      to avoid listing multiple notations for every shortcut.</para>
+    </table>
+        
+    <para>The <emphasis role="bold">Key identifiers</emphasis> above enable us
+    to avoid listing multiple notations for every shortcut.</para>
 
-          <example id="example.avoid.listing.multiple.notations"><title id="example.avoid.listing.multiple.notations.title">How we avoid listing multiple notations:</title>
-		<para>On Windows and Linux:
-		  <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo>
-		</para>
-		<para>On macOS:
-		  <keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>N</keycap></keycombo>
-		</para>
-  		<para>In this guide:
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
-		</para>
-		</example>
+    <example id="example.avoid.listing.multiple.notations">
+	  <title id="example.avoid.listing.multiple.notations.title">How we avoid
+	  listing multiple notations:</title>
+	  <para>On Windows and Linux:
+	  <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo></para>
+
+	  <para>On macOS:
+	  <keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>N</keycap></keycombo></para>
+
+	  <para>In this manual:
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></para>
+	</example>
   </section>
   
   <section id="app.shortcuts.streamline.workflow">
-    <title id="app.shortcuts.streamline.workflow.title">A shortcut based workflow</title>
+    <title id="app.shortcuts.streamline.workflow.title">A shortcut based
+    workflow</title>
 
     <para>Remembering the main editing and navigation shortcuts (or <link
     linkend="app.shortcuts.customization">modifying them to suit your
     needs</link>) can help you streamline your work.</para>
     <para>This is best illustrated with an example:</para>
 
-      <example id="example.shortcuts.streamline.workflow">
-        <title id="example.shortcuts.streamline.workflow.title">Using shortcuts
-        to streamline the translation process</title>
+    <example id="example.shortcuts.streamline.workflow">
+      <title id="example.shortcuts.streamline.workflow.title">Using shortcuts to
+      streamline the translation process</title>
 
-        <para>Picture a technical translator tasked with translating an updated
-        version of a manual from a previous job.</para>
+      <para>Picture a technical translator tasked with translating an updated
+      version of a manual from a previous job.</para>
         
-        <para>Since the first few pages have not changed, the translator is
-        greeted with a screenful of already translated segments from the
-        previous job's memory upon opening the project.</para>
+      <para>Since the first few pages have not changed, the translator is
+      greeted with a screenful of already translated segments from the previous
+      job's memory upon opening the project.</para>
 
-		<para>Rather than tediously scroll down until she finds the first
-		segment to translate, the translator quickly presses
-		<keycombo><keycap>C</keycap><keycap>U</keycap></keycombo> to <link
-		linkend="menus.goto.next.untranslated.segment">jump straight into the
-		action</link> and start translating. (And doing so again each time she
-		reaches a large unchanged section.)</para>
+	  <para>Rather than tediously scroll down until she finds the first segment
+	  to translate, the translator quickly presses
+	  <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo> to <link
+	  linkend="menus.goto.next.untranslated.segment">jump straight into the
+	  action</link> and start translating. (And doing so again each time she
+	  reaches a large unchanged section.)</para>
 
-        <para>A few segments later, the translator comes across a term she
-        should add to the glossary. Instead of reaching for the mouse, she unlocks the cursor with <link linkend="panes.editor.cursor.lock"><keycap>F2</keycap></link>,
-       uses the cursor keys and standard system shortcuts to navigate to the
-        term and select it, and then presses
-        <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap>
-        </keycombo> to <link linkend="menus.edit.create.glossary.entry">call up
-        the glossary entry dialog</link> to enter the source term, and then
-        switches back to the editor and repeats the process to enter the target
-        term.</para>
+      <para>A few segments later, the translator comes across a term she should
+      add to the glossary. Instead of reaching for the mouse, she unlocks the
+      cursor with <link
+      linkend="panes.editor.cursor.lock"><keycap>F2</keycap></link>, uses the
+      cursor keys and standard system shortcuts to navigate to the term and
+      select it, and then presses
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
+      to <link linkend="menus.edit.create.glossary.entry">call up the glossary
+      entry dialog</link> to enter the source term, and then switches back to
+      the editor and repeats the process to enter the target term.</para>
 
-		<para>The translator has enabled the <link
-		linkend="dialog.preferences.auto.completion"
-		endterm="dialog.preferences.auto.completion.title"/> to automatically
-		display not only history predictions, but also glossary terms, and
-		pre-defined short strings, which can be entered with simple arrow
-		navigation.</para>
+	  <para>The translator has enabled the <link
+	  linkend="dialog.preferences.auto.completion">auto-completion</link> to
+	  automatically display not only history predictions, but also glossary
+	  terms, and pre-defined short strings, which can be entered with simple
+	  arrow navigation.</para>
 		
-        <para>The translator then reaches a revised section of the text where
-        the <link linkend="panes.fuzzy.matches"
-        endterm="panes.fuzzy.matches.title"/> pane shows a number of similar
-        segments from the previous job.</para>
+      <para>The translator then reaches a revised section of the text where the
+      <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>
+      pane shows a number of similar segments from the previous job.</para>
 
-		<para>After quickly tapping
-        <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo> to insert the
-        match, she makes the necessary changes to match the revised text. This
-        continues, with the occasional sequence of
-        <keycombo><keycap>C</keycap><keycap>2</keycap></keycombo> (or other
-        number) followed by
-        <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo> when one of
-        the matches from 2 to 5 is more suitable.</para>
+	  <para>After quickly tapping
+	  <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo> to insert the
+	  match, she makes the necessary changes to match the revised text.</para>
 
-		<para>By the time she gets near the
-        end of the section, she has also used
-        <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo> once or twice
-        to replace already automatically entered fuzzy matches from the previous
-        translation with better matches from earlier in the current
-        section.</para>
+	  <para>This continues, with the occasional sequence of
+	  <keycombo><keycap>C</keycap><keycap>2</keycap></keycombo> (or other
+	  number) followed by
+	  <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo> when one of the
+	  matches from 2 to 5 is more suitable.</para>
 
-        <para>Later on, the translator comes up with a better way to phrase a
-        somewhat thorny expression that had come up earlier, so she
-        selects it in the source text, presses
-        <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo> <link
-        linkend="windows.text.search">to find</link> it, and then uses
-        <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo> to immediately
-        jump to that segment from the search dialog.</para>
+	  <para>Some segments will require modifications later on, so she uses
+	  <keycombo><keycap>A</keycap><keycap>C</keycap><keycap>N</keycap></keycombo>
+	  to enter the Notes pane, leave herself a note and comes back to the Editor
+	  pane with
+	  <keycombo><keycap>A</keycap><keycap>C</keycap><keycap>E</keycap></keycombo>.</para>
+	  
+	  <para>By the time she gets near the end of the section, she has also used
+	  <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo> once or twice to
+	  replace already automatically entered fuzzy matches from the previous
+	  translation with better matches from earlier in the current
+	  section.</para>
 
-		<para>Since OmegaT has registered her navigation history, she only needs
-		to use
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>J</keycap></keycombo>
-		to immediately continue from where she left off.</para>
+      <para>Later on, the translator comes up with a better way to phrase a
+      somewhat thorny expression that had come up earlier, so she selects it in
+      the source text, presses
+      <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo> <link
+      linkend="windows.text.search">to find</link> it, and then uses
+      <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo> to immediately
+      jump to that segment from the search dialog.</para>
 
-        <para>Time for a break. As she savours her coffee, the translator
-        reflects on how much more smoothly she was able to use the various
-        OmegaT functions compared to when she had just gotten started and spent
-        a lot of time clicking through menus.</para>
+	  <para>Since OmegaT has registered her navigation history, she only needs
+	  to use
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>J</keycap></keycombo>
+	  to immediately continue from where she left off.</para>
+
+	  <para>She now decides to review the annoted segments. She uses
+	  <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo> to find them,
+	  and in the search window uses
+	  <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo> and
+	  <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo> to navigate the
+	  results. OmegaT synchronises the Editor contents with the selected result,
+	  so she can edit the segments right away.</para>
         
-        <para>The smoother workfow, in turn, allowed her to better focus on the
-        translation itself.</para>
+      <para>Time for a break. As she savours her coffee, the translator reflects
+      on how much more smoothly she was able to use the various OmegaT functions
+      compared to when she had just gotten started and spent a lot of time
+      clicking through menus.</para>
+
+      <para>The smoother workfow, in turn, allowed her to better focus on the
+      translation itself.</para>
         
-        <para>At the same time, the translator realized that during her
-        session, she used the menu and cursor keys to select the
-        <link linkend="menus.edit.create.alternative.translation"
-        endterm="menus.edit.create.alternative.translation.title"/> function
-        several times, and decides to <link
-        linkend="example.shortcut.addition">add a new shortcut</link> to
-        streamline that part of the process as well.</para>
-      </example>
+      <para>At the same time, the translator realized that during her session,
+      she used the <link linkend="menus.edit" endterm="menus.edit.title"/><link
+      linkend="menus.edit.create.alternative.translation"
+      endterm="menus.edit.create.alternative.translation.title"/> menu and the
+      cursor keys several times, and decides to <link
+      linkend="example.shortcut.addition">add a new shortcut</link> to
+      streamline that part of the process as well.</para>
+	  
+    </example>
     
     <para>Taking the time to learn the shortcuts for the functions you use often
-    will be well worth your while.</para>    
+    will be well worth your while.</para>
   </section>
 
   <section id="app.shortcuts.customization">
     <title id="app.shortcuts.customization.title">Customization</title>
 
     <para>OmegaT assigns shortcuts to most of the functions available in the
-    <link linkend="menus.project" endterm="menus.project.title"/>,
-    <link linkend="menus.edit" endterm="menus.edit.title"/>, and
-    <link linkend="menus.goto" endterm="menus.goto.title"/> menus and	to a
-    number of functions in the Editor window. You can also add or modify the
-    shortcuts for most of the functions.</para>
-    <para>To do so, you have to put the appropriate shortcut definition file in
-    your OmegaT configuration folder. See <link
-    endterm="configuration.folder.title" linkend="configuration.folder"/> for
-    details.</para>
+    <link linkend="menus.project" endterm="menus.project.title"/>, <link
+    linkend="menus.edit" endterm="menus.edit.title"/>, and <link
+    linkend="menus.goto" endterm="menus.goto.title"/> menus and to a number of
+    functions in the Editor window. You can also add or modify the shortcuts for
+    most of the functions.</para>
+
+	<para>To do so, you have to put the appropriate shortcut definition file in
+	your OmegaT configuration folder. See the <link
+	endterm="configuration.folder.title" linkend="configuration.folder"/>
+	appendix for details.</para>
 
     <para>There are two shortcut definition files.</para>
-    <variablelist>
+
+	<variablelist>
       <varlistentry>
         <term id="MainMenuShortcuts.properties">MainMenuShortcuts.properties</term>
         <listitem>
@@ -201,7 +222,8 @@
           items.</para>
         </listitem>
       </varlistentry>
-      <varlistentry>
+
+	  <varlistentry>
         <term id="EditorShortcuts.properties">EditorShortcuts.properties</term>
         <listitem><para>The shortcut definition file for the editor.</para>
         </listitem>
@@ -213,9 +235,9 @@
 
     <note>
       <para>You can copy the default OmegaT shortcut files from the OmegaT
-      development site on Sourceforge to
-      <link linkend="configuration.folder">your configuration folder</link> and
-      modify them to suit your needs:</para>
+      development site on Sourceforge to <link
+      linkend="configuration.folder">your configuration folder</link> and modify
+      them to suit your needs:</para>
 
       <variablelist>
         <varlistentry>
@@ -226,6 +248,7 @@
                 <para><ulink
                 url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.properties">MainMenuShortcuts.properties</ulink></para>
               </listitem>
+
               <listitem>
                 <para><ulink
                 url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.properties">EditorShortcuts.properties</ulink></para>
@@ -233,6 +256,7 @@
             </itemizedlist>
           </listitem>
         </varlistentry>
+		
         <varlistentry><term>macOS default shortcuts</term>
           <listitem>
             <itemizedlist>
@@ -240,6 +264,7 @@
                 <para><ulink
                 url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties">MainMenuShortcuts.mac.properties</ulink></para>
               </listitem>
+
               <listitem>
                 <para><ulink
                 url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.mac.properties">EditorShortcuts.mac.properties</ulink></para>
@@ -248,28 +273,32 @@
           </listitem>
         </varlistentry>
       </variablelist>
-        <para>The macOS files must be renamed <link linkend="MainMenuShortcuts.properties" endterm="MainMenuShortcuts.properties"/> and
-        <link linkend="EditorShortcuts.properties"
+
+      <para>The macOS files must be renamed <link
+      linkend="MainMenuShortcuts.properties"
+      endterm="MainMenuShortcuts.properties"/> and <link
+      linkend="EditorShortcuts.properties"
       endterm="EditorShortcuts.properties"/> for OmegaT to recognize
       them.</para>
     </note>
-    <para>
-      The next section describes the syntax used in the shortcut definition
-      files, and provides an example modification.
-    </para>
+
+    <para>The next section describes the syntax used in the shortcut definition
+    files, and provides an example modification.</para>
   </section>
 
   <section id="app.shortcuts.syntax">
     <title id="app.shortcuts.syntax.title">Syntax</title>
 
     <para>The basic syntax of the shortcut definitions files is simply:</para>
+
     <para><code>function code=shortcut</code></para>
-    <para>Use the tables in the <link linkend="app.shortcuts.lists"
-    endterm="app.shortcuts.lists.title"/> section below to find the values for
-    <code>function code</code>.</para>
+
+	<para>Use the tables in the <link linkend="app.shortcuts.lists"
+	endterm="app.shortcuts.lists.title"/> section below to find the values for
+	<code>function code</code>.</para>
     
     <para>The <code>shortcut</code> represents the key combination pressed by
-    the user. It takes the following form:
+    the user. It takes the following form:</para>
     
     <itemizedlist>
       <listitem>
@@ -284,22 +313,21 @@
         <para>followed by 1 <code>key</code></para>
       </listitem>
     </itemizedlist>
-    where:</para>
-    
+
     <itemizedlist>
       <listitem>
-        <para><code>modifier</code> can be:
-        <literal>shift</literal>, <literal>ctrl</literal>,
-        <literal>meta</literal>, <literal>alt</literal>, or
-        <literal>altGraph</literal></para>
+        <para>where <code>modifier</code> can be: <literal>shift</literal>,
+        <literal>ctrl</literal>, <literal>meta</literal>,
+        <literal>alt</literal>, or <literal>altGraph</literal></para>
 
         <note>
-          <para><literal>meta</literal> refers to the key with the Windows
-          logo on most keyboards for Windows or Linux systems, and to the
+          <para><literal>meta</literal> refers to the key with the Windows logo
+          on most keyboards for Windows or Linux systems, and to the
           <literal>command</literal> on macOS.</para>
+
           <para><literal>altGraph</literal> refers to the
-          <emphasis>Alt</emphasis> key to the right of the spacebar on
-          keyboards with two <emphasis>Alt</emphasis> keys.</para>
+          <emphasis>Alt</emphasis> key to the right of the spacebar on keyboards
+          with two <emphasis>Alt</emphasis> keys.</para>
         </note>
       </listitem>
 
@@ -311,9 +339,10 @@
       <listitem>
         <para>and <code>key</code> can be any key available on your
         keyboard. You can refer to the <link
-        linkend="app.shortcuts.lists.function.codes.editor.table">table presenting the different
-        editor shortcuts</link> to find the values for keys such as
-        <literal>Home</literal>, <literal>Page Up</literal>, or the arrow keys.</para>
+        linkend="app.shortcuts.lists.function.codes.editor.table">table
+        presenting the different editor shortcuts</link> to find the values for
+        keys such as <literal>Home</literal>, <literal>Page Up</literal>, or the
+        arrow keys.</para>
       </listitem>
     </itemizedlist>
 
@@ -330,32 +359,29 @@
       shortcut</title>
 
       <para>The default shortcut for <link linkend="menus.project.close">closing
-      a project</link> is defined as:
-        <simplelist>
-          <member><code>projectCloseMenuItem=ctrl shift W</code></member>
-        </simplelist>
-      on Windows and Linux, and as
-        <simplelist>
-          <member><code>projectCloseMenuItem=meta shift W</code></member>
-        </simplelist>
-      on macOS.
-      </para>
+      a project</link> is defined on Windows and Linux as:</para>
+
+	  <para><code>projectCloseMenuItem=ctrl shift W</code></para>
+
+      <para>and on macOS as:</para>
+	  
+	  <para><code>projectCloseMenuItem=meta shift W</code></para>
 
       <para>However, you may want to remove the <keycap>S</keycap> key from the
       shortcut to make it only
       <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo> (or
       <keycombo><keycap>Command</keycap><keycap>W</keycap></keycombo> on macOS)
-      to match the shortcut you use in other applications. To do so, modify the
-      <filename>MainMenuShortcuts.properties</filename> as follows:
-        <simplelist>
-          <member><code>projectCloseMenuItem=ctrl W</code></member>
-        </simplelist>
-      in Windows or Linux, or</para>
-      <para>
-        <simplelist>
-          <member><code>projectCloseMenuItem=meta W</code></member>
-        </simplelist>
-      on macOS.</para>
+      to match the shortcut you use in other applications.</para>
+
+	  <para>To do so, modify the
+	  <filename>MainMenuShortcuts.properties</filename> as follows for Windows
+	  or Linux:</para>
+
+	  <para><code>projectCloseMenuItem=ctrl W</code></para>
+
+	  <para>or as follows for macOS:</para>
+
+      <para><code>projectCloseMenuItem=meta W</code></para>
     </example>
 
     <example id="example.shortcut.addition">
@@ -367,53 +393,56 @@
       since it does not have one by default.</para>
 
       <para>The steps below demonstrate how to assign the
-      <keycombo><keycap>Alt</keycap><keycap>X</keycap></keycombo> shortcut to the
-      <link linkend="menus.edit.create.alternative.translation"
-      endterm="menus.edit.create.alternative.translation.title"/> function.
-        <orderedlist>
-          <listitem>
-            <para>Open the <filename>MainMenuShortcuts.properties</filename> you
-            have copied to <link linkend="configuration.folder">your
-            configuration folder</link> in a text editor.</para>
-          </listitem>
-          <listitem>
-            <para>As shown in the <link
-            linkend="app.shortcuts.lists.function.codes.edit.menu.table">Edit
-            menu table</link> below, the function code for the <guimenuitem>Create Alternative Translation</guimenuitem> function
-            is <code>editMultipleAlternate</code>.</para>
-            <para>Searching for that code in the file will bring you to the
-            following line:
-              <simplelist>
-                <member><code>#	editMultipleAlternate=</code></member>                
-              </simplelist>
-            </para>
-          </listitem>
-          <listitem>
+      <keycombo><keycap>Alt</keycap><keycap>X</keycap></keycombo> shortcut to
+      the <link linkend="menus.edit" endterm="menus.edit.title"/><link
+      linkend="menus.edit.create.alternative.translation"
+      endterm="menus.edit.create.alternative.translation.title"/> menu item.</para>
+	  
+      <orderedlist>
+        <listitem>
+          <para>Open the <filename>MainMenuShortcuts.properties</filename> you
+          have copied to <link linkend="configuration.folder">your configuration
+          folder</link> in a text editor.</para>
+        </listitem>
+
+		<listitem>
+          <para>As shown in the <link
+          linkend="app.shortcuts.lists.function.codes.edit.menu.table">Edit menu
+          table</link> below, the function code for the <guimenuitem>Create
+          Alternative Translation</guimenuitem> function is
+          <code>editMultipleAlternate</code>.</para>
+
+          <para>Searching for that code in the file will bring you to the
+          following line:</para>
+		  
+          <para><code>#	editMultipleAlternate=</code></para>
+        </listitem>
+
+		<listitem>
             <para>The line is currently a comment. Delete the <code>#</code> at
             the beginning of the line so OmegaT will recognize the shortcut, and
             add <option>alt X</option> after the <code>=</code> sign at the end
-            of the line:
-              <simplelist>
-                <member><code>editMultipleAlternate=alt X</code></member>
-              </simplelist>
-            </para>
-          </listitem>
-          <listitem>
+            of the line:</para>
+			
+            <para><code>editMultipleAlternate=alt X</code></para>
+        </listitem>
+
+		<listitem>
             <para>Save and close the file. The next time you start OmegaT, your
             new shortcut should be active and displayed next to the name of the
             function in the menu.</para>
           </listitem>
         </orderedlist>
-      </para>
     </example>
 
     <para>Save the file after you have finished making your changes. If OmegaT
     is open, you will have to restart it for your changes to take effect.</para>
     <para>Your modified or added shortcuts should now be displayed next to the
     menu items you have changed. They will now be available in OmegaT as long as
-    there are no conflicts with other functions or with system-wide shortcuts.</para>
+    there are no conflicts with other functions or with system-wide
+    shortcuts.</para>
 
-    <para>The next section presents tables with the function codes and 
+    <para>The next section presents tables with the function codes and
     corresponding default shortcut for each menu or editor function in
     OmegaT.</para>
   </section>
@@ -433,7 +462,9 @@
       <filename>EditorShortcuts.properties</filename>.</para>
 
       <table id="app.shortcuts.lists.function.codes.project.menu.table">
-        <title id="app.shortcuts.lists.function.codes.project.menu.table.title">Project Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.project.menu.table.title">Project
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -609,7 +640,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.edit.menu.table">
-        <title id="app.shortcuts.lists.function.codes.edit.menu.table.title">Edit Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.edit.menu.table.title">Edit
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -866,7 +899,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.goto.menu.table">
-        <title id="app.shortcuts.lists.function.codes.goto.menu.table.title">GoTo Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.goto.menu.table.title">GoTo
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -956,12 +991,29 @@
               <entry>ctrl shift P</entry>
               <entry>meta shift P</entry>
             </row>
+
+            <row>
+              <entry>Notes Pane</entry>
+              <entry>gotoNotesPanelMenuItem</entry>
+              <entry>ctrl alt N</entry>
+              <entry>meta alt N</entry>
+            </row>
+
+            <row>
+              <entry>Editor Pane</entry>
+              <entry>gotoEditorPanelMenuItem</entry>
+              <entry>ctrl alt E</entry>
+              <entry>meta alt E</entry>
+            </row>
+
           </tbody>
         </tgroup>
       </table>
 
       <table id="app.shortcuts.lists.function.codes.view.menu.table">
-        <title id="app.shortcuts.lists.function.codes.view.menu.table.title">View Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.view.menu.table.title">View
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1063,7 +1115,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.tools.menu.table">
-        <title id="app.shortcuts.lists.function.codes.tools.menu.table.title">Tools Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.tools.menu.table.title">Tools
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1121,6 +1175,7 @@
         endterm="windows.scripts.title"/> item in the <link
         linkend="menus.tools" endterm="menus.tools.title"/> menu is an
         exception.</para>
+
         <para>It is not possible to add a shortcut to call the script editor, or
         to modify the shortcuts assigned to the scripts.</para>
       </note>
@@ -1205,7 +1260,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.help.menu.table">
-        <title id="app.shortcuts.lists.function.codes.help.menu.table.title">Help Menu</title>
+        <title
+        id="app.shortcuts.lists.function.codes.help.menu.table.title">Help
+        Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1224,7 +1281,7 @@
 
           <tbody>
             <row>
-              <entry>User Guide...</entry>
+              <entry>User Manual...</entry>
               <entry>helpContentsMenuItem</entry>
               <entry namest="3" nameend="4">F1</entry>
             </row>
@@ -1253,7 +1310,9 @@
       </table>
       
       <table id="app.shortcuts.lists.function.codes.search.window.table">
-        <title id="app.shortcuts.lists.function.codes.search.window.table.title">Search Window</title>
+        <title
+        id="app.shortcuts.lists.function.codes.search.window.table.title">Search
+        Window</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1433,7 +1492,8 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.autocompleter.table">
-        <title id="app.shortcuts.lists.function.codes.autocompleter.table.title">Autocompleter</title>
+        <title
+        id="app.shortcuts.lists.function.codes.autocompleter.table.title">Autocompleter</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -1,32 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="dialogs.project.properties">
-  <title id="dialogs.project.properties.title">Project Properties</title>
+  <title id="dialogs.project.properties.title"><guilabel>Project
+  Properties</guilabel></title>
 
-  <para>Use <link
+  <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
   linkend="menus.project.properties" endterm="menus.project.properties.title"/>
-  in the <link linkend="menus.project" endterm="menus.project.title"/>
-  menu to open the dialog.</para>
-
+  to open the dialog.</para>
+  
   <para>The dialog is used to set the initial project properties when creating a
   new project and also to modify them later, after the project has been
-  created. See <link linkend="introduction.create.and.open.new.project"
-  endterm="introduction.create.and.open.new.project.title"/> for details.</para>
+  created.</para>
+
+  <para>See the <link linkend="introduction.create.and.open.new.project"
+  endterm="introduction.create.and.open.new.project.title"/> chapter for
+  details.</para>
   
 
   <section id="dialogs.project.properties.languages">
-    <title id="dialogs.project.properties.languages.title">Languages</title>
+    <title
+    id="dialogs.project.properties.languages.title"><guilabel>Languages</guilabel></title>
 
-    <para>Select the source and target languages by hand, or use
-    the drop-down menus.</para>
-	<para>Language codes are used in <link linkend="panes.fuzzy.matches"
-	endterm="panes.fuzzy.matches.title"/>, <link
-	linkend="dialogs.preferences.segmentation.setup"
-	endterm="dialogs.preferences.segmentation.setup.title"/>, the <link
-	linkend="dialog.preferences.spellchecker"
-	endterm="dialog.preferences.spellchecker.title"/>, <link
-	linkend="dialog.preferences.languagetool.plugin"
-	endterm="dialog.preferences.languagetool.plugin.title"/>, etc.</para>
+    <para>Select the source and target languages by hand, or use the drop-down
+    menus.</para>
+
+	<warning>
+	  <para>A number of issues come from not selecting the right language here,
+	  or from not matching it in other preferences.</para>
+	</warning>
+
+	<para>Language codes are used in various places in OmegaT:</para>
+	
+	<itemizedlist>
+	  <listitem>
+		<para>to get results in the <link linkend="panes.fuzzy.matches"
+		endterm="panes.fuzzy.matches.title"/> pane,</para>
+	  </listitem>
+
+	  <listitem>
+		<para>to apply the segmentation rules defined in the <link
+		linkend="dialogs.preferences.segmentation.setup"
+		endterm="dialogs.preferences.segmentation.setup.title"/>
+		preferences,</para>
+	  </listitem>
+
+	  <listitem>
+		<para>to find spelling mistakes from the dictionaries installed in the
+		<link linkend="dialog.preferences.spellchecker"
+		endterm="dialog.preferences.spellchecker.title"/> preferences,</para>
+	  </listitem>
+
+	  <listitem>
+		<para>to find grammatical and typographical mistakes from the rules set
+		in the <link linkend="dialog.preferences.languagetool.plugin"
+		endterm="dialog.preferences.languagetool.plugin.title"/>
+		preferences, etc.</para>
+	  </listitem>
+	</itemizedlist>
 	
     <para>OmegaT automatically selects the tokenizers that correspond to the
     source and target languages but you can manually modify the
@@ -34,13 +65,16 @@
   </section>
 
   <section id="dialogs.project.properties.options">
-    <title id="dialogs.project.properties.options.title">Options</title>
+    <title
+    id="dialogs.project.properties.options.title"><guilabel>Options</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.project.properties.options.segmentation">
-        <term id="dialogs.project.properties.options.segmentation.title">Sentence-level segmenting</term>
-        <listitem>
-		  
+        <term
+        id="dialogs.project.properties.options.segmentation.title"><option>Sentence-level
+        segmenting</option></term>
+
+		<listitem>		  
           <para>Sentence-level segmentation splits the source file “paragraphs”
           into segments based on segmentation rules.</para>
 
@@ -50,21 +84,26 @@
 		  <para>By default, segmentation rules are global and apply to all
 		  projects.</para>
 
-		  <para>You can access the global rules with <link
+		  <para>Use <link linkend="menus.options"
+		  endterm="menus.options.title"/><link
 		  linkend="menus.options.segmentation"
-		  endterm="menus.options.segmentation.title"/> in the <link
-		  linkend="menus.options" endterm="menus.options.title"/> menu.</para>
+		  endterm="menus.options.segmentation.title"/> to access the global
+		  segmentation rules.</para>
 		  
-		  <para>Click <link
+		  <para>Click on <link
 		  linkend="dialogs.project.properties.local.segmentation"
-		  endterm="dialogs.project.properties.local.segmentation.title"/>
-		  if you want to use project specific segmentation rules (local
-		  rules) and not global rules, or start OmegaT from the command
-		  line. See <link linkend="launch.with.command.line"
-		  endterm="launch.with.command.line.title"/> for details.</para>
+		  endterm="dialogs.project.properties.local.segmentation.title"/> to use
+		  project specific segmentation rules (local rules) and not the global
+		  rules. You can also start OmegaT from the command line with a project
+		  specific configuration setting to achieve a similar result.</para>
 
-		  <note><para>If you use local rules, you can still access the global rules, but
-		  modifying them will have no effect on your project.</para></note>
+		  <para>See the <link linkend="launch.with.command.line"
+		  endterm="launch.with.command.line.title"/> section for details.</para>
+
+		  <note>
+			<para>If you use local rules, you can still access the global rules,
+			but modifying them will have no effect on your project.</para>
+		  </note>
 		  
 		  <para>Changing the segmentation rules settings during a translation
 		  does not modify the segments registered in the project translation
@@ -77,446 +116,561 @@
 		  OmegaT will attempt to create fuzzy matches for paragraphs by
 		  combining existing sentence translations.</para>
 
-		  <para>If you change the segmentation while translating, you will have to
-		  reload the project for the new segmentation to take effect. This will
-		  split or merge some previously translated segments, which will therefore
-		  no longer be considered translated. Nonetheless, their original
-		  translation will still be in the project memory.</para>
+		  <para>If you change the segmentation while translating, you will have
+		  to reload the project for the new segmentation to take effect. This
+		  will split or merge some previously translated segments, which will
+		  therefore no longer be considered translated. Nonetheless, their
+		  original translation will still be in the project memory.</para>
 
-		  <para>See <link linkend="app.segmentation"
-		  endterm="app.segmentation.title"/> for general explanations about
-		  segmentation (global or local, paragraph or sentence, setting, etc.)</para>
+		  <para>See the <link linkend="app.segmentation"
+		  endterm="app.segmentation.title"/> appendix for general explanations about
+		  segmentation (global or local, paragraph or sentence, setting,
+		  etc.)</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.local.segmentation">
         <term
-			id="dialogs.project.properties.local.segmentation.title">Local Segmentation Rules...</term>
-        <listitem>
+        id="dialogs.project.properties.local.segmentation.title"><guibutton>Local
+        Segmentation Rules...</guibutton></term>
+
+		<listitem>
 		  <para>By default, segmentation rules are global and apply to all
 		  projects.</para>
 		  
           <para>Segmentation rules found when you open the <link
           linkend="dialogs.preferences.segmentation.setup"
-          endterm="dialogs.preferences.segmentation.setup.title"/> preferences (with <link
+          endterm="dialogs.preferences.segmentation.setup.title"/> preferences
+          (use <link linkend="menus.options"
+          endterm="menus.options.title"/><link
           linkend="menus.options.segmentation"
-          endterm="menus.options.segmentation.title"/> in the <link
-          linkend="menus.options" endterm="menus.options.title"/> menu) are
-          global rules.</para>
+          endterm="menus.options.segmentation.title"/>) are the global
+          rules.</para>
 
 		  <para>Use this button to create local rules specific to your
-		  project. Check the <guilabel>Use local segmentation rules</guilabel>
+		  project. Check the <option>Use local segmentation rules</option>
 		  box, and adjust the segmentation rules as desired.</para>
 		  
 		  <para>The project will store the new set of rules in the <link
 		  linkend="project.folder.omegat.segmentation"
-		  endterm="project.folder.omegat.segmentation.title"/> file of its <link
-		  linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder,
-		  and the rules will supersede the global segmentation rules.</para>
+		  endterm="project.folder.omegat.segmentation.title"/> file located in
+		  its <link linkend="project.folder.omegat.folder"
+		  endterm="project.folder.omegat.folder.title"/> folder, and the rules
+		  will supersede the global segmentation rules.</para>
 		  
-		  <para>To disable local segmentation rules, disable this option
-		  or remove that file.</para>
+		  <para>To disable local segmentation rules, disable this option or
+		  remove that file.</para>
 
-		  <warning><para>If you use local rules, you can still access the global
-		  rules, but modifying them will have no effect on your
-		  project.</para></warning>
+		  <warning>
+			<para>If you use local rules, you can still access the global rules,
+			but modifying them will have no effect on your project.</para>
+		  </warning>
 
-		  <para>See <link linkend="app.segmentation"
-		  endterm="app.segmentation.title"/> for general explanations about
-		  segmentation (global or local, paragraph or sentence, setting, etc.)</para>
-		  
+		  <para>See the <link linkend="app.segmentation"
+		  endterm="app.segmentation.title"/> appendix for general explanations
+		  about segmentation (global or local, paragraph or sentence, setting,
+		  etc.)</para>
         </listitem>
       </varlistentry>
 	  
 	  
       <varlistentry id="dialogs.project.properties.auto.propagation">
         <term
-			id="dialogs.project.properties.auto.propagation.title">Auto-propagation
-        of translations</term>
+        id="dialogs.project.properties.auto.propagation.title"><option>Auto-propagation
+        of translations</option></term>
 
-        <listitem>
+		<listitem>
           <para>If there are duplicated (non-unique) segments in the source
           documents, checking this option will set the first translated segment
           as the default translation and automatically use the same target text
           in the remaining repeated segments.</para>
-
-		  <para>You can use <link
+		  
+		  <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
 		  linkend="menus.edit.create.alternative.translation"
 		  endterm="menus.edit.create.alternative.translation.title"/> to assign
 		  an alternative translation to segments that require a different
 		  translation.</para>
-
-		  <para>If you do not activate this option, all segments can be assigned a different
-		  translation, even if they are duplicated in the project.</para>
+		  
+		  <para>If you do not activate this option, all segments can be assigned
+		  a different translation, even if they are duplicated in the
+		  project.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.remove.tags">
-        <term id="dialogs.project.properties.remove.tags.title">Remove
-        tags</term>
+        <term id="dialogs.project.properties.remove.tags.title"><option>Remove
+        tags</option></term>
 
-        <listitem>
-          <para>Tags are generally useful to reproduce specific layouts or characteristics of the source text into the translated text.</para>
+		<listitem>
+          <para>Tags are generally useful to reproduce specific layouts or
+          characteristics of the source text into the translated text.</para>
 
 		  <para>If you activate this function, no tag will be displayed in the
-          source segments.</para>
+		  source segments.</para>
 		  
-		<para>This is especially useful when dealing with texts
-          where inline formatting is not particularly useful (e.g., OCRed PDF,
-          or poorly converted .odt or .docx files.)</para>
+		  <para>This is especially useful when dealing with texts where inline
+		  formatting is not particularly useful (e.g., OCRed PDF, or poorly
+		  converted .odt or .docx files.)</para>
 
-		  <note><para>The tags are not really removed from the document, but
-		  rather stacked at the end of the segment. In most cases, this should
-		  not keep the translated file from opening. If you just need to reduce
-		  the number of tags, you can use the <link
-		  linkend="windows.scripts.distribution.tagwipe"
-		  endterm="windows.scripts.distribution.tagwipe.title"/> script. See
-		  <link linkend="windows.scripts" endterm="windows.scripts.title"/> for
-		  details.</para></note>
+		  <note>
+			<para>The tags are not really removed from the document, but rather
+			stacked at the end of the segment. In most cases, this should not
+			keep the translated file from opening. If you just need to reduce
+			the number of tags, you can use the <link
+			linkend="windows.scripts.distribution.tagwipe"
+			endterm="windows.scripts.distribution.tagwipe.title"/> script.</para>
+
+			<para>See the <link linkend="windows.scripts"
+			endterm="windows.scripts.title"/> window for details.</para>
+		  </note>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.processing.command">
         <term
-			id="dialogs.project.properties.external.processing.command.title">Local
-        post-processing commands</term>
+        id="dialogs.project.properties.external.processing.command.title"><option>Local
+        post-processing commands</option></term>
 
-        <listitem>
-		  <warning><para>For security reasons, local post-processing commands are
-		  disabled by default. See <link
-		  linkend="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands"
-		  endterm="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"/>
-		  for details.</para></warning>
+		<listitem>
+		  <warning>
+			<para>For security reasons, local post-processing commands are
+			disabled by default.</para>
 
-		  <para>Specify the commands that will automatically be run after using <link
-		linkend="menus.project.create.translated.documents"
-		endterm="menus.project.create.translated.documents.title"/> or <link linkend="menus.project.create.current.translated.document" endterm="menus.project.create.current.translated.document.title"/>.</para>
+			<para>See the <link
+			linkend="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands"
+			endterm="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"/>
+			preferences for details.</para>
+		  </warning>
+
+		  <para>OmegaT can automatically run commands after the target files
+		  have been created.</para>
+
+		  <para>Specify here the commands that will be run.</para>
+
+		  <para>Use <link linkend="menus.project"
+		  endterm="menus.project.title"/><link
+		  linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project" endterm="menus.project.title"/><link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/> to
+		  create the target files and trigger the command launch.</para>
 
 		  <para>Commands specified here are only available to this project. They
-		  are saved in <link linkend="project.folder.omegat.project.file"
-		  endterm="project.folder.omegat.project.file.title"/>. Only enable
+		  are saved in the <link linkend="project.folder.omegat.project.file"
+		  endterm="project.folder.omegat.project.file.title"/> file. Only enable
 		  local post-processing commands if you trust the source of that
 		  file.</para>
 		
-		<para>The template variables list gives you access to various project
-		data and system variables. See <link linkend="post.processing.commands.template.variables" endterm="post.processing.commands.template.variables.title"/> for details.</para>
+		  <para>The template variables list gives you access to various project
+		  data and system variables.</para>
 
-		<para>You can also define global post-processing commands
-		  available to all projects that share the same configuration folder. Such commands are defined in <link
+		  <para>See the <link linkend="post.processing.commands"
+		  endterm="post.processing.commands.title"/> appendix for
+		  details.</para>
+
+		  <para>You can also define global post-processing commands available to
+		  all projects that share the same configuration folder. Such commands
+		  are defined in the <link
 		  linkend="dialogs.preferences.saving.and.output.external.post-processing.command"
-		  endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/>.</para>
-		  <note><para>Local commands are run before global commands.</para></note>
+		  endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/>
+		  preference.</para>
+
+		  <note>
+			<para>Local commands are run before global commands.</para>
+		  </note>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.filters">
-        <term id="dialogs.project.properties.filters.title">Local File
-        Filters...</term>
+        <term id="dialogs.project.properties.filters.title"><guibutton>Local
+        File Filters...</guibutton></term>
+
         <listitem>
           <para>By default, file filter settings are global and shared by
-          all projects. They are found in <link
+          all projects. They are found in the <link
           linkend="dialogs.preferences.file.filters"
-          endterm="dialogs.preferences.file.filters.title"/>.</para>
+          endterm="dialogs.preferences.file.filters.title"/> preferences.</para>
 
 		  <para>Use this button to create local file filters specific to your
-		  project. Check the <guilabel>Use local file filter
-		  settings</guilabel> box, and adjust the settings as desired.</para>
+		  project. Check the <option>Use local file filter
+		  settings</option> box, and adjust the settings as desired.</para>
 
 		  <para>The project will store the new set of file filters in the <link
 		  linkend="project.folder.omegat.filters"
-		  endterm="project.folder.omegat.filters.title"/> file of its omegat folder, and the settings will supersede the global file filter settings.</para>
+		  endterm="project.folder.omegat.filters.title"/> file located in its
+		  omegat folder, and the settings will supersede the global file filter
+		  settings.</para>
 
-		  <note><para>To disable project specific file filters, uncheck the
-		  box or remove that file.</para></note>
+		  <note>
+			<para>To disable project specific file filters, uncheck the
+			box or remove that file.</para>
+		  </note>
 		  
-		  <para>See <link linkend="file.filters"
-		  endterm="file.filters.title"/> for details.</para>
+		  <para>See the <link linkend="file.filters"
+		  endterm="file.filters.title"/> appendix for details.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.repository.mapping">
         <term
-			id="dialogs.project.properties.repository.mapping.title">Repository
-        Mapping...</term>
+        id="dialogs.project.properties.repository.mapping.title"><guibutton>Repository
+        Mapping...</guibutton></term>
 
         <listitem>
           <para>When working on a team project, this window allows you to define
-          the mapping between the remote and local folders. See <link
-          linkend="how.to.setup.team.project.mapping.parameters"
-          endterm="how.to.setup.team.project.mapping.parameters.title"/> in
-          <link linkend="how.to.setup.team.project"
-				endterm="how.to.setup.team.project.title"/> for details.</para>
+          the mapping between the remote and local folders.</para>
+
+		  <para>See the <link
+		  linkend="how.to.setup.team.project.mapping.parameters"
+		  endterm="how.to.setup.team.project.mapping.parameters.title"/> section
+		  of the <link linkend="how.to.setup.team.project"
+		  endterm="how.to.setup.team.project.title"/> how-to for details.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.searches">
-        <term id="dialogs.project.properties.external.searches.title">Local External
-        Searches</term>
+        <term
+        id="dialogs.project.properties.external.searches.title"><guibutton>Local
+        External Searches</guibutton></term>
 
         <listitem>
           <para>By default, external searches are global and are shared by all
-          projects. They are defined in <link
+          projects. They are defined in the <link
           linkend="dialogs.preferences.external.searches"
-          endterm="dialogs.preferences.external.searches.title"/>.</para>
+          endterm="dialogs.preferences.external.searches.title"/>
+          preferences.</para>
 
 		  <para>Use this button to create local external searches specific to your
 		  project and adjust the settings as desired.</para>
 
-		  <para>The project will store the new set of external searches in the <link
-		  linkend="project.folder.omegat.finder"
-		  endterm="project.folder.omegat.finder.title"/> file of its <link
-		  linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder, and the settings will supersede the global external searches settings.</para>
+		  <para>The project will store the new set of external searches in the
+		  <link linkend="project.folder.omegat.finder"
+		  endterm="project.folder.omegat.finder.title"/> file located in its
+		  <link linkend="project.folder.omegat.folder"
+		  endterm="project.folder.omegat.folder.title"/> folder, and the
+		  settings will supersede the global external searches settings.</para>
 
-		  <para>To delete project specific external searches, click
+		  <para>To delete project specific external searches, click on
 		  <guibutton>Remove</guibutton> or remove that file.</para>
 		  
-		  <para>See <link linkend="dialogs.preferences.external.searches"
-		  endterm="dialogs.preferences.external.searches.title"/> for
-		  details.</para>
+		  <para>See the <link linkend="dialogs.preferences.external.searches"
+		  endterm="dialogs.preferences.external.searches.title"/> preferences
+		  for details.</para>
 
-		  <note><para>For security purposes, local project-based external searches are
-		  disabled by default. You can enable them by checking <link
-		  linkend="dialogs.preferences.external.search.enable.project.specific.commands"
-		  endterm="dialogs.preferences.external.search.enable.project.specific.commands.title"/>
-		  in the <link linkend="dialogs.preferences.external.searches"
-		  endterm="dialogs.preferences.external.searches.title"/>
-		  preferences.</para></note>
-
+		  <note>
+			<para>For security purposes, local project-based external searches
+			are disabled by default. To enable them, check <link
+			linkend="dialogs.preferences.external.search.enable.project.specific.commands"
+			endterm="dialogs.preferences.external.search.enable.project.specific.commands.title"/>
+			in the <link linkend="dialogs.preferences.external.searches"
+			endterm="dialogs.preferences.external.searches.title"/>
+			preferences.</para>
+		  </note>
         </listitem>
       </varlistentry>
 	</variablelist>
   </section>
 
   <section id="dialogs.project.properties.file.locations">
-    <title id="dialogs.project.properties.file.locations.title">File locations</title>
+    <title id="dialogs.project.properties.file.locations.title"><guilabel>File
+    locations</guilabel></title>
 
 	<para>An OmegaT translation project consists of a number of resources in
 	separate folders.</para>
 
-	<para>When a new project is created, OmegaT proposes to create a project
-	folder that contains all the resources used in the translation, but that
-	structure is not compulsory.</para>
+	<para>When a new project is created, OmegaT proposes to create a default
+	project folder that contains all the resources used in the translation, but
+	that structure is not compulsory.</para>
 
-	<para>Resource folders can be located anywhere on
-	your machine, including on shared disks. See <link
-	linkend="project.folder" endterm="project.folder.title"/> for
-	details.</para>
+	<para>Resource folders can be located anywhere on your machine, including on
+	shared disks.</para>
+
+	<para>See the <link linkend="chapter.project.folder"
+	endterm="chapter.project.folder.title"/> chapter for details.</para>
 
 	<para>You can modify the structure of your project by adding or removing
 	files from the folders, or even by changing the folders the project
 	will use, at will, even during the course of the translation.</para>
 
-	<para>You can access all the locations with <link
+	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
 	linkend="menus.project.access.project.contents"
-	endterm="menus.project.access.project.contents.title"/> and its
-	submenus.</para>
+	endterm="menus.project.access.project.contents.title"/> and its submenus to
+	access all the project ressource locations.</para>
 
 	<variablelist>
 	  <varlistentry id="dialogs.project.properties.file.locations.browse">
 		<term
 		id="dialogs.project.properties.file.locations.browse.title"><guibutton>Browse</guibutton></term>
-		<listitem><para>The <guibutton>Browse</guibutton> button is available
-		for all the user-defined project resources.</para>
-		<note><para>Resources do not have to be contained in the default project
-		folder that OmegaT creates. You can select any folder that you want to
-		hold your resources, even folders located on shared disks.</para></note>
-		<para>Click on the button to select the folder that you want to use
-		instead of the default resource folder.</para></listitem>
+
+		<listitem>
+		  <para>The <guibutton>Browse</guibutton> button is available for all
+		  the user-defined project resources.</para>
+
+		  <note>
+			<para>Resources do not have to be contained in the default project
+			folder that OmegaT creates. You can select any folder that you want
+			to hold your resources, even folders located on shared disks.</para>
+		  </note>
+
+		  <para>Click on the button to select the folder that you want to use
+		  instead of the default resource folder.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.source.files">
 		<term
-		id="dialogs.project.properties.file.locations.source.files.title">Source
-		files folder</term>
-		<listitem><para>This folder contains the files
-		that you want to translate. OmegaT will try to read all the files at once,
-		and will display in the editor the translatable contents that it has
-		found. See <link linkend="project.folder.source"
-		endterm="project.folder.source.title"/> for details.</para>
-		<para>If the folder is empty, if none of the files contain translatable
-		contents, or if there are no files supported by OmegaT’s file filters,
-		OmegaT will tell you that the folder is empty.</para>
+		id="dialogs.project.properties.file.locations.source.files.title"><option>Source
+		files folder</option></term>
 
-		<variablelist>
-		<varlistentry id="dialogs.project.properties.file.locations.exclusions">
-		<term
-		id="dialogs.project.properties.file.locations.exclusions.title">Exclusions...</term>
 		<listitem>
-		  <para>Click <guibutton>Exclusions...</guibutton> to define the
-		  files or folders that will be ignored by OmegaT. An ignored file or
-		  folder:</para>
-		  
-		  <itemizedlist>
-			<listitem>
-			  <para>is not displayed in the <link linkend="panes.editor"
-			  endterm="panes.editor.title"/> pane,</para>
-			</listitem>
-			<listitem>
-			  <para>is not taken into account in the <link
-			  linkend="menus.tools.statistics"
-			  endterm="menus.tools.statistics.title"/> window, and</para>
-			</listitem>
-			<listitem>
-			  <para>is not copied to the <link linkend="project.folder.target"
-			  endterm="project.folder.target.title"/> folder when the translated files
-			  are created.</para>
-			</listitem>
-		  </itemizedlist>
+		  <para>This folder contains the files that you want to
+		  translate. OmegaT will try to read all the files at once, and will
+		  display in the editor the translatable contents that it has found.</para>
 
-		  <para>The Exclusion patterns dialog allows you to add or remove a
-		  pattern or to edit one by double-clicking it, or selecting it and
-		  pressing <keycap>F2</keycap>. You can use wildcards that follow the
-		  <ulink
-		  url="https://ant.apache.org/manual/dirtasks.html#patterns">Apache ant
-		  syntax</ulink>.</para>
-		</listitem>
-		</varlistentry>
-		</variablelist>
+		  <para>See the <link linkend="project.folder.source"
+		  endterm="project.folder.source.title"/> section for details.</para>
+
+		  <para>If the folder is empty, if none of the files contain
+		  translatable contents, or if there are no files supported by OmegaT’s
+		  file filters, OmegaT will tell you that the folder is empty.</para>
+
+		  <variablelist>
+			<varlistentry id="dialogs.project.properties.file.locations.exclusions">
+			  <term
+			  id="dialogs.project.properties.file.locations.exclusions.title"><guibutton>Exclusions...</guibutton></term>
+
+			  <listitem>
+				<para>Click <guibutton>Exclusions...</guibutton> to define the
+				files or folders that will be ignored by OmegaT. An ignored file
+				or folder:</para>
+		  
+				<itemizedlist>
+				  <listitem>
+					<para>is not displayed in the <link linkend="panes.editor"
+					endterm="panes.editor.title"/> pane,</para>
+				  </listitem>
+
+				  <listitem>
+					<para>is not taken into account in the various statistics
+					reports (use <link linkend="menus.tools"
+					endterm="menus.tools.title"/><link
+					linkend="menus.tools.statistics"
+					endterm="menus.tools.statistics.title"/>, etc.), and</para>
+				  </listitem>
+
+				  <listitem>
+					<para>is not copied to the <link
+					linkend="project.folder.target"
+					endterm="project.folder.target.title"/> folder when the
+					translated files are created.</para>
+				  </listitem>
+				</itemizedlist>
+
+				<para>The Exclusion patterns dialog allows you to add or remove
+				a pattern or to edit one by double-clicking it, or selecting it
+				and pressing <keycap>F2</keycap>. To define exclusions, use the
+				<ulink
+				url="https://ant.apache.org/manual/dirtasks.html#patterns">Apache
+				ant syntax</ulink>.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
 		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translation.memories">
 		<term
-		id="dialogs.project.properties.file.locations.translation.memories.title">Translation
-		memories folder</term>
-		<listitem><para>This folder contains the files
-		that you want to use as reference translation memories. OmegaT will try to
-		read all the files at once, and will match their contents to the segment
-		you are translating. See <link linkend="project.folder.tm"
-		endterm="project.folder.tm.title"/> for details.</para>
-		<para>If matches are found, they will be displayed in the <link
-		linkend="panes.fuzzy.matches"
-		endterm="panes.fuzzy.matches.title"/> pane.</para></listitem>
+		id="dialogs.project.properties.file.locations.translation.memories.title"><option>Translation
+		memories folder</option></term>
+		<listitem>
+		  <para>This folder contains the files that you want to use as reference
+		  translation memories. OmegaT will try to read all the files at once,
+		  and will match their contents to the segment you are translating.</para>
+
+		  <para>See the <link linkend="project.folder.tm"
+		  endterm="project.folder.tm.title"/> section for details.</para>
+
+		  <para>If matches are found, they will be displayed in the <link
+		  linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>
+		  pane.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.glossaries">
 		<term
-		id="dialogs.project.properties.file.locations.glossaries.title">Glossary
-		files folder</term>
-		<listitem><para>This folder contains the files
-		that you want to use as reference glossaries. OmegaT will try to read all
-		the files at once, and will match their contents to the segment you are
-		translating. See <link linkend="project.folder.glossary"
-		endterm="project.folder.glossary.title"/> for details.</para>
-		<para>If matches are found, they will be displayed in the <link
-		linkend="panes.glossary" endterm="panes.glossary.title"/>
-		pane.</para>
-		<para>See the <link linkend="app.glossaries"
-		endterm="app.glossaries.title"/> appendix for details.</para></listitem>
+		id="dialogs.project.properties.file.locations.glossaries.title"><option>Glossary
+		files folder</option></term>
+
+		<listitem>
+		  <para>This folder contains the files that you want to use as reference
+		  glossaries. OmegaT will try to read all the files at once, and will
+		  match their contents to the segment you are translating.</para>
+
+		  <para>See the <link linkend="project.folder.glossary"
+		  endterm="project.folder.glossary.title"/> section for details.</para>
+		  
+		  <para>If matches are found, they will be displayed in the <link
+		  linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
+
+		  <para>See the <link linkend="app.glossaries"
+		  endterm="app.glossaries.title"/> appendix for details.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.writable.glossary">
 		<term
-		id="dialogs.project.properties.file.locations.writable.glossary.title">Writable
-	Glossary File</term>
-		<listitem><para>The writable glossary is the file that OmegaT uses
-		when you add translated glossary terms to your project with
-		<link linkend="menus.edit.create.glossary.entry"
-		endterm="menus.edit.create.glossary.entry.title"/>.</para>
-		<para>Added items are automatically recognized and displayed if they
-		match terms in the current segment.</para>
-		<para>This file is <emphasis>always</emphasis> located in the
-		<link linkend="project.folder.glossary"
-		endterm="project.folder.glossary.title"/> folder.</para></listitem>
+		id="dialogs.project.properties.file.locations.writable.glossary.title"><option>Writable
+		Glossary File</option></term>
+
+		<listitem>
+		  <para>The writable glossary is the file that OmegaT uses when you add
+		  translated glossary terms to your project with the <link
+		  linkend="menus.edit"
+		  endterm="menus.edit.title"/><link
+		  linkend="menus.edit.create.glossary.entry"
+		  endterm="menus.edit.create.glossary.entry.title"/> menu.</para>
+
+		  <para>It is automatically created the first time a term is
+		  added.</para>
+
+		  <para>Added items are automatically recognized and displayed if they
+		  match terms in the current segment.</para>
+
+		  <para>This file is <emphasis>always</emphasis> located in the <link
+		  linkend="project.folder.glossary"
+		  endterm="project.folder.glossary.title"/> folder.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.dictionaries">
 		<term
-		id="dialogs.project.properties.file.locations.dictionaries.title">Dictionaries
-		folder</term>
-		<listitem><para>This folder contains the files
-		that you want to use as reference dictionaries. OmegaT tries to read all
-		the files at once, and matches their contents to the segment you are
-		translating. See <link linkend="project.folder.dictionary"
-		endterm="project.folder.dictionary.title"/> for details.</para>
-		<para>If matches are found, they are displayed in the <link
-		linkend="panes.dictionary" endterm="panes.dictionary.title"/>
-		pane.</para></listitem>
+		id="dialogs.project.properties.file.locations.dictionaries.title"><option>Dictionaries
+		folder</option></term>
+
+		<listitem>
+		  <para>This folder contains the files that you want to use as reference
+		  dictionaries. OmegaT tries to read all the files at once, and matches
+		  their contents to the segment you are translating.</para>
+
+		  <para>See the <link linkend="project.folder.dictionary"
+		  endterm="project.folder.dictionary.title"/> section for
+		  details.</para>
+
+		  <para>If matches are found, they are displayed in the <link
+		  linkend="panes.dictionary" endterm="panes.dictionary.title"/>
+		  pane.</para>
+		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translated.files">
 		<term
-		id="dialogs.project.properties.file.locations.translated.files.title">Translated
-		files folder</term>
-		<listitem><para>This is the folder where OmegaT creates the translated files.</para>
-		<para>The translated files are the translated versions of the files located in the <link
-		linkend="project.folder.source"
-		endterm="project.folder.source.title"/>
-		folder.</para>
+		id="dialogs.project.properties.file.locations.translated.files.title"><option>Translated
+		files folder</option></term>
 
-		<para>Segments that have been translated will be replaced by their
-		translation and untranslated segments will remain in the source language.</para>
+		<listitem>
+		  <para>This is the folder where OmegaT creates the translated
+		  files.</para>
+
+		  <para>The translated files are the translated versions of the files
+		  located in the <link linkend="project.folder.source"
+		  endterm="project.folder.source.title"/> folder.</para>
+
+		  <para>Segments that have been translated will be replaced by their
+		  translation and untranslated segments will remain in the source
+		  language.</para>
 		
-		<para>The folder structure reflects the copied contents and files
-		that are not supported by OmegaT’s file filters will be copied without
-		modifications.</para>
+		  <para>The folder structure reflects the copied contents and files that
+		  are not supported by OmegaT’s file filters will be copied without
+		  modifications.</para>
 
-		<para>Use <link linkend="menus.project.create.translated.documents"
-		endterm="menus.project.create.translated.documents.title"/> or <link
-		linkend="menus.project.create.current.translated.document"
-		endterm="menus.project.create.current.translated.document.title"/> to
-		create the translated files. See <link linkend="project.folder.target"
-		endterm="project.folder.target.title"/> for details.</para></listitem>
+		  <para>Use <link linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/> to
+		  create the translated files.</para>
+
+		  <para>See the <link linkend="project.folder.target"
+		  endterm="project.folder.target.title"/> section for
+		  details.</para></listitem>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.project.properties.file.locations.exported.tms">
 		<term
-		id="dialogs.project.properties.file.locations.exported.tms.title">Exported
-		translation memories folder</term>
-		<listitem><para>This is the folder where OmegaT copies the current
-		state of the translation in the form of TMX files when you create the
-		translated files.</para>
-		<para>The TMX files will contain only the segments that correspond to the current contents of the <link linkend="project.folder.source"
-		endterm="project.folder.source.title"/> folder.</para>
-		<para>Use
-		<link linkend="menus.project.create.translated.documents"
-		endterm="menus.project.create.translated.documents.title"/> or <link
-		linkend="menus.project.create.current.translated.document"
-		endterm="menus.project.create.current.translated.document.title"/> to create the translated files and the exported TMX files.</para>
-		<note><para>By default, that folder is the project folder itself but you
-		can change its location to make it more practical to share exported TM
-		files. See <link linkend="how.to.tm.share.translation.memories"
-		endterm="how.to.tm.share.translation.memories.title"/> for
-		details.</para></note>
+		id="dialogs.project.properties.file.locations.exported.tms.title"><option>Exported
+		translation memories folder</option></term>
 
-		<variablelist>
-	  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export">
-		<term
-		id="dialogs.project.properties.file.locations.tms.to.export.title">Translation
-		memories to export</term>
-		<listitem><para>This checkbox lets you choose in which format you
-		want OmegaT to create the above TMX files. See <link
-		linkend="how.to.use.tm" endterm="how.to.use.tm.title"/> for
-		details.</para>
-		<variablelist>
-		  <varlistentry>
-			<term>OmegaT</term>
-			<listitem><para>An “OmegaT” TMX contains the tags that OmegaT
-			created, in a form that can only be properly used by an OmegaT
-			project.</para></listitem>
-		  </varlistentry>
+		<listitem>
+		  <para>This is the folder where OmegaT copies the current state of the
+		  translation in the form of TMX files when you create the translated
+		  files.</para>
+		
+		  <para>The TMX files will contain only the segments that correspond to
+		  the current contents of the <link linkend="project.folder.source"
+		  endterm="project.folder.source.title"/> folder.</para>
+
+		  <para>Use <link linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/> to
+		  create the translated files and the exported TMX files.</para>
+
+		  <note>
+			<para>By default, that folder is the project folder itself but you
+			can change its location to make it more practical to share exported
+			TM files.</para>
+
+			<para>See the <link linkend="how.to.tm.share.translation.memories"
+			endterm="how.to.tm.share.translation.memories.title"/> how-to for
+			details.</para>
+		  </note>
+
+		  <variablelist>
+			<varlistentry id="dialogs.project.properties.file.locations.tms.to.export">
+			  <term
+			  id="dialogs.project.properties.file.locations.tms.to.export.title"><option>Translation
+			  memories to export</option></term>
+			  <listitem>
+				<para>This checkbox lets you choose in which format you want
+				OmegaT to create the above TMX files.</para>
+
+				<para>See the <link linkend="how.to.use.tm"
+				endterm="how.to.use.tm.title"/> how-to for details.</para>
+		
+				<variablelist>
+				  <varlistentry>
+					<term><option>OmegaT</option></term>
+					<listitem>
+					  <para>An “OmegaT” TMX contains the tags that OmegaT
+					  created, in a form that can only be properly used by an
+					  OmegaT project.</para>
+					</listitem>
+				  </varlistentry>
 		  
-		  <varlistentry>
-			<term>TMX Level 1</term>
-			<listitem><para>A “level 1” TMX contains only textual data and has
-			removed all tag information.</para></listitem>
-		  </varlistentry>
-
-		  <varlistentry>
-			<term>TMX Level 2</term>
-			<listitem><para>A “level 2” TMX contains textual data along with
-			tags encapsulated in a way that is compatible with other CAT
-			tools.</para></listitem>
-		  </varlistentry>
-		</variablelist>
-		</listitem>
-	  </varlistentry>
-		</variablelist>
-		<para>See the <ulink
-		url="https://www.gala-global.org/tmx-14b#SectionIntroduction">TMX 1.4b
-		Specification</ulink> for details.</para>
+				  <varlistentry>
+					<term><option>TMX Level 1</option></term>
+					<listitem>
+					  <para>A “level 1” TMX contains only textual data and has
+					  removed all tag information.</para>
+					</listitem>
+				  </varlistentry>
+				
+				  <varlistentry>
+					<term><option>TMX Level 2</option></term>
+					<listitem>
+					  <para>A “level 2” TMX contains textual data along with
+					  tags encapsulated in a way that is compatible with other
+					  CAT tools.</para>
+					</listitem>
+				  </varlistentry>
+				</variablelist>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		  
+		  <para>See the <ulink
+		  url="https://www.gala-global.org/tmx-14b#SectionIntroduction">TMX 1.4b
+		  Specification</ulink> for details.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>

--- a/doc_src/en/HowTo_Install.xml
+++ b/doc_src/en/HowTo_Install.xml
@@ -4,8 +4,8 @@
 <!ENTITY % manualvariables SYSTEM "manualvariables.mod">
 %manualvariables;
 ]>
-<section id="installing.omegat">
-  <title id="installing.omegat.title">Install
+<section id="how.to.installing.omegat">
+  <title id="how.to.installing.omegat.title">Install
   OmegaT</title>
 
   <para>OmegaT comes in two editions:</para>
@@ -13,31 +13,42 @@
   <variablelist>
 	<varlistentry>
 	  <term>Standard: OmegaT &vernb;</term>
-	  <listitem><para>This edition is recommended for everyday use.</para></listitem>
+	  <listitem>
+		<para>This edition is recommended for everyday use.</para>
+	  </listitem>
 	</varlistentry>
 	<varlistentry>
 	  <term>Developer: OmegaT Nightly</term>
-	  <listitem><para>This edition is automatically generated every time new
+	  <listitem>
+		<para>This edition is automatically generated every time new
 	  code is added to OmegaT. It is used for testing
-	  purposes.</para></listitem>
+		purposes.</para>
+	  </listitem>
 	</varlistentry>
   </variablelist>
 
   <para>The files are downloadable directly from <ulink
   url="https://omegat.org/download">https://omegat.org</ulink>.</para>
 
-  <note><para>OmegaT &vernb; requires a &javaversionlong; (JRE) to run.</para>
+  <note>
+	<para>OmegaT &vernb; requires a &javaversionlong; (JRE) to run.</para>
 
-  <para>OmegaT packages are available both in versions bundled with Java, and
-  versions without it. Packages without Java rely on a &javaversionlong;
-  installed systemwide.</para>
+	<para>OmegaT packages are available both in versions bundled with Java, and
+	versions without it. Packages without Java rely on a &javaversionlong;
+	installed systemwide.</para>
 
-  <para>OmegaT 5.8.0 and later also support Java 11 Runtime Environment on any
-  platforms.</para>
+	<para>OmegaT 5.8.0 and later can also run with Java 11 Runtime Environment
+	on any platforms.</para>
 
-  <para>Due to licensing considerations, the OmegaT team recommends the Java
-  runtime Eclipse Temurin provided by the &preferedopenjdk;, but any Java 8
-  compatible runtime environment should work.</para></note>
+	<para>Due to licensing considerations, the OmegaT team recommends the Java
+	runtime Eclipse Temurin provided by the &preferedopenjdk;, but any Java 8
+	compatible runtime environment should work. See <ulink
+	url="https://projects.eclipse.org/projects/adoptium.temurin">The Eclipse
+	Temurin™ project</ulink>.</para>
+
+	<para>IBM provides JREs for Linux PowerPC at <ulink
+	url="https://developer.ibm.com/languages/java/semeru-runtimes/downloads/"/>.</para>
+  </note>
 
   <section id="installing.omegat.windows">
     <title id="installing.omegat.windows.title">On Windows</title>
@@ -62,40 +73,39 @@
     folder named after the package you downloaded. That folder contains
     all the files needed to run OmegaT.</para>
 
-    <note><para>Although you can run OmegaT directly from the available
-    files, you can also run the <filename>linux-install.sh</filename>
-    script found there to have OmegaT installed in more appropriate
-    locations.</para>
+    <note>
+	  <para>Although you can run OmegaT directly from the available files, you
+	  can also run the <filename>linux-install.sh</filename> script found there
+	  to have OmegaT installed in more appropriate locations.</para>
 
-    <para>Running the script will require you to enter your
-    <filename>sudo</filename> password.</para>
+      <para>Running the script will require you to enter your
+      <filename>sudo</filename> password.</para>
 
-    <para>The script checks for an existing installation of the same
-    OmegaT version in <filename>/opt/omegat/</filename>. If there isn’t
-    one, it installs the program in
-    <filename>/opt/omegat/OmegaT_&vernb;</filename> and sets it as the
-    default version (in
-    <filename>/opt/omegat/OmegaT-default</filename>).</para></note>
+      <para>The script checks for an existing installation of the same OmegaT
+      version in <filename>/opt/omegat/</filename>. If there isn’t one, it
+      installs the program in <filename>/opt/omegat/OmegaT_&vernb;</filename>
+      and sets it as the default version (in
+      <filename>/opt/omegat/OmegaT-default</filename>).</para>
+	</note>
 
-    <para>After the unpacking or installation is complete, you can
-    delete the downloaded file as it is no longer needed.</para>
+    <para>After the unpacking or installation is complete, you can delete the
+    downloaded file as it is no longer needed.</para>
   </section>
 
   <section id="Installing.omegat.macos">
     <title id="Installing.omegat.macos.title">On macOS</title>
 
-    <para>Double click on the package you downloaded to unpack it.  This
-    creates a folder called <filename>OmegaT</filename>. The folder contains
-    two files: <filename>index.html</filename> (the user guide index) and
+    <para>Double click on the package you downloaded to unpack it.  This creates
+    a folder called <filename>OmegaT</filename>. The folder contains two files:
+    <filename>index.html</filename> (the user manual entry file) and
     <filename>OmegaT.app</filename> (the application). Copy the folder to a
     suitable location (e.g.  <filename>Applications</filename>).</para>
 
     <para>Eventually, drag and drop <filename>OmegaT.app</filename> onto the
     Dock to easily access it.</para>
 
-	<para>Once you have done this, you can delete the downloaded file as it
-    is no longer needed.</para>
-
+	<para>Once you have done this, you can delete the downloaded package as it
+	is no longer needed.</para>
   </section>
 
   <section id="installing.omegat.other.systems">
@@ -109,30 +119,19 @@
     <para>Download the <emphasis>Cross-platform without JRE</emphasis>
     version.</para>
 
-    <note><para>The Eclipse Foundation provides OpenJDK Runtime Environments
-    JREs for many systems at <ulink
-    url="https://adoptium.net/temurin"/>.</para>
+    <para>Unpack the file that you downloaded. This creates a folder with all
+    the files necessary to run OmegaT.</para>
 
-    <para>IBM provides JREs for Linux PowerPC at <ulink
-    url="https://developer.ibm.com/languages/java/semeru-runtimes/downloads/"/>.</para>
-
-    <para>Follow the installation instructions of the package you
-    need.</para></note>
-
-    <para>Unpack the file that you downloaded. This creates a folder with
-    all the files necessary to run OmegaT.</para>
-
-      <para>Follow your system’s instructions to install OmegaT shortcuts in
-      convenient places of your choosing.</para>
+    <para>Follow your system’s instructions to install OmegaT shortcuts in
+    convenient places of your choosing.</para>
   </section>
 
   <section id="update.and.delete.omegat">
 	<title id="update.and.delete.omegat.title">Upgrade</title>
 
-	<para>OmegaT can tell you when a new version is available. See <link
+	<para>OmegaT can tell you when a new version is available. See the <link
 	endterm="dialogs.preferences.updates.title"
-	linkend="dialogs.preferences.updates"/>
-	for details.</para>
+	linkend="dialogs.preferences.updates"/> preference for details.</para>
 
 	<para>The changes between your version and the current version are
 	documented in the development site’s <ulink
@@ -145,10 +144,10 @@
 
 	  <itemizedlist>
 		<listitem>
-		  <para>OmegaT’s preferences are stored in the configuration folder
-		  and will <emphasis>not</emphasis> be modified by the new version.
-		  See <link endterm="configuration.folder.title"
-		  linkend="configuration.folder"/> for details.</para>
+		  <para>OmegaT’s preferences are stored in the configuration folder and
+		  will <emphasis>not</emphasis> be modified by the new version.  See the
+		  <link endterm="configuration.folder.title"
+		  linkend="configuration.folder"/> chapter for details.</para>
 		</listitem>
 
 		<listitem>
@@ -182,31 +181,34 @@
 	<variablelist>
 	  <varlistentry id="update.and.delete.omegat.over.existing.package">
 		<term id="update.and.delete.omegat.over.existing.package.title">Over an existing version</term>
+
 		<listitem>
-	  <para>To do this, simply select the same installation folder as the
-	  existing installation when installing the new version. The “old” version
-	  of OmegaT will be overwritten, but settings made from the OmegaT
-	  interface will be retained in the various configurations folders (see
-	  above).</para>
+		  <para>To do this, simply select the same installation folder as the
+		  existing installation when installing the new version. The “old”
+		  version of OmegaT will be overwritten, but settings made from the
+		  OmegaT interface will be retained in the various configurations
+		  folders (see above).</para>
 		</listitem>
 	  </varlistentry>
 	  
 	<varlistentry id="update.and.delete.omegat.along.existing.package">
 	  <term  id="update.and.delete.omegat.along.existing.package.title">Alongside an existing version</term>
-	  <listitem>
-	  <para>This will enable you to keep any number of versions side-by-side,
-	  which you may wish to do until you feel comfortable with the new
-	  version.</para>
 
-	  <para>All the parameters located in the <link
-	  endterm="configuration.folder.title" linkend="configuration.folder"/> will
+	  <listitem>
+		<para>This will enable you to keep any number of versions side-by-side,
+		which you may wish to do until you feel comfortable with the new
+		version.</para>
+
+	  <para>All the parameters located in the OmegaT configuration folder will
 	  be shared unless you specify a different configuration folder with the
-	  <literal>--config-dir=&lt;path&gt;</literal> option from the <link
+	  <literal>--config-dir=&lt;path&gt;</literal> option on the command
+	  line. See the <link
 	  endterm="launch.with.command.line.omegat.options.title"
-	  linkend="launch.with.command.line.omegat.options"/> on the
-	  command line. All the parameters located in a <link
-	  endterm="project.folder.title" linkend="project.folder"/> will apply to
-	  that project regardless of which version of OmegaT opens it.</para>
+	  linkend="launch.with.command.line.omegat.options"/> section.</para>
+
+	  <para>All the parameters located in a <link
+	  linkend="chapter.project.folder">project folder</link> will apply to that
+	  project regardless of which version of OmegaT opens it.</para>
 	  </listitem>
 	</varlistentry>
 	</variablelist>
@@ -215,9 +217,9 @@
 	<section id="update.and.delete.omegat.delete">
 	  <title id="update.and.delete.omegat.delete.title">Delete OmegaT</title>
 
-	  <para>Use your operating system’s standard procedure to remove OmegaT.
-	  If you want to remove OmegaT completely, you will also have to delete
-	  the configuration folder.</para>
+	  <para>Use your operating system’s standard procedure to remove OmegaT.  If
+	  you want to remove OmegaT completely, you will also have to delete the
+	  configuration folder.</para>
 
 	  <para>If you performed a manual installation on Linux, you will have to
 	  manually delete the OmegaT folders in <filename>opt/</filename>, as well
@@ -228,9 +230,12 @@
   <section id="build.omegat.from.source">
 	<title id="build.omegat.from.source.title">Build OmegaT</title>
 
-	<para>The source code for the current version can be either be downloaded directly from the OmegaT <ulink
-	url="https://omegat.org/download">download page</ulink>, or cloned from the
-	<ulink url="https://git.code.sf.net/p/omegat/code">Sourceforge</ulink> or <ulink url="https://github.com/omegat-org/omegat.git">GitHub</ulink> repositories.</para>
+	<para>The source code for the current version can be either be downloaded
+	directly from the OmegaT <ulink url="https://omegat.org/download">download
+	page</ulink>, or cloned from the <ulink
+	url="https://git.code.sf.net/p/omegat/code">Sourceforge</ulink> or <ulink
+	url="https://github.com/omegat-org/omegat.git">GitHub</ulink>
+	repositories.</para>
 	<para>Once the code is downloaded, open a terminal in the source folder
 	(<filename>omegat-code/</filename> if you cloned from Sourceforge, or
 	<filename>/omegat</filename> if you cloned from GitHub) and type:</para>

--- a/doc_src/en/HowTo_RestoreYourData.xml
+++ b/doc_src/en/HowTo_RestoreYourData.xml
@@ -4,9 +4,11 @@
 <section id="how.to.restore.your.data">
   <title id="how.to.restore.your.data.title">Troubleshoot issues</title>
 
-  <warning><para>OmegaT is a robust and trustworthy application, but even so, it
-  is smart to take precautions to guard against data loss when using it, just as
-  with any other application.</para></warning>
+  <warning>
+	<para>OmegaT is a robust and trustworthy application, but even so, it is
+	smart to take precautions to guard against data loss when using it, just as
+	with any other application.</para>
+  </warning>
 
   <section id="how.to.restore.your.data.automatic.backup">
 	<title id="how.to.restore.your.data.automatic.backup.title">Automatic
@@ -20,58 +22,81 @@
 	backups of that file.</para>
 
 	<orderedlist>
-	  <listitem><para>When you open a project, OmegaT backs
-	  <filename>project_save.tmx</filename> up into a timestamped backup
-	  file.</para>
-	  <para>OmegaT keeps up to 10 of those files.</para>
-	  <note><para>The backup filename follows the pattern <filename>project_save.tmx.YYYYMMDDhhmm.bak</filename> where <code>YYYY</code>
-	  represents the 4-digit year, <code>MM</code> the month, <code>DD</code> the day of the month, and <code>hh</code>
-	  and <code>mm</code> indicate the hours and minutes.</para></note>
+	  <listitem>
+		<para>When you open a project, OmegaT backs
+		<filename>project_save.tmx</filename> up into a timestamped backup
+		file.</para>
+
+		<para>OmegaT keeps up to 10 of those files.</para>
+
+		<note>
+		  <para>The backup filename follows the pattern
+		  <filename>project_save.tmx.YYYYMMDDhhmm.bak</filename> where
+		  <code>YYYY</code> represents the 4-digit year, <code>MM</code> the
+		  month, <code>DD</code> the day of the month, and <code>hh</code> and
+		  <code>mm</code> indicate the hours and minutes.</para>
+		</note>
 	  </listitem>
 	  
 	  <listitem>
 		<para>Every time <filename>project_save.tmx</filename> has been
-		modified:
+		modified:</para>
+		
 		<itemizedlist>
-		  <listitem><para>either after using <link linkend="menus.project.save" endterm="menus.project.save.title"/>,</para>
+		  <listitem>
+			<para>either after saving the project data (use <link
+			linkend="menus.project" endterm="menus.project.title"/><link
+			linkend="menus.project.save"
+			endterm="menus.project.save.title"/>),</para>
 		  </listitem>
-		  <listitem><para>or as a regular backup every 3 minutes by default,</para>
+
+		  <listitem>
+			<para>or as a regular backup every 3 minutes by default,</para>
 		  </listitem>
 		</itemizedlist>
-		OmegaT creates a backup with the name
+
+		<para>OmegaT creates a backup with the name
 		<filename>project_save.tmx.bak</filename>.</para>
+
 		<para>That file is a copy of <filename>project_save.tmx</filename>
 		<emphasis>before</emphasis> the modification.</para>
 	  </listitem>
 
 	  <listitem>
-		<para>Every time you use <link linkend="menus.project.save"
-		endterm="menus.project.save.title"/>, or as a regular backup every 3
-		minutes by default, OmegaT saves the current state of the translation
-		into <filename>project_save.tmx</filename></para>
+		<para>Every time you save the project data (use <link
+		linkend="menus.project" endterm="menus.project.title"/><link
+		linkend="menus.project.save" endterm="menus.project.save.title"/>), or
+		as a regular backup every 3 minutes by default, OmegaT saves the current
+		state of the translation into
+		<filename>project_save.tmx</filename></para>
 	  </listitem>
 	</orderedlist>
 
 	<para>The file <filename>project_save.tmx</filename> always contains the
-most recent data.</para>
+	most recent data.</para>
 
-	<note><para>You can control the frequency of the file saving in <link
-	linkend="dialogs.preferences.saving.and.output"
-	endterm="dialogs.preferences.saving.and.output.title"/>.</para></note>
+	<note>
+	  <para>You can control the frequency of the file saving in the <link
+	  linkend="dialogs.preferences.saving.and.output"
+	  endterm="dialogs.preferences.saving.and.output.title"/> preference.</para>
+	</note>
 
   </section>
 
   <section id="how.to.restore.your.data.lost.in.translation">
 	<title id="how.to.restore.your.data.lost.in.translation.title">You lost your
 	translation?</title>
+
 	<para>Even if you fear you might have lost translation data, it is probably
 	safely stored in your most recent backup memory, which is usually less than
 	a few minutes old or so.</para>
 
-	<para>Proceed as follows:
+	<para>Proceed as follows:</para>
+	
 	<orderedlist>
       <listitem>
-		<para>Close the project, preventing any modification to the current status of the backup files.</para>
+		<para>Close the project, preventing any modification to the current
+		status of the backup files.</para>
       </listitem>
 
       <listitem>
@@ -80,8 +105,8 @@ most recent data.</para>
       </listitem>
 
       <listitem>
-		<para>Select the backup translation memory most likely to contain the data
-		you are looking for.</para>
+		<para>Select the backup translation memory most likely to contain the
+		data you are looking for.</para>
       </listitem>
 
       <listitem>
@@ -92,7 +117,6 @@ most recent data.</para>
 		<para>Reopen the project.</para>
       </listitem>
 	</orderedlist>
-	</para>
 
 	<para>This action will restore the status of the translation to the moment
 	on which the selected backup was created. You may repeat this operation as
@@ -101,33 +125,40 @@ most recent data.</para>
 	modifying the project configuration or adding TMX files in the meantime, as
 	that may affect the results.</para>
 
-	<note><para>Be cautious about making changes to the files in the source
-	folder, to the segmentation rules, or to the file filters, partway through a
-	project. Modifying either after you have started your translation could
-	result in some segments not being displayed anymore, or unexpected new
-	segments appearing instead.</para></note>
-
-
+	<note>
+	  <para>Be cautious about making changes to the files in the source folder,
+	  to the segmentation rules, or to the file filters, partway through a
+	  project. Modifying either after you have started your translation could
+	  result in some segments not being displayed anymore, or unexpected new
+	  segments appearing instead.</para>
+	</note>
   </section>
 
 
   <section id="how.to.restore.your.data.project.wont.open">
-	<title id="how.to.restore.your.data.project.wont.open.title">Your project won’t open?</title>
-	<para>In rare cases where your computer freezes and OmegaT does not have the time to properly close, some important files can be broken and keep your project from reopening after you have rebooted your machine.</para>
+	<title id="how.to.restore.your.data.project.wont.open.title">Your project
+	won’t open?</title>
 
-	<para>Proceed as follows:
+	<para>In rare cases where your computer freezes and OmegaT does not have the
+	time to properly close, some important files can be broken and keep your
+	project from reopening after you have rebooted your machine.</para>
+
+	<para>Proceed as follows:</para>
+
 	<orderedlist>
       <listitem>
 		<para>Create a new project with the same settings.</para>
       </listitem>
 
 	  <listitem>
-		<para>Copy the contents of the various user folders to their equivalent in the new project (source files, reference translation memory files, glossary files).</para>
+		<para>Copy the contents of the various user folders to their equivalent
+		in the new project (source files, reference translation memory files,
+		glossary files).</para>
       </listitem>
 
       <listitem>
-		<para>In the old project, select the translation memory (backup or not) most likely
-		to contain the data you are looking for.</para>
+		<para>In the old project, select the translation memory (backup or not)
+		most likely to contain the data you are looking for.</para>
       </listitem>
 
       <listitem>
@@ -135,30 +166,41 @@ most recent data.</para>
       </listitem>
 
       <listitem>
-		<para>Copy it to the <filename>omegat/</filename> folder of your new project.</para>
+		<para>Copy it to the <filename>omegat/</filename> folder of your new
+		project.</para>
       </listitem>
 
       <listitem>
 		<para>Open the new project.</para>
       </listitem>
 	</orderedlist>
-	</para>
 
-	<para>This action will restore in the new project the status of the translation to the moment on which the selected project translation memory was created in the old project.</para>
+	<para>This action will restore in the new project the status of the
+	translation to the moment on which the selected project translation memory
+	was created in the old project.</para>
   </section>
 
   <section id="how.to.restore.your.data.translated.file.broken">
-	<title id="how.to.restore.your.data.translated.file.broken.title">Your translated file won’t open?</title>
-	<para>Very often, office suite files contain tags that must be copied into the translation to ensure that the translated file can be opened in the original application. In some cases, missing tags will keep the file from opening.</para>
+	<title id="how.to.restore.your.data.translated.file.broken.title">Your
+	translated file won’t open?</title>
+
+	<para>Very often, office suite files contain tags that must be copied into
+	the translation to ensure that the translated file can be opened in the
+	original application. In some cases, missing tags will keep the file from
+	opening.</para>
 	
-	<para>Proceed as follows:
+	<para>Proceed as follows:</para>
+
 	<orderedlist>
       <listitem>
 		<para>Open the project in OmegaT.</para>
       </listitem>
 
 	  <listitem>
-		<para>Use <link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/> and focus on <guilabel>Tag issues</guilabel>.</para>
+		<para>Use <link linkend="menus.tools" endterm="menus.tools.title"/><link
+		linkend="menus.tools.check.issues"
+		endterm="menus.tools.check.issues.title"/> and focus on <guilabel>Tag
+		issues</guilabel>.</para>
       </listitem>
 
       <listitem>
@@ -166,29 +208,46 @@ most recent data.</para>
       </listitem>
 
       <listitem>
-		<para>Use <link linkend="menus.project.create.translated.documents" endterm="menus.project.create.translated.documents.title"/> to recreate the documents.</para>
+		<para>Use <link linkend="menus.project"
+		endterm="menus.project.title"/><link
+		linkend="menus.project.create.translated.documents"
+		endterm="menus.project.create.translated.documents.title"/> to recreate
+		the documents.</para>
       </listitem>
 
       <listitem>
 		<para>Open the documents again in the original application.</para>
       </listitem>
 	</orderedlist>
-	</para>
 
-	<para>This action will fix the internal tag consistency issues that might have been induced by not properly inserting the tags in the translation while in OmegaT.</para>
+	<para>This action will fix the internal tag consistency issues that might
+	have been induced by not properly inserting the tags in the translation
+	while in OmegaT.</para>
   </section>
 
   <section id="how.to.restore.your.data.omegat.wont.behave">
-	<title id="how.to.restore.your.data.omegat.wont.behave.title">OmegaT won’t behave?</title>
+	<title id="how.to.restore.your.data.omegat.wont.behave.title">OmegaT won’t
+	behave?</title>
 
-	<para>Something has happened and OmegaT won’t behave anymore. Whatever you try, you can’t seem to be able to fix it. You want to try one last thing before calling for help: restart OmegaT with its default settings.</para>
+	<para>Something has happened and OmegaT won’t behave anymore. Whatever you
+	try, you can’t seem to be able to fix it. You want to try one last thing
+	before calling for help: restart OmegaT with its default settings.</para>
 
-	<para>Proceed as follows:
+	<para>Proceed as follows:</para>
+	
 	<orderedlist>
-
 	  <listitem>
-		<para>Use <link linkend="menus.options.access.configuration.folder" endterm="menus.options.access.configuration.folder.title"/> from the <link linkend="menus.options" endterm="menus.options.title"/> menu to access the configuration folder.</para>
-		<note><para>If you can’t use OmegaT’s menus, see <link linkend="configuration.folder" endterm="configuration.folder.title"/> to find the configuration folder location.</para></note>
+		<para>Use <link linkend="menus.options"
+		endterm="menus.options.title"/><link
+		linkend="menus.options.access.configuration.folder"
+		endterm="menus.options.access.configuration.folder.title"/> to access
+		the configuration folder.</para>
+		
+		<note>
+		  <para>If you can’t use OmegaT’s menus, see the <link
+		  linkend="configuration.folder" endterm="configuration.folder.title"/>
+		  chapter to find the configuration folder location.</para>
+		</note>
       </listitem>
 
       <listitem>
@@ -196,12 +255,17 @@ most recent data.</para>
       </listitem>
 
       <listitem>
-		<para>Make a backup of the contents and delete the original folder. </para>
+		<para>Make a backup of the contents and delete the original
+		folder. </para>
       </listitem>
 
       <listitem>
 		<para>Restart OmegaT.</para>
-		<note><para>If OmegaT does not work as expected at this point, feel free to reach out for support.</para></note>
+
+		<note>
+		  <para>If OmegaT does not work as expected at this point, feel free to
+		  reach out for support.</para>
+		</note>
       </listitem>
 
       <listitem>
@@ -209,20 +273,25 @@ most recent data.</para>
       </listitem>
 
       <listitem>
-		<para>Copy one of the old files into the new configuration folder.</para>
+		<para>Copy one of the old files into the new configuration
+		folder.</para>
       </listitem>
 	  
 	  <listitem>
 		<para>Restart OmegaT.</para>
-		<note><para>If OmegaT does not work as expected at this point, you have identified the faulty file. Remove it from the configuration folder and proceed.</para></note>
+
+		<note>
+		  <para>If OmegaT does not work as expected at this point, you have
+		  identified the faulty file. Remove it from the configuration folder
+		  and proceed.</para>
+		</note>
       </listitem>
 
 	  <listitem>
-		<para>Go back to step 5. above and proceed until you are satisfied.</para>
+		<para>Go back to step 5. above and proceed until you are
+		satisfied.</para>
       </listitem>
-
 	</orderedlist>
-	</para>
   </section>
 
   <section id="how.to.restore.your.data.summary">
@@ -231,14 +300,14 @@ most recent data.</para>
 	<itemizedlist>
       <listitem>
 		<para>To avoid losing important data, make regular copies of the file
-		<filename>/omegat/project_save.tmx</filename> to a backup media, such as a
-		USB key or an external hard drive, or to a cloud service.</para>
+		<filename>/omegat/project_save.tmx</filename> to a backup media, such as
+		a USB key or an external hard drive, or to a cloud service.</para>
       </listitem>
 
       <listitem>
-		<para>Regularly “practice emergency” measures such as restoring translations
-		from a project, to make sure you won’t lose too much time the day you need
-		to use those skills.</para>
+		<para>Regularly “practice emergency” measures such as restoring
+		translations from a project, to make sure you won’t lose too much time
+		the day you need to use those skills.</para>
       </listitem>
 	</itemizedlist>
   </section>

--- a/doc_src/en/HowTo_Run.xml
+++ b/doc_src/en/HowTo_Run.xml
@@ -4,19 +4,18 @@
 <!ENTITY % manualvariables SYSTEM "manualvariables.mod">
 %manualvariables;
 ]>
-<section id="running.omegat">
-  <title id="running.omegat.title">Run
-  OmegaT</title>
+<section id="how.to.running.omegat">
+  <title id="how.to.running.omegat.title">Run OmegaT</title>
 
   <section id="running.omegat.on.windows">
 	<title id="running.omegat.on.windows.title">On Windows</title>
-
+	
 	<para>The simplest way to launch OmegaT is to execute the
 	<filename>OmegaT.exe</filename> program. The options for the program
 	start-up will be read from the <filename>OmegaT.l4J.ini</filename> file,
-	which resides in the same folder as the exe file and which you can edit
-	to reflect your setup. The following example for the INI file reserves 1
-	GB of memory, requests French as the user language and Canada as the
+	which resides in the same folder as the exe file and which you can edit to
+	reflect your setup. The following example for the INI file reserves 1 GB of
+	memory, requests French as the user language and Canada as the
 	country:</para>
 
 	<programlisting># OmegaT.exe runtime configuration
@@ -47,11 +46,10 @@
 	directly if the <filename>.jar</filename> extension is associated to the
 	system Java launcher.</para>
 
-	<para>The package also provides a <filename>omegat.kaptn</filename>
-	Kaptain script, which KDE users might find useful, as well as an
+	<para>The package also provides a <filename>omegat.kaptn</filename> Kaptain
+	script, which KDE users might find useful, as well as an
 	<filename>OmegaT</filename> bash script that automatically launches the
-	appropriate <application>java</application> command to run
-	OmegaT.</para>
+	appropriate <application>java</application> command to run OmegaT.</para>
   </section>
 
   <section id="running.omegat.on.macos">
@@ -72,24 +70,27 @@
 	linkend="launch.with.command.line"/> for details.</para>
 
 	<para>You can modify the behavior of OmegaT.app by editing the
-	<filename>Configuration.properties</filename> (OmegaT configuration) as
-	well as the <filename>Info.plist</filename> (Java configuration) files
-	located inside the OmegaT.app package.</para>
+	<filename>Configuration.properties</filename> (OmegaT configuration) as well
+	as the <filename>Info.plist</filename> (Java configuration) files located
+	inside the OmegaT.app package.</para>
 
 	<para><filename>Configuration.properties</filename> is located in
 	<filename>Contents/Resources/</filename>.</para>
 	<para><filename>Info.plist</filename> is located in
 	<filename>Contents/</filename>.</para>
 
-	<note><para>To access the files inside <filename>OmegaT.app</filename>,
-	right-click on <filename>OmegaT.app</filename> and select “Show Package
-	Contents”.</para></note>
+	<note>
+	  <para>To access the files inside <filename>OmegaT.app</filename>,
+	  right-click on <filename>OmegaT.app</filename> and select “Show Package
+	  Contents”.</para>
+	</note>
 
 	<para>Use your text editor of choice to modify the files.</para>
 
 	<variablelist>
 	  <varlistentry>
 		<term>Configuration.properties</term>
+
 		<listitem>
 		  <para>For predefined options, remove the <literal>#</literal> before a
 		  parameter to enable it. For example,
@@ -99,22 +100,27 @@
 	  </varlistentry>
 	  <varlistentry>
 		<term>Info.plist</term>
+
 		<listitem>
 		  <para>For example, to change the amount of memory available uncomment
 		  the line</para>
+
 		  <para><literal>&lt;!-- &lt;string&gt;-Xmx6g&lt;/string&gt;
 		  --&gt;</literal></para>
 		  <para>by removing the <literal>&lt;!--</literal> and
 		  <literal>--&gt;</literal>.</para>
-		  <para>This will launch OmegaT with 6 GB of
-		  memory; change the <literal>6g</literal> to the desired amount.</para>
+
+		  <para>This will launch OmegaT with 6 GB of memory; change the
+		  <literal>6g</literal> to the desired amount.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
 	
-	<note><para><filename>OmegaT.app</filename> can make use of macOS Services.
-	You can also use AppleScript, Automator or Shortcuts to create
-	Services or scripts that will automate frequent actions.</para></note>
+	<note>
+	  <para><filename>OmegaT.app</filename> can make use of macOS Services.  You
+	  can also use AppleScript, Automator or Shortcuts to create Services or
+	  scripts that will automate frequent actions.</para>
+	</note>
   </section>
 
   <section id="running.omegat.on.other.systems">
@@ -125,23 +131,22 @@
 	endterm="launch.with.command.line.title"
 	linkend="launch.with.command.line"/> for details.</para>
 
-	<para>You can
-	create a script that includes the desired command line launch
-	parameters. If <filename>.jar</filename> files are properly associated
-	with &javaversionlong; and your PATH settings are correct, you can also
-	simply click (or double-click) on <filename>OmegaT.jar</filename> to
-	launch it directly.</para>
+	<para>You can create a script that includes the desired command line launch
+	parameters. If <filename>.jar</filename> files are properly associated with
+	&javaversionlong; and your PATH settings are correct, you can also simply
+	click (or double-click) on <filename>OmegaT.jar</filename> to launch it
+	directly.</para>
 
-	<para>Consult the documentation for your system for more
-	information.</para>
+	<para>Consult the documentation for your system for more information.</para>
   </section>
   
   <section id="launch.with.command.line">
 	<title id="launch.with.command.line.title">Command line launch</title>
-	<para>Using the command line allows you to set various options that control or
-	modify the behavior of the application. You can also define and save sets of
-	options in scripts that you can then use to launch OmegaT for a particular
-	purpose.</para>
+
+	<para>Using the command line allows you to set various options that control
+	or modify the behavior of the application. You can also define and save sets
+	of options in scripts that you can then use to launch OmegaT for a
+	particular purpose.</para>
 
 
 	<section id="launch.with.command.line.tutorial">
@@ -150,10 +155,10 @@
 
 	  <para>Before graphical interfaces became common, users interacted with
 	  computers via a command-line interface (CLI), which requires typing
-	  commands to give instructions to the computer. On modern systems, the
-	  CLI is accessed through an application generally called a
-	  &quot;terminal&quot; or &quot;console&quot;. For the sake of simplicity,
-	  this manual refers to it as the terminal.</para>
+	  commands to give instructions to the computer. On modern systems, the CLI
+	  is accessed through an application generally called a &quot;terminal&quot;
+	  or &quot;console&quot;. For the sake of simplicity, this manual refers to
+	  it as the terminal.</para>
 	  
 	  <para>On Windows, you can use either the <application>Command
 	  Prompt</application> or <application>Powershell</application> as a
@@ -174,12 +179,13 @@
 
 	  <note>
 		<para>The syntax used to specify the location of an application or
-		folder depends on the platform. On Windows, the <code>\</code>
-		character is used to separate folder and file names, while macOS and
-		Linux use the <code>/</code> to do so.</para>
+		folder depends on the platform. On Windows, the <code>\</code> character
+		is used to separate folder and file names, while macOS and Linux use the
+		<code>/</code> to do so.</para>
 
 		<para>Here are the default OmegaT.jar locations for
-		each major platform: 
+		each major platform:</para>
+		
 		<variablelist>
 		  <varlistentry id="launch.with.command.line.windows">
 			<term id="launch.with.command.line.windows.title">Windows</term>
@@ -197,73 +203,88 @@
 			<term id="launch.with.command.line.linux.title">Linux</term>
 			<listitem>
 			  <para><filename>/opt/omegat/OmegaT.jar</filename></para>
-				<para>(This can vary depending on your distribution.)</para>
+
+			  <para>(This can vary depending on your distribution.)</para>
 			</listitem>
 		  </varlistentry>
 		</variablelist>
-		That location is presented as <filename>path/to/OmegaT.jar</filename> in this chapter. Replace it with the actual location on your system.
-		</para>
+		
+		<para>That location is presented as
+		<filename>path/to/OmegaT.jar</filename> in this chapter. Replace it with
+		the actual location on your system.</para>
 	  </note>	
 	</section>
 
 	<section id="launch.with.command.line.omegat.terminal.command.syntax">
 	  <title
-		  id="launch.with.command.line.omegat.terminal.command.syntax.title">Command syntax</title>
+		  id="launch.with.command.line.omegat.terminal.command.syntax.title">Command
+	  syntax</title>
 
 	  <para>The syntax to launch OmegaT from the terminal is:
 	  <programlisting>java -jar &lt;java parameters&gt; path/to/OmegaT.jar &lt;OmegaT options&gt; </programlisting></para>
-	  <para>
-		<variablelist>
-		  <varlistentry id="launch.with.command.line.java.jar">
-			<term id="launch.with.command.line.java.jar.title">java -jar</term>
-			<listitem>
-			  <para>This command tells the Java Virtual Machine to run a
-			  Jar package.</para>
-			</listitem>
-		  </varlistentry>
 
-		  <varlistentry id="launch.with.command.line.intro.java.parameters">
-			<term id="launch.with.command.line.intro.java.parameters.title"><emphasis>&lt;java parameters&gt;</emphasis></term>
-			<listitem>
-			  <para>Optional parameters accepted by the
-			  <command>java</command> command. The parameters relevant
-			  to running OmegaT are described <link
-			  linkend="launch.with.command.line.java.parameters">below</link>.</para>
-			</listitem>					
-		  </varlistentry>
-		  <varlistentry id="launch.with.command.line.intro.omegat.jar">
-			<term id="launch.with.command.line.intro.omegat.jar.title">path/to/OmegaT.jar</term>
-			<listitem>
-			  <para>The location of the OmegaT java executable.</para>
-			  
-			</listitem>
-		  </varlistentry>
-		  <varlistentry id="launch.with.command.line.intro.omegat.options">
-			<term id="launch.with.command.line.intro.omegat.options.title"><emphasis>&lt;OmegaT options&gt;</emphasis></term>
-			<listitem>
-			  <para>The options specific to OmegaT are described <link
-			  linkend="launch.with.command.line.omegat.options">later
-			  in this section</link></para>
-			</listitem>					
-		  </varlistentry>
-		</variablelist>
-	  </para>
+	  <variablelist>
+		<varlistentry id="launch.with.command.line.java.jar">
+		  <term id="launch.with.command.line.java.jar.title"><option>java -jar</option></term>
+		  <listitem>
+			<para>This command tells the Java Virtual Machine to run a Jar
+			package.</para>
+		  </listitem>
+		</varlistentry>
+
+		<varlistentry id="launch.with.command.line.intro.java.parameters">
+		  <term
+			  id="launch.with.command.line.intro.java.parameters.title"><option>&lt;java
+		  parameters&gt;</option></term>
+		  <listitem>
+			<para>Optional parameters accepted by the <command>java</command>
+			command. The parameters relevant to running OmegaT are described
+			<link
+				linkend="launch.with.command.line.java.parameters">below</link>.</para>
+		  </listitem>					
+		</varlistentry>
+
+		<varlistentry id="launch.with.command.line.intro.omegat.jar">
+		  <term
+			  id="launch.with.command.line.intro.omegat.jar.title"><option>path/to/OmegaT.jar</option></term>
+		  <listitem>
+			<para>The location of the OmegaT java executable.</para>	  
+		  </listitem>
+		</varlistentry>
+
+		<varlistentry id="launch.with.command.line.intro.omegat.options">
+		  <term
+			  id="launch.with.command.line.intro.omegat.options.title"><emphasis><option>&lt;OmegaT
+		  options&gt;</option></emphasis></term>
+		  <listitem>
+			<para>The options specific to OmegaT are described <link
+			linkend="launch.with.command.line.omegat.options">later in this
+			section</link></para>
+		  </listitem>					
+		</varlistentry>
+	  </variablelist>
 	</section>
 
 	<section id="launch.with.command.line.java.parameters">
 	  <title id="launch.with.command.line.java.parameters.title">Java
 	  parameters</title>
 
-	  <para>The list below presents parameters for the <command>java</command> command that can be useful when working with OmegaT.
+	  <para>The list below presents parameters for the <command>java</command>
+	  command that can be useful when working with OmegaT.</para>
+	  
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.user.interface.language">
-		  <term id="launch.with.command.line.user.interface.language.title">User interface language</term>
+		  <term id="launch.with.command.line.user.interface.language.title">User
+		  interface language</term>
+
 		  <listitem>
-			<para><code>-Duser.language=LL</code></para>
+			<para><option>-Duser.language=LL</option></para>
+
 			<para>Replace <code>LL</code> with the desired
 			two-letter language code from the <ulink
 			url="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">ISO
 			639.1</ulink> list.</para>
+
 			<para>Using this parameter launches OmegaT with the user
 			interface in the specified language, if available (even
 			partially). If the language is not available, OmegaT
@@ -273,49 +294,59 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.user.country">
-		  <term id="launch.with.command.line.user.country.title">User country</term>
+		  <term id="launch.with.command.line.user.country.title">User
+		  country</term>
 		  <listitem>
-			<para><code>-Duser.country=CC</code></para>
-			<para>Replace <code>CC</code> with the desired
-			two-letter country code from the <ulink
-			url="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
-			3166-1 alpha-2</ulink> list.</para>
-			<para>This parameter combines with the previous user
-			interface language parameter to specify a regional
-			variant. If that variant is not available, the user
-			interface follows the same priority as above.</para>
+			<para><option>-Duser.country=CC</option></para>
+
+			<para>Replace <code>CC</code> with the desired two-letter country
+			code from the <ulink
+			url="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1
+			alpha-2</ulink> list.</para>
+
+			<para>This parameter combines with the previous user interface
+			language parameter to specify a regional variant. If that variant is
+			not available, the user interface follows the same priority as
+			above.</para>
 		  </listitem>
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.maximum.memory.assignment">
-		  <term id="launch.with.command.line.maximum.memory.assignment.title">Maximum memory assignment</term>
+		  <term
+			  id="launch.with.command.line.maximum.memory.assignment.title">Maximum
+		  memory assignment</term>
 		  <listitem>
-			<para><code>-XmxSIZE</code></para>
-			<para>Replace <code>SIZE</code> with a number consisting of a multiple of
-			1024 followed by <code>k</code> for kilobytes, <code>m</code> for
-			megabytes, or <code>g</code> for gigabytes. The number must correspond to at least 2 MB.</para>
+			<para><option>-XmxSIZE</option></para>
+
+			<para>Replace <code>SIZE</code> with a number consisting of a
+			multiple of 1024 followed by <code>k</code> for kilobytes,
+			<code>m</code> for megabytes, or <code>g</code> for gigabytes. The
+			number must correspond to at least 2 MB.</para>
 		  </listitem>
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.ip.address">
-		  <term id="launch.with.command.line.proxy.host.ip.address.title">Proxy host ip address</term>
+		  <term id="launch.with.command.line.proxy.host.ip.address.title">Proxy
+		  host ip address</term>
 		  <listitem>
-			<para><code>-Dhttp.proxyHost=&lt;proxy IP&gt;</code></para>
-			<para>Replace <code>&lt;proxy IP&gt;</code> with the IP
-			address of your proxy server, if your system uses one.</para>
+			<para><option>-Dhttp.proxyHost=&lt;proxy IP&gt;</option></para>
+
+			<para>Replace <code>&lt;proxy IP&gt;</code> with the IP address of
+			your proxy server, if your system uses one.</para>
 		  </listitem>
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.port.number">
-		  <term id="launch.with.command.line.proxy.host.port.number.title">Proxy host port number</term>
+		  <term id="launch.with.command.line.proxy.host.port.number.title">Proxy
+		  host port number</term>
 		  <listitem>
-			<para><code>-Dhttp.proxyPort=&lt;port number&gt;</code></para>
-			<para>Replace <code>&lt;port number&gt;</code> with the port
+			<para><option>-Dhttp.proxyPort=&lt;port number&gt;</option></para>
+
+			<para>Replace <option>&lt;port number&gt;</option> with the port
 			number your system uses to access the proxy server.</para>
 		  </listitem>
 		</varlistentry>
 	  </variablelist>
-	  </para>
 	</section>
 
 	<section id="launch.with.command.line.omegat.options">
@@ -326,307 +357,356 @@
 	  <command>java -jar OmegaT.jar --help</command>
 	  command. The OmegaT GUI is launched if no option is specified.</para>
 
-	  <para>		
-		<variablelist>
-		  <varlistentry id="launch.with.command.line.general.options.">
-			<term id="launch.with.command.line.general.options.title">General options:</term>
-			<listitem>
-			  <variablelist>
-				<varlistentry id="launch.with.command.line.h.help">
-				  <term id="launch.with.command.line.h.help.title">-h, --help</term>
-				  <listitem>
-					<para>Show usage information.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.path.to.an.omegat.project">
-				  <term id="launch.with.command.line.path.to.an.omegat.project.title">path to an omegat project</term>
-				  <listitem>
-					<para>Launch the GUI and load the specified
-					project</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.remote.project.">
-				  <term id="launch.with.command.line.remote.project.title">--remote-project
-				  <emphasis>&lt;path-to-omegat-project-file&gt;</emphasis></term>
-				  <listitem>
-					<para>Download the OmegaT project from the
-					URL specified in
-					<emphasis>&lt;path-to-omegat-project-file&gt;</emphasis>,
-					and load it.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.no.team">
-				  <term id="launch.with.command.line.no.team.title">--no-team</term>
-				  <listitem>
-					<para>Disable team project
-					functionality. Use this option if you want
-					to prevent OmegaT from synchronizing the
-					project contents.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.team.init">
-				  <term id="launch.with.command.line.team.init.title">team init <emphasis>SL</emphasis>
-				  <emphasis>TL</emphasis></term>
-				  <listitem>
-					<para>Initialize a team project using
-					<emphasis>SL</emphasis> and
-					<emphasis>TL</emphasis> as the source and
-					target two-letter language codes,
-					respectively. </para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.disable.project.locking">
-				  <term id="launch.with.command.line.disable.project.locking.title">--disable-project-locking</term>
-				  <listitem>
-					<para>Do not lock the omegat.project file.</para>
-					<para>On some platforms, the omegat.project
-					file is locked by default and attempting to
-					open an already open project in another
-					instance of OmegaT results in an error. This
-					option prevents that error.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.disable.location.save">
-				  <term id="launch.with.command.line.disable.location.save.title">--disable-location-save</term>
-				  <listitem>
-					<para>Do not remember the last folder
-					opened in the file picker.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.itokenizer.lt.classname.gt.">
-				  <term id="launch.with.command.line.itokenizer.lt.classname.gt.title">--ITokenizer=&lt;classname&gt;</term>
-				  <term>--ITokenizerTarget=&lt;classname&gt;</term>
-				  <listitem>
-					<para>Specify a source- or target-language
-					tokenizer (using this option overrides
-					project settings). See
-					OmegaT.jar/META-INF/MANIFEST.MF for valid
-					values.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.config.dir.">
-				  <term id="launch.with.command.line.config.dir.title">--config-dir=<emphasis>&lt;path&gt;</emphasis></term>
-				  <listitem>
-					<para>The folder used to read and write
-					OmegaT configuration files.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.config.file.">
-				  <term id="launch.with.command.line.config.file.title">--config-file=<emphasis>&lt;path&gt;</emphasis></term>
-				  <listitem>
-					<para>A file written in the Java .properties
-					format used to specify a batch of command line
-					options.</para>
-					<para>The options are presented as a list of
-					<parameter>key=value</parameter> pairs. Both Java
-					parameters and OmegaT options can be used.</para>
-					<note>
-					  <para>Remove the initial <code>-D</code> or
-					  <code>-X</code> to use Java parameters:</para>
-					  <programlisting>user.language=fr
+	  <variablelist>
+		<varlistentry id="launch.with.command.line.general.options.">
+		  <term id="launch.with.command.line.general.options.title">General
+		  options:</term>
+		  <listitem>
+			<variablelist>
+			  <varlistentry id="launch.with.command.line.h.help">
+				<term
+				id="launch.with.command.line.h.help.title"><option>-h</option>,
+				<option>--help</option></term>
+				<listitem>
+				  <para>Show usage information.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.path.to.an.omegat.project">
+				<term
+					id="launch.with.command.line.path.to.an.omegat.project.title"><emphasis>path
+				to an omegat project</emphasis></term>
+				<listitem>
+				  <para>Launch the GUI and load the specified project</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.remote.project.">
+				<term
+				id="launch.with.command.line.remote.project.title"><option>--remote-project</option>
+				<emphasis>&lt;path-to-omegat-project-file&gt;</emphasis></term>
+				<listitem>
+				  <para>Download the OmegaT project from the URL specified in
+				  <emphasis>&lt;path-to-omegat-project-file&gt;</emphasis>, and
+				  load it.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.no.team">
+				<term id="launch.with.command.line.no.team.title"><option>--no-team</option></term>
+				<listitem>
+				  <para>Disable team project functionality. Use this option if
+				  you want to prevent OmegaT from synchronizing the project
+				  contents.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.team.init">
+				<term id="launch.with.command.line.team.init.title"><option>team
+				init <emphasis>SL</emphasis>
+				<emphasis>TL</emphasis></option></term>
+				<listitem>
+				  <para>Initialize a team project using <emphasis>SL</emphasis>
+				  and <emphasis>TL</emphasis> as the source and target
+				  two-letter language codes, respectively. </para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.disable.project.locking">
+				<term
+				id="launch.with.command.line.disable.project.locking.title"><option>--disable-project-locking</option></term>
+				<listitem>
+				  <para>Do not lock the omegat.project file.</para>
+
+				  <para>On some platforms, the omegat.project file is locked by
+				  default and attempting to open an already open project in
+				  another instance of OmegaT results in an error. This option
+				  prevents that error.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.disable.location.save">
+				<term
+					id="launch.with.command.line.disable.location.save.title"><option>--disable-location-save</option></term>
+				<listitem>
+				  <para>Do not remember the last folder opened in the file
+				  picker.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.itokenizer.lt.classname.gt.">
+				<term
+				id="launch.with.command.line.itokenizer.lt.classname.gt.title"><option>--ITokenizer=&lt;classname&gt;</option></term>
+				<term><option>--ITokenizerTarget=&lt;classname&gt;</option></term>
+				<listitem>
+				  <para>Specify a source- or target-language tokenizer (using
+				  this option overrides project settings). See
+				  OmegaT.jar/META-INF/MANIFEST.MF for valid values.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.config.dir.">
+				<term
+					id="launch.with.command.line.config.dir.title"><option>--config-dir=<emphasis>&lt;path&gt;</emphasis></option></term>
+				<listitem>
+				  <para>The folder used to read and write OmegaT configuration
+				  files. See the <link endterm="configuration.folder.title"
+				  linkend="configuration.folder"/> chapter for details.</para>
+				</listitem>
+			  </varlistentry>
+			  <varlistentry id="launch.with.command.line.config.file.">
+				<term id="launch.with.command.line.config.file.title"><option>--config-file=<emphasis>&lt;path&gt;</emphasis></option></term>
+				<listitem>
+				  <para>A file written in the Java .properties format used to
+				  specify a batch of command line options.</para>
+
+				  <para>The options are presented as a list of
+				  <parameter>key=value</parameter> pairs. Both Java parameters
+				  and OmegaT options can be used.</para>
+				  <note>
+					<para>Remove the initial <code>-D</code> or <code>-X</code>
+					to use Java parameters:</para>
+
+					<programlisting>user.language=fr
 config-dir="path/to/new/configdir"</programlisting>
-					</note>
-					<para>Almost all parameters presented in this
-					section can be used in a config file. The notable
-					exception is <code>remote-project</code>.</para>
-					<para>It is possible to combine
-					<code>--config-file</code> with other command line
-					options compatible with launching the GUI. In such
-					cases, options defined in the config file take
-					precedence over any option with duplicate
-					functionality also passed on the command
-					line.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.resource.bundle.">
-				  <term id="launch.with.command.line.resource.bundle.title">--resource-bundle=<emphasis>&lt;path&gt;</emphasis></term>
-				  <listitem>
-					<para>A Java .properties file to use for interface text.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.">
-				  <term id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title">--mode=[console mode name]</term>
-				  <listitem>
-					<para>Specify a mode other than the GUI default. The following
-					options are available:</para>
-					<variablelist>
-					  <varlistentry id="launch.with.command.line.mode.console.translate">
-						<term id="launch.with.command.line.mode.console.translate.title">--mode=console-translate</term>
-						<listitem>
-						  <para>In this mode, OmegaT attempts to translate the
-						  files in the source folder with the available
-						  translation memories.</para>
-						  <para>This is useful if OmegaT is run on
-						  a server with TMX files automatically fed to a project.
-						  <variablelist>
-							<varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt.">
-							  <term id="launch.with.command.line.source.pattern.lt.pattern.gt.title">--source-pattern=&lt;pattern&gt;</term>
-							  <listitem>
-								<para>A whitelist of regular expressions defining
-								the source files to process. Remember that in
-								regular expressions, the period and backslash
-								character must be escaped: <code>\.</code> and
-								<code>\\</code>.</para>
-								<para>Here are some typical examples:
-								<variablelist>
-								  <varlistentry id="launch.with.command.line.html">
-									<term id="launch.with.command.line.html.title">.*\.html</term>
-									<listitem>
-									  <para>Translate all HTML files.</para>
-									</listitem>
-								  </varlistentry>
-								  <varlistentry id="launch.with.command.line.test.html">
-									<term id="launch.with.command.line.test.html.title">test\.html</term>
-									<listitem>
-									  <para>Only translate
-									  <filename>test.html</filename> file in the
-									  source folder itself. Any files also named
-									  test.html in other subfolders will be
-									  ignored.</para>
-									</listitem>
-								  </varlistentry>
-								  <varlistentry id="launch.with.command.line.dir.test.html">
-									<term id="launch.with.command.line.dir.test.html.title">dir-10\\test\.html</term>
-									<listitem>
-									  <para>Only translate the
-									  <filename>test.html</filename> file in the
-									  <filename
-										  class="directory">dir-10</filename>
-									  folder.</para>
-									</listitem>
-								  </varlistentry>
-								</variablelist>
-								See <link linkend="app.regex"
-								endterm="app.regex.title"/> for details.
-								</para>
-							  </listitem>
-							</varlistentry>
-						  </variablelist>
-						  </para>
-						</listitem>
-					  </varlistentry>
+				  </note>
 
-					  <varlistentry id="launch.with.command.line.mode.console.pseudotranslatetmx">
-						<term id="launch.with.command.line.mode.console.pseudotranslatetmx.title">--mode=console-createpseudotranslatetmx</term>
-						<listitem>
-						  <para>In this mode OmegaT will create a TMX for the
-						  whole project using only the source files.</para>
-						  <para>Specify the
-						  TMX file to be created with:
-						  <variablelist>
-							<varlistentry id="launch.with.command.line.pseudotranslatetmx.">
-							  <term id="launch.with.command.line.pseudotranslatetmx.title">--pseudotranslatetmx=<emphasis>&lt;path&gt;</emphasis></term>
-							  <listitem>
-								<para>The output pseudotranslated TMX file.</para>
-							  </listitem>
-							</varlistentry>
-							<varlistentry id="launch.with.command.line.pseudotranslatetype.equal.empty.">
-							  <term id="launch.with.command.line.pseudotranslatetype.equal.empty.title">--pseudotranslatetype=[equal|empty]</term>
-							  <listitem>
-								<para>What to fill the pseudotranslated TMX
-								with.</para>
-							  </listitem>
-							</varlistentry>
-						  </variablelist>
-						  </para>
-						</listitem>
-					  </varlistentry>
+				  <para>Almost all parameters presented in this section can be
+				  used in a config file. The notable exception is
+				  <code>remote-project</code>.</para>
 
-					  <varlistentry id="launch.with.command.line.mode.console.align">
-						<term id="launch.with.command.line.mode.console.align.title">--mode=console-align
-						<emphasis>--alignDir=<emphasis>&lt;path&gt;</emphasis></emphasis></term>
-						<listitem>
-						  <para>In this mode, OmegaT will align the files in the
-						  /source folder of the project with those at the location
-						  specified by the <emphasis>--alignDir</emphasis>
-						  parameter.</para>
-						  <para>The resulting TMX file is saved in the
-						  /omegat folder as align.tmx. The file types that can be
-						  aligned depend on whether the alignment is supported by the
-						  file filter. Supported filters include: ILIAS Language
-						  File, Java(TM) Resource Bundles, Key=Value Text, Magento
-						  CE Locale CSV, MoodlePHP, Mozilla DTD, Mozilla FTL, PO,
-						  RC, SubRip Subtitles, and Windows Resources.</para>
-						  <para>The <emphasis>--alignDir</emphasis> parameter is
-						  used to specify the location of the data in the target
-						  language, which must be a folder containing the
-						  translated files.</para>
-						  <para>That folder must contain a translation in the
-						  target language of the project. For instance, if the
-						  project is EN-to-FR, the folder must contain a bundle
-						  ending with _fr. The resulting TMX file is saved in
-						  the /omegat folder as align.tmx.</para>
-						</listitem>
-					  </varlistentry>
+				  <para>It is possible to combine <code>--config-file</code>
+				  with other command line options compatible with launching the
+				  GUI. In such cases, options defined in the config file take
+				  precedence over any option with duplicate functionality also
+				  passed on the command line.</para>
+				</listitem>
+			  </varlistentry>
 
-					  <varlistentry id="launch.with.command.line.mode.console.stats">
-						<term id="launch.with.command.line.mode.console.stats.title">--mode=console-stats <emphasis>&lt;path&gt;</emphasis></term>
-						<listitem>
-						  <variablelist>
-							<varlistentry id="launch.with.command.line.console.stats.output.file">
-							  <term id="launch.with.command.line.console.stats.output.file.title">--output-file=[stats-output-file]</term>
-							  <listitem>
-								<para>Prints to that file, or to standard output if absent. Without <emphasis>--stats-type</emphasis>, detects format from file extension. The output defaults to xml.</para>
-							  </listitem>
-							</varlistentry>
-							<varlistentry id="launch.with.command.line.console.stats.output.format">
-							  <term id="launch.with.command.line.console.stats.output.format.title">--stats-type=[xml|text][txt][json]]]</term>
-							  <listitem>
-								<para>Requires <emphasis>--output-file</emphasis>. Specifies the output format.</para>
-							  </listitem>
-							</varlistentry>
-						  </variablelist>
-						  <para>The data is the same as when using <link linkend="menus.tools.statistics" endterm="menus.tools.statistics.title"/>.
-						  </para>
-						</listitem>
-					  </varlistentry>
-					</variablelist>												
-				  </listitem>								
-				</varlistentry>
-			  </variablelist>
-			</listitem>
-		  </varlistentry>	
-		  <varlistentry id="launch.with.command.line.non.gui.mode.options.">
-			<term id="launch.with.command.line.non.gui.mode.options.title">Non-gui mode options:</term>
-			<listitem>
-			  <variablelist>
-				<varlistentry id="launch.with.command.line.quiet">
-				  <term id="launch.with.command.line.quiet.title">--quiet</term>
-				  <listitem><para>Minimize the output shown on the command
-				  line.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.script.">
-				  <term id="launch.with.command.line.script.title">--script=<emphasis><emphasis>&lt;path&gt;</emphasis></emphasis></term>
-				  <listitem>
-					<para>A script file to run when a project event is
-					triggered.</para>
-				  </listitem>
-				</varlistentry>
-				<varlistentry id="launch.with.command.line.tag.validation.abort.warn.">
-				  <term id="launch.with.command.line.tag.validation.abort.warn.title">--tag-validation=[abort|warn]</term>
-				  <listitem>
-					<para>Check tag issues.
-					<itemizedlist>
+			  <varlistentry id="launch.with.command.line.resource.bundle.">
+				<term
+				id="launch.with.command.line.resource.bundle.title"><option>--resource-bundle=<emphasis>&lt;path&gt;</emphasis></option></term>
+				<listitem>
+				  <para>A Java .properties file to use for interface
+				  text.</para>
+				</listitem>
+			  </varlistentry>
+
+			  <varlistentry id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.">
+				<term
+				id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title"><option>--mode=[console
+				mode name]</option></term>
+				<listitem>
+				  <para>Specify a mode other than the GUI default. The following
+				  options are available:</para>
+
+				  <variablelist>
+					<varlistentry id="launch.with.command.line.mode.console.translate">
+					  <term
+						  id="launch.with.command.line.mode.console.translate.title"><option>--mode=console-translate</option></term>
 					  <listitem>
-						<para>Abort: Exit with an error if there are tag issues.</para>
+						<para>In this mode, OmegaT attempts to translate the
+						files in the source folder with the available
+						translation memories.</para>
+
+						<para>This is useful if OmegaT is run on a server with
+						TMX files automatically fed to a project.</para>
+						  
+						<variablelist>
+						  <varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt.">
+							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title"><option>--source-pattern=&lt;pattern&gt;</option></term>
+							<listitem>
+							  <para>A whitelist of regular expressions defining
+							  the source files to process. Remember that in
+							  regular expressions, the period and backslash
+							  character must be escaped: <code>\.</code> and
+							  <code>\\</code>.</para>
+
+							  <para>Here are some typical examples:</para>
+							  
+							  <variablelist>
+								<varlistentry id="launch.with.command.line.html">
+								  <term id="launch.with.command.line.html.title"><option>.*\.html</option></term>
+								  <listitem>
+									<para>Translate all HTML files.</para>
+								  </listitem>
+								</varlistentry>
+								<varlistentry id="launch.with.command.line.test.html">
+								  <term id="launch.with.command.line.test.html.title"><option>test\.html</option></term>
+								  <listitem>
+									<para>Only translate
+									<filename>test.html</filename> file in the
+									source folder itself. Any files also named
+									test.html in other subfolders will be
+									ignored.</para>
+								  </listitem>
+								</varlistentry>
+
+								<varlistentry id="launch.with.command.line.dir.test.html">
+								  <term
+									  id="launch.with.command.line.dir.test.html.title"><option>dir-10\\test\.html</option></term>
+								  <listitem>
+									<para>Only translate the
+									<filename>test.html</filename> file in the
+									<filename
+										class="directory">dir-10</filename>
+									folder.</para>
+								  </listitem>
+								</varlistentry>
+							  </variablelist>
+
+							  <para>See the <link linkend="app.regex"
+							  endterm="app.regex.title"/> appendix for
+							  details.</para>
+							</listitem>
+						  </varlistentry>
+						</variablelist>
 					  </listitem>
+					</varlistentry>
+
+					<varlistentry id="launch.with.command.line.mode.console.pseudotranslatetmx">
+					  <term
+						  id="launch.with.command.line.mode.console.pseudotranslatetmx.title"><option>--mode=console-createpseudotranslatetmx</option></term>
 					  <listitem>
-						<para>Warn: Show warnings without exiting if there are tag issues.</para>
-					  </listitem>											
-					</itemizedlist>
-					<note>
-					  <para>Reports about tag issues are output to the terminal
-					  window.</para>
-					</note>
-					</para>
-				  </listitem>
-				</varlistentry>
-			  </variablelist>
-			</listitem>
-		  </varlistentry>
-		</variablelist>
-	  </para>
+						<para>In this mode OmegaT will create a TMX for the
+						whole project using only the source files.</para>
+						
+						<para>Specify the
+						TMX file to be created with:</para>
+						
+						<variablelist>
+						  <varlistentry id="launch.with.command.line.pseudotranslatetmx.">
+							<term
+								id="launch.with.command.line.pseudotranslatetmx.title"><option>--pseudotranslatetmx=<emphasis>&lt;path&gt;</emphasis></option></term>
+							<listitem>
+							  <para>The output pseudotranslated TMX file.</para>
+							</listitem>
+						  </varlistentry>
+
+						  <varlistentry id="launch.with.command.line.pseudotranslatetype.equal.empty.">
+							<term
+								id="launch.with.command.line.pseudotranslatetype.equal.empty.title"><option>--pseudotranslatetype=[equal|empty]</option></term>
+							<listitem>
+							  <para>What to fill the pseudotranslated TMX
+							  with.</para>
+							</listitem>
+						  </varlistentry>
+						</variablelist>
+					  </listitem>
+					</varlistentry>
+					
+					<varlistentry id="launch.with.command.line.mode.console.align">
+					  <term
+						  id="launch.with.command.line.mode.console.align.title"><option>--mode=console-align
+					  <emphasis>--alignDir=&lt;path&gt;</emphasis></option></term>
+					  <listitem>
+						<para>In this mode, OmegaT will align the files in the
+						/source folder of the project with those at the location
+						specified by the <emphasis>--alignDir</emphasis>
+						parameter.</para>
+
+						<para>The resulting TMX file is saved in the /omegat
+						folder as align.tmx. The file types that can be aligned
+						depend on whether the alignment is supported by the file
+						filter. Supported filters include: ILIAS Language File,
+						Java(TM) Resource Bundles, Key=Value Text, Magento CE
+						Locale CSV, MoodlePHP, Mozilla DTD, Mozilla FTL, PO, RC,
+						SubRip Subtitles, and Windows Resources.</para>
+
+						<para>The <emphasis>--alignDir</emphasis> parameter is
+						used to specify the location of the data in the target
+						language, which must be a folder containing the
+						translated files.</para>
+
+						<para>That folder must contain a translation in the
+						target language of the project. For instance, if the
+						project is EN-to-FR, the folder must contain a bundle
+						ending with _fr. The resulting TMX file is saved in the
+						/omegat folder as align.tmx.</para>
+					  </listitem>
+					</varlistentry>
+
+					<varlistentry id="launch.with.command.line.mode.console.stats">
+					  <term
+						  id="launch.with.command.line.mode.console.stats.title"><option>--mode=console-stats
+					  <emphasis>&lt;path&gt;</emphasis></option></term>
+					  <listitem>
+						<variablelist>
+						  <varlistentry id="launch.with.command.line.console.stats.output.file">
+							<term
+							id="launch.with.command.line.console.stats.output.file.title"><option>--output-file=[stats-output-file]</option></term>
+							<listitem>
+							  <para>Prints to that file, or to standard output
+							  if absent. Without
+							  <emphasis>--stats-type</emphasis>, detects format
+							  from file extension. The output defaults to
+							  xml.</para>
+							</listitem>
+						  </varlistentry>
+							
+						  <varlistentry id="launch.with.command.line.console.stats.output.format">
+							<term
+								id="launch.with.command.line.console.stats.output.format.title"><option>--stats-type=[xml|text][txt][json]]]</option></term>
+							<listitem>
+							  <para>Requires
+							  <emphasis>--output-file</emphasis>. Specifies the
+							  output format.</para>
+							</listitem>
+						  </varlistentry>
+						</variablelist>
+						  
+						<para>The data is the same as when using <link
+						linkend="menus.tools" endterm="menus.tools.title"/><link
+						linkend="menus.tools.statistics"
+						endterm="menus.tools.statistics.title"/>.</para>
+					  </listitem>
+					</varlistentry>
+				  </variablelist>												
+				</listitem>								
+			  </varlistentry>
+			</variablelist>
+		  </listitem>
+		</varlistentry>
+		  
+		<varlistentry id="launch.with.command.line.non.gui.mode.options.">
+		  <term id="launch.with.command.line.non.gui.mode.options.title">Non-gui
+		  mode options:</term>
+		  <listitem>
+			<variablelist>
+			  <varlistentry id="launch.with.command.line.quiet">
+				<term id="launch.with.command.line.quiet.title"><option>--quiet</option></term>
+				<listitem>
+				  <para>Minimize the output shown on the command line.</para>
+				</listitem>
+			  </varlistentry>
+				
+			  <varlistentry id="launch.with.command.line.script.">
+				<term
+					id="launch.with.command.line.script.title"><option>--script=<emphasis>&lt;path&gt;</emphasis></option></term>
+				<listitem>
+				  <para>A script file to run when a project event is
+				  triggered.</para>
+				</listitem>
+			  </varlistentry>
+
+			  <varlistentry id="launch.with.command.line.tag.validation.abort.warn.">
+				<term
+					id="launch.with.command.line.tag.validation.abort.warn.title"><option>--tag-validation=[abort|warn]</option></term>
+				<listitem>
+				  <para>Check tag issues.</para>
+				  
+				  <itemizedlist>
+					<listitem>
+					  <para>Abort: Exit with an error if there are tag issues.</para>
+					</listitem>
+
+					<listitem>
+					  <para>Warn: Show warnings without exiting if there are tag issues.</para>
+					</listitem>											
+				  </itemizedlist>
+
+				  <note>
+					<para>Reports about tag issues are output to the terminal
+					window.</para>
+				  </note>
+				</listitem>
+			  </varlistentry>
+			</variablelist>
+		  </listitem>
+		</varlistentry>
+	  </variablelist>
 	</section>
   </section>
 </section>

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -2,168 +2,206 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.setup.team.project">
-  <title id="how.to.setup.team.project.title">Set up a team
-  project</title>
+  <title id="how.to.setup.team.project.title">Set up a team project</title>
 
-  <para>Managing a team project calls for some knowledge of either the <emphasis>SVN</emphasis> or <emphasis>Git</emphasis>
-  version control system (<emphasis>VCS</emphasis> in the rest of this section).</para>
+  <para>Managing a team project calls for some knowledge of either the
+  <emphasis>SVN</emphasis> or <emphasis>Git</emphasis> version control system
+  (<emphasis>VCS</emphasis> in the rest of this section).</para>
 
-  <para>As information on those topics is readily available, this guide
-  limits itself to describing their use in the context of an OmegaT team
+  <para>As information on those topics is readily available, this manual limits
+  itself to describing their use in the context of an OmegaT team
   project.</para>
 
-  <note><para>An OmegaT team projects synchronizes the project translation memory <link linkend="project.folder.project.save.tmx" endterm="project.folder.project.save.tmx.title"/> and the project writable glossary <link linkend="project.folder.glossary.txt" endterm="project.folder.glossary.txt.title"/> between the hosting server and all the participating team members, and manages all possible conflicts between them.</para></note>
+  <note>
+	<para>An OmegaT team projects synchronizes the project translation memory
+	<link linkend="project.folder.project.save.tmx"
+	endterm="project.folder.project.save.tmx.title"/> and the project writable
+	glossary <link linkend="project.folder.glossary.txt"
+	endterm="project.folder.glossary.txt.title"/> between the hosting server and
+	all the participating team members, and manages all possible conflicts
+	between them.</para>
+  </note>
 
-  <para>The steps to set up a team project are the following:
-  <orderedlist>
-    <listitem id="how.to.setup.team.project.create.empty.repository"><para id="how.to.setup.team.project.create.empty.repository.title">Create an empty repository on your VCS hosting server</para></listitem>
-	<listitem id="how.to.setup.team.project.clone.locally"><para id="how.to.setup.team.project.clone.locally.title">Use the local VCS to make a local copy (clone)</para></listitem>
-	<listitem id="how.to.setup.team.project.fill.local.clone"><para id="how.to.setup.team.project.fill.local.clone.title">Fill the empty local copy with a real OmegaT project</para></listitem>
-	<listitem id="how.to.setup.team.project.register"><para id="how.to.setup.team.project.register.title">Register the project files into the local VCS</para></listitem>
-	<listitem id="how.to.setup.team.project.push"><para id="how.to.setup.team.project.push.title">Put the registered files on the hosting server</para></listitem>
-	<listitem id="how.to.setup.team.project.give.access.rights"><para id="how.to.setup.team.project.give.access.rights.title">Give access rights to your team</para></listitem>
-	<listitem id="how.to.setup.team.project.have.members.download"><para id="how.to.setup.team.project.have.members.download.title">Have everybody download the project from OmegaT</para></listitem>
-	<listitem id="how.to.setup.team.project.download.if.needed"><para id="how.to.setup.team.project.download.if.needed.title">If you need to work on the project too, download the project yourself to a local location different from the local team project location</para></listitem>
-	<listitem id="how.to.setup.team.project.translate"><para id="how.to.setup.team.project.translate.title">You can now also work on the project with the team</para></listitem>
-  </orderedlist>
-  </para>
-  
-  
-  
   <section id="how.to.setup.team.project.prepare.the.repository">
-    <title id="how.to.setup.team.project.prepare.the.repository.title">Preparations</title>
+    <title
+    id="how.to.setup.team.project.prepare.the.repository.title">Preparations</title>
 
-    <orderedlist>
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.create.empty.repository" endterm="how.to.setup.team.project.create.empty.repository.title"/></para>
-        <para>This can normally be done through a web interface, a graphical
-        application, or the command line. Consult the documentation for your
-        server or hosting service for details.</para>
+	<para>The steps to set up a team project are the following:</para>
+
+	<orderedlist>
+      <listitem id="how.to.setup.team.project.create.empty.repository">
+		<para
+		id="how.to.setup.team.project.create.empty.repository.title">Create an
+		empty repository on your VCS hosting server</para>
+
+		<para>This can normally be done through a web interface, a graphical
+		application, or the command line. Consult the documentation for your
+		server or hosting service for details.</para>
 	  </listitem>
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.clone.locally" endterm="how.to.setup.team.project.clone.locally.title"/></para>
+
+	  <listitem id="how.to.setup.team.project.clone.locally">
+		<para id="how.to.setup.team.project.clone.locally.title">Use the local
+		VCS to make a local copy (clone)</para>
+
 		<note>
 		  <para>This local version contains your <emphasis>project
 		  manager</emphasis> copy of the OmegaT project. Use it to make
 		  modifications that affect the entire team.</para>
 		</note>
 
-        <para>The local repository is used to add the initial project to the
-        server, and can also be used for maintenance tasks, such as deleting
-        files, that cannot be performed directly within OmegaT.</para>
-
-		<para>We
-        recommend that you avoid using that folder for translation tasks. If
-        you need to perform translation or review tasks on that project, use
-        OmegaT to download a separate copy of the team project and work from
-        there. See <link linkend="how.to.use.team.project"
-        endterm="how.to.use.team.project.title"/> for details.</para>
-	  </listitem>
-	  <listitem><para><link linkend="how.to.setup.team.project.fill.local.clone" endterm="how.to.setup.team.project.fill.local.clone.title"/></para>
-
-	  <itemizedlist>
-		<listitem><para>Create the project structure</para>
-		<para>If you are creating a new empty project, you can follow the
-		<link linkend="introduction.create.and.open.new.project">usual GUI procedure</link>,
-		or create it directly from the command line:
-
-		<command>java -jar OmegaT.jar team init
-        &lt;source language&gt; &lt;target language&gt;</command></para>
-
-        <para>This command also automatically registers the project in
-        the version control system.</para>
-		</listitem>
-		<listitem><para>Choose the appropriate settings</para>
-		<para>Make the necessary changes to the project properties at this
-		stage, including local file filters or segmentation settings. See <link linkend="dialogs.project.properties" endterm="dialogs.project.properties.title"/> for details.</para>
-		</listitem>
-		<listitem><para>Add the necessary files</para>
-		<para>Similarly add any relevant lists of spellchecker files you want to
-		make available to everyone working on the project. See <link
-		linkend="project.folder.omegat.spellcheck">spellchecker files</link> for
-		details.</para>
-
-		<para>If you are converting an existing project, make sure you delete
-		any files in the project that you do not need or want to upload to the
-		server before proceeding to the next step.</para>
-
-		<para>Copy the files to translate to the source/ folder, and use your
-		SVN or Git client, or the command line, to add and publish them to the
-		repository. Source files can also be added from OmegaT using the <link
-		endterm="menus.project.commit.source.files.title"
-		linkend="menus.project.commit.source.files"/> command in the <link
-		endterm="menus.project.title" linkend="menus.project"/> menu.</para>
-
-		<para>You must use your SVN or Git client, or the command line, to add
-		and publish any dictionaries, glossaries, translation memories or
-		other files you want to include in the project.</para>
-
-		<para>This step can be performed before the registering and publishing
-		the project for the first time, and can also be used to add new files,
-		or update existing ones after the project has been created.</para>
-		</listitem>
-	  </itemizedlist>
-      <note>
-        <para>In team projects that use a simple mapping between the local
-        repository and the remote repository (the default), <emphasis
-        role="bold">and only in such projects</emphasis>, the source and
-				target files can be modified locally and uploaded to the server
-				using the <link
-        endterm="menus.project.commit.source.files.title"
-        linkend="menus.project.commit.source.files"/> and <link
-        linkend="menus.project.commit.target.files"
-        endterm="menus.project.commit.target.files.title"/> commands from the
-        <link linkend="menus.project" endterm="menus.project.title"/>
-        menu.</para>
-        <para>The team project administrator must use the local VCS
-        to <emphasis role="bold">modify</emphasis> or <emphasis
-        role="bold">delete</emphasis> those files. Some plugins can make this task easier. See <link linkend="dialogs.preferences.plugins" endterm="dialogs.preferences.plugins.title"/> for details.</para>
-      </note>
-	  </listitem>
-	  
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.register" endterm="how.to.setup.team.project.register.title"/></para>
-		<para>If you created the project from the GUI, you then have to explicitly add
-		it to the version control system (<command>add</command> in both SVN and
-		Git).</para>
+		<para>The local repository is used to add the initial project to the
+		server, and can also be used for maintenance tasks, such as deleting
+		files, that cannot be performed directly within OmegaT.</para>
+		<para>We recommend that you avoid using that folder for translation
+		tasks. If you need to perform translation or review tasks on that
+		project, use OmegaT to download a separate copy of the team project and
+		work from there. See the <link linkend="how.to.use.team.project"
+		endterm="how.to.use.team.project.title"/> how-to for details.</para>
 	  </listitem>
 
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.push" endterm="how.to.setup.team.project.push.title"/></para>
+	  <listitem id="how.to.setup.team.project.fill.local.clone">
+		<para id="how.to.setup.team.project.fill.local.clone.title">Fill the
+		empty local copy with a real OmegaT project</para>
+		<itemizedlist>
+		  <listitem>
+			<para>Create the project structure</para>
+
+			<para>If you are creating a new empty project, you can follow the
+			<link linkend="introduction.create.and.open.new.project">GUI
+			procedure</link>, or create it directly from the command line:
+			<command>java -jar OmegaT.jar team init &lt;source language&gt;
+			&lt;target language&gt;</command></para>
+
+			<para>This command also automatically registers the project in the
+			version control system.</para>
+		  </listitem>
+		  <listitem>
+			<para>Choose the appropriate settings</para>
+
+			<para>Make the necessary changes to the project properties at this
+			stage, including local file filters or segmentation settings. See
+			the <link linkend="dialogs.project.properties"
+			endterm="dialogs.project.properties.title"/> dialog for
+			details.</para>
+		  </listitem>
+
+		  <listitem>
+			<para>Add the necessary files</para>
+
+			<para>Similarly add any relevant lists of spellchecker files you
+			want to make available to everyone working on the project. See <link
+			linkend="project.folder.omegat.spellcheck">spellchecker files</link>
+			for details.</para>
+
+			<para>If you are converting an existing project, make sure you
+			delete any files in the project that you do not need or want to
+			upload to the server before proceeding to the next step.</para>
+
+			<para>Copy the files to translate to the source/ folder, and use
+			your SVN or Git client, or the command line, to add and publish them
+			to the repository. Use <link endterm="menus.project.title"
+			linkend="menus.project"/><link
+			linkend="menus.project.commit.source.files"
+			endterm="menus.project.commit.source.files.title"/> to add files
+			from OmegaT.</para>
+
+			<para>You must use your SVN or Git client, or the command line, to
+			add and publish any dictionaries, glossaries, translation memories
+			or other files you want to include in the project.</para>
+
+			<para>This step can be performed before the registering and publishing
+			the project for the first time, and can also be used to add new files,
+			or update existing ones after the project has been created.</para>
+		  </listitem>
+		</itemizedlist>
+
+		<note>
+          <para>In team projects that use a simple mapping between the local
+          repository and the remote repository (the default), <emphasis
+          role="bold">and only in such projects</emphasis>, the source and
+          target files can be modified locally and uploaded to the server using
+          <link linkend="menus.project" endterm="menus.project.title"/><link
+          endterm="menus.project.commit.source.files.title"
+          linkend="menus.project.commit.source.files"/> and <link
+          linkend="menus.project" endterm="menus.project.title"/><link
+          linkend="menus.project.commit.target.files"
+          endterm="menus.project.commit.target.files.title"/>.</para>
+
+          <para>The team project administrator must use the local VCS to
+          <emphasis role="bold">modify</emphasis> or <emphasis
+          role="bold">delete</emphasis> those files. Some plugins can make this
+          task easier. See the <link linkend="dialogs.preferences.plugins"
+          endterm="dialogs.preferences.plugins.title"/> preference for
+          details.</para>
+		</note>
+	  </listitem>
+
+	  <listitem id="how.to.setup.team.project.register">
+		<para id="how.to.setup.team.project.register.title">Register the project
+		files into the local VCS</para>
+
+		<para>If you created the project from the GUI, you then have to
+		explicitly add it to the version control system (<command>add</command>
+		in both SVN and Git).</para>
+	  </listitem>
+
+	  <listitem id="how.to.setup.team.project.push">
+		<para id="how.to.setup.team.project.push.title">Put the registered files
+		on the hosting server</para>
+
 		<para>Finally, publish your project to the remote server
 		(<command>commit</command> in SVN, <command>commit</command> and
 		<command>push</command> in Git).</para>
 	  </listitem>
 
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.give.access.rights" endterm="how.to.setup.team.project.give.access.rights.title"/></para>
-		<para>After the project is ready and has been uploaded to the server, the
-		team project administrator has to set up access for the translators.
+	  <listitem id="how.to.setup.team.project.give.access.rights">
+		<para id="how.to.setup.team.project.give.access.rights.title">Give
+		access rights to your team</para>
+
+		<para>After the project is ready and has been uploaded to the server,
+		the team project administrator has to set up access for the translators.
 		Accessing a team project requires the following information:</para>
 
 		<orderedlist>
           <listitem>
 			<para>Projects on a hosting service</para>
-			<para>The translators will have to create an account for the service, and send their user name to the team project administrator.</para>
-			<para>The administrator will then grant write access to the repository to those accounts.</para>
+
+			<para>The translators will have to create an account for the
+			service, and send their user name to the team project
+			administrator.</para>
+
+			<para>The administrator will then grant write access to the
+			repository to those accounts.</para>
           </listitem>
+
           <listitem>
 			<para>Projects on a self-hosted server</para>
-			<para>If the server is self-hosted that does not have a provision for translators to register an account themselves, the team project administrator must create accounts with write access for the translators.</para>
-			<para>After creating the accounts, the administrator must send the translators their individual credentials.</para> 
+
+			<para>If the server is self-hosted that does not have a provision
+			for translators to register an account themselves, the team project
+			administrator must create accounts with write access for the
+			translators.</para>
+
+			<para>After creating the accounts, the administrator must send the
+			translators their individual credentials.</para>
           </listitem>
-		</orderedlist>
+		</orderedlist>	  
 	  </listitem>
 
-	  <listitem>
-		<para><link linkend="how.to.setup.team.project.have.members.download" endterm="how.to.setup.team.project.have.members.download.title"/></para>
+	  <listitem id="how.to.setup.team.project.have.members.download">
+		<para id="how.to.setup.team.project.have.members.download.title">Have
+		everybody download the project from OmegaT</para>
+
 		<para>Administrators have two options for sending the location of the
 		project to the translators:</para>
 
 		<orderedlist>
           <listitem>
-			<para>Send a URL and ask the translators to use the <link linkend="menus.project.download.team.project" endterm="menus.project.download.team.project.title"/> command to
-			create a local copy of the project on their own system.</para>
+			<para>Send a URL and ask the translators to use <link
+			linkend="menus.project" endterm="menus.project.title"/><link
+			linkend="menus.project.download.team.project"
+			endterm="menus.project.download.team.project.title"/> to create a
+			local copy of the project on their own system.</para>
           </listitem>
 
           <listitem>
@@ -181,28 +219,42 @@
 		that the <link linkend="menus.tools.statistics">project
 		statistics</link> are the same for both the administrator (on the
 		server) and the translator (locally).</para>
+
 		<para>If they do not match, make sure the
 		<filename>filters.xml</filename> and
 		<filename>segmentation.conf</filename> files are properly shared.</para>
+	  </listitem>
+
+	  <listitem id="how.to.setup.team.project.download.if.needed">
+		<para id="how.to.setup.team.project.download.if.needed.title">If you
+		need to work on the project too, download the project yourself to a
+		local location different from the local team project location</para>
+	  </listitem>
+
+	  <listitem id="how.to.setup.team.project.translate">
+		<para id="how.to.setup.team.project.translate.title">You can now also
+		work on the project with the team</para>
 	  </listitem>
 	</orderedlist>
   </section>
 
   <section id="how.to.setup.team.project.mapping.parameters">
-	<title id="how.to.setup.team.project.mapping.parameters.title">Repository mappings</title>
+	<title id="how.to.setup.team.project.mapping.parameters.title">Repository
+	mappings</title>
 
-	<para>It is possible to map various remote locations to local files via the OmegaT user interface using <link
+	<para>It is possible to map various remote locations to local files via the
+	OmegaT user interface using <link
 	linkend="dialogs.project.properties.repository.mapping.title"
 	endterm="dialogs.project.properties.repository.mapping.title"/> in the <link
 	linkend="dialogs.project.properties"
 	endterm="dialogs.project.properties.title"/> dialog, or by editing the <link
 	linkend="project.folder.omegat.project.file.title"
-	endterm="project.folder.omegat.project.file.title"/> file. Although the mapping feature is
-	primarily intended for gathering source files from disparate locations, it
-	can also be used for other types of files.</para>
+	endterm="project.folder.omegat.project.file.title"/> file. Although the
+	mapping feature is primarily intended for gathering source files from
+	disparate locations, it can also be used for other types of files.</para>
 
-	<para>A list of mapping parameters is presented below, and examples of
-	their use is provided in the next section.</para>
+	<para>A list of mapping parameters is presented below, and examples of their
+	use is provided in the next section.</para>
 
 	<variablelist>
       <varlistentry>
@@ -240,8 +292,8 @@
       <varlistentry>
 		<term>excludes</term>
 		<listitem>
-          <para>Use wildcards (following the Apache Ant style: *, ?, **) to
-          add patterns for files that should not be part of the mapping. Use a
+          <para>Use wildcards (following the Apache Ant style: *, ?, **) to add
+          patterns for files that should not be part of the mapping. Use a
           semicolon to separate different patterns.</para>
           <para>Example: <userinput>**/excludedfolder/**;*.txt</userinput>
           excludes files that have /excludedfolder/ in the path, as well as
@@ -253,8 +305,8 @@
 		<term>includes</term>
 		<listitem>
           <para>As above, but for files that should be part of the mapping.
-          Since files are included by default unless specifically excluded,
-          this option is only necessary to specify exceptions to an exclusion
+          Since files are included by default unless specifically excluded, this
+          option is only necessary to specify exceptions to an exclusion
           pattern.</para>
           <para>Example: <userinput>**/*.docx</userinput> to add all .docx
           files in the project, even if they are located in an excluded
@@ -269,19 +321,17 @@
 	mappings</title>
 
 	<para>Default project mapping:
-	<programlisting>
-&lt;repository type="svn" url="https://repo_for_OmegaT_team_project"&gt;
-  &lt;mapping local="" repository=""/&gt;
+	<programlisting>&lt;repository type="svn" url="https://repo_for_OmegaT_team_project"&gt;
+	&lt;mapping local="" repository=""/&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>All the contents of
-	<filename>https://repo_for_OmegaT_team_project</filename> are mapped to
-	the local OmegaT project</para>
+	<filename>https://repo_for_OmegaT_team_project</filename> are mapped to the
+	local OmegaT project</para>
 
 	<para>Mapping for projects in a subfolder of the repository:
-	<programlisting>
-&lt;repository type="svn" url="https://repo_for_All_OmegaT_team_projects"&gt;
-  &lt;mapping local="" repository="En-US_DE_project"/&gt;
+	<programlisting>&lt;repository type="svn" url="https://repo_for_All_OmegaT_team_projects"&gt;
+	&lt;mapping local="" repository="En-US_DE_project"/&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>All the contents of
@@ -290,12 +340,11 @@
 
 	<para>Mapping for additional sources from a remote repository, with
 	filters:
-	<programlisting>
-&lt;repository type="svn" url="https://repo_for_All_OmegaT_team_project_sources"&gt;
-  &lt;mapping local="source/subdir" repository=""&gt;
-    &lt;excludes&gt;**/*.bak&lt;/excludes&gt;
-    &lt;includes&gt;readme.bak&lt;/includes&gt;
-  &lt;/mapping&gt;
+	<programlisting>&lt;repository type="svn" url="https://repo_for_All_OmegaT_team_project_sources"&gt;
+	&lt;mapping local="source/subdir" repository=""&gt;
+	    &lt;excludes&gt;**/*.bak&lt;/excludes&gt;
+    	&lt;includes&gt;readme.bak&lt;/includes&gt;
+	&lt;/mapping&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>Everything in
@@ -305,9 +354,8 @@
 	<filename>readme.bak</filename> is also included.</para>
 
 	<para>Mapping for extra source files from the web:
-	<programlisting>
-&lt;repository type="http" url="https://github.com/omegat-org/omegat/raw/master/"&gt;
-  &lt;mapping local="source/Bundle.properties" repository="src/org/omegat/Bundle.properties"/&gt;
+	<programlisting>&lt;repository type="http" url="https://github.com/omegat-org/omegat/raw/master/"&gt;
+	&lt;mapping local="source/Bundle.properties" repository="src/org/omegat/Bundle.properties"/&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>The remote file
@@ -316,9 +364,8 @@
 	<filename>source/Bundle.properties</filename>.</para>
 
 	<para>Mapping with renaming:
-	<programlisting>
-&lt;repository type="http" url="https://github.com/omegat-org/omegat/raw/master/"&gt;
-  &lt;mapping local="source/readme_tr.txt" repository="release/readme.txt"/&gt;
+	<programlisting>&lt;repository type="http" url="https://github.com/omegat-org/omegat/raw/master/"&gt;
+	&lt;mapping local="source/readme_tr.txt" repository="release/readme.txt"/&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>The remote file
@@ -329,10 +376,9 @@
 	<para>This makes it possible to rename the file to translate.</para>
 
 	<para>Local file mapping:
-	<programlisting>
-&lt;repository type="file" url="/home/me/myfiles"&gt;
-  &lt;mapping local="source/file.txt" repository="my/file.txt"/&gt;
-  &lt;mapping local="source/file2.txt" repository="some/file.txt"/&gt;
+	<programlisting>&lt;repository type="file" url="/home/me/myfiles"&gt;
+	&lt;mapping local="source/file.txt" repository="my/file.txt"/&gt;
+	&lt;mapping local="source/file2.txt" repository="some/file.txt"/&gt;
 &lt;/repository&gt;</programlisting></para>
 
 	<para>The local file <filename>/home/me/myfiles/my/file.txt</filename> is
@@ -341,30 +387,31 @@
 	file <filename>source/file2.txt</filename>.</para>
 
 	<warning>
-      <para>The project will not load if a file specified in a mapping does
-      not exist.</para>
+      <para>The project will not load if a file specified in a mapping does not
+      exist.</para>
 	</warning>
 
-	<para>You can add as many mappings as you want, but one of the mappings must include the
-	<filename>omegat.project</filename> file.</para>
+	<para>You can add as many mappings as you want, but one of the mappings must
+	include the <filename>omegat.project</filename> file.</para>
 
   </section>
   <section id="how.to.setup.team.project.selective.sharing">
-	<title id="how.to.setup.team.project.selective.sharing.title">Selective sharing</title>
+	<title id="how.to.setup.team.project.selective.sharing.title">Selective
+	sharing</title>
 
 	<para>The above process describes the most common scenario, in which the
 	team project administrator has full control of the project and all files
-	(and statistics) are identical in all instances of the project, both on
-	the server and the local systems of the translators.</para>
+	(and statistics) are identical in all instances of the project, both on the
+	server and the local systems of the translators.</para>
 
-	<para>It is also possible to use a team project configuration where
-	several translators share the <filename>project_save.tmx</filename> file,
-	and only a subset of the other files.</para>
+	<para>It is also possible to use a team project configuration where several
+	translators share the <filename>project_save.tmx</filename> file, and only a
+	subset of the other files.</para>
 
-	<para>The basic procedure is essentially the same, except that the
-	team project administrator does not add every file to the
-	version-controlled project on the server. The remaining files are either
-	copied by the translators themselves, or mappings that synchronize files
-	from other locations are defined.</para>
+	<para>The basic procedure is essentially the same, except that the team
+	project administrator does not add every file to the version-controlled
+	project on the server. The remaining files are either copied by the
+	translators themselves, or mappings that synchronize files from other
+	locations are defined.</para>
   </section>
 </section>

--- a/doc_src/en/HowTo_TranslateOtherFiles.xml
+++ b/doc_src/en/HowTo_TranslateOtherFiles.xml
@@ -1,71 +1,196 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.translate.other.files">
   <title id="how.to.translate.other.files.title">Support other formats</title>
 
-  <para>OmegaT's file filters provide a wide range of support for common and less common file formats. If you need to support formats that are not covered by OmegaT, there are four ways to do that:
+  <para>OmegaT's file filters provide a wide range of support for common and
+  less common file formats. If you need to support formats that are not covered
+  by OmegaT, there are four ways to do that:</para>
 
   <itemizedlist>
-	<listitem><para>by associating the format to an already supported format,</para></listitem>
-	<listitem><para>by converting the format to an already supported format,</para></listitem>
-	<listitem><para>by extending OmegaT with third-party plugins that offer support for that format,</para></listitem>
-	<listitem><para>or by developping a filter for that format.</para></listitem>
+	<listitem>
+	  <para>by associating the format to an already supported format,</para>
+	</listitem>
+	
+	<listitem>
+	  <para>by converting the format to an already supported format,</para>
+	</listitem>
+
+	<listitem>
+	  <para>by extending OmegaT with third-party plugins that offer support for
+	  that format,</para>
+	</listitem>
+
+	<listitem>
+	  <para>or by developping a filter for that format.</para>
+	</listitem>
   </itemizedlist>
-  </para>
   
 	<section>
 	  <title>Association</title>
-		<para>File filters have a list of file extensions that are associated to them. If the format you want to translate is structurally close to an already supported format, just add its file extension to the supported format extension list, or change the file extension to one that is accepted by the file filter that you want to use. See <link linkend="file.filters" endterm="file.filters.title"/> for details.</para>
-		<para>You can also use OmegaT's custom tag function to register format specific strings and have OmegaT handle them as if they were normal tags. See <link linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags" endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/> for details.</para>
+
+	  <para>File filters have a list of file extensions that are associated to
+	  them. If the format you want to translate is structurally close to an
+	  already supported format, just add its file extension to the supported
+	  format extension list, or change the file extension to one that is
+	  accepted by the file filter that you want to use. See the <link
+	  linkend="file.filters" endterm="file.filters.title"/> chapter for
+	  details.</para>
+		
+	  <para>You can also use OmegaT's custom tag function to register format
+	  specific strings and have OmegaT handle them as if they were normal
+	  tags. See the <link
+	  linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"
+	  endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/>
+	  preferences for details.</para>
 	</section>
 	
 	<section>
 	  <title>Conversion</title>
-		<para>To ensure that all the properties of a format are properly taken into account, it is sometimes preferable to convert the file to a supported format and then convert the translated file back to the original format.</para>
-		<para>A number of free software third party utilities provide such "round-trip" conversion, including:
-		<itemizedlist>
-		  <listitem><para>Rainbow, from the <ulink url="https://okapiframework.org">Okapi Framework</ulink></para>
-		  <para>License: Apache License Version 2.0</para>
-		  <para>The Okapi Framework comes with a number of file filters, among which some that are not supported natively by OmegaT. See <ulink url="https://okapiframework.org/wiki/index.php?title=Filters">List of file filters</ulink> for details.</para>
-		  <para>Rainbow can create XLIFF 1.2 compliant files or OmegaT projects from all the files set as "input" files. Rainbow supported files are converted into XLIFF and inserted as source files into a full fledged OmegaT project that you can open with OmegaT right away. See <ulink url="https://okapiframework.org/wiki/index.php/Rainbow_TKit_-_OmegaT_Project">Rainbow TKit - OmegaT Project</ulink> for details.</para></listitem>
-		  <listitem><para><ulink url="https://po4a.org">po4a</ulink></para>
-		  <para>License: GNU General Public License v2</para>
-		  <para>po4a supports a number of free software documentation formats, listed on the site front page, and offers conversion tools to and from the po format. See <link linkend="file.filters.po" endterm="file.filters.po.title"/> for details.</para></listitem>
-		  <listitem><para>The converters from the <ulink url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/index.html">Translate Toolkit</ulink></para>
-		  <para>License: GNU General Public License v2</para>
-		  <para>The Translate Toolkit offers a number of conversion tools to and from the po format. See <ulink url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/index.html">Converters</ulink> for details.</para></listitem>
-		  <listitem><para>OpenXLIFF from <ulink url="https://maxprograms.com/">Maxprograms</ulink></para>
-		  <para>License:  Eclipse Public License v1.0</para>
-		  <para>OpenXLIFF supports a number of file filters, among which some that are not supported natively by OmegaT. See <ulink url="https://maxprograms.com/products/openxliff.html">OpenXLIFF Filters</ulink> for details. Maxprograms also distributes <ulink url="https://maxprograms.com/products/xliffmanager.html">XLIFF Manager</ulink>, which is a graphical user interface for the OpenXLIFF Filters.</para>
-		  <para>OpenXLIFF produces XLIFF 1.2 compliant files.</para></listitem>
-		</itemizedlist>
-		<warning><para>OmegaT's po support is robust enough to handle most po files, but OmegaT's default XLIFF filter will not be sufficient to support XLIFF files created by Rainbow, OpenXLIFF or any other CAT tool. Proper XLIFF support in OmegaT can only be obtained thought third-party plugins. See below.</para></warning>
-		</para>
-		<para>Some formats, like PDF, cannot be properly handled through "round trip" conversions. They require a first conversion to a supported format, and that format must be used as a base to manually create a proper target language document.</para>
-		<para>In the case of PDF, you will find a number of online or offline utilities that provide a conversion to common office formats, but the conversion will always require a lot of manual modifications to the target document before being able to produce a proper PDF document. Make sure you understand the format requirements when you start working on a PDF or similar file.</para>
-	</section>
 
-	<section>
-	  <title>Third-party plugin</title>
+	  <para>To ensure that all the properties of a format are properly taken
+	  into account, it is sometimes preferable to convert the file to a
+	  supported format and then convert the translated file back to the original
+	  format.</para>
+
+	  <para>A number of free software third party utilities provide such
+	  "round-trip" conversion, including:</para>
+	  
+	  <itemizedlist id="how.to.translate.other.files.third.party.utilities">
+		<listitem id="how.to.translate.other.files.third.party.utilities.rainbow">
+		  <para>Rainbow, from the <ulink url="https://okapiframework.org">Okapi
+		  Framework</ulink></para>
+
+		  <para>License: Apache License Version 2.0</para>
+
+		  <para>The Okapi Framework comes with a number of file filters, among
+		  which some that are not supported natively by OmegaT. See <ulink
+		  url="https://okapiframework.org/wiki/index.php?title=Filters">List of
+		  file filters</ulink> for details.</para>
+
+		  <para>Rainbow can create XLIFF 1.2 compliant files or OmegaT projects
+		  from all the files set as "input" files. Rainbow supported files are
+		  converted into XLIFF and inserted as source files into a full fledged
+		  OmegaT project that you can open with OmegaT right away. See <ulink
+		  url="https://okapiframework.org/wiki/index.php/Rainbow_TKit_-_OmegaT_Project">Rainbow
+		  TKit - OmegaT Project</ulink> for details.</para>
+		</listitem>
+
+		<listitem id="how.to.translate.other.files.third.party.utilities.po4a">
+		  <para><ulink url="https://po4a.org">po4a</ulink></para>
+
+		  <para>License: GNU General Public License v2</para>
+
+		  <para>po4a supports a number of free software documentation formats,
+		  listed on the site front page, and offers conversion tools to and from
+		  the po format. See the <link linkend="file.filters.po"
+		  endterm="file.filters.po.title"/> section for details.</para>
+		</listitem>
+
+		<listitem>
+		  <para>The converters from the <ulink
+		  url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/index.html">Translate
+		  Toolkit</ulink></para>
+
+		  <para>License: GNU General Public License v2</para>
+
+		  <para>The Translate Toolkit offers a number of convertion tools to and
+		  from the po format. See <ulink
+		  url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/index.html">Converters</ulink>
+		  for details.</para>
+		</listitem>
+
+		<listitem id="how.to.translate.other.files.third.party.utilities.openxliff">
+		  <para>OpenXLIFF from <ulink
+		  url="https://maxprograms.com/">Maxprograms</ulink></para>
+
+		  <para>License:  Eclipse Public License v1.0</para>
+
+		  <para>OpenXLIFF supports a number of file filters, among which some
+		  that are not supported natively by OmegaT. See <ulink
+		  url="https://maxprograms.com/products/openxliff.html">OpenXLIFF
+		  Filters</ulink> for details. Maxprograms also distributes <ulink
+		  url="https://maxprograms.com/products/xliffmanager.html">XLIFF
+		  Manager</ulink>, which is a graphical user interface for the OpenXLIFF
+		  Filters.</para>
+
+		  <para>OpenXLIFF produces XLIFF 1.2 compliant files.</para>
+		</listitem>
+	  </itemizedlist>
+	  
+	  <warning>
+		<para>OmegaT's po support is robust enough to handle most po files, but
+		OmegaT's default XLIFF filter will not be sufficient to support XLIFF
+		files created by Rainbow, OpenXLIFF or any other CAT tool. Proper XLIFF
+		support in OmegaT can only be obtained thought third-party plugins. See
+		<link
+		linkend="how.to.translate.other.files.third.party.plugins">below</link>.</para>
+	  </warning>
+
+		<para>Some formats, like PDF, cannot be properly handled through "round
+		trip" conversions. They require a first conversion to a supported
+		format, and that format must be used as a base to manually create a
+		proper target language document.</para>
+		
+		<para>In the case of PDF, you will find a number of online or offline
+		utilities that provide a conversion to common office formats, but the
+		conversion will always require a lot of manual modifications to the
+		target document before being able to produce a proper PDF document. Make
+		sure you understand the format requirements when you start working on a
+		PDF or similar file.</para>
+	  </section>
+
+	  <section
+		  id="how.to.translate.other.files.third.party.plugins">
+		<title
+		id="how.to.translate.other.files.third.party.plugins.title">Third-party
+		plugin</title>
+
 		<itemizedlist>
 		  <listitem>
-			<para>The Okapi Filters Plugin for OmegaT, from the <ulink url="https://okapiframework.org">Okapi Framework</ulink></para>
+			<para>The Okapi Filters Plugin for OmegaT, from the <ulink
+			url="https://okapiframework.org">Okapi Framework</ulink></para>
+
 			<para>License: Apache License Version 2.0</para>
-			<para>Not all of the Okapi Framework file filters are included into the file filter plugin. See <ulink url="https://okapiframework.org/wiki/index.php/Okapi_Filters_Plugin_for_OmegaT#Filters_Included">Filters Included</ulink> for details.</para>
-			<para>When installed, the plugin offers direct access to the added formats and also allows you to associate a custom filter parameters file that you have created in Rainbow. See above.</para>	
+
+			<para>Not all of the Okapi Framework file filters are included into
+			the file filter plugin. See <ulink
+			url="https://okapiframework.org/wiki/index.php/Okapi_Filters_Plugin_for_OmegaT#Filters_Included">Filters
+			Included</ulink> for details.</para>
+
+			<para>When installed, the plugin offers direct access to the added
+			formats and also allows you to associate a custom filter parameters
+			file that you have created in Rainbow. See <link
+			linkend="how.to.translate.other.files.third.party.utilities.rainbow">above</link>.</para>
 		  </listitem>
+
 		  <listitem>
-			<para>The <ulink url="http://185.13.37.79:8003/index.php/p/stax-filters/downloads/">StaX</ulink> filters</para>
+			<para>The <ulink
+			url="http://185.13.37.79:8003/index.php/p/stax-filters/downloads/">StaX</ulink>
+			filters</para>
+
 			<para>License: GNU General Public License v3+</para>
-			<para>StaX provides OmegaT with filters for SDLXLIFF files and packages, XLIFF 1 and 2, MqXliff and DOCX.</para>
-			<para>The filters originate from the European Union DGT version of OmegaT.</para>
+
+			<para>StaX provides OmegaT with filters for SDLXLIFF files and
+			packages, XLIFF 1 and 2, MqXliff and DOCX.</para>
+
+			<para>The filters originate from the European Union DGT version of
+			OmegaT.</para>
 		  </listitem>
 		</itemizedlist>
-		<para>Other plugins for less common formats are listed on the OmegaT wiki. See <ulink url="https://sourceforge.net/p/omegat/wiki/Plugins/">Plugins</ulink>.</para>
+
+		<para>Other plugins for less common formats are listed on the OmegaT
+		wiki. See <ulink
+		url="https://sourceforge.net/p/omegat/wiki/Plugins/">Plugins</ulink>.</para>
 	</section>
 
 	<section>
 	  <title>Development</title>
-	  <para>OmegaT provides developers with thorough documentation to create file filter plugins. See <ulink url="https://sourceforge.net/p/omegat/code/ci/master/tree/docs_devel/HowToCreateFilterPlugin.md">How to create a file filter plugin for OmegaT</ulink> for details.</para>
+
+	  <para>OmegaT provides developers with thorough documentation to create
+	  file filter plugins. See <ulink
+	  url="https://sourceforge.net/p/omegat/code/ci/master/tree/docs_devel/HowToCreateFilterPlugin.md">How
+	  to create a file filter plugin for OmegaT</ulink> for details.</para>
 	</section>
   </section>

--- a/doc_src/en/HowTo_UseTM.xml
+++ b/doc_src/en/HowTo_UseTM.xml
@@ -5,8 +5,8 @@
   <title id="how.to.use.tm.title">Use translation memories</title>
 
   <para>When a project is initially created, it comes with its own empty project
-  translation memory, <link linkend="project.folder.project.save.tmx.title"
-  endterm="project.folder.project.save.tmx.title"/>, located in the <link
+  translation memory, the <link linkend="project.folder.project.save.tmx.title"
+  endterm="project.folder.project.save.tmx.title"/> file, located in the <link
   linkend="project.folder.omegat" endterm="project.folder.omegat.title"/>
   folder. This memory is gradually filled as your translation progresses.</para>
 
@@ -16,18 +16,17 @@
 	<itemizedlist>
 	  <listitem>
 		<para>If a given sentence has already been translated once, there is no
-		need to retranslate it. See <link
+		need to retranslate it. See the <link
 		linkend="dialogs.project.properties.auto.propagation"
-		endterm="dialogs.project.properties.auto.propagation.title"/> in the
-		<link linkend="dialogs.project.properties"
-		endterm="dialogs.project.properties.title"/> dialog.</para>
+		endterm="dialogs.project.properties.auto.propagation.title"/> project
+		property.</para>
 	  </listitem>
 
 	  <listitem>
-		<para>If an old translation is similar to the contents of the segment you
-		are translating, you can recycle it in your translation. See <link
-		linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/> for
-		details.</para>
+		<para>If an old translation is similar to the contents of the segment
+		you are translating, you can recycle it in your translation. See the
+		<link linkend="panes.fuzzy.matches"
+		endterm="panes.fuzzy.matches.title"/> pane for details.</para>
 	  </listitem>
 
 	  <listitem>
@@ -40,21 +39,25 @@
   <section id="how.to.use.tm.create.your.tm">
 	<title id="how.to.use.tm.create.your.tm.title">Create your own TMs</title>
 	
-	<para>When you use <link linkend="menus.project.create.translated.documents"
+	<para>When you use <link linkend="menus.project"
+	endterm="menus.project.title"/><link
+	linkend="menus.project.create.translated.documents"
 	endterm="menus.project.create.translated.documents.title"/> to create the
 	target documents for a project, OmegaT also outputs three translation
 	memories that reflect the current state of the translation for the files in
-	the source folder (see <link
+	the source folder. See the <link
 	linkend="dialogs.project.properties.file.locations.exported.tms"
-	endterm="dialogs.project.properties.file.locations.exported.tms.title"/>).</para>
+	endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
+	project property for details.</para>
 
 	<para>Each of the three files constitutes a bilingual export of the current
-	content of your translation. Their content comes from the global project memory
-	(<link linkend="project.folder.project.save.tmx"
+	content of your translation. Their content comes from the global project
+	memory (<link linkend="project.folder.project.save.tmx"
 	endterm="project.folder.project.save.tmx.title"/>) but is <emphasis>strictly
 	limited</emphasis> to what you have translated so far.</para>
 
-	<para>You can also use the <link linkend="menus.tools.align.files"
+	<para>You can also use the <link linkend="menus.tools"
+	endterm="menus.tools.title"/><link linkend="menus.tools.align.files"
 	endterm="menus.tools.align.files.title"/> tool to create a TMX from two
 	files in a format that OmegaT supports.</para>
   </section>
@@ -63,107 +66,127 @@
 	<title id="how.to.use.tm.reuse.tm.title">Reuse TMs</title>
 	
 	<para>To reuse translation memories from a previous project you have 2
-	options:
+	options:</para>
 
 	<itemizedlist>
 	  <listitem>
 		<para>Open the old project and put the new source files in its <link
 		linkend="project.folder.source" endterm="project.folder.source.title"/>
 		folder.</para>
-		<para>After reloading the old project, all its translation memory will be
-		applied to the new source files.</para>
-		<note><para>That’s the easiest way to work on the new version of an
-		already translated document.</para></note>
+		
+		<para>After reloading the old project, all its translation memory will
+		be applied to the new source files.</para>
+
+		<note>
+		  <para>That’s the easiest way to work on the new version of an already
+		  translated document.</para>
+		</note>
 	  </listitem>
 	  
 	  <listitem>
 		<para>Put the reference memories that you took from the old project and
 		put them in the <link linkend="project.folder.tm"
 		endterm="project.folder.tm.title"/> folder of the new project. Depending
-		on how reliable the memory is, you can prefer <link
-		linkend="project.folder.tm.enforce"
-		endterm="project.folder.tm.enforce.title"/>, <link
-		linkend="project.folder.tm.auto"
-		endterm="project.folder.tm.auto.title"/>, <link
-		linkend="project.folder.tm.penalty"
-		endterm="project.folder.tm.penalty.title"/>, or even <link
-		linkend="project.folder.tm.mt" endterm="project.folder.tm.mt.title"/> if
-		it comes from machine translation.</para>
-		<note><para>That’s the preferred method if you want to start your
-		translation from scratch.</para></note>
+		on how reliable the memory is, you can prefer to put it in either of the
+		following subfolder:</para>
+
+		<itemizedlist>
+		  <listitem>
+			<para><link linkend="project.folder.tm.enforce"
+			endterm="project.folder.tm.enforce.title"/>,</para>
+		  </listitem>
+		  <listitem>
+			<para><link linkend="project.folder.tm.auto"
+			endterm="project.folder.tm.auto.title"/>,</para>
+		  </listitem>
+		  <listitem>
+			<para><link linkend="project.folder.tm.penalty"
+			endterm="project.folder.tm.penalty.title"/>,</para>
+		  </listitem>
+		</itemizedlist>
+		
+		<note>
+		  <para>That’s the preferred method if you want to start your
+		  translation from scratch.</para>
+		</note>
 	  </listitem>
 	</itemizedlist>
 	
-  </para>
-
     <section id="how.to.tm.read.and.write">
-    <title id="how.to.tm.read.and.write.title">Reading TMs  from other tools</title>
+      <title id="how.to.tm.read.and.write.title">Reading TMs from other
+      tools</title>
 
-    <para>OmegaT can read conformant TMX memories produced by other
-    tools.</para>
+      <para>OmegaT can read conformant TMX memories produced by other
+      tools.</para>
 
-    <para>Some tools produce invalid TMX files under certain conditions. You
-    will have to fix them if you want to use them as reference memories,
-    otherwise OmegaT will report an error and fail to load them. Fixes are
-    generally simple, and the error message provided by OmegaT will help you
-    pinpoint the error. You can also ask the user group for advice if you have
-    problems.</para>
-  </section>
+      <para>Some tools produce invalid TMX files under certain conditions. You
+      will have to fix them if you want to use them as reference memories,
+      otherwise OmegaT will report an error and fail to load them. Fixes are
+      generally simple, and the error message provided by OmegaT will help you
+      pinpoint the error. You can also ask the user group for advice if you have
+      problems.</para>
+	</section>
 
-  <section id="how.to.use.tm.store.your.tm">
-	<title id="how.to.use.tm.store.your.tm.title">Managing your TMs</title>
+	<section id="how.to.use.tm.store.your.tm">
+	  <title id="how.to.use.tm.store.your.tm.title">Managing your TMs</title>
 
-	<para>You may want to store translation memories in separate folders, by
-	client or by specialty so as to be able to reuse them quickly when need
-	arises. In which case you will just need to use the appropriate folder as
-	the
-  <link linkend="dialogs.project.properties.file.locations.translation.memories"
-  endterm="dialogs.project.properties.file.locations.translation.memories.title"/>
-  of your project.</para>
-  </section>
+	  <para>You may want to store translation memories in separate folders, by
+	  client or by specialty so as to be able to reuse them quickly when need
+	  arises. Any storage folder can be used in replacement of the project <link
+	  linkend="project.folder.tm" endterm="project.folder.tm.title"/>
+	  folder. See the <link linkend="dialogs.project.properties.file.locations"
+	  endterm="dialogs.project.properties.file.locations.title"/> section of the
+	  project property dialog.</para>
+	</section>
   
-  <section id="how.to.tm.creating.a.tm.for.selected.documents">
-    <title
-    id="how.to.tm.creating.a.tm.for.selected.documents.title">Creating a
-    TM specific to selected documents</title>
+	<section id="how.to.tm.creating.a.tm.for.selected.documents">
+      <title id="how.to.tm.creating.a.tm.for.selected.documents.title">Creating
+      a TM specific to selected documents</title>
 
-    <para>In situations where you need to share a TMX that contain only the text
-    from certain specific files and excludes other content, follow the procedure
-    below:</para>
+      <para>In situations where you need to share a TMX that contain only the
+      text from certain specific files and excludes other content, follow the
+      procedure below:</para>
 
-    <itemizedlist>
-      <listitem>
-        <para>Copy the documents for which you want to create a translation
-        memory into the <filename class="directory">source</filename> folder of
-        your project.</para>
-      </listitem>
- 
-      <listitem>
-        <para>Open the project.</para>
-	  </listitem>
+      <itemizedlist>
+		<listitem>
+          <para>Copy the documents for which you want to create a translation
+          memory into the <filename class="directory">source</filename> folder
+          of your project.</para>
+		</listitem>
+		
+		<listitem>
+          <para>Open the project.</para>
+		</listitem>
 
-	  <listitem>
-		<para>Use <link linkend="menus.goto.next.untranslated.segment" endterm="menus.goto.next.untranslated.segment.title"/> to
-		find any untranslated segments (and eventually translate them),</para>
-	  </listitem>
+		<listitem>
+		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.next.untranslated.segment"
+		  endterm="menus.goto.next.untranslated.segment.title"/> to find any
+		  untranslated segments (and eventually translate them),</para>
+		</listitem>
 
-	  <listitem>
-		<para>Use <link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/> to check for
-        possible issues,</para>
-	  </listitem>
+		<listitem>
+		  <para>Use <link linkend="menus.tools"
+		  endterm="menus.tools.title"/><link linkend="menus.tools.check.issues"
+		  endterm="menus.tools.check.issues.title"/> to check for possible
+		  issues,</para>
+		</listitem>
 
-	  <listitem>
-		<para>Use <link linkend="menus.project.create.translated.documents" endterm="menus.project.create.translated.documents.title"/> to create
-        the TMX files that correspond to the current contents.</para>
-      </listitem>
-    </itemizedlist>
+		<listitem>
+		  <para>Use <link linkend="menus.project"
+		  endterm="menus.project.title"/><link
+		  linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> to create
+		  the TMX files that correspond to the current contents.</para>
+		</listitem>
+      </itemizedlist>
 
-    <para>The TMX files located in the <link
-    linkend="dialogs.project.properties.file.locations.exported.tms"
-    endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
-    folder now contain only the original and translated text, in the selected
-    language pair, of the files you copied into the source folder.</para>
-
+      <para>The TMX files located in the exported translation memory folder now
+      contain only the original and translated text, in the selected language
+      pair, of the files you copied into the source folder. See the <link
+      linkend="dialogs.project.properties.file.locations.exported.tms"
+      endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
+      project property for details.</para>
   </section>
 </section>
 
@@ -171,79 +194,90 @@
   <title id="how.to.tm.share.translation.memories.title">Share TMs</title>
 
   <para>For large jobs involving a team of translators, it is easier for
-  everyone involved in sharing common translation memories rather than pass local
-  versions back and forth.</para>
+  everyone involved in sharing common translation memories rather than pass
+  local versions back and forth.</para>
 
-  <para>There are two ways to share translation memories:
+  <para>There are two ways to share translation memories:</para>
 
   <variablelist>
 	<varlistentry>
 	  <term>The good enough way</term>
 	  <listitem>
-		<para>See <link linkend="how.to.use.tm.create.your.tm" endterm="how.to.use.tm.create.your.tm.title"/> above.</para>
+		
+		<para>See the <link linkend="how.to.use.tm.create.your.tm"
+		endterm="how.to.use.tm.create.your.tm.title"/> section above.</para>
 
 		<para>If you write the TMX file to a folder on a shared disk, you can
-		ask your partner to use that folder as the <link
+		ask your partner to use that folder in replacement of the <link
 		linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder
 		for the current translation.</para>
 
 		<para>Conversely, you can ask your partner to write the project TMX
-		files to a folder on a shared disk that you will use as your <link
-		linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder
-		for the current translation.</para>
+		files to a folder on a shared disk that you will use in replacement of
+		your <link linkend="project.folder.tm"
+		endterm="project.folder.tm.title"/> folder for the current
+		translation.</para>
 
 		<para>OmegaT instantaneously notices modifications to TMX files.
-		Therefore, any time one side creates or modifies such a TMX using
-		<link linkend="menus.project.create.translated.documents"
+		Therefore, any time one side creates or modifies such a TMX using <link
+		linkend="menus.project"
+		endterm="menus.project.title"/><link
+		linkend="menus.project.create.translated.documents"
 		endterm="menus.project.create.translated.documents.title"/>, the other
-		side does not need to do anything to have that TMX recognized locally.</para>
+		side does not need to do anything to have that TMX recognized
+		locally.</para>
 
 		<para>This approach also works just as well for sharing glossaries where
-		the <link
-		linkend="dialogs.project.properties.file.locations.writable.glossary"
-		endterm="dialogs.project.properties.file.locations.writable.glossary.title"/>,
-		named appropriately to prevent overwriting, is located in the <link
-		linkend="dialogs.project.properties.file.locations.glossaries"
-		endterm="dialogs.project.properties.file.locations.glossaries.title"/>
-		that the partner will use only as reference, and vice-versa.</para>
+		the project writable glossary (with a non-default name to avoir
+		overwriting) is located in a common glossary folder. See the <link
+		linkend="app.glossaries" endterm="app.glossaries.title"/> appendix for
+		details.</para>
 
-		<note><para>Such sharing works well when the lag between TMX updates is
-		not important, for example, a translator sends data to a reviewer a few
-		times a day.</para></note>
+		<note>
+		  <para>Such sharing works well when the lag between TMX updates is not
+		  important, for example, a translator sends data to a reviewer a few
+		  times a day.</para>
+		</note>
 	  </listitem>
 	</varlistentry>
-  
+	
 	<varlistentry>
 	  <term>The technical approach</term>
 	  <listitem>
-		<para>OmegaT uses collaborative version control systems to share data.</para>
+		<para>OmegaT uses collaborative version control systems to share
+		data.</para>
+
 		<para>Such systems are free to use, install and manage and are widely
 		used in the computer development world, making them extremely
 		robust.</para>
-		<para>See <link linkend="how.to.setup.team.project"
-		endterm="how.to.setup.team.project.title"/> for details.</para>
+
+		<para>See the <link linkend="how.to.setup.team.project"
+		endterm="how.to.setup.team.project.title"/> how-to for details.</para>
 	  </listitem>
 	</varlistentry>
   </variablelist>
-  </para>
 </section>
 
 <section id="how.to.tm.bridge.two.languages">
-  <title id="how.to.tm.bridge.two.languages.title">Bridge two
-  languages</title>
+  <title id="how.to.tm.bridge.two.languages.title">Bridge two languages</title>
 
   <para>OmegaT displays fuzzy matches in the <link linkend="panes.fuzzy.matches"
   endterm="panes.fuzzy.matches.title"/> pane. Such matches are by default
-  limited to the source and target languages defined in <link
+  limited to the source and target languages defined in the <link
   linkend="dialogs.project.properties"
-  endterm="dialogs.project.properties.title"/>, but you can also add matches in languages that are not the target language. See <link linkend="dialog.preferences.tm.matches.other.languages" endterm="dialog.preferences.tm.matches.other.languages.title"/> for details.</para>
+  endterm="dialogs.project.properties.title"/> dialog, but you can also add
+  matches in languages that are not the target language. See the <link
+  linkend="dialog.preferences.tm.matches.other.languages"
+  endterm="dialog.preferences.tm.matches.other.languages.title"/> preference for
+  details.</para>
 
   <para>With OmegaT, you can also display a third language <emphasis>right
   under</emphasis> the source segment to use as an alternative language
   reference for the source text.</para>
 
   <example id="bridge.english.and.french.with.japanese">
-	<title id="replace.with.allemand.title">Bridge English and French with Japanese</title>
+	<title id="replace.with.allemand.title">Bridge English and French with
+	Japanese</title>
 	<para>
 	  <programlisting>— ¶ —————————————————————
 <token>A whitespace character: [ \t\n\x0B\f\r]
@@ -251,20 +285,23 @@ fr-ZB: Un caractère d'espacement (espace, tabulation, etc.) :  [ \t\n\x0B\f\r
 ja-RV: 空白文字：[ \t\n\x0B\f\r]</token>
 Un caractère d'espacement : [ \t\n\r\f\x0B]<token>&lt;segment 3075 ¶></token>
 — ¶ —————————————————————</programlisting></para>
-<para>The first line is the original English, the second an old French version, the third the Japanese version, and the 4th the current translation to French.</para>	
+<para>The first line is the original English, the second an old French version
+with an arbitrary language code, the third the Japanese version with an equally
+arbitrary language code, and the 4th the current translation to French.</para>
   </example>
   
-    <para>To achieve this:
+    <para>To achieve this:</para>
 
 	<orderedlist>
 	  <listitem>
 		<para>create a folder called <filename
-		class="directory">tmx2source</filename> in the <link linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder,</para>
+		class="directory">tmx2source</filename> in the <link
+		linkend="project.folder.tm" endterm="project.folder.tm.title"/>
+		folder,</para>
 	  </listitem>
 
 	  <listitem>
-		<para>copy your "first-third" language translation
-		memory there,</para>
+		<para>copy your "first-third" language translation memory there,</para>
 	  </listitem>
 
 	  <listitem>
@@ -275,9 +312,9 @@ Un caractère d'espacement : [ \t\n\r\f\x0B]<token>&lt;segment 3075 ¶></toke
 	  </listitem>
 	</orderedlist>
 	
-    <note><para>You can use any number of TMX files in as many different
-    language pairs as "bridge" languages as you want.</para>
+    <note>
+	  <para>You can use any number of TMX files in as many different language
+	  pairs as "bridge" languages as you want.</para>	  
 	</note>
-	</para>
   </section>
 </section>

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -11,16 +11,26 @@
   location of the project, or an <filename>omegat.project</filename>
   file.</para>
 
-  <para>Once the project is downloaded, it is installed locally and must only be opened locally to synchronize with the server.</para>
+  <para>Once the project is downloaded, it is installed locally and must only be
+  opened locally to synchronize with the server.</para>
 
-  <para>Repository credentials are stored in <link linkend="configuration.folder.extra.contents.repositories" endterm="configuration.folder.extra.contents.repositories.title"/> and can be deleted from <link linkend="dialog.preferences.team.title.repository.credentials" endterm="dialog.preferences.team.title.repository.credentials.title"/>.</para>
+  <para>Repository credentials are stored in the <link
+  linkend="configuration.folder.extra.contents.repositories"
+  endterm="configuration.folder.extra.contents.repositories.title"/> file and
+  can be deleted from the <link
+  linkend="dialog.preferences.team.title.repository.credentials"
+  endterm="dialog.preferences.team.title.repository.credentials.title"/>
+  preferences.</para>
 
   <para>Since synchronization takes place by default every 3 minutes, project
-  members will sometime translate or modify a segment that was already translated by
-  another member but not synchronized yet. When that happens, members have to
-  select the appropriate translation.</para>
+  members will sometime translate or modify a segment that was already
+  translated by another member but not synchronized yet. When that happens,
+  members have to select the appropriate translation.</para>
 
-  <para>Members can take turns translating and reviewing the files. The Search function allows them to filter the editor pane on contents translated by a given person, or on contents translated after or before a given time, etc.</para>
+  <para>Members can take turns translating and reviewing the files. The Search
+  function allows them to filter the editor pane on contents translated by a
+  given person, or on contents translated after or before a given time,
+  etc.</para>
   
   <variablelist>
     <varlistentry>
@@ -30,18 +40,18 @@
 		  <listitem>
 			<para>From a URL</para>
 
-			<para>Click the <link
+			<para>Use <link endterm="menus.project.title"
+			linkend="menus.project"/><link
 			endterm="menus.project.download.team.project.title"
-			linkend="menus.project.download.team.project"/> command in the <link
-			endterm="menus.project.title" linkend="menus.project"/> menu. This will
-			bring up the <guilabel>Download Team Project</guilabel> dialog.</para>
+			linkend="menus.project.download.team.project"/> to bring up the
+			<guilabel>Download Team Project</guilabel> dialog.</para>
 
 			<para>Enter the URL provided by the team project manager in the
-			<guilabel>Repository URL:</guilabel> field at the top of the dialog, and
-			specify a folder for the project in the <guilabel>New Local Project
-			Folder:</guilabel> field. Leave the <guilabel>Default branch</guilabel>
-			option checked unless the project administrator has provided instructions
-			for using a custom branch.</para>
+			<guilabel>Repository URL:</guilabel> field at the top of the dialog,
+			and specify a folder for the project in the <guilabel>New Local
+			Project Folder:</guilabel> field. Leave the <guilabel>Default
+			branch</guilabel> option checked unless the project administrator
+			has provided instructions for using a custom branch.</para>
 		  </listitem>
 
 		  <listitem>
@@ -54,22 +64,25 @@
 		</orderedlist>
 
 		<note>
-		  <para>Servers generally use two main types of authentication: entering a
-		  <emphasis>username/password</emphasis>, or
+		  <para>Servers generally use two main types of authentication: entering
+		  a <emphasis>username/password</emphasis>, or
 		  <emphasis>SSH</emphasis>.</para>
 
-		  <para>If the server relies on username/password authentication, OmegaT will
-		  present you with an <guilabel>Authentication</guilabel> dialog to enter your
-		  username and password either when you first download the project or later on
-		  in the process. OmegaT will then remember your credentials for that specific
-		  project unless you explicitly delete them. See <link linkend="dialog.preferences.team.title.repository.credentials" endterm="dialog.preferences.team.title.repository.credentials.title"/> for details.</para>
+		  <para>If the server relies on username/password authentication, OmegaT
+		  will present you with an <guilabel>Authentication</guilabel> dialog to
+		  enter your username and password either when you first download the
+		  project or later on in the process. OmegaT will then remember your
+		  credentials for that specific project unless you explicitly delete
+		  them. See the <link
+		  linkend="dialog.preferences.team.title.repository.credentials"
+		  endterm="dialog.preferences.team.title.repository.credentials.title"/>
+		  preferences for details.</para>
 
-		  <para>If the server uses SSH authentication, make sure you update your SSH
-		  configuration to include that server before attempting to download the
-		  project, otherwise you will get an authentication error and the project
-		  will fail to load.</para>
+		  <para>If the server uses SSH authentication, make sure you update your
+		  SSH configuration to include that server before attempting to download
+		  the project, otherwise you will get an authentication error and the
+		  project will fail to load.</para>
 		</note>
-
 	  </listitem>
 	</varlistentry>
 
@@ -78,25 +91,30 @@
 
       <listitem>
         <para>Synchronizing the project adds translations made by all the team
-        members to local copies of the project. Only the contents of
-        the two following files are synchronized: <itemizedlist>
-        <listitem>
-          <para><filename>project.save</filename></para>
-        </listitem>
+        members to local copies of the project. Only the contents of the two
+        following files are synchronized:</para>
 
-        <listitem>
-          <para><filename>glossary.txt</filename></para>
-        </listitem>
-        </itemizedlist></para>
+		<itemizedlist>
+          <listitem>
+			<para><filename>project.save</filename></para>
+          </listitem>
 
-        <para>During synchronization, all the other local files are overwritten with the versions on the remote server, exept for <filename>omegat.project</filename>, see below.</para>
+          <listitem>
+			<para><filename>glossary.txt</filename></para>
+          </listitem>
+        </itemizedlist>
+
+        <para>During synchronization, all the other local files are overwritten
+        with the versions on the remote server, exept for
+        <filename>omegat.project</filename>, see below.</para>
 
         <para>OmegaT synchronizes a team project when it is opened, reloaded,
         closed or saved. This means the automatic save function also regularly
         synchronizes local versions with the version on the server at the
-        interval specified in <link
+        interval specified in the <link
         endterm="dialog.preferences.saving.and.output.interval.title"
-        linkend="dialog.preferences.saving.and.output.interval"/>.</para>
+        linkend="dialog.preferences.saving.and.output.interval"/>
+        preference.</para>
       </listitem>
     </varlistentry>
 
@@ -118,17 +136,18 @@
             <para><emphasis>Basic project configuration:</emphasis> Source and
             languages, tokenizers, and the project folder hierarchy.</para>
 
-			<para>In a team
-            project, the basic configuration parameters of the local project
-            are always overridden by the configuration on the server that was
-            set by the project administrator.</para>
+			<para>In a team project, the basic configuration parameters of the
+			local project are always overridden by the configuration on the
+			server that was set by the project administrator.</para>
           </listitem>
 
           <listitem>
             <para><emphasis>Repository mappings</emphasis></para>
 
-            <para>See <link
-            linkend="how.to.setup.team.project.mapping.parameters" endterm="how.to.setup.team.project.mapping.parameters.title"/> for details.
+            <para>See the <link
+            linkend="how.to.setup.team.project.mapping.parameters"
+            endterm="how.to.setup.team.project.mapping.parameters.title"/>
+            how-to for details.</para>
 
             <itemizedlist>
               <listitem>
@@ -140,14 +159,14 @@
 
               <listitem>
                 <para>If the remote project contains custom mappings, but the
-                local project does not, the mappings from the server are
-                applied to the local project.</para>
+                local project does not, the mappings from the server are applied
+                to the local project.</para>
               </listitem>
 
               <listitem>
                 <para>If the remote project specifies a URL protocol and you
-                download it using a different protocol, your local
-                configuration will be preserved.</para>
+                download it using a different protocol, your local configuration
+                will be preserved.</para>
 
                 <para>For example, many hosting services support access to the
                 same repository using either the SSH +Git or https protocol.
@@ -156,9 +175,9 @@
 
               <listitem>
                 <para>If you first download the remote project using an
-                <filename>omegat.project</filename> file provided by the
-                project administrator, OmegaT will use the mappings in that
-                file, if any.</para>
+                <filename>omegat.project</filename> file provided by the project
+                administrator, OmegaT will use the mappings in that file, if
+                any.</para>
               </listitem>
 
               <listitem>
@@ -170,24 +189,27 @@
                 backups are automatically deleted.</para>
               </listitem>
             </itemizedlist>
-			</para>
 		  </listitem>
 		</itemizedlist>
 
         <warning>
           <para>Remember that any modifications to the local project
-          configuration files will be overwritten by the versions on the
-          server when the project is synchronized.</para>
+          configuration files will be overwritten by the versions on the server
+          when the project is synchronized.</para>
         </warning>
       </listitem>
     </varlistentry>
 
     <varlistentry>
       <term>Source files</term>
+
       <listitem>
-        <warning><para>The <link
-        endterm="menus.project.commit.source.files.title"
-        linkend="menus.project.commit.source.files"/> command should only be used by the project administrator.</para></warning>
+        <warning>
+		  <para>Only the project administrator should use <link
+		  endterm="menus.project.title" linkend="menus.project"/><link
+		  endterm="menus.project.commit.source.files.title"
+		  linkend="menus.project.commit.source.files"/>.</para>
+		</warning>
       </listitem>
     </varlistentry>
 
@@ -196,9 +218,10 @@
 
       <listitem>
         <para>After you generate the target files, and if the project
-        administrator requests so, you can use the <link
+        administrator requests so, use <link endterm="menus.project.title"
+        linkend="menus.project"/><link
         endterm="menus.project.commit.target.files.title"
-        linkend="menus.project.commit.target.files"/> command to add them to the
+        linkend="menus.project.commit.target.files"/> to add them to the
         server.</para>
       </listitem>
     </varlistentry>
@@ -207,8 +230,8 @@
       <term>Deleting files</term>
 
       <listitem>
-        <para>Files in a team project cannot be deleted from OmegaT or the
-        local file system. They will be restored the next time the project is
+        <para>Files in a team project cannot be deleted from OmegaT or the local
+        file system. They will be restored the next time the project is
         synchronized. This task is normally performed by the project
         administrator.</para>
       </listitem>
@@ -231,7 +254,10 @@
 
           <listitem>
             <para>Open the project from the command line with the
-            <parameter>--no-team</parameter> option. See <link linkend="launch.with.command.line" endterm="launch.with.command.line.title"/> for details.</para>
+            <parameter>--no-team</parameter> option. See the <link
+            linkend="launch.with.command.line"
+            endterm="launch.with.command.line.title"/> section for
+            details.</para>
           </listitem>
         </itemizedlist>
       </listitem>

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -1,188 +1,259 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-"../../../docbook-xml-4.5/docbookx.dtd">
+"../../../docbook-xml-4.5/docbookx.dtd"
+[<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
+
 <chapter id="chapter.instant.start.guide">
   <title id="chapter.instant.start.guide.title">Introduction to OmegaT</title>
 
-  <section id="introduction.omegat.">
-		<title id="introduction.omegat.principles.title">Principles</title>
-    
-    <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool
-    that offers great flexibility, performance and robustness, as well as
-    features beyond those of commercial offerings, even for beginning
-    translators.</para>
+  <section id="introduction.how.to.use.the.manual">
+	<title id="introduction.how.to.use.the.manual.title">Conventions used in
+	this manual</title>
 
-      <variablelist>
-        <varlistentry>
-          <term>Translation project</term>
-          <listitem>
-            <para>An OmegaT translation project consists of a number of
-            resources stored in separate folders, of a <link
-            linkend="project.folder.omegat.project.file"
-            endterm="project.folder.omegat.project.file.title"/> file that
-            stores the location of all the resources and of a <link
-            linkend="project.folder.project.save.tmx"
-            endterm="project.folder.project.save.tmx.title"/> translation
-            memory file that stores all the translations made while working
-            on that project.</para>
-            
-            <para>Translators can easily modify the contents or location of
-            those resources at any time during the translation.</para>
-      
-            <para>By default, resources include the project’s translation
-            memory, which is automatically created upon project creation,
-            and the files to translate. They can also include reference
-            translation memories, glossaries, and other reference
-            files.</para>
-      
-            <para>See <link linkend="project.folder"
-              endterm="project.folder.title"/> for details.</para>
-          </listitem>
-        </varlistentry>
-        
-        <varlistentry>
-          <term>Translation memories</term>
-          <listitem>
-            <para>Translators do not have to <emphasis>create</emphasis> a
-            translation memory or <emphasis>associate</emphasis> one to a
-            new project. OmegaT takes care of that
-            <emphasis>automatically</emphasis>.</para>
-            
-            <para>Translators can very easily reuse an existing projectʼs
-            translation memory by simply adding new translation files to
-            the old project, or by copying the old translation memory to
-            a new project.</para>
-            
-            <para>There is no limit to the number of translation memories
-            that can be used as reference in a translation project, and
-            OmegaT makes it very easy to assign different levels of
-            priority to these additional memories.</para>
-            
-            <para>See <link linkend="how.to.use.tm"
-            endterm="how.to.use.tm.title"/> for details.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>Collaboration</term>
-          <listitem>
-            <para>Simple settings enable translators to easily share
-            resources and work together on a project.</para>
-    
-            <para>The team functionality offers industrial grade
-            robustness and flexibility to synchronize project resources
-            among team members, while allowing easy resolution of
-            conflicts between different translations.</para>
-    
-            <para>See <link
-            linkend="how.to.tm.share.translation.memories"
-            endterm="how.to.tm.share.translation.memories.title"/> for
-            details.</para>
-          </listitem>
-        </varlistentry>
-		<varlistentry>
-		  <term>Made for translators</term>
-		  <listitem>
-			<para>OmegaT is designed not only to facilitate the translation
-			process, but also to ensure the translator does not have to worry
-			about losing data.</para>
-      
-			<note>
-			  <para>You have not used OmegaT yet, but you remember the times you
-			  were translating in your word processor and a computer glitch
-			  wiped out the book translation you had been working on for the
-			  last six months, or the report that was due in one hour.</para>
-        
-			  <para>You're considering OmegaT, but… </para>
-			  <para>How can OmegaT help against such glitches?</para>
+	<para>Elements of the OmegaT user interface are displayed in a way that
+	makes it easier to identify their function. The action associated to that
+	item also tries to suggest its function in case the display does not convey
+	the graphical differentiation: <emphasis>use</emphasis> a menu item, or
+	<emphasis>click</emphasis> on a button.</para>
 
-			  <para>Not to worry. The robust design of OmegaT makes it
-			  <emphasis>extremely</emphasis> unlikely that you have lost more
-			  than a few minutes of work.</para>
-        
-			  <para>Even if things look very broken, do not panic. Just follow
-			  the simple steps described in <link
-			  linkend="how.to.restore.your.data"
-			  endterm="how.to.restore.your.data.title"/>.</para>
-			</note>
+	<para>Similarly, links to the various parts of the manual are displayed in a
+	way that make it easier to identify the function of the linked item.</para>
 
-			<para>And before you ever need to follow those steps, OmegaT will
-			allow you to focus on actually translating, and hopefully help you
-			become a better translator.</para>
-		  </listitem>
-		</varlistentry>
-	  </variablelist>
+	<variablelist>
+	  <varlistentry>
+		<term>Menu items</term>
+		<listitem>
+		<para>Use <link linkend="menus.project"
+		endterm="menus.project.title"/><link linkend="menus.project.new"
+		endterm="menus.project.new.title"/>.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Buttons</term>
+		<listitem>
+		<para>Click on <link linkend="windows.source.files.list.copy.files"
+		endterm="windows.source.files.list.copy.files.title"/>.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Panes, windows, dialogs</term>
+		<listitem>
+		<para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
+		pane.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Files and folders</term>
+		<listitem>
+		<para>The <link linkend="project.folder.omegat.project.file">
+		<filename>omegat.project</filename> </link> file.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Preference settings and project properties</term>
+		<listitem>
+		<para>The <link endterm="dialogs.preferences.fonts.title"
+		linkend="dialogs.preferences.fonts"/> preference.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Chapters, how-to and appendices</term>
+		<listitem>
+		<para>The <link linkend="chapter.project.folder"
+		endterm="chapter.project.folder.title"/> chapter.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Links to external ressources</term>
+		<listitem>
+		<para>The <ulink url="&javaregex;">Java Regex
+		documentation</ulink>.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Shortcuts</term>
+		<listitem>
+		  <para>To avoid duplication of shortcut description, we use single
+		  letters as a common identifier for modifiers. See the <link
+		  linkend="chapter.menus" endterm="chapter.menus.title"/> chapter for
+		  details.</para>
+
+		  <example id="example.introduction.note.on.shortcuts">
+			<title id="example.introduction.note.on.shortcuts.title">Key
+			modifiers are identified by a single letter.</title>
+
+			<para>On Windows and Linux:
+			<keycombo><keycap>Control</keycap><keycap>E</keycap></keycombo></para>
+
+			<para>On macOS:
+			<keycombo><keycap>Command</keycap><keycap>E</keycap></keycombo></para>
+
+			<para><emphasis role="bold">In this manual:</emphasis>
+			<keycombo><keycap>C</keycap><keycap>E</keycap></keycombo></para>
+		  </example>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
   </section>
-  
-  <section id="introduction.note.on.shortcuts">
-		<title id="introduction.note.on.shortcuts.title">Shortcuts</title>
 
-	<para>OmegaT looks a bit stern, if not outright unfriendly, to people who
-	are used to button based interfaces. Buttons are very few in OmegaT. Most
-	of the action takes place with the help of shortcuts associated to menu
-	items.</para>
+  <section id="introduction.omegat.principles">
+	<title id="introduction.omegat.principles.title">Principles</title>
 
-	<para>Shortcuts are ubiquitous in this guide and you should be able very
-	shortly to remember the few that are useful in the course of a standard
-	translation day.</para>
+    <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
+    offers great flexibility, performance and robustness, as well as features
+    beyond those of commercial offerings, even for beginning translators.</para>
 
-	<para>To avoid duplication of shortcut description, we have adopted the
-	following notation in this guide: <example
-	id="example.introduction.note.on.shortcuts"><title
-	id="example.introduction.note.on.shortcuts.title">Single letters are used
-	as a common identifier for modifiers.</title>
+	<section id="introduction.omegat.principles.translation.project">
+      <title
+      id="introduction.omegat.principles.translation.project.title">Translation
+      project</title>
 
-	<para>In this guide:
-	<keycombo><keycap>C</keycap><keycap>E</keycap></keycombo>
-	</para>
+      <para>An OmegaT translation project consists of a number of resources
+      stored in separate folders, of an <link
+      linkend="project.folder.omegat.project.file"><filename>omegat.project</filename></link>
+      file that stores the location of all the resources and of a <link
+      linkend="project.folder.project.save.tmx"><filename>project_save.tmx</filename></link>
+      translation memory file that stores all the translations made while
+      working on that project.</para>
 
-	<para>On Windows and Linux:
-	<keycombo><keycap>Control</keycap><keycap>E</keycap></keycombo>
-	</para>
+      <para>Translators can easily modify the contents or location of
+      those resources at any time during the translation.</para>
 
-	<para>On macOS:
-	<keycombo><keycap>Command</keycap><keycap>E</keycap></keycombo>
-	</para>
-	</example></para>
+      <para>By default, resources include the project’s translation
+      memory, which is automatically created upon project creation,
+      and the files to translate. They can also include reference
+      translation memories, glossaries, and other reference
+      files.</para>
 
-	<para>See <link linkend="menus" endterm="menus.title"/> for details.</para>
+      <para>See the <link linkend="chapter.project.folder"
+      endterm="chapter.project.folder.title"/> chapter for details.</para>
+    </section>
+
+	<section id="introduction.omegat.principles.translation.memories">
+      <title
+      id="introduction.omegat.principles.translation.memories.title">Translation
+      memories</title>
+
+      <para>Translators do not have to <emphasis>create</emphasis> a
+      translation memory or <emphasis>associate</emphasis> one to a
+      new project. OmegaT takes care of that
+      <emphasis>automatically</emphasis>.</para>
+
+      <para>Translators can very easily reuse an existing projectʼs
+      translation memory by simply adding new translation files to
+      the old project, or by copying the old translation memory to
+      a new project.</para>
+
+      <para>There is no limit to the number of translation memories
+      that can be used as reference in a translation project, and
+      OmegaT makes it very easy to assign different levels of
+      priority to these additional memories.</para>
+
+      <para>See the <link linkend="how.to.use.tm"
+      endterm="how.to.use.tm.title"/> how-to for details.</para>
+	</section>
+
+	<section id="introduction.omegat.principles.collaboration">
+      <title
+      id="introduction.omegat.principles.collaboration.title">Collaboration</title>
+
+      <para>Simple settings enable translators to easily share
+      resources and work together on a project.</para>
+
+      <para>The team functionality offers industrial grade
+      robustness and flexibility to synchronize project resources
+      among team members, while allowing easy resolution of
+      conflicts between different translations.</para>
+
+      <para>See the <link
+      linkend="how.to.tm.share.translation.memories"
+      endterm="how.to.tm.share.translation.memories.title"/> how-to for
+      details.</para>
+	</section>
+
+	<section id="introduction.omegat.principles.made.for.translators">
+      <title id="introduction.omegat.principles.made.for.translators.title">Made
+      for translators</title>
+
+	  <para>OmegaT is designed not only to facilitate the translation process,
+	  but also to ensure the translator does not have to worry about losing
+	  data.</para>
+      
+	  <note>
+		<para>You have not used OmegaT yet, but you remember the times you were
+		translating in your word processor and a computer glitch wiped out the
+		book translation you had been working on for the last six months, or the
+		report that was due in one hour.</para>
+        
+		<para>You're considering OmegaT, but… </para>
+		<para>How can OmegaT help against such glitches?</para>
+
+		<para>Not to worry. The robust design of OmegaT makes it
+		<emphasis>extremely</emphasis> unlikely that you have lost more than a
+		few minutes of work.</para>
+        
+		<para>Even if things look very broken, do not panic. Just follow the
+		simple steps described in the <link linkend="how.to.restore.your.data"
+		endterm="how.to.restore.your.data.title"/> how-to.</para>
+	  </note>
+
+	  <para>And before you ever need to follow those steps, OmegaT will allow
+	  you to focus on actually translating, and hopefully help you become a
+	  better translator.</para>
+	</section>
   </section>
 
   <section id="introduction.create.and.open.new.project">
-    <title id="introduction.create.and.open.new.project.title">Create a new project</title>
+    <title id="introduction.create.and.open.new.project.title">Create a new
+    project</title>
 
-	<warning><para>If you have not yet installed OmegaT, check <link
-	linkend="installing.omegat"
-	endterm="installing.omegat.title"/> and <link
-	linkend="running.omegat"
-	endterm="running.omegat.title"/>.</para></warning>
+	<warning>
+	  <para>If you have not yet installed OmegaT, see the <link
+	  linkend="how.to.installing.omegat"
+	  endterm="how.to.installing.omegat.title"/> how-to.</para>
+
+	  <para>To learn how to launch OmegaT, see the <link
+	  linkend="how.to.running.omegat" endterm="how.to.running.omegat.title"/>
+	  how-to.</para>
+	</warning>
 
 
 	<para>To start using OmegaT, you first have to create a project to hold all
-    your files.</para>
+	your files.</para>
 
-	<para>Use <link linkend="menus.project.new"
-	endterm="menus.project.new.title"/>, select an empty folder, or create a new
-	one with the name of your project.</para>
+	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
+	linkend="menus.project.new" endterm="menus.project.new.title"/>, select an
+	empty folder, or create a new one with the name of your project.</para>
 
     <para>An OmegaT project is simply a set of folders and folders that holds
     all your default resources.</para>
 
     <para>The <link linkend="dialogs.project.properties"
-    endterm="dialogs.project.properties.title"/> dialog opens
-    after you have named your project.</para>
+    endterm="dialogs.project.properties.title"/> dialog opens after you have
+    named your project.</para>
 
 	<para>At the top of that dialog, select the languages of your source and
-	translated files, set the various options, and click the
-	<guibutton>OK</guibutton> button to continue.</para>
+	translated files, set the various options, and click on
+	<guibutton>OK</guibutton> to continue.</para>
 
-    <para>After you have created the project, you can use <link
-		linkend="menus.project.properties"
-    endterm="menus.project.properties.title"/> to come back to this dialog as necessary.</para>
+    <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
+    linkend="menus.project.properties"
+    endterm="menus.project.properties.title"/> to come back to this dialog after
+    you have created the project,.</para>
 
-	<note><para>You can modify the structure of a project at any time after you
-	have started translating. In the dialog, just tell OmegaT what new resource
-	folders to use. It will then just ask you to reload the project and start
-	using the new locations.</para></note>
+	<note>
+	  <para>You can modify the structure of a project at any time after you have
+	  started translating. In the dialog, just tell OmegaT what new resource
+	  folders to use. It will then just ask you to reload the project and start
+	  using the new locations.</para>
+	</note>
 	
     <para>The <link linkend="windows.source.files.list"
     endterm="windows.source.files.list.title"/> dialog opens next.</para>
@@ -193,44 +264,69 @@
 	endterm="windows.source.files.list.download.page.title"/> and add source
 	files.</para>
 
-	<para>If you don’t remember where your project is, you can use <link
+	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
 	linkend="menus.project.access.project.contents"
-	endterm="menus.project.access.project.contents.title"/> from the <link
-	linkend="menus.project" endterm="menus.project.title"/> menu.</para>
+	endterm="menus.project.access.project.contents.title"/> if you don’t
+	remember where your project is.</para>
 
 	<para>If a file does not appear into the <link linkend="panes.editor"
 	endterm="panes.editor.title"/> pane, then it could be that it is empty, or
 	in a format that is not supported by OmegaT. Use <link
+	linkend="menus.options" endterm="menus.options.title"/><link
 	linkend="menus.options.file.filters"
 	endterm="menus.options.file.filters.title"/> to open the list of supported
-	file formats. If the format is not there, use third party plugins or convert the file to a
-	format that is supported. See <link linkend="how.to.translate.other.files"
-	endterm="how.to.translate.other.files.title"/> for details.</para>
+	file formats. If the format is not there, use third party plugins or convert
+	the file to a format that is supported. See the <link
+	linkend="how.to.translate.other.files"
+	endterm="how.to.translate.other.files.title"/> how-to for details.</para>
   </section>
 
-    <section id="introduction.manage.your.segments">
-    <title id="introduction.manage.your.segments.title">Manage your segments</title>
-	<para>The default setting for a translation project is to create <emphasis>sentences</emphasis> by splitting the <emphasis>paragraph blocks</emphasis> found in the document. See <link linkend="dialogs.project.properties.options.segmentation" endterm="dialogs.project.properties.options.segmentation.title"/> for details.</para>
+  <section id="introduction.manage.your.segments">
+    <title id="introduction.manage.your.segments.title">Manage your
+    segments</title>
+
+	<para>The default setting for a translation project is to create
+	<emphasis>sentences</emphasis> by splitting the <emphasis>paragraph
+	blocks</emphasis> found in the document. See the <link
+	linkend="dialogs.project.properties.options.segmentation"
+	endterm="dialogs.project.properties.options.segmentation.title"/> project
+	property for details.</para>
 	
-	<para>Segments that are within paragraph can be further segmented, or "unsegmented" (merged).</para>
+	<para>Segments that are within paragraph can be further segmented, or
+	"unsegmented" (merged). Add a segmentation rule to further segment them, or
+	an exception rule to merge them with the part they were split from. See the
+	<link linkend="app.segmentation" endterm="app.segmentation.title"/> appendix
+	for details.</para>
 
-	<para>To further segment them, add a segmentation rule, to merge them, add an exception rule. See <link linkend="app.segmentation" endterm="app.segmentation.title"/> for details.</para>
-
-	<note><para>Since a standard space character is often used as a boundary for a segment, if you want to merge two parts that are separated by a space character,
-
-	<orderedlist>
-	  <listitem><para>go to the source file with <link
-	  linkend="menus.project.access.project.contents"
-	  endterm="menus.project.access.project.contents.title"/>,</para></listitem>
-	  <listitem><para>find the location of that space,</para></listitem>
-	  <listitem><para>replace it by anything that is not a standard space but
-	  looks like a standard space, like a "non breakable space" for
-	  example,</para></listitem>
-	  <listitem><para>save your modifications,</para></listitem>
-	  <listitem><para>go back to OmegaT and <link
-	linkend="menus.project.reload"
-	endterm="menus.project.reload.title"/>.</para></listitem>
-	</orderedlist></para></note>
+	<note>
+	  <para>Since a standard space character is often used as a boundary for a
+	  segment, if you want to merge two parts that are separated by a space
+	  character,</para>
+	  
+	  <orderedlist>
+		<listitem>
+		  <para>go to the source file with <link linkend="menus.project"
+		  endterm="menus.project.title"/><link
+		  linkend="menus.project.access.project.contents"
+		  endterm="menus.project.access.project.contents.title"/>,</para>
+		</listitem>
+		<listitem>
+		  <para>find the location of that space,</para>
+		</listitem>
+		<listitem>
+		  <para>replace it by "non breakable space" for example,</para>
+		</listitem>
+		<listitem>
+		  <para>save your modifications,</para>
+		</listitem>
+		<listitem>
+		  <para>go back to OmegaT and use <link linkend="menus.project"
+		  endterm="menus.project.title"/><link linkend="menus.project.reload"
+		  endterm="menus.project.reload.title"/> to take the modifications into
+		  account.</para>
+		</listitem>
+	  </orderedlist>
+	</note>
   </section>
 
   <section id="introduction.make.it.look.good">
@@ -252,10 +348,10 @@
       </mediaobject>
     </figure>
 
-	<para>Use the various <link linkend="menus.view"
-	endterm="menus.view.title"/> options and move the <link linkend="panes"
-	endterm="panes.title"/> around to obtain the layout that fits your workflow
-	best:</para>
+	<para>Use the various options in the <link linkend="menus.view"
+	endterm="menus.view.title"/> menu and move the various <link
+	linkend="chapter.panes">panes</link> around to obtain the layout that fits
+	your workflow best:</para>
 	
 	<figure id="modified.omegat.layout">
       <title id="modified.omegat.layout.title">Modified OmegaT layout with
@@ -270,58 +366,88 @@
       </mediaobject>
     </figure>
 
-	<note><para>To display paragraph marks and see which paragraph each
-	segment is part of, use <link linkend="menus.view.mark.paragraph.delimitations"
-	endterm="menus.view.mark.paragraph.delimitations.title"/>. You can find  how to set the paragraph mark here: <link
-	linkend="dialogs.preferences.editor.paragraph.delimitation.format"
-	endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>.</para></note>
-
-	
+	<note>
+	  <para>To display paragraph delimitations and see which paragraph each
+	  segment is part of, use <link linkend="menus.view"
+	  endterm="menus.view.title"/><link
+	  linkend="menus.view.mark.paragraph.delimitations"
+	  endterm="menus.view.mark.paragraph.delimitations.title"/>. Paragraphe
+	  delimitations are defined in the <link
+	  linkend="dialogs.preferences.editor.paragraph.delimitation.format"
+	  endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>
+	  preference.</para>
+	</note>
   </section>
 
   <section id="introduction.translate.the.segments.one.by.one">
     <title id="introduction.translate.the.segments.one.by.one.title">Translate
     your files</title>
 
-    <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
-    pane is the place where you type your translation.</para>
+    <para>The <link linkend="panes.editor" endterm="panes.editor.title"/> pane
+    is the place where you type your translation.</para>
 
-	<note><para>To see how efficient you can be with shortcuts, see <link
-	linkend="app.shortcuts.streamline.workflow"
-	endterm="app.shortcuts.streamline.workflow.title"/>. </para>
+	<note>
+	  <para>To see how efficient you can be with shortcuts, see the <link
+	  linkend="app.shortcuts.streamline.workflow"
+	  endterm="app.shortcuts.streamline.workflow.title"/> section.</para>
 	</note>
 	
 	<para>After you have typed the translation of a segment, use <link
+	linkend="menus.goto" endterm="menus.goto.title"/><link
 	linkend="menus.goto.next.untranslated.segment"
 	endterm="menus.goto.next.untranslated.segment.title"/> to move to the next
 	untranslated segment.</para>
 
 	<para>Once you leave the segment, its translation is automatically stored
-	into <link linkend="project.folder.project.save.tmx"
-	endterm="project.folder.project.save.tmx.title"/> and will be used as
+	into the <link linkend="project.folder.project.save.tmx"
+	endterm="project.folder.project.save.tmx.title"/> file and will be used as
 	reference for the rest of your translation.</para>
 
 	<para>See the <link linkend="menus.goto" endterm="menus.goto.title"/> menu
 	for more navigation options.</para>
 
-	<note><para>OmegaT does not have different statuses for translated
-	segments. Either a segment is translated, or it is not. If you need a
-	separate review process, you can for example use the <link
-	linkend="panes.notes" endterm="panes.notes.title"/> panes for problematic
-	segments, or use <link linkend="menus.edit.search.project"
-	endterm="menus.edit.search.project.title"/> to filter segments based on
-	criteria that you set, and review only those, etc.</para></note>
-	
-	<para>Use <link
-	linkend="menus.edit.create.glossary.entry"
-	endterm="menus.edit.create.glossary.entry.title"/> to add terms to your glossary.</para>
+	<note>
+	  <para>OmegaT does not have different statuses for translated
+	  segments. Either a segment is translated, or it is not.</para>
 
-	<para>Use <link linkend="menus.view.mark.glossary.matches"
-	endterm="menus.view.mark.glossary.matches.title"/> in the <link
-	linkend="menus.view" endterm="menus.view.title"/> menu and <link
+	  <para>If you need a specific review process, you can for example:</para>
+
+	  <itemizedlist>
+		<listitem>
+		  <para>add reminders in the <link linkend="panes.notes"
+		  endterm="panes.notes.title"/> pane for problematic segments</para>
+
+		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.notes.pane"
+		  endterm="menus.goto.notes.pane.title"/> to enter the Notes pane and
+		  add your remark,</para>
+
+		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.editor.pane"
+		  endterm="menus.goto.editor.pane.title"/> to return to the Editor pane
+		  and resume your translation</para>
+		</listitem>
+
+		<listitem>
+		  <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+		  linkend="menus.edit.search.project"
+		  endterm="menus.edit.search.project.title"/> to filter segments based
+		  on criteria that you set, and review only those, etc.</para>
+		</listitem>
+	  </itemizedlist>
+	</note>
+	
+	<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+	linkend="menus.edit.create.glossary.entry"
+	endterm="menus.edit.create.glossary.entry.title"/> to add terms to your
+	glossary.</para>
+
+	<para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
+	linkend="menus.view.mark.glossary.matches"
+	endterm="menus.view.mark.glossary.matches.title"/> and the <link
 	linkend="dialog.preferences.auto.completion"
-	endterm="dialog.preferences.auto.completion.title"/> to
-	manage glossary matches.</para>
+	endterm="dialog.preferences.auto.completion.title"/> preferences to manage
+	glossary matches.</para>
 
 	<para>When you enter a segment where terms match terms in your glossaries,
 	the terms and their translations will be displayed in the <link
@@ -342,25 +468,25 @@
 	regular expression searches, as well as narrow the scope of the search based
 	on information such as author or date.</para>
 
-	<para>You can also focus only on the
-	results by filtering them in the Editor. See
+	<para>You can also focus only on the results by filtering them in the
+	Editor. See
 	<link linkend="windows.text.search" endterm="windows.text.search.title"/>
 	for details.</para>
 
 	<para>You can replace terms with <link
 	linkend="menus.edit.search.and.replace"
-	endterm="menus.edit.search.and.replace.title"/> using a similar
-	dialog. See <link linkend="windows.text.replace"
-	endterm="windows.text.replace.title"/> for details.</para>
+	endterm="menus.edit.search.and.replace.title"/> using a similar dialog. See
+	<link linkend="windows.text.replace" endterm="windows.text.replace.title"/>
+	for details.</para>
 
 	<para>You can leave notes to yourself or team members in the <link
 	linkend="panes.notes" endterm="panes.notes.title"/> pane while you
 	translate, and go back to annotated segments with <link
 	linkend="menus.goto.next.note" endterm="menus.goto.next.note.title"/> or
 	<link linkend="menus.goto.previous.note"
-		  endterm="menus.goto.previous.note.title"/> in the <link linkend="menus.goto"
-		  endterm="menus.goto.title"/> menu, or from the <link
-		  linkend="windows.text.search" endterm="windows.text.search.title"/>
+	endterm="menus.goto.previous.note.title"/> in the <link linkend="menus.goto"
+	endterm="menus.goto.title"/> menu, or from the <link
+	linkend="windows.text.search" endterm="windows.text.search.title"/>
 	window.</para>
 
 	<para>The <link linkend="panes.editor.context.menu"
@@ -370,7 +496,7 @@
 	endterm="panes.editor.auto.completion.menu.title"/> is also available in the
 	Editor pane.</para>
   </section>
-    
+  
   <section id="introduction.manage.your.tags">
     <title id="introduction.manage.your.tags.title">Manage your tags</title>
 
@@ -406,9 +532,9 @@
     protected to prevent you from modifying their contents, but you can delete
     them, enter them by hand or move them around in the target sentence. See
     <link linkend="menus.edit.insert.missing.source.tag"
-		  endterm="menus.edit.insert.missing.source.tag.title"/> and <link
-		  linkend="menus.edit.insert.next.missing.tag"
-		  endterm="menus.edit.insert.next.missing.tag.title"/> for details.</para>
+    endterm="menus.edit.insert.missing.source.tag.title"/> and <link
+    linkend="menus.edit.insert.next.missing.tag"
+    endterm="menus.edit.insert.next.missing.tag.title"/> for details.</para>
 
 	<para>You can define custom tags that will be managed in the same
 	manner. See <link
@@ -417,53 +543,60 @@
 	for details. You can also define strings that OmegaT should warn you about
 	if you leave them in a translation. See <link
 	linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
-	endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/> for details.</para>
+	endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/>
+	for details.</para>
 
 	<para>If you make mistakes when you manage the tags, your translated files
 	might fail to open. Use
 	<link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/>
 	to check your tags before you generate your translated files.</para>
 
-	<warning><para>If a file refuses to open in LibreOffice, Word or other
-	application, it is often due to errors in the management of OmegaT
-	tags. Return to OmegaT, check your document for tag issues and recreate the
-	translated file.</para></warning>
+	<warning>
+	  <para>If a file refuses to open in LibreOffice, Word or other application,
+	  it is often due to errors in the management of OmegaT tags. Return to
+	  OmegaT, check your document for tag issues and recreate the translated
+	  file.</para>
+	</warning>
   </section>
 
   <section id="introduction.review.the.translation">
-    <title id="introduction.review.the.translation.title">Review your translation</title>
+    <title id="introduction.review.the.translation.title">Review your
+    translation</title>
 
-	<para>Feel free to modify the <link
-	linkend="panes" endterm="panes.title"/> layout and <link
-	linkend="menus.view" endterm="menus.view.title"/> options when you review the translation.</para>
+	<para>Feel free to modify the <link linkend="chapter.panes"
+	endterm="chapter.panes.title"/> layout and <link linkend="menus.view"
+	endterm="menus.view.title"/> options when you review the translation.</para>
 
 	<para>Use <link linkend="menus.tools.check.issues"
-	endterm="menus.tools.check.issues.title"/> to make various checks
-	on the contents.</para>
+	endterm="menus.tools.check.issues.title"/> to make various checks on the
+	contents.</para>
   </section>
   
   <section id="introduction.generate.the.translated.file">
-    <title id="introduction.generate.the.translated.file.title">Create the translated files</title>
+    <title id="introduction.generate.the.translated.file.title">Create the
+    translated files</title>
 
 	<para>Whenever you want to see what your translation will look like in its
 	final format, use <link linkend="menus.project.create.translated.documents"
 	endterm="menus.project.create.translated.documents.title"/>.</para>
 
-	<warning><para>Any time you create the translated files, any previously
-	created files with the same name will be overwritten. If you want to keep
-	files from being overwritten, change their name after you created them, or
-	automate the name modification with <link linkend="edit.filter.dialog"
-	endterm="edit.filter.dialog.title"/>.</para>
+	<warning>
+	  <para>Any time you create the translated files, any previously created
+	  files with the same name will be overwritten. If you want to keep files
+	  from being overwritten, change their name after you created them, or
+	  automate the name modification with <link linkend="edit.filter.dialog"
+	  endterm="edit.filter.dialog.title"/>.</para>
 	
-	<para>Your translations are <emphasis>always</emphasis> stored in
-	<link linkend="project.folder.project.save.tmx"
-		  endterm="project.folder.project.save.tmx.title"/>, the project translation
-	memory, located in the <link linkend="project.folder.omegat"
-	endterm="project.folder.omegat.title"/> folder of your project.</para>
+	  <para>Your translations are <emphasis>always</emphasis> stored in <link
+	  linkend="project.folder.project.save.tmx"
+	  endterm="project.folder.project.save.tmx.title"/>, the project translation
+	  memory, located in the <link linkend="project.folder.omegat"
+	  endterm="project.folder.omegat.title"/> folder of your project.</para>
 
-	<para>Deleting the contents of the <link linkend="project.folder.target"
-	endterm="project.folder.target.title"/> folder will
-	<emphasis>never</emphasis> impact your translations.</para></warning>
+	  <para>Deleting the contents of the <link linkend="project.folder.target"
+	  endterm="project.folder.target.title"/> folder will
+	  <emphasis>never</emphasis> impact your translations.</para>
+	</warning>
 
 	<para>The documents will be created in the <link
 	linkend="project.folder.target" endterm="project.folder.target.title"/>
@@ -484,7 +617,6 @@
 	endterm="project.folder.tm.enforce.title"/> folder of your project
 	folder. See <link linkend="windows.aligner"
 	endterm="windows.aligner.title"/> for details.</para>
-	
   </section>
 
   <section id="introduction.one.more.thing">
@@ -503,8 +635,8 @@
         linkend="menus.project.properties"
         endterm="menus.project.properties.title"/>. To see the list of files in
         the project, use <link linkend="menus.project.source.files.list"
-        endterm="menus.project.source.files.list.title"/>. You can access all the
-        resource contents at any time with <link
+        endterm="menus.project.source.files.list.title"/>. You can access all
+        the resource contents at any time with <link
         linkend="menus.project.access.project.contents"
         endterm="menus.project.access.project.contents.title"/>.</para>
       </listitem>
@@ -521,12 +653,12 @@
         endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
         for details.</para>
       </listitem>
-
     </itemizedlist>
+	
     <para>For a more comprehensive introduction see <ulink
     url="https://omegat.org/files/OmegaT_for_Beginners.pdf">OmegaT for
-    beginners</ulink> on the OmegaT web site. If you need assistance with
-    any aspect of OmegaT, feel free to join the <ulink
+    beginners</ulink> on the OmegaT web site. If you need assistance with any
+    aspect of OmegaT, feel free to join the <ulink
     url="https://omegat.org/support">OmegaT user groups.</ulink></para>
   </section>
 </chapter>

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -5,15 +5,119 @@
 
 <chapter id="chapter.instant.start.guide">
   <title id="chapter.instant.start.guide.title">Introduction to OmegaT</title>
+  
+  <section id="introduction.omegat.principles">
+	<title id="introduction.omegat.principles.title">Principles</title>
+
+    <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
+    offers great flexibility, performance and robustness, as well as features
+    beyond those of commercial offerings, even for beginning translators.</para>
+
+	<section id="introduction.omegat.principles.translation.project">
+      <title
+      id="introduction.omegat.principles.translation.project.title">Translation
+      project</title>
+
+      <para>An OmegaT translation project consists of a number of resources
+      stored in separate folders, of an <link
+      linkend="project.folder.omegat.project.file"><filename>omegat.project</filename></link>
+      file that stores the location of all the resources and of a <link
+      linkend="project.folder.project.save.tmx"><filename>project_save.tmx</filename></link>
+      translation memory file that stores all the translations made while
+      working on that project.</para>
+
+      <para>Translators can easily modify the contents or location of those
+      resources at any time during the translation.</para>
+
+      <para>By default, resources include the project’s translation memory,
+      which is automatically created upon project creation, and the files to
+      translate. They can also include reference translation memories,
+      glossaries, and other reference files.</para>
+
+      <para>See the <link linkend="chapter.project.folder"
+      endterm="chapter.project.folder.title"/> chapter for details.</para>
+    </section>
+
+	<section id="introduction.omegat.principles.translation.memories">
+      <title
+      id="introduction.omegat.principles.translation.memories.title">Translation
+      memories</title>
+
+      <para>Translators do not have to <emphasis>create</emphasis> a translation
+      memory or <emphasis>associate</emphasis> one to a new project. OmegaT
+      takes care of that <emphasis>automatically</emphasis>.</para>
+
+      <para>Translators can very easily reuse an existing projectʼs translation
+      memory by simply adding new translation files to the old project, or by
+      copying the old translation memory to a new project.</para>
+
+      <para>There is no limit to the number of translation memories that can be
+      used as reference in a translation project, and OmegaT makes it very easy
+      to assign different levels of priority to these additional
+      memories.</para>
+
+      <para>See the <link linkend="how.to.use.tm"
+      endterm="how.to.use.tm.title"/> how-to for details.</para>
+	</section>
+
+	<section id="introduction.omegat.principles.collaboration">
+      <title
+      id="introduction.omegat.principles.collaboration.title">Collaboration</title>
+
+      <para>Simple settings enable translators to easily share resources and
+      work together on a project.</para>
+
+      <para>The team functionality offers industrial grade robustness and
+      flexibility to synchronize project resources among team members, while
+      allowing easy resolution of conflicts between different
+      translations.</para>
+
+      <para>See the <link linkend="how.to.tm.share.translation.memories"
+      endterm="how.to.tm.share.translation.memories.title"/> how-to for
+      details.</para>
+	</section>
+
+	<section id="introduction.omegat.principles.made.for.translators">
+      <title id="introduction.omegat.principles.made.for.translators.title">Made
+      for translators</title>
+
+	  <para>OmegaT is designed not only to facilitate the translation process,
+	  but also to ensure the translator does not have to worry about losing
+	  data.</para>
+
+	  <note>
+		<para>You have not used OmegaT yet, but you remember the times you were
+		translating in your word processor and a computer glitch wiped out the
+		book translation you had been working on for the last six months, or the
+		report that was due in one hour.</para>
+
+		<para>You're considering OmegaT, but… </para>
+
+		<para>How can OmegaT help against such glitches?</para>
+
+		<para>Not to worry. The robust design of OmegaT makes it
+		<emphasis>extremely</emphasis> unlikely that you have lost more than a
+		few minutes of work.</para>
+
+		<para>Even if things look very broken, do not panic. Just follow the
+		simple steps described in the <link linkend="how.to.restore.your.data"
+		endterm="how.to.restore.your.data.title"/> how-to.</para>
+	  </note>
+
+	  <para>And before you ever need to follow those steps, OmegaT will allow
+	  you to focus on actually translating, and hopefully help you become a
+	  better translator.</para>
+	</section>
+  </section>
 
   <section id="introduction.how.to.use.the.manual">
 	<title id="introduction.how.to.use.the.manual.title">Conventions used in
 	this manual</title>
-
-	<para>Elements of the OmegaT user interface are displayed in a way that
-	makes it easier to identify their function. The action associated to that
-	item also tries to suggest its function in case the display does not convey
-	the graphical differentiation: <emphasis>use</emphasis> a menu item, or
+	<para>This section presents the conventions used to distinguish the elements
+	of the OmegaT user interface in this manual. They are displayed in a way
+	that makes it easier to identify their function. The action associated with
+	an item also hints at its function in case the display fails to convey the
+	visual differences: <emphasis>use</emphasis> a menu item, or
 	<emphasis>click</emphasis> on a button.</para>
 
 	<para>Similarly, links to the various parts of the manual are displayed in a
@@ -23,64 +127,64 @@
 	  <varlistentry>
 		<term>Menu items</term>
 		<listitem>
-		<para>Use <link linkend="menus.project"
-		endterm="menus.project.title"/><link linkend="menus.project.new"
-		endterm="menus.project.new.title"/>.</para>
+		  <para>Use <link linkend="menus.project"
+		  endterm="menus.project.title"/><link linkend="menus.project.new"
+		  endterm="menus.project.new.title"/>.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Buttons</term>
 		<listitem>
-		<para>Click on <link linkend="windows.source.files.list.copy.files"
-		endterm="windows.source.files.list.copy.files.title"/>.</para>
+		  <para>Click on <link linkend="windows.source.files.list.copy.files"
+		  endterm="windows.source.files.list.copy.files.title"/>.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Panes, windows, dialogs</term>
 		<listitem>
-		<para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
-		pane.</para>
+		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
+		  pane.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Files and folders</term>
 		<listitem>
-		<para>The <link linkend="project.folder.omegat.project.file">
-		<filename>omegat.project</filename> </link> file.</para>
+		  <para>The <link linkend="project.folder.omegat.project.file">
+		  <filename>omegat.project</filename> </link> file.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Preference settings and project properties</term>
 		<listitem>
-		<para>The <link endterm="dialogs.preferences.fonts.title"
-		linkend="dialogs.preferences.fonts"/> preference.</para>
+		  <para>The <link endterm="dialogs.preferences.fonts.title"
+		  linkend="dialogs.preferences.fonts"/> preference.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Chapters, how-to and appendices</term>
 		<listitem>
-		<para>The <link linkend="chapter.project.folder"
-		endterm="chapter.project.folder.title"/> chapter.</para>
+		  <para>The <link linkend="chapter.project.folder"
+		  endterm="chapter.project.folder.title"/> chapter.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
-		<term>Links to external ressources</term>
+		<term>Links to external resources</term>
 		<listitem>
-		<para>The <ulink url="&javaregex;">Java Regex
-		documentation</ulink>.</para>
+		  <para>The <ulink url="&javaregex;">Java Regex
+		  documentation</ulink>.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry>
 		<term>Shortcuts</term>
 		<listitem>
-		  <para>To avoid duplication of shortcut description, we use single
+		  <para>To avoid duplicating shortcut descriptions, we use single
 		  letters as a common identifier for modifiers. See the <link
 		  linkend="chapter.menus" endterm="chapter.menus.title"/> chapter for
 		  details.</para>
@@ -103,113 +207,6 @@
 	</variablelist>
   </section>
 
-  <section id="introduction.omegat.principles">
-	<title id="introduction.omegat.principles.title">Principles</title>
-
-    <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
-    offers great flexibility, performance and robustness, as well as features
-    beyond those of commercial offerings, even for beginning translators.</para>
-
-	<section id="introduction.omegat.principles.translation.project">
-      <title
-      id="introduction.omegat.principles.translation.project.title">Translation
-      project</title>
-
-      <para>An OmegaT translation project consists of a number of resources
-      stored in separate folders, of an <link
-      linkend="project.folder.omegat.project.file"><filename>omegat.project</filename></link>
-      file that stores the location of all the resources and of a <link
-      linkend="project.folder.project.save.tmx"><filename>project_save.tmx</filename></link>
-      translation memory file that stores all the translations made while
-      working on that project.</para>
-
-      <para>Translators can easily modify the contents or location of
-      those resources at any time during the translation.</para>
-
-      <para>By default, resources include the project’s translation
-      memory, which is automatically created upon project creation,
-      and the files to translate. They can also include reference
-      translation memories, glossaries, and other reference
-      files.</para>
-
-      <para>See the <link linkend="chapter.project.folder"
-      endterm="chapter.project.folder.title"/> chapter for details.</para>
-    </section>
-
-	<section id="introduction.omegat.principles.translation.memories">
-      <title
-      id="introduction.omegat.principles.translation.memories.title">Translation
-      memories</title>
-
-      <para>Translators do not have to <emphasis>create</emphasis> a
-      translation memory or <emphasis>associate</emphasis> one to a
-      new project. OmegaT takes care of that
-      <emphasis>automatically</emphasis>.</para>
-
-      <para>Translators can very easily reuse an existing projectʼs
-      translation memory by simply adding new translation files to
-      the old project, or by copying the old translation memory to
-      a new project.</para>
-
-      <para>There is no limit to the number of translation memories
-      that can be used as reference in a translation project, and
-      OmegaT makes it very easy to assign different levels of
-      priority to these additional memories.</para>
-
-      <para>See the <link linkend="how.to.use.tm"
-      endterm="how.to.use.tm.title"/> how-to for details.</para>
-	</section>
-
-	<section id="introduction.omegat.principles.collaboration">
-      <title
-      id="introduction.omegat.principles.collaboration.title">Collaboration</title>
-
-      <para>Simple settings enable translators to easily share
-      resources and work together on a project.</para>
-
-      <para>The team functionality offers industrial grade
-      robustness and flexibility to synchronize project resources
-      among team members, while allowing easy resolution of
-      conflicts between different translations.</para>
-
-      <para>See the <link
-      linkend="how.to.tm.share.translation.memories"
-      endterm="how.to.tm.share.translation.memories.title"/> how-to for
-      details.</para>
-	</section>
-
-	<section id="introduction.omegat.principles.made.for.translators">
-      <title id="introduction.omegat.principles.made.for.translators.title">Made
-      for translators</title>
-
-	  <para>OmegaT is designed not only to facilitate the translation process,
-	  but also to ensure the translator does not have to worry about losing
-	  data.</para>
-      
-	  <note>
-		<para>You have not used OmegaT yet, but you remember the times you were
-		translating in your word processor and a computer glitch wiped out the
-		book translation you had been working on for the last six months, or the
-		report that was due in one hour.</para>
-        
-		<para>You're considering OmegaT, but… </para>
-		<para>How can OmegaT help against such glitches?</para>
-
-		<para>Not to worry. The robust design of OmegaT makes it
-		<emphasis>extremely</emphasis> unlikely that you have lost more than a
-		few minutes of work.</para>
-        
-		<para>Even if things look very broken, do not panic. Just follow the
-		simple steps described in the <link linkend="how.to.restore.your.data"
-		endterm="how.to.restore.your.data.title"/> how-to.</para>
-	  </note>
-
-	  <para>And before you ever need to follow those steps, OmegaT will allow
-	  you to focus on actually translating, and hopefully help you become a
-	  better translator.</para>
-	</section>
-  </section>
-
   <section id="introduction.create.and.open.new.project">
     <title id="introduction.create.and.open.new.project.title">Create a new
     project</title>
@@ -229,8 +226,8 @@
 	your files.</para>
 
 	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
-	linkend="menus.project.new" endterm="menus.project.new.title"/>, select an
-	empty folder, or create a new one with the name of your project.</para>
+	linkend="menus.project.new" endterm="menus.project.new.title"/>, and select
+	an empty folder or create a new one with the name of your project.</para>
 
     <para>An OmegaT project is simply a set of folders and folders that holds
     all your default resources.</para>
@@ -239,9 +236,9 @@
     endterm="dialogs.project.properties.title"/> dialog opens after you have
     named your project.</para>
 
-	<para>At the top of that dialog, select the languages of your source and
-	translated files, set the various options, and click on
-	<guibutton>OK</guibutton> to continue.</para>
+	<para>In that dialog, select the languages of your source and translated
+	files, set the various options, and click on <guibutton>OK</guibutton> to
+	continue.</para>
 
     <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
     linkend="menus.project.properties"
@@ -269,14 +266,14 @@
 	endterm="menus.project.access.project.contents.title"/> if you don’t
 	remember where your project is.</para>
 
-	<para>If a file does not appear into the <link linkend="panes.editor"
-	endterm="panes.editor.title"/> pane, then it could be that it is empty, or
-	in a format that is not supported by OmegaT. Use <link
+	<para>If you do not see the contents of a file in the <link
+	linkend="panes.editor" endterm="panes.editor.title"/> pane, that file might
+	be empty, or in a format that is not supported by OmegaT.  Use <link
 	linkend="menus.options" endterm="menus.options.title"/><link
 	linkend="menus.options.file.filters"
 	endterm="menus.options.file.filters.title"/> to open the list of supported
-	file formats. If the format is not there, use third party plugins or convert
-	the file to a format that is supported. See the <link
+	file formats. If the format of your file is not listed, use third-party
+	plugins or convert the file to a format that is supported. See the <link
 	linkend="how.to.translate.other.files"
 	endterm="how.to.translate.other.files.title"/> how-to for details.</para>
   </section>
@@ -292,38 +289,42 @@
 	endterm="dialogs.project.properties.options.segmentation.title"/> project
 	property for details.</para>
 	
-	<para>Segments that are within paragraph can be further segmented, or
-	"unsegmented" (merged). Add a segmentation rule to further segment them, or
-	an exception rule to merge them with the part they were split from. See the
-	<link linkend="app.segmentation" endterm="app.segmentation.title"/> appendix
-	for details.</para>
+	<para>Segments within a paragraph can be further segmented, or "unsegmented"
+	(merged). Add a segmentation rule to segment further them, or an exception
+	rule to merge them with the part they were split from. See the <link
+	linkend="app.segmentation" endterm="app.segmentation.title"/> appendix for
+	details.</para>
 
 	<note>
-	  <para>Since a standard space character is often used as a boundary for a
-	  segment, if you want to merge two parts that are separated by a space
-	  character,</para>
+	  <para>The standard space character is often used as a segment boundary.
+	  You can follow the steps below to merge two text sections separated by a
+	  space character:</para>
 	  
 	  <orderedlist>
 		<listitem>
-		  <para>go to the source file with <link linkend="menus.project"
+		  <para>Go to the source file with <link linkend="menus.project"
 		  endterm="menus.project.title"/><link
 		  linkend="menus.project.access.project.contents"
-		  endterm="menus.project.access.project.contents.title"/>,</para>
+		  endterm="menus.project.access.project.contents.title"/>.</para>
 		</listitem>
+		
 		<listitem>
-		  <para>find the location of that space,</para>
+		  <para>Find the location of that space.</para>
 		</listitem>
+
 		<listitem>
-		  <para>replace it by "non breakable space" for example,</para>
+		  <para>Replace it with a non-breakable space.</para>
 		</listitem>
+
 		<listitem>
-		  <para>save your modifications,</para>
+		  <para>Save the file.</para>
 		</listitem>
+
 		<listitem>
-		  <para>go back to OmegaT and use <link linkend="menus.project"
+		  <para>Go back to OmegaT and use <link linkend="menus.project"
 		  endterm="menus.project.title"/><link linkend="menus.project.reload"
-		  endterm="menus.project.reload.title"/> to take the modifications into
-		  account.</para>
+		  endterm="menus.project.reload.title"/> to have OmegaT recognize the
+		  change.</para>
 		</listitem>
 	  </orderedlist>
 	</note>
@@ -331,7 +332,6 @@
 
   <section id="introduction.make.it.look.good">
 	<title id="introduction.make.it.look.good.title">Make it look good!</title>
-
 	<para>Once all that is done, the source files appear in OmegaT in a layout
 	that looks like this:</para>
 
@@ -371,7 +371,7 @@
 	  segment is part of, use <link linkend="menus.view"
 	  endterm="menus.view.title"/><link
 	  linkend="menus.view.mark.paragraph.delimitations"
-	  endterm="menus.view.mark.paragraph.delimitations.title"/>. Paragraphe
+	  endterm="menus.view.mark.paragraph.delimitations.title"/>. Paragraph
 	  delimitations are defined in the <link
 	  linkend="dialogs.preferences.editor.paragraph.delimitation.format"
 	  endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>
@@ -384,7 +384,7 @@
     your files</title>
 
     <para>The <link linkend="panes.editor" endterm="panes.editor.title"/> pane
-    is the place where you type your translation.</para>
+    is where you type your translation.</para>
 
 	<note>
 	  <para>To see how efficient you can be with shortcuts, see the <link
@@ -398,7 +398,7 @@
 	endterm="menus.goto.next.untranslated.segment.title"/> to move to the next
 	untranslated segment.</para>
 
-	<para>Once you leave the segment, its translation is automatically stored
+	<para>When you leave the segment, its translation is automatically stored
 	into the <link linkend="project.folder.project.save.tmx"
 	endterm="project.folder.project.save.tmx.title"/> file and will be used as
 	reference for the rest of your translation.</para>
@@ -407,14 +407,14 @@
 	for more navigation options.</para>
 
 	<note>
-	  <para>OmegaT does not have different statuses for translated
+	  <para>OmegaT does not assign different statuses to translated
 	  segments. Either a segment is translated, or it is not.</para>
 
-	  <para>If you need a specific review process, you can for example:</para>
+	  <para>If you need a specific review process you can, for example:</para>
 
 	  <itemizedlist>
 		<listitem>
-		  <para>add reminders in the <link linkend="panes.notes"
+		  <para>Add reminders in the <link linkend="panes.notes"
 		  endterm="panes.notes.title"/> pane for problematic segments</para>
 
 		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
@@ -425,14 +425,14 @@
 		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
 		  linkend="menus.goto.editor.pane"
 		  endterm="menus.goto.editor.pane.title"/> to return to the Editor pane
-		  and resume your translation</para>
+		  and resume your translation.</para>
 		</listitem>
 
 		<listitem>
 		  <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
 		  linkend="menus.edit.search.project"
 		  endterm="menus.edit.search.project.title"/> to filter segments based
-		  on criteria that you set, and review only those, etc.</para>
+		  on criteria that you set, and review only those.</para>
 		</listitem>
 	  </itemizedlist>
 	</note>
@@ -449,11 +449,11 @@
 	endterm="dialog.preferences.auto.completion.title"/> preferences to manage
 	glossary matches.</para>
 
-	<para>When you enter a segment where terms match terms in your glossaries,
-	the terms and their translations will be displayed in the <link
-	linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
+	<para>When you enter a segment containing terms that match entries in your
+	glossaries, those terms and their translations will be displayed in the
+	<link linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
 	
-	<para>When you enter a segment that matches some of the content of the
+	<para>When you enter a segment that matches part of the content of the
 	project translation memories, OmegaT displays the matches in the <link
 	linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>
 	pane.</para>
@@ -462,22 +462,22 @@
 	to manage translation memory matches and perform other various useful
 	functions.</para>
 
-	<para>With <link linkend="menus.edit.search.project"
-	endterm="menus.edit.search.project.title"/>, you can search the whole
-	project for terms, sentence fragments and so on, using exact, keyword, or
-	regular expression searches, as well as narrow the scope of the search based
-	on information such as author or date.</para>
+	<para>The <link linkend="menus.edit.search.project"
+	endterm="menus.edit.search.project.title"/> function lets you search the
+	entire project for terms, sentence fragments and so on, using exact,
+	keyword, or regular expression searches. You can also narrow the scope of
+	the search based on information such as author or date.</para>
 
 	<para>You can also focus only on the results by filtering them in the
-	Editor. See
+	Editor. See the
 	<link linkend="windows.text.search" endterm="windows.text.search.title"/>
-	for details.</para>
+	section for details.</para>
 
-	<para>You can replace terms with <link
+	<para>You can replace terms with the <link
 	linkend="menus.edit.search.and.replace"
-	endterm="menus.edit.search.and.replace.title"/> using a similar dialog. See
-	<link linkend="windows.text.replace" endterm="windows.text.replace.title"/>
-	for details.</para>
+	endterm="menus.edit.search.and.replace.title"/> function using a similar
+	dialog. See the <link linkend="windows.text.replace"
+	endterm="windows.text.replace.title"/> section for details.</para>
 
 	<para>You can leave notes to yourself or team members in the <link
 	linkend="panes.notes" endterm="panes.notes.title"/> pane while you
@@ -490,7 +490,7 @@
 	window.</para>
 
 	<para>The <link linkend="panes.editor.context.menu"
-	endterm="panes.editor.context.menu.title"/> gives easy access to some
+	endterm="panes.editor.context.menu.title"/> gives easy access to various
 	frequently used functions. The <link
 	linkend="panes.editor.auto.completion.menu"
 	endterm="panes.editor.auto.completion.menu.title"/> is also available in the
@@ -501,11 +501,11 @@
     <title id="introduction.manage.your.tags.title">Manage your tags</title>
 
     <para>If the documents you translate use bold, italics, or other decorative
-    elements, OmegaT will convert them into tags that enclose the decorated
-    text. Such files include LibreOffice files, HTML files, Microsoft Office
-    files, etc. Documents will often also contain tags that have nothing to do
-    with decorations, but are nevertheless important in the source files (and,
-    consequently, in the translated files as well).</para>
+    elements, OmegaT will convert those elements into tags that enclose the
+    decorated text. Such files include LibreOffice files, HTML files an
+    Microsoft Office files for example. Documents often also contain tags that
+    have nothing to do with decorations, but are nevertheless important in the
+    source files (and, consequently, in the translated files).</para>
 
 	<para>A source sentence might look like:</para>
     
@@ -531,25 +531,27 @@
     <para>The tags in OmegaT are grayed, making them easy to recognize. They are
     protected to prevent you from modifying their contents, but you can delete
     them, enter them by hand or move them around in the target sentence. See
+    <link linkend="menus.edit" endterm="menus.edit.title"/>
     <link linkend="menus.edit.insert.missing.source.tag"
     endterm="menus.edit.insert.missing.source.tag.title"/> and <link
     linkend="menus.edit.insert.next.missing.tag"
     endterm="menus.edit.insert.next.missing.tag.title"/> for details.</para>
 
 	<para>You can define custom tags that will be managed in the same
-	manner. See <link
+	manner. See the <link
 	linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"
 	endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/>
-	for details. You can also define strings that OmegaT should warn you about
-	if you leave them in a translation. See <link
+	section for details. You can also define strings that OmegaT should warn you
+	about if you leave them in a translation. See the <link
 	linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
 	endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/>
-	for details.</para>
+	section for details.</para>
 
 	<para>If you make mistakes when you manage the tags, your translated files
-	might fail to open. Use
-	<link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/>
-	to check your tags before you generate your translated files.</para>
+	might fail to open. Use <link linkend="menus.tools"
+	endterm="menus.tools.title"/> <link linkend="menus.tools.check.issues"
+	endterm="menus.tools.check.issues.title"/> to check your tags before you
+	generate your translated files.</para>
 
 	<warning>
 	  <para>If a file refuses to open in LibreOffice, Word or other application,
@@ -567,9 +569,9 @@
 	endterm="chapter.panes.title"/> layout and <link linkend="menus.view"
 	endterm="menus.view.title"/> options when you review the translation.</para>
 
-	<para>Use <link linkend="menus.tools.check.issues"
-	endterm="menus.tools.check.issues.title"/> to make various checks on the
-	contents.</para>
+	<para>Use the <link linkend="menus.tools.check.issues"
+	endterm="menus.tools.check.issues.title"/> option to perform various checks
+	on the contents of your translation.</para>
   </section>
   
   <section id="introduction.generate.the.translated.file">
@@ -577,25 +579,28 @@
     translated files</title>
 
 	<para>Whenever you want to see what your translation will look like in its
-	final format, use <link linkend="menus.project.create.translated.documents"
+	final format, use <link linkend="menus.project"
+	endterm="menus.project.title"/> <link
+	linkend="menus.project.create.translated.documents"
 	endterm="menus.project.create.translated.documents.title"/>.</para>
 
 	<warning>
 	  <para>Any time you create the translated files, any previously created
 	  files with the same name will be overwritten. If you want to keep files
-	  from being overwritten, change their name after you created them, or
-	  automate the name modification with <link linkend="edit.filter.dialog"
-	  endterm="edit.filter.dialog.title"/>.</para>
+	  from being overwritten, change their name after you create them. You can
+	  automate file name changes using the <link linkend="edit.filter.dialog"
+	  endterm="edit.filter.dialog.title"/> option for the file filter.</para>
 	
-	  <para>Your translations are <emphasis>always</emphasis> stored in <link
-	  linkend="project.folder.project.save.tmx"
-	  endterm="project.folder.project.save.tmx.title"/>, the project translation
-	  memory, located in the <link linkend="project.folder.omegat"
-	  endterm="project.folder.omegat.title"/> folder of your project.</para>
+	  <para>Your translations are <emphasis>always</emphasis> stored in the
+	  <link linkend="project.folder.project.save.tmx"
+	  endterm="project.folder.project.save.tmx.title"/> file, which is the
+	  project translation memory, located in the <link
+	  linkend="project.folder.omegat" endterm="project.folder.omegat.title"/>
+	  folder of your project.</para>
 
 	  <para>Deleting the contents of the <link linkend="project.folder.target"
 	  endterm="project.folder.target.title"/> folder will
-	  <emphasis>never</emphasis> impact your translations.</para>
+	  <emphasis>never</emphasis> impact the content of your translations.</para>
 	</warning>
 
 	<para>The documents will be created in the <link
@@ -615,15 +620,14 @@
 	file and the final translated file to create a new translation memory (TMX)
 	file that will be put in the <link linkend="project.folder.tm.enforce"
 	endterm="project.folder.tm.enforce.title"/> folder of your project
-	folder. See <link linkend="windows.aligner"
-	endterm="windows.aligner.title"/> for details.</para>
+	folder. See the <link linkend="windows.aligner"
+	endterm="windows.aligner.title"/> section for details.</para>
   </section>
 
   <section id="introduction.one.more.thing">
     <title id="introduction.one.more.thing.title">Manage your projects</title>
 
     <itemizedlist>
-
       <listitem>
         <para>Translation projects are just folders containing files. You can
         create a new project for each new job, or you can add new source files
@@ -631,14 +635,15 @@
       </listitem>
 
       <listitem>
-        <para>You can access and modify the project settings with <link
+        <para>You can access and modify the project settings using <link
+        linkend="menus.project" endterm="menus.project.title"/> <link
         linkend="menus.project.properties"
         endterm="menus.project.properties.title"/>. To see the list of files in
         the project, use <link linkend="menus.project.source.files.list"
-        endterm="menus.project.source.files.list.title"/>. You can access all
-        the resource contents at any time with <link
+        endterm="menus.project.source.files.list.title"/> from the same menu.
+        You can access the contents of all resources at any time with the <link
         linkend="menus.project.access.project.contents"
-        endterm="menus.project.access.project.contents.title"/>.</para>
+        endterm="menus.project.access.project.contents.title"/> option.</para>
       </listitem>
 
       <listitem>
@@ -648,10 +653,10 @@
         OmegaT creates three translation memories that contain the state of the
         translation of the files currently in the <link
         linkend="project.folder.source" endterm="project.folder.source.title"/>
-        folder. See <link
+        folder. See the <link
         linkend="dialogs.project.properties.file.locations.exported.tms"
         endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
-        for details.</para>
+        section for details.</para>
       </listitem>
     </itemizedlist>
 	

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -2,75 +2,85 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.edit">
-  <title id="menus.edit.title">Edit</title>
+  <title id="menus.edit.title"><guimenu>Edit</guimenu></title>
 
-	<example id="example.undo.last.action">
-	  <title id="example.undo.last.action.title">Undo Last Action</title>
-	  <para>In this guide:
-	  <keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo>
-	  </para>
+  <para>This menu gives you access to segment edition commands.</para>
 
-	  <para>On Windows and Linux:
-	  <keycombo><keycap>Control</keycap><keycap>Z</keycap></keycombo>
-	  </para>
+  <example id="example.undo.last.action">
+	<title id="example.undo.last.action.title">Shortcut description example</title>
+	<para>On Windows and Linux:
+	<keycombo><keycap>Control</keycap><keycap>Z</keycap></keycombo></para>
 
-	  <para>On macOS:
-	  <keycombo><keycap>Command</keycap><keycap>Z</keycap></keycombo>
-	  </para>
-	</example>
+	<para>On macOS:
+	<keycombo><keycap>Command</keycap><keycap>Z</keycap></keycombo></para>
+
+	<para><emphasis role="bold">In this manual:</emphasis>
+	<keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></para>
+  </example>
 
   <variablelist>
     <varlistentry id="menus.edit.undo.last.action">
-      <term id="menus.edit.undo.last.action.title">Undo Last Action
+      <term id="menus.edit.undo.last.action.title"><guimenuitem>Undo Last
+      Action</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></term>
       <listitem>
-        <para>Restores the status before the last edit made in the current
-        segment. This command cannot restore that status after the user moves to
-        a different segment.</para>
+        <para>Cancels the modifications made to the segment while the segment is
+        current. Once the segment is left, the modification history is
+        lost.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.redo.last.action">
-      <term id="menus.edit.redo.last.action.title">Redo Last Action <keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
+      <term id="menus.edit.redo.last.action.title"><guimenuitem>Redo Last Action</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Restores the status before the last editing action was
-        canceled. This command cannot restore that status after the user
-        moves to a different segment.</para>
+        <para>Reapplies the modifications that were cancelled while the segment
+        is current. Once the segment is left, the modification history is
+        lost.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.match.or.selection">
-      <term id="menus.edit.replace.with.match.or.selection.title">Replace With Match or Selection		  <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>
+      <term id="menus.edit.replace.with.match.or.selection.title"><guimenuitem>Replace With Match or Selection</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Replaces the entire target segment with the currently selected
-        fuzzy match (by default the first match is selected). See <link
-        linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/> for
-        details.</para>
-        <para>Any text selected in the <link linkend="panes.fuzzy.matches"
-        endterm="panes.fuzzy.matches.title"/> pane will have priority over the
-        selected match and will replace the entire target segment.</para>
+        <para>Replaces the target segment with the currently selected fuzzy
+        match (by default the first match is selected) or with the text selected
+        in the <link linkend="panes.fuzzy.matches"
+        endterm="panes.fuzzy.matches.title"/> pane.</para>
+
+        <para>The selected text has priority over the selected match.</para>
+
+		<para>See the <link linkend="panes.fuzzy.matches"
+		endterm="panes.fuzzy.matches.title"/> pane description for
+		details..</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.match.or.selection">
-      <term id="menus.edit.insert.match.or.selection.title">Insert Match or Selection		  <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo>
-	  </term>
+      <term id="menus.edit.insert.match.or.selection.title"><guimenuitem>Insert
+      Match or Selection</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo></term>
       <listitem>
-        <para>Inserts the currently selected fuzzy match at the cursor
-        position. If part of the target segment has been selected, this function
-        overwrites the selected portion. See <link linkend="panes.fuzzy.matches"
-        endterm="panes.fuzzy.matches.title"/> for details.</para>
-		
-        <para>Any text selected in the <link linkend="panes.fuzzy.matches"
-        endterm="panes.fuzzy.matches.title"/> pane will have priority over the
-        selected match and be inserted at the cursor position.</para>
-      </listitem>
+        <para>Inserts the currently selected fuzzy match or the text selected in
+        the <link linkend="panes.fuzzy.matches"
+        endterm="panes.fuzzy.matches.title"/> pane at the cursor position. If a
+        part of the target segment has been selected, that part will be
+        overwriten.</para>
+
+        <para>The selected text has priority over the selected match.</para>
+
+		<para>See the <link linkend="panes.fuzzy.matches"
+		endterm="panes.fuzzy.matches.title"/> pane description for
+		details..</para>
+	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.source">
-      <term id="menus.edit.replace.with.source.title">Replace with Source		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>
+      <term id="menus.edit.replace.with.source.title"><guimenuitem>Replace with Source</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Replaces the entire target segment with the segment source.</para>
@@ -78,35 +88,41 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.source">
-      <term id="menus.edit.insert.source.title">Insert Source		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>
+      <term id="menus.edit.insert.source.title"><guimenuitem>Insert Source</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Inserts the segment source at the cursor position.</para>
+        <para>Inserts the segment source at the cursor position. If a part of
+        the target segment has been selected, that part will be
+        overwriten.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.mt">
-      <term id="menus.edit.replace.with.mt.title">Replace with Machine Translation		  <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
+      <term id="menus.edit.replace.with.mt.title"><guimenuitem>Replace with Machine Translation</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Replaces the target segment with the translation, provided by the
         selected Machine Translation service.</para>
-		<para>If <link
+		<para>If the <link
 		linkend="dialogs.preferences.mt.automatically.fetch.translations"
 		endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/>
-		is disabled, use this action a first time to fetch the translation and a
-		second time to insert it.</para>
+		preference is disabled, use this action a first time to fetch the
+		translation and a second time to insert it.</para>
 		
-		<para>No action is taken if no Machine
-        Translation service has been activated (in <link
-        linkend="menus.options.mt" endterm="menus.options.mt.title"/>). See 
-        <link linkend="dialogs.preferences.mt" endterm="dialogs.preferences.mt.title"/> for
-        details.</para>
+		<para>No action is taken if no machine translation service has been
+		activated in the <link linkend="menus.options"
+		endterm="menus.options.title"/><link linkend="menus.options.mt"
+		endterm="menus.options.mt.title"/> menu. See the <link
+		linkend="dialogs.preferences.mt"
+		endterm="dialogs.preferences.mt.title"/> preferences for details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.missing.source.tag">
-      <term id="menus.edit.insert.missing.source.tag.title">Insert Missing Source Tags		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo>
+      <term id="menus.edit.insert.missing.source.tag.title"><guimenuitem>Insert Missing Source Tags</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Inserts the remaining missing source tags at the cursor
@@ -115,7 +131,8 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.next.missing.tag">
-      <term id="menus.edit.insert.next.missing.tag.title">Insert Next Missing Tag		  <keycombo><keycap>C</keycap><keycap>T</keycap></keycombo>
+      <term id="menus.edit.insert.next.missing.tag.title"><guimenuitem>Insert Next Missing Tag</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>T</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Inserts the next missing tag at the cursor position.</para>
@@ -123,79 +140,117 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.export.selection">
-      <term id="menus.edit.export.selection.title">Export Selection		  <keycombo><keycap>C</keycap><keycap>C</keycap><keycap>S</keycap></keycombo>
+      <term id="menus.edit.export.selection.title"><guimenuitem>Export Selection</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>C</keycap><keycap>S</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Exports the current selection to a text file for processing. If no
         text has been selected, the current source segment is written to this
         file. To remain consistent with usual clipboard behavior this file is
         not emptied when the user exits OmegaT. The exported contents are copied
-        to the file <link
+        to the <link
         linkend="configuration.folder.default.contents.script.selection.title"
         endterm="configuration.folder.default.contents.script.selection.title"/>
-        located in the <link linkend="configuration.folder"
-        endterm="configuration.folder.title"/> folder.</para>
+        file located in the <link
+        linkend="configuration.folder">configuration</link> folder.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.create.glossary.entry">
-      <term id="menus.edit.create.glossary.entry.title">Create Glossary Entry...		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
+      <term id="menus.edit.create.glossary.entry.title"><guimenuitem>Create Glossary Entry...</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Allows the user to create an entry in <link
-        linkend="project.folder.glossary.txt"
-        endterm="project.folder.glossary.txt.title"/>.</para>
-		<para>There are two ways to use this function. The first is to call
-		the dialog and then manually fill in the various fields. The second is
-		to select items in one of the OmegaT panes and sequentially call the
-		dialog after each selection to have OmegaT enter it automatically in the
-		various fields:</para>
-		<orderedlist>
-		  <listitem><para>Select a text string in any pane</para>
-		  <para>Press
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
-		  </para>
-		  <para>The selection will be entered in the <guilabel>Source
-		  term</guilabel> field.</para></listitem>
-		  <listitem><para>Select a text string in any pane</para>
-		  <para>Press
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
-		  </para>
-		  <para>The selection will be entered in the <guilabel>Target
-		  term</guilabel> field.</para></listitem>
-		  <listitem><para>[Optional] Select a text string in any pane</para>
-		  <para>Press
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
-		  </para>
-		  <para>The selection will be entered in the
-		  <guilabel>Comment</guilabel> field. You can also enter your comment
-		  manually.</para></listitem>
-		  <listitem><para>Hit <keycap>Enter</keycap> or click on
-		  <guibutton>OK</guibutton></para></listitem>
-		</orderedlist>
+        <para>Allows the user to create an entry in the project writable
+        glossary (<link linkend="project.folder.glossary.txt"
+        endterm="project.folder.glossary.txt.title"/>).</para>
+
+		<para>There are two ways to use this function.</para>
+
+		<itemizedlist>
+		  <listitem>
+			<para>The first is to call the dialog and then manually fill
+			in the various fields.</para>
+		  </listitem>
+
+		  <listitem>
+			<para>The second is to select items in one of the OmegaT panes and
+			sequentially call the dialog after each selection to have OmegaT
+			enter it automatically in the various fields:</para>
+			
+			<orderedlist>
+			  <listitem>
+				<para>Select a text string in any pane</para>
+			  </listitem>
+
+			  <listitem>
+				<para>Press
+				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
+				
+				<para>The selection will be entered in the <guilabel>Source
+				term</guilabel> field.</para>
+			  </listitem>
+
+			  <listitem>
+				<para>Select a text string in any pane</para>
+			  </listitem>
+
+			  <listitem>
+				<para>Press
+				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
+
+				<para>The selection will be entered in the <guilabel>Target
+				term</guilabel> field.</para>
+			  </listitem>
+
+			  <listitem>
+				<para>[Optional] Select a text string in any pane</para>
+			  </listitem>
+
+			  <listitem>
+				<para>[Optional] Press
+				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
+
+				<para>The selection will be entered in the
+				<guilabel>Comment</guilabel> field.</para>
+			  </listitem>
+
+			  <listitem>
+				<para>Hit <keycap>Enter</keycap> or click on
+				<guibutton>OK</guibutton></para>
+			  </listitem>
+			</orderedlist>
+		  </listitem>
+		</itemizedlist>
 	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.search.project">
-      <term id="menus.edit.search.project.title">Search...		  <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>
+      <term id="menus.edit.search.project.title"><guimenuitem>Search...</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Opens a new <link linkend="windows.text.search" endterm="windows.text.search.title"/>.</para>
+        <para>Opens a new <link linkend="windows.text.search"
+        endterm="windows.text.search.title"/> window.</para>
+
         <para>If you select a text string (in any pane) before calling the
         function, the text will be pasted by default in the <guilabel>Search
         for:</guilabel> field.</para>
-		<para>
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>F</keycap></keycombo>
-		  reuses the most recent still open Search window (instead of opening a
+
+		<para><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>F</keycap></keycombo>
+		reuses the most recent still open Search window (instead of opening a
 		new one).</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.search.and.replace">
-      <term id="menus.edit.search.and.replace.title">Replace...		  <keycombo><keycap>C</keycap><keycap>K</keycap></keycombo>
+      <term id="menus.edit.search.and.replace.title"><guimenuitem>Replace...</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>K</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Opens a new <link linkend="windows.text.replace" endterm="windows.text.replace.title"/>.</para>
+        <para>Opens a new <link linkend="windows.text.replace"
+        endterm="windows.text.replace.title"/> window.</para>
+
         <para>If you select a text string (in any pane) before calling the
         function, the text will be pasted by default in the <guilabel>Search
         for:</guilabel> field.</para>
@@ -203,112 +258,136 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.dictionaries">
-      <term id="menus.edit.search.dictionaries.title">Search Dictionaries</term>
+      <term id="menus.edit.search.dictionaries.title"><guimenuitem>Search Dictionaries</guimenuitem></term>
       <listitem>
-        <para>If <link
+        <para>If the <link
         linkend="dialogs.preferences.dictionary.automatically.search.segment"
         endterm="dialogs.preferences.dictionary.automatically.search.segment.title"/>
-        is disabled, this function allows you to search for the selected word in
-        the dictionaries.</para>
+        preference is disabled, this function allows you to search for the
+        selected word in the dictionaries.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.switch.case">
-      <term id="menus.edit.switch.case.title">Switch case to</term>
+      <term id="menus.edit.switch.case.title"><guisubmenu>Switch case to</guisubmenu></term>
       <listitem>
         <para>Changes the case of the selected text in the target segment to the
         selected option, or cycles through the options. If no text is selected,
         OmegaT selects the word starting with the character immediately to the
         right of the cursor.</para>
+
 		<itemizedlist>
-		  <listitem><para><guimenuitem>lower case</guimenuitem></para>
-		  <para>all letters in lower case</para>
+		  <listitem>
+			<para><guimenuitem>lower case</guimenuitem></para>
+
+			<para>all letters in lower case</para>
 		  </listitem>
-		  <listitem><para><guimenuitem>UPPER CASE</guimenuitem></para>
-		  <para>ALL LETTERS IN UPPER CASE</para>
+
+		  <listitem>
+			<para><guimenuitem>UPPER CASE</guimenuitem></para>
+
+			<para>ALL LETTERS IN UPPER CASE</para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Title Case</guimenuitem></para>
-		  <para>Almost all Letters in Lower Case</para>
+
+		  <listitem>
+			<para><guimenuitem>Title Case</guimenuitem></para>
+
+			<para>Almost all Letters in Lower Case</para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Sentence case</guimenuitem></para>
-		  <para>Only the first letter in upper case.</para>
+
+		  <listitem>
+			<para><guimenuitem>Sentence case</guimenuitem></para>
+			<para>Only the first letter in upper case.</para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Cycle</guimenuitem>			<keycombo><keycap>S</keycap><keycap>F3</keycap></keycombo>
-	  </para>
+
+		  <listitem>
+			<para><guimenuitem>Cycle</guimenuitem>
+			<keycombo><keycap>S</keycap><keycap>F3</keycap></keycombo></para>
 		  </listitem>
 		</itemizedlist>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="menus.edit.select.match">
-      <term id="menus.edit.select.match.title">Select Match</term>
+      <term id="menus.edit.select.match.title"><guisubmenu>Select Match</guisubmenu></term>
       <listitem>
 		<para>Selects the previous, next or <varname>n</varname>th fuzzy match
 		displayed in the fuzzy match pane to replace or insert it to the
 		segment.</para>
+		
 		<itemizedlist>
-		  <listitem><para><guimenuitem>Select Previous Match</guimenuitem> 			<keycombo><keycap>A</keycap><keycap>↑</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+		  <listitem>
+			<para><guimenuitem>Select Previous Match</guimenuitem>
+			<keycombo><keycap>A</keycap><keycap>↑</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Next Match</guimenuitem>			<keycombo><keycap>A</keycap><keycap>↓</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+
+		  <listitem>
+			<para><guimenuitem>Select Next Match</guimenuitem>
+			<keycombo><keycap>A</keycap><keycap>↓</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Match #1</guimenuitem>			<keycombo><keycap>C</keycap><keycap>1</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+
+		  <listitem>
+			<para><guimenuitem>Select Match #1</guimenuitem>
+			<keycombo><keycap>C</keycap><keycap>1</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Match #2</guimenuitem>			<keycombo><keycap>C</keycap><keycap>2</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+		  
+		  <listitem>
+			<para><guimenuitem>Select Match #2</guimenuitem>
+			<keycombo><keycap>C</keycap><keycap>2</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Match #3</guimenuitem>			<keycombo><keycap>C</keycap><keycap>3</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+		  <listitem>
+			<para><guimenuitem>Select Match #3</guimenuitem>
+			<keycombo><keycap>C</keycap><keycap>3</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Match #4</guimenuitem>			<keycombo><keycap>C</keycap><keycap>4</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+
+		  <listitem>
+			<para><guimenuitem>Select Match #4</guimenuitem>
+			<keycombo><keycap>C</keycap><keycap>4</keycap></keycombo></para>
 		  </listitem>
-		  <listitem><para><guimenuitem>Select Match #5</guimenuitem>			<keycombo><keycap>C</keycap><keycap>5</keycap></keycombo>
-	  </para>
-	  <para>
-	  </para>
+
+		  <listitem>
+			<para><guimenuitem>Select Match #5</guimenuitem>
+			<keycombo><keycap>C</keycap><keycap>5</keycap></keycombo></para>
 		  </listitem>
 		</itemizedlist>
       </listitem>
 	</varlistentry>
 
 	<varlistentry id="menus.edit.insert.unicode.control.character">
-      <term id="menus.edit.insert.unicode.control.character.title">Insert
-      Bidirectional Control Character</term>
-	  <listitem><para>Inserts the selected bidirectional control character. See <ulink
-	  url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional Algorithm</ulink> for details.</para>
-	  <itemizedlist>
-		<listitem><para><guimenuitem>Left-to-Right Mark (LRM U+200E)</guimenuitem></para>
-		</listitem>
-		<listitem><para><guimenuitem>Right-to-Left Mark (RLM U+200F)</guimenuitem></para>
-		</listitem>
-		<listitem><para><guimenuitem>Left-to-Right Embedding (LRE U+202A)</guimenuitem></para>
-		</listitem>
-		<listitem><para><guimenuitem>Right-to-Left Embedding (RLE U+202B)</guimenuitem></para>
-		</listitem>
-		<listitem><para><guimenuitem>Pop Directional Formatting (PDF U+202C)</guimenuitem></para>
-		</listitem>
-	  </itemizedlist>
+      <term id="menus.edit.insert.unicode.control.character.title"><guisubmenu>Insert
+      Unicode Control Character</guisubmenu></term>
+	  <listitem>
+		<para>Inserts the selected Unicode control character. See <ulink
+		url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
+		Algorithm</ulink> for details.</para>
+
+		<itemizedlist>
+		  <listitem>
+			<para><guimenuitem>Left-to-Right Mark (LRM U+200E)</guimenuitem></para>
+		  </listitem>
+		
+		  <listitem>
+			<para><guimenuitem>Right-to-Left Mark (RLM U+200F)</guimenuitem></para>
+		  </listitem>
+		  
+		  <listitem>
+			<para><guimenuitem>Left-to-Right Embedding (LRE U+202A)</guimenuitem></para>
+		  </listitem>
+		  
+		  <listitem>
+			<para><guimenuitem>Right-to-Left Embedding (RLE U+202B)</guimenuitem></para>
+		  </listitem>
+		  
+		  <listitem>
+			<para><guimenuitem>Pop Directional Formatting (PDF U+202C)</guimenuitem></para>
+		  </listitem>
+		</itemizedlist>
       </listitem>
 	</varlistentry>
 
 	<varlistentry id="menus.edit.use.as.default.translation">
-      <term id="menus.edit.use.as.default.translation.title">Use as Default
-      Translation</term>
+      <term id="menus.edit.use.as.default.translation.title"><guimenuitem>Use as Default
+      Translation</guimenuitem></term>
       <listitem>
 		<para>If several alternative translations are available for the active
 		segment, you can label the alternative selected as the default
@@ -318,8 +397,9 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.create.alternative.translation">
-      <term id="menus.edit.create.alternative.translation.title">Create
-      Alternative Translation</term>
+      <term
+      id="menus.edit.create.alternative.translation.title"><guimenuitem>Create
+      Alternative Translation</guimenuitem></term>
       <listitem>
 		<para>Segments that are one and the same segment may, depending on the
 		context, require different translations. If the current translation does
@@ -329,7 +409,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.remove.translation">
-      <term id="menus.edit.remove.translation.title">Remove Translation</term>
+      <term id="menus.edit.remove.translation.title"><guimenuitem>Remove
+      Translation</guimenuitem></term>
       <listitem>
 		<para>Deletes the current translation and sets the segment as
 		untranslated.</para>
@@ -337,8 +418,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.set.empty.translation">
-      <term id="menus.edit.set.empty.translation.title">Set Empty
-      Translation</term>
+      <term id="menus.edit.set.empty.translation.title"><guimenuitem>Set Empty
+      Translation</guimenuitem></term>
       <listitem>
 		<para>Define the translation as empty. In the target document, nothing
 		will appear for this segment. In the Editor, the translation is
@@ -347,13 +428,15 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.register.identical.translation">
-      <term id="menus.edit.register.identical.translation.title">Register Identical Translation			<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo>
+      <term id="menus.edit.register.identical.translation.title"><guimenuitem>Register Identical Translation</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo>
 	  </term>
       <listitem>
 		<para>Use this command to register a translation as identical to the
-		source, even if <link
-		linkend="dialogs.preferences.editor.allow.translation.to.be.equal.to.source" endterm="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"/> is not
-		checked.</para>
+		source, even if the <link
+		linkend="dialogs.preferences.editor.allow.translation.to.be.equal.to.source"
+		endterm="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"/>
+		preference is not enabled.</para>
       </listitem>
 	</varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -2,24 +2,28 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.goto">
-  <title id="menus.goto.title">Go To</title>
+  <title id="menus.goto.title"><guimenu>Go To</guimenu></title>
 
-    <example id="example.next.untranslated.segment"><title id="example.next.untranslated.segment.title">Next Untranslated Segment</title>
-  		<para>In this guide:
-		  <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo>
-		</para>
-		<para>On Windows and Linux:
-		  <keycombo><keycap>Control</keycap><keycap>U</keycap></keycombo>
-		</para>
-		<para>On macOS:
-		  <keycombo><keycap>Command</keycap><keycap>U</keycap></keycombo>
-		</para>
-		</example>
+  <para>This menu gives you access to the segment and panes navigation commands.</para>
+
+  <example id="example.next.untranslated.segment">
+	<title id="example.next.untranslated.segment.title">Shortcut description
+	example</title>
+	<para>On Windows and Linux:
+	<keycombo><keycap>Control</keycap><keycap>U</keycap></keycombo></para>
+
+	<para>On macOS:
+	<keycombo><keycap>Command</keycap><keycap>U</keycap></keycombo></para>
+
+	<para><emphasis role="bold">In this
+	manual:</emphasis><keycombo><keycap>C</keycap><keycap>U</keycap></keycombo></para>
+  </example>
 
   <variablelist>
     <varlistentry id="menus.goto.next.untranslated.segment">
-      <term id="menus.goto.next.untranslated.segment.title">Next Untranslated Segment		  <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo>
-</term>
+      <term id="menus.goto.next.untranslated.segment.title"><guimenuitem>Next
+      Untranslated Segment</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
         <para>Moves to the next segment with no target language entry in the
@@ -28,8 +32,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.translated.segment">
-      <term id="menus.goto.next.translated.segment.title">Next Translated Segment		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>U</keycap></keycombo>
-</term>
+      <term id="menus.goto.next.translated.segment.title"><guimenuitem>Next
+      Translated Segment</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
         <para>Moves to the next already translated segment, ignoring
@@ -38,75 +43,90 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.segment">
-      <term id="menus.goto.next.segment.title">Next Segment		  <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo>
-</term>
+      <term id="menus.goto.next.segment.title"><guimenuitem>Next
+      Segment</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
 
       <listitem>
-		<para>Also:
-		  <keycombo><keycap>Enter</keycap></keycombo>
-		</para>
+		<para>Also: <keycombo><keycap>Enter</keycap></keycombo></para>
+
         <para>Moves to the next segment, or to the first segment of the next
         file if the current segment is the last one in the file.</para>
 
-        <note><para><keycap>TAB</keycap> can be used as an
-        alternate shortcut if <link
-        linkend="dialogs.preferences.general.use.tab.to.advance" endterm="dialogs.preferences.general.use.tab.to.advance.title"/> is selected.</para>
-		<para>This is useful for character entry systems that use
-		<keycap>Enter</keycap> to validate input.</para></note>
+        <note>
+		  <para><keycap>TAB</keycap> can be used as an alternate shortcut if the
+		  <link linkend="dialogs.preferences.general.use.tab.to.advance"
+		  endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
+		  preference is enabled.</para>
+		  
+		  <para>This is useful for character entry systems that use
+		  <keycap>Enter</keycap> to validate input.</para></note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.segment">
-      <term id="menus.goto.previous.segment.title">Previous Segment		  <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo>
-</term>
+      <term id="menus.goto.previous.segment.title"><guimenuitem>Previous
+      Segment</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Also:
-		  <keycombo><keycap>C</keycap><keycap>Enter</keycap></keycombo>
-		</para>
-        <para>Moves to the previous segment, or to the last segment of the previous
-        file if the current segment is the first one in the file.</para>
-		<para>
-		</para>
+		<keycombo><keycap>C</keycap><keycap>Enter</keycap></keycombo></para>
 
-        <note><para><keycombo><keycap>C</keycap><keycap>TAB</keycap></keycombo>
-        can be used as an alternate shortcut if <link
-        linkend="dialogs.preferences.general.use.tab.to.advance" endterm="dialogs.preferences.general.use.tab.to.advance.title"/> is selected.</para>
-		<para>This is useful for character entry systems that use
-		<keycap>Enter</keycap> to validate input.</para></note>
+        <para>Moves to the previous segment, or to the last segment of the
+        previous file if the current segment is the first one in the
+        file.</para>
+
+        <note>
+		  <para><keycombo><keycap>C</keycap><keycap>TAB</keycap></keycombo> can
+		  be used as an alternate shortcut if the <link
+		  linkend="dialogs.preferences.general.use.tab.to.advance"
+		  endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
+		  preference is enabled.</para>
+		  
+		  <para>This is useful for character entry systems that use
+		  <keycap>Enter</keycap> to validate input.</para>
+		</note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.segment.number">
-      <term id="menus.goto.segment.number.title">Segment number...		  <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo>
-</term>
+      <term id="menus.goto.segment.number.title"><guimenuitem>Segment
+      number...</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
       <listitem>
         <para>Jumps to the segment whose call-out or number is entered.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.next.note">
-      <term id="menus.goto.next.note.title">Next Note</term>
+      <term id="menus.goto.next.note.title"><guimenuitem>Next
+      Note</guimenuitem></term>
       <listitem>
-        <para>Moves to the next segment with a note.</para>      </listitem>
+		<para>Moves to the next segment with a note.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.note">
-      <term id="menus.goto.previous.note.title">Previous Note</term>
+      <term id="menus.goto.previous.note.title"><guimenuitem>Previous
+      Note</guimenuitem></term>
       <listitem>
-        <para>Moves to the previous segment with a note.</para>      </listitem>
+		<para>Moves to the previous segment with a note.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.next.unique.segment">
-      <term id="menus.goto.next.unique.segment.title">Next Unique Segment		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>K</keycap></keycombo>
-</term>
+      <term id="menus.goto.next.unique.segment.title"><guimenuitem>Next Unique
+      Segment</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>K</keycap></keycombo></term>
       <listitem>
         <para>Moves to the next unique segment.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.source.of.selected.match">
-      <term id="menus.goto.source.of.selected.match.title">Source of Selected Match		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>M</keycap></keycombo>
-</term>
+      <term id="menus.goto.source.of.selected.match.title"><guimenuitem>Source
+      of Selected Match</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>M</keycap></keycombo></term>
       <listitem>
         <para>Moves to the segment that corresponds to the currently
         selected match in the <guilabel>Fuzzy matches</guilabel> pane.</para>
@@ -114,22 +134,50 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.forward.in.history">
-      <term id="menus.goto.forward.in.history.title">Forward in History		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
-</term>
+      <term id="menus.goto.forward.in.history.title"><guimenuitem>Forward in
+      History</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
-        <para>This command allows you to move forward one segment at a time to segments that you have previously visited with <link
-		linkend="menus.goto.back.in.history"
-		endterm="menus.goto.back.in.history.title"/>.</para>
+
+        <para>This command allows you to move forward one segment at a time to
+        segments that you have previously visited with <link
+        linkend="menus.goto"
+        endterm="menus.goto.title"/><link
+        linkend="menus.goto.back.in.history"
+        endterm="menus.goto.back.in.history.title"/>.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.back.in.history">
-      <term id="menus.goto.back.in.history.title">Back in History		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo>
-</term>
+      <term id="menus.goto.back.in.history.title"><guimenuitem>Back in
+      History</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
-        <para>This command allows you to move backward one segment at a time to segments that you have previously visited.</para>
+        <para>This command allows you to move backward one segment at a time to
+        segments that you have previously visited.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.goto.notes.pane">
+      <term id="menus.goto.notes.pane.title"><guimenuitem>Notes Pane</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
+      <listitem>
+        <para>Enter the <link linkend="panes.notes"
+        endterm="panes.notes.title"/> pane to write or modify a note associated
+        to the current segment.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.goto.editor.pane">
+      <term id="menus.goto.editor.pane.title"><guimenuitem>Editor
+      Pane</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>E</keycap></keycombo></term>
+      <listitem>
+        <para>Enter the <link linkend="panes.editor"
+        endterm="panes.editor.title"/> pane to proceed with your
+        translation.</para>
       </listitem>
     </varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_Help.xml
+++ b/doc_src/en/Menus_Help.xml
@@ -1,43 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.help">
-  <title id="menus.help.title">Help</title>
+  <title id="menus.help.title"><guimenu>Help</guimenu></title>
+
+  <para>This menu gives you access to information that will help you make the
+  best of OmegaT.</para>
 
   <variablelist>
     <varlistentry id="menus.help.user.manual">
-      <term id="menus.help.user.manual.title">User Guide...		  <keycombo><keycap>F1</keycap></keycombo>
-</term>
+      <term id="menus.help.user.manual.title"><guimenuitem>User
+      Manual...</guimenuitem> <keycombo><keycap>F1</keycap></keycombo></term>
       <listitem>
-        <para>Opens this guide in the default browser.</para>
-		<para>
-		</para>
-      </listitem>
+        <para>Opens this manual in the default browser.</para>
+    </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.about">
-      <term id="menus.help.about.title">About...</term>
+      <term
+      id="menus.help.about.title"><guimenuitem>About...</guimenuitem></term>
       <listitem>
-        <para>Displays copyright, credits and license information.</para>      </listitem>
+        <para>Displays copyright, credits and license information.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.last.changes">
-      <term id="menus.help.last.changes.title">Last Changes...</term>
+      <term id="menus.help.last.changes.title"><guimenuitem>Last
+      Changes...</guimenuitem></term>
       <listitem>
-        <para>Displays the list of new functionality, enhancements and bug fixes for each new release.</para>
+        <para>Displays the list of new functionality, enhancements and bug fixes
+        for each new release.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.log">
-      <term id="menus.help.log.title">Log...</term>
+      <term id="menus.help.log.title"><guimenuitem>Log...</guimenuitem></term>
       <listitem>
-        <para>Displays the current log file. The title of the dialog reflects the file currently in use (which depends on the number of concurrently running OmegaT instances).</para>
+        <para>Displays the current log file. The title of the dialog reflects
+        the file currently in use (which depends on the number of concurrently
+        running OmegaT instances).</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.check.for.updates">
-      <term id="menus.help.check.for.updates.title">Check for Updates...</term>
+      <term id="menus.help.check.for.updates.title"><guimenuitem>Check for
+      Updates...</guimenuitem></term>
       <listitem>
-        <para>Checks to see if a newer version of OmegaT is available.</para>      </listitem>
+        <para>Checks to see if a newer version of OmegaT is available.</para>
+      </listitem>
     </varlistentry>
   </variablelist>
 </section>

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -1,97 +1,147 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.options">
-  <title id="menus.options.title">Options</title>
+  <title id="menus.options.title"><guimenu>Options</guimenu></title>
 
+  <para>This menu gives quick access to a few frequently used
+  preferences.</para>
+  
   <variablelist>
     <varlistentry id="menus.options.preferences">
-      <term id="menus.options.preferences.title">Preferences...</term>
+      <term id="menus.options.preferences.title"><guimenuitem>Preferences...</guimenuitem></term>
       <listitem>
-        <para>Opens the <link linkend="dialogs.preferences"
-        endterm="dialogs.preferences.title"/> dialog.</para>
-		<note><para>In macOS, this menu item is found under the
-		<guimenu>OmegaT</guimenu> menu.</para></note>
+        <para>Opens the <link linkend="chapter.dialogs.preferences"
+        endterm="chapter.dialogs.preferences.title"/> dialog.</para>
+
+		<note>
+		  <para>In macOS, this menu item is found under the
+		  <guimenu>OmegaT</guimenu> menu.</para>
+		</note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.mt">
-      <term id="menus.options.mt.title">Machine Translation</term>
+      <term id="menus.options.mt.title"><guisubmenu>Machine Translation</guisubmenu></term>
       <listitem>
-        <para>Select <link linkend="dialogs.preferences.mt.automatically.fetch.translations"
-        endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/> to activate it.</para>
+		<itemizedlist>
+		  <listitem>
+			<para><link linkend="dialogs.preferences.mt.automatically.fetch.translations"
+        endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/></para>
+		  </listitem>
+		</itemizedlist>
+
 		<para>Allows you to activate/deactivate the available machine
 		translation engines.</para>
+
         <para>If several translation engines are selected, you can also use
         <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo> to switch
-        between them and insert the last one selected. See <link
+        between them and insert the last one selected. See the <link
         linkend="dialogs.preferences.mt"
-        endterm="dialogs.preferences.mt.title"/> for details.</para>
+        endterm="dialogs.preferences.mt.title"/> preferences for details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.glossary">
-      <term id="menus.options.glossary.title">Glossary</term>
+      <term
+      id="menus.options.glossary.title"><guisubmenu>Glossary</guisubmenu></term>
       <listitem>
-        <para>Select <link linkend="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries" endterm="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"/> to activate it.</para>
+		<itemizedlist>
+		  <listitem>
+			<para><link linkend="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries" endterm="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"/></para>
+		  </listitem>
+		</itemizedlist>
+
+        <para>Allows you to activate/deactivate fuzzy matching for glossary
+        maches.</para>
+
+		<para>See the <link linkend="dialogs.preferences.glossary"
+		endterm="dialogs.preferences.glossary.title"/> preferences for
+		details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.dictionary">
-      <term id="menus.options.dictionary.title">Dictionary</term>
+      <term
+      id="menus.options.dictionary.title"><guisubmenu>Dictionary</guisubmenu></term>
       <listitem>
-        <para>Select <link linkend="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries" endterm="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"/> to activate it.</para>
+		<itemizedlist>
+		  <listitem>
+			<para><link linkend="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries" endterm="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"/></para>
+		  </listitem>
+		</itemizedlist>
+
+        <para>Allows you to activate/deactivate fuzzy matching for dictionary
+        maches.</para>
+
+		<para>See the <link linkend="dialogs.preferences.dictionary"
+		endterm="dialogs.preferences.dictionary.title"/> preferences for
+		details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.autocompletion">
-      <term id="menus.options.autocompletion.title">Auto-Completion</term>
+      <term
+      id="menus.options.autocompletion.title"><guisubmenu>Auto-Completion</guisubmenu></term>
       <listitem>
-      <para>Select the various options to activate them. See <link
-      linkend="dialog.preferences.auto.completion"
-      endterm="dialog.preferences.auto.completion.title"/> for details.</para></listitem>
+		<para>Select the various options to activate/deactivate them. See the
+		<link linkend="dialog.preferences.auto.completion"
+		endterm="dialog.preferences.auto.completion.title"/> preferences for
+		details.</para>
+	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.file.filters">
-      <term id="menus.options.file.filters.title">Global File Filters...</term>
+      <term id="menus.options.file.filters.title"><guimenuitem>Global File
+      Filters...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.file.filters"
-        endterm="dialogs.preferences.file.filters.title"/> global preference
-        dialog.</para>
-        <para>Project-specific settings are accessible with <link
-        linkend="menus.project.properties"
-        endterm="menus.project.properties.title"/>.</para>
+        endterm="dialogs.preferences.file.filters.title"/> preferences.</para>
+
+        <para>Use <link linkend="menus.project"
+        endterm="menus.project.title"/><link linkend="menus.project.properties"
+        endterm="menus.project.properties.title"/> to access the local file
+        filter preferences.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.segmentation">
-      <term id="menus.options.segmentation.title">Global Segmentation Rules...</term>
+      <term id="menus.options.segmentation.title"><guimenuitem>Global
+      Segmentation Rules...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.segmentation.setup"
-        endterm="dialogs.preferences.segmentation.setup.title"/> global
-        preference dialog.</para>
-        <para>Project-specific settings are accessible with <link
-        linkend="menus.project.properties"
-        endterm="menus.project.properties.title"/>.</para>
+        endterm="dialogs.preferences.segmentation.setup.title"/>
+        preferences.</para>
+
+        <para>Use <link linkend="menus.project"
+        endterm="menus.project.title"/><link linkend="menus.project.properties"
+        endterm="menus.project.properties.title"/> to access the local
+        segmentation rules preferences.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.editor">
-      <term id="menus.options.editor.title">Editor...</term>
+      <term
+      id="menus.options.editor.title"><guimenuitem>Editor...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.editor"
-        endterm="dialogs.preferences.editor.title"/> global preferences dialog.</para>
+        endterm="dialogs.preferences.editor.title"/> preferences.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.access.configuration.folder">
-      <term id="menus.options.access.configuration.folder.title">Access
-      Configuration Folder</term>
+      <term
+      id="menus.options.access.configuration.folder.title"><guimenuitem>Access
+      Configuration Folder</guimenuitem></term>
       <listitem>
         <para>Opens the local folder where OmegaT configuration files are
         stored.</para>
-		<note><para>The location depends on the operating system and launch
-		options. See <link linkend="configuration.folder"
-		endterm="configuration.folder.title"/> for details.</para></note>
+
+		<note>
+		  <para>The location depends on the operating system and launch
+		  options. See the <link linkend="configuration.folder"
+		  endterm="configuration.folder.title"/> appendix for details.</para>
+		</note>
       </listitem>
     </varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -2,47 +2,59 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.project">
-  <title id="menus.project.title">Project</title>
-      <example id="example.new.project.shortcut"><title id="example.new.project.shortcut.title">New...</title>
-  		<para>In this guide:
-		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
-		</para>
-		<para>On Windows and Linux:
-		  <keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo>
-		</para>
-		<para>On macOS:
-		  <keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>N</keycap></keycombo>
-		</para>
-		</example>
+  <title id="menus.project.title"><guimenu>Project</guimenu></title>
+  <para>This menu gives you access to project management commands.</para>
+
+  <example id="example.new.project.shortcut">
+	<title id="example.new.project.shortcut.title">Shortcut description
+	example</title>
+	<para>On Windows and Linux:
+	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo>
+	</para>
+
+	<para>On macOS:
+	<keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>N</keycap></keycombo>
+	</para>
+
+	<para><emphasis role="bold">In this manual:</emphasis>
+	<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
+	</para>
+  </example>
   
   <variablelist>
     <varlistentry id="menus.project.new">
-      <term id="menus.project.new.title">New...		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
-</term>
+      <term id="menus.project.new.title"><guimenuitem>New...</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
+	  </term>
       <listitem>
-        <para>Creates and opens a new project. See <link
-        linkend="introduction.create.and.open.new.project" endterm="introduction.create.and.open.new.project.title"/> for details.</para>
+        <para>Creates and opens a new project. See the <link
+        linkend="introduction.create.and.open.new.project"
+        endterm="introduction.create.and.open.new.project.title"/> section for
+        details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.download.team.project">
-      <term id="menus.project.download.team.project.title">Download Team Project...</term>
+      <term id="menus.project.download.team.project.title"><guimenuitem>Download
+      Team Project...</guimenuitem></term>
       <listitem>
-        <para>Creates a local copy of a remote OmegaT project. See <link
+        <para>Creates a local copy of a remote OmegaT project. See the <link
         linkend="how.to.use.team.project"
-        endterm="how.to.use.team.project.title"/> for details.</para>
+        endterm="how.to.use.team.project.title"/> how-to for details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.open">
-      <term id="menus.project.open.title">Open... <keycombo><keycap>C</keycap><keycap>O</keycap></keycombo></term>
+      <term id="menus.project.open.title"><guimenuitem>Open...</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>O</keycap></keycombo></term>
       <listitem>
         <para>Opens a previously created project.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.open.recent">
-      <term id="menus.project.open.recent.title">Open Recent...</term>
+      <term id="menus.project.open.recent.title"><guimenuitem>Open
+      Recent...</guimenuitem></term>
       <listitem>
         <para>Gives access to the last ten edited projects. Clicking one will
         save the current project, close it and open the selected project.</para>
@@ -52,47 +64,51 @@
     </varlistentry>
 
     <varlistentry id="menus.project.reload">
-      <term id="menus.project.reload.title">Reload		  <keycombo><keycap>F5</keycap></keycombo>
-</term>
+      <term id="menus.project.reload.title"><guimenuitem>Reload</guimenuitem>
+	  <keycombo><keycap>F5</keycap></keycombo></term>
       <listitem>
         <para>Reloads the project to take external changes in source files and
         project settings into account.</para>
         <note><para>New translation memories placed in the <link
         linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder
-        while translating are loaded automatically as soon as the cursor moves
-        from one segment to another. Similarly, the contents of the <link
-        linkend="project.folder.glossary"
+        while translating are automatically taken into account as soon as the
+        cursor moves from one segment to another. Similarly, the contents of the
+        <link linkend="project.folder.glossary"
         endterm="project.folder.glossary.title"/> folder are automatically
         recognized and do not require reloading the project.</para></note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.close">
-      <term id="menus.project.close.title">Close		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>W</keycap></keycombo>
-</term>
+      <term id="menus.project.close.title"><guimenuitem>Close</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>W</keycap></keycombo></term>
       <listitem>
-        <para>Saves the project translation memory and closes the project. See
-        <link linkend="project.folder.project.save.tmx" endterm="project.folder.project.save.tmx.title"/> for details.</para>
+        <para>Saves the project translation memory (<link
+        linkend="project.folder.project.save.tmx"
+        endterm="project.folder.project.save.tmx.title"/>) and closes the
+        project.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.save">
-      <term id="menus.project.save.title">Save		  <keycombo><keycap>C</keycap><keycap>S</keycap></keycombo>
-</term>
+      <term id="menus.project.save.title"><guimenuitem>Save</guimenuitem>
+	  <keycombo><keycap>C</keycap><keycap>S</keycap></keycombo></term>
       <listitem>
-        <para>Saves the project translation memory. See <link
+        <para>Saves the project translation memory (<link
         linkend="project.folder.project.save.tmx"
-        endterm="project.folder.project.save.tmx.title"/> for details.</para>
+        endterm="project.folder.project.save.tmx.title"/>).</para>
 		<para>OmegaT automatically saves translations every 3 minutes as well as
-		when you close the project or quit OmegaT. See <link
+		when you close the project or quit OmegaT. See the <link
 		linkend="dialog.preferences.saving.and.output.interval"
-		endterm="dialog.preferences.saving.and.output.interval.title"/> for
-		details.</para>
+		endterm="dialog.preferences.saving.and.output.interval.title"/>
+		preference for details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.copy.files.to.source.folder">
-      <term id="menus.project.copy.files.to.source.folder.title">Add Files...</term>
+      <term
+		  id="menus.project.copy.files.to.source.folder.title"><guimenuitem>Add
+      Files...</guimenuitem></term>
       <listitem>
         <para>Copies the selected files to the <link
         linkend="project.folder.source" endterm="project.folder.source.title"/>
@@ -102,46 +118,70 @@
     </varlistentry>
 
     <varlistentry id="menus.project.download.mediawiki.page">
-      <term id="menus.project.download.mediawiki.page.title">Add Online MediaWiki Page...</term>
+      <term id="menus.project.download.mediawiki.page.title"><guimenuitem>Add
+      Online MediaWiki Page...</guimenuitem></term>
       <listitem>
-		<para>Opens a dialog where you can paste the URL of the Mediawiki page you want to translate. The source data of the page will be copied into the <link
-        linkend="project.folder.source" endterm="project.folder.source.title"/> folder, as a text file, with the <filename>.utf8</filename> extension.</para>
+		<para>Opens a dialog where you can paste the URL of the Mediawiki page
+		you want to translate. The source data of the page will be copied into
+		the <link linkend="project.folder.source"
+		endterm="project.folder.source.title"/> folder, as a text file, with the
+		<filename>.utf8</filename> extension.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.commit.source.files">
-      <term id="menus.project.commit.source.files.title">Commit Source Files</term>
+      <term id="menus.project.commit.source.files.title"><guimenuitem>Commit
+      Source Files</guimenuitem></term>
       <listitem>
-        <warning><para>This function is specific to team projects. <emphasis>Only the team project manager should use this function</emphasis>. See <link linkend="how.to.use.team.project" endterm="how.to.use.team.project.title"/> for details.</para></warning>
-        <para>Uploads locally added or modified files from the <filename class="directory">source</filename> folder to the team project repository.</para>
+        <warning><para>This function is specific to team
+        projects. <emphasis>Only the team project manager should use this
+        function</emphasis>. See the <link linkend="how.to.use.team.project"
+        endterm="how.to.use.team.project.title"/> how-to for details.</para></warning>
+        <para>Uploads locally added or modified files from the <filename
+        class="directory">source</filename> folder to the team project
+        repository.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.commit.target.files">
-      <term id="menus.project.commit.target.files.title">Commit Target Files</term>
+      <term id="menus.project.commit.target.files.title"><guimenuitem>Commit
+      Target Files</guimenuitem></term>
       <listitem>
-        <warning><para>This function is specific to team projects. <emphasis>Use this function only if the team project manager requested so</emphasis>. See <link linkend="how.to.use.team.project" endterm="how.to.use.team.project.title"/> for details.</para></warning>
-        <para>Uploads locally created files from the <link linkend="project.folder.target"
-        endterm="project.folder.target.title"/> folder to the team project repository.</para>
+        <warning><para>This function is specific to team projects. <emphasis>Use
+        this function only if the team project manager requested
+        so</emphasis>. See the <link linkend="how.to.use.team.project"
+        endterm="how.to.use.team.project.title"/> how-to for details.</para></warning>
+        <para>Uploads locally created from the <link
+        linkend="project.folder.target" endterm="project.folder.target.title"/>
+        folder to the team project repository.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.create.translated.documents">
-      <term id="menus.project.create.translated.documents.title">Create Translated Files <keycombo><keycap>C</keycap><keycap>D</keycap></keycombo>
-</term>
+      <term
+		  id="menus.project.create.translated.documents.title"><guimenuitem>Create
+      Translated Files</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
-        <para>Creates the target files based on your translation. The
-        created target files are located in the <link
-        linkend="project.folder.target" endterm="project.folder.target.title"/> folder.</para>
-		<note><para>You can block target file creation if tag issues are found. See <link linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues" endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/> for details.</para></note>
+        <para>Creates the target files based on your translation. The created
+        target files are located in the <link linkend="project.folder.target"
+        endterm="project.folder.target.title"/> folder.</para>
+		<note><para>You can block target file creation if tag issues are
+		found. See the <link
+		linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"
+		endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/>
+		preference for details.</para></note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.create.current.translated.document">
-      <term id="menus.project.create.current.translated.document.title">Create Current Translated File		  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>D</keycap></keycombo>
-</term>
+      <term
+		  id="menus.project.create.current.translated.document.title"><guimenuitem>Create
+      Current Translated File</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
-        <para>Creates the target file corresponding to source file currently being translated. The resulting file is located in the <link
+        <para>Creates the target file corresponding to source file currently
+        being translated. The resulting file is located in the <link
         linkend="project.folder.target" endterm="project.folder.target.title"/>
         folder.</para>
 		<para>
@@ -150,7 +190,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open.med.project">
-      <term id="menus.project.open.med.project.title">Open MED Project...</term>
+      <term id="menus.project.open.med.project.title"><guimenuitem>Open MED
+      Project...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
         <para>Opens a project package in the MED format defined by the EU
@@ -159,7 +200,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.med.project">
-      <term id="menus.project.create.med.project.title">Create MED Projects...</term>
+      <term id="menus.project.create.med.project.title"><guimenuitem>Create MED
+      Projects...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
         <para>Converts the current project into a MED package.</para>
@@ -167,107 +209,158 @@
     </varlistentry>
 
     <varlistentry id="menus.project.properties">
-      <term id="menus.project.properties.title">Properties...		  <keycombo><keycap>C</keycap><keycap>E</keycap></keycombo>
-</term>
+      <term
+		  id="menus.project.properties.title"><guimenuitem>Properties...</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>E</keycap></keycombo></term>
       <listitem>
-        <para>Displays the <link linkend="dialogs.project.properties" endterm="dialogs.project.properties.title"/> dialog to edit the project languages and folder
-        locations.</para>
+        <para>Displays the <link linkend="dialogs.project.properties"
+        endterm="dialogs.project.properties.title"/> dialog to edit the project
+        languages and folder locations.</para>
 		<para>
 		</para>		
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.source.files.list">
-      <term id="menus.project.source.files.list.title">Source Files...		  <keycombo><keycap>C</keycap><keycap>L</keycap></keycombo>
-</term>
+      <term id="menus.project.source.files.list.title"><guimenuitem>Source
+      Files...</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>L</keycap></keycombo></term>
       <listitem>
-        <para>Opens the <link linkend="windows.source.files.list" endterm="windows.source.files.list.title"/> window.</para>
+        <para>Opens the <link linkend="windows.source.files.list"
+        endterm="windows.source.files.list.title"/> window.</para>
 		<para>
 		</para>				
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.access.project.contents">
-      <term id="menus.project.access.project.contents.title">Access Project
-      Contents</term>
+      <term id="menus.project.access.project.contents.title"><guisubmenu>Access
+      Project Contents</guisubmenu></term>
       <listitem>
-        <para>Gives access to the various project folders. See <link
-        linkend="project.folder" endterm="project.folder.title"/> for more details.</para>
-        <para>In addition, there are three menu entries that directly open the current
-        source or target files, or the writable glossary. The files are
-        opened in the default application set by the operating system. The options are grayed out if the files do not exist.</para>
+        <para>Gives access to the various project folders. See the <link
+        linkend="chapter.project.folder"
+        endterm="chapter.project.folder.title"/> chapter for more
+        details.</para>
+        <para>In addition, there are three menu entries that directly open the
+        current source or target files, or the writable glossary. The files are
+        opened in the default application set by the operating system. The
+        options are grayed out if the files do not exist.</para>
 
 		<variablelist>
 		  <varlistentry>
-			<term><link linkend="project.folder">Project Folder</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link linkend="chapter.project.folder"><guimenuitem>Project
+			Folder</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term><link linkend="project.folder.dictionary">Dictionaries</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link
+			linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term><link linkend="project.folder.glossary">Glossaries</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link
+			linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term><link linkend="project.folder.source">Source Files</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link linkend="project.folder.source"><guimenuitem>Source
+			Files</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term><link linkend="project.folder.target">Target Files</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link linkend="project.folder.target"><guimenuitem>Target
+			Files</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term><link linkend="project.folder.tm">TMs</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link
+			linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+		  
 		  <varlistentry>
-			<term><link linkend="project.folder.exported.tm">Exported TMs</link></term>
-			<listitem><para>Opens the folder in your file management application</para></listitem>
+			<term><link
+			linkend="project.folder.exported.tm"><guimenuitem>Exported
+			TMs</guimenuitem></link></term>
+			<listitem>
+			  <para>Opens the folder in your file management application</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term>Current Source File</term>
+			<term><guimenuitem>Current Source File</guimenuitem></term>
 			<listitem>
 			  <para>The current source file is located in the <link
 			  linkend="project.folder.source"
 			  endterm="project.folder.source.title"/> folder.</para>
-			<para>Opens the file in its associated application if it exists.</para></listitem>
+
+			  <para>Opens the file in its associated application.</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term>Current Target File</term>
+			<term><guimenuitem>Current Target File</guimenuitem></term>
 			<listitem>
 			  <para>The current target file is located in the <link
 			  linkend="project.folder.target"
 			  endterm="project.folder.target.title"/> folder.</para>
-			<para>Opens the file in its associated application if it exists.</para></listitem>
+
+			  <para>Opens the file in its associated application if it exists.</para>
+			</listitem>
 		  </varlistentry>
+
 		  <varlistentry>
-			<term>Writable Glossary</term>
+			<term><guimenuitem>Writable Glossary</guimenuitem></term>
 			<listitem>
 			  <para>The writable glossary is located in the <link
-			  linkend="project.folder.glossary" endterm="project.folder.glossary.title"/> folder.</para>
-			<para>Opens the file in its associated application, if it exists.</para></listitem>
+			  linkend="project.folder.glossary"
+			  endterm="project.folder.glossary.title"/> folder.</para>
+
+			  <para>Opens the file in its associated application, if it exists.</para>
+			</listitem>
 		  </varlistentry>
 		</variablelist>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.restart">
-      <term id="menus.project.restart.title">Restart</term>
+      <term
+      id="menus.project.restart.title"><guimenuitem>Restart</guimenuitem></term>
       <listitem>
-        <para>Saves the project and restarts OmegaT. You are asked to confirm that you really want to quit if you have not yet saved the project.</para>
+        <para>Saves the project and restarts OmegaT. You are asked to confirm
+        that you really want to quit if you have not yet saved the
+        project.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.quit">
-      <term id="menus.project.quit.title">Quit		  <keycombo><keycap>C</keycap><keycap>Q</keycap></keycombo>
-</term>
+      <term id="menus.project.quit.title"><guimenuitem>Quit</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>Q</keycap></keycombo></term>
       <listitem>
         <para>Saves the project and quits OmegaT. You are asked to confirm that
         you really want to quit if you have not yet saved the project.</para>
-		<note><para>In macOS, this menu item is found under the
-		<guimenu>OmegaT</guimenu> menu.</para></note>
+
+		<note>
+		  <para>In macOS, this menu item is found under the
+		  <guimenu>OmegaT</guimenu> menu.</para>
+		</note>
       </listitem>
     </varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -2,85 +2,111 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.tools">
-  <title id="menus.tools.title">Tools</title>
+  <title id="menus.tools.title"><guimenu>Tools</guimenu></title>
 
-	<example id="example.check.issues"><title id="example.check.issues.title">Check Issues...</title>
-	<para>In this manual:
-	<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo>
-	</para>
+  <para>This menu gives you access to a number of tools, including QA
+  validation, match reports, an aligner, scripting, etc.</para>
+
+  <example id="example.check.issues">
+	<title id="example.check.issues.title">Shortcut description example</title>
 	<para>On Windows and Linux:
-	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>V</keycap></keycombo>
-	</para>
+	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>V</keycap></keycombo></para>
+
 	<para>On macOS:
-	<keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>V</keycap></keycombo>
-	</para>
-	</example>
+	<keycombo><keycap>Shift</keycap><keycap>Command</keycap><keycap>V</keycap></keycombo></para>
+
+	<para><emphasis role="bold">In this manual:</emphasis>
+	<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo></para>
+  </example>
 
   <variablelist>
     <varlistentry id="menus.tools.check.issues">
-      <term id="menus.tools.check.issues.title">Check Issues...	<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo>
-</term>
+      <term id="menus.tools.check.issues.title"><guimenuitem>Check
+      Issues...</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo></term>
       <listitem>
         <para>This quality assurance tool carries out all automatic checks in
         one go and displays the results in a window.</para>
+
         <para>Four types of issues can be detected:</para>
+
         <itemizedlist>
           <listitem>
             <para><guilabel>Tag Issues</guilabel> (always selected): detects
-            missing or displaced tags, including custom tags and flagged text. See <link linkend="dialogs.preferences.tag.processing"
-            endterm="dialogs.preferences.tag.processing.title"/> for details.
-            The option is always selected.</para>
+            missing or displaced tags, including custom tags and flagged
+            text. See the <link linkend="dialogs.preferences.tag.processing"
+            endterm="dialogs.preferences.tag.processing.title"/> preferences for
+            details.</para>
+
+			<note>
+			  <para>The option is always selected.</para>
+			</note>
           </listitem>
+
           <listitem>
             <para><guilabel>Spelling Issues</guilabel> (optional): detects
             spelling mistakes. Only works if a spelling dictionary is
-            installed. See <link linkend="dialog.preferences.spellchecker"
-            endterm="dialog.preferences.spellchecker.title"/> for
+            installed. See the <link linkend="dialog.preferences.spellchecker"
+            endterm="dialog.preferences.spellchecker.title"/> preferences for
             details.</para>
           </listitem>
+
           <listitem>
             <para><guilabel>Terminology Issues</guilabel> (optional): detects
-            all the glossary items that are not properly translated. See <link
-            linkend="dialogs.preferences.glossary"
-            endterm="dialogs.preferences.glossary.title"/> for details.</para>
-          </listitem>
-          <listitem>
-            <para><guilabel>LanguageTool Issues</guilabel> (optional): detects
-            grammatical or typographical issues. See <link
-            linkend="dialog.preferences.languagetool.plugin"
-            endterm="dialog.preferences.languagetool.plugin.title"/> for
+            all the glossary items that are not properly translated. See the
+            <link linkend="dialogs.preferences.glossary"
+            endterm="dialogs.preferences.glossary.title"/> preferences for
             details.</para>
           </listitem>
+
+		  <listitem>
+            <para><guilabel>LanguageTool Issues</guilabel> (optional): detects
+            grammatical or typographical issues. See the <link
+            linkend="dialog.preferences.languagetool.plugin"
+            endterm="dialog.preferences.languagetool.plugin.title"/> preferences
+            for details.</para>
+          </listitem>
         </itemizedlist>
+
         <para>The results are presented as a table in which:</para>
         <itemizedlist>
           <listitem>
             <para>double-clicking a row activates the corresponding segment in
             the Editor pane,</para>
           </listitem>
+
           <listitem>
-            <para>clicking a column header changes the sort order for that column,</para>
+            <para>clicking a column header changes the sort order for that
+            column,</para>
           </listitem>
+
           <listitem>
             <para>selecting a row, or moving the mouse over it, displays a
             context menu icon in the last column; clicking that icon presents
             actions available to correct or ignore the error.</para>
-			<note><para>You can force issue checking each time you leave a
-			segment (see <link
-			linkend="dialogs.preferences.editor.validate.tags.when.leaving.a.segment"
-			endterm="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"/>)
-			and block translated files creation if tag issues are found (see
-			<link
-			linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"
-			endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/>).</para></note>
+
+			<note>
+			  <para>To force issue checking each time you leave a segment,
+			  enable the <link
+			  linkend="dialogs.preferences.editor.validate.tags.when.leaving.a.segment"
+			  endterm="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"/>
+			  preference.</para>
+
+			  <para>To block translated files creation if tag issues are found,
+			  enable the <link
+			  linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"
+			  endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/>
+			  preference.</para>
+			</note>
           </listitem>
         </itemizedlist>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.tools.check.issues.for.current.document">
-      <term id="menus.tools.check.issues.for.current.document.title">Check
-      Issues for Current File</term>
+      <term
+      id="menus.tools.check.issues.for.current.document.title"><guimenuitem>Check
+      Issues for Current File</guimenuitem></term>
       <listitem>
         <para>As above, but only for the document currently displayed in the
         Editor pane.</para>
@@ -88,66 +114,108 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.statistics">
-      <term id="menus.tools.statistics.title">Statistics</term>
+      <term
+      id="menus.tools.statistics.title"><guimenuitem>Statistics</guimenuitem></term>
       <listitem>
         <para>Opens a new window and displays project statistics such as the
         overall project word count or segment totals, and totals for every file
         in the project.</para>
-		<para>The data is also saved as a text file in <link
+
+		<para>The data is saved in the <link
+		linkend="project.folder.project.stats"
+		endterm="project.folder.project.stats.title"/> file located in the <link
 		linkend="project.folder.omegat.folder"
-		endterm="project.folder.omegat.folder.title"/>.</para>
-		<note><para>Word count, segment total and other items can be influenced by the following factors:
-		<itemizedlist>
-		  <listitem>
-			<para>File filter settings: some filters allow for extra parts to be considered for translation. See <link linkend="filters.options" endterm="filters.options.title"/> for details.</para>
-		  </listitem>
-		  <listitem>
-			<para>Segmentation rules: different rules will generate a different number of segment. See <link linkend="app.segmentation" endterm="app.segmentation.title"/> for details.</para>
-		  </listitem>
-		  <listitem>
-			<para>Tags: OmegaT tags are never counted in the statistics but in some cases can split terms and create discrepancies in the way OmegaT counts them. See <link linkend="dialogs.project.properties.remove.tags" endterm="dialogs.project.properties.remove.tags.title"/> for details.</para>
-		  </listitem>
-		  <listitem>
-			<para>Custom tags and flagged text: as for OmegaT tags, they are not counted by default in the statistics, but you can have OmegaT count them as words. See <link linkend="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics" endterm="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"/> for details.</para>
-		  </listitem>
-		</itemizedlist>
-		</para></note>
+		endterm="project.folder.omegat.folder.title"/> folder of the
+		project.</para>
+
+		<note>
+		  <para>Word count, segment total and other items can be influenced by
+		  the following factors:</para>
+		  
+		  <itemizedlist>
+			<listitem>
+			  <para>File filter settings: some filters allow for extra parts to
+			  be considered for translation. See the file filter <link
+			  linkend="filters.options">options</link> for details.</para>
+			</listitem>
+
+			<listitem>
+			  <para>Segmentation rules: different rules will generate a
+			  different number of segment. See the <link
+			  linkend="app.segmentation" endterm="app.segmentation.title"/>
+			  appendix for details.</para>
+			</listitem>
+
+			<listitem>
+			  <para>Tags: OmegaT tags are never counted in the statistics but in
+			  some cases can split terms and create discrepancies in the way
+			  OmegaT counts them. See the <link
+			  linkend="dialogs.project.properties.remove.tags"
+			  endterm="dialogs.project.properties.remove.tags.title"/>
+			  preference in the <link linkend="dialogs.project.properties"
+			  endterm="dialogs.project.properties.title"/> dialog for
+			  details.</para>
+			</listitem>
+
+			<listitem>
+			  <para>Custom tags and flagged text: as for OmegaT tags, they are
+			  not counted by default in the statistics, but you can have OmegaT
+			  count them as words. See the <link
+			  linkend="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics"
+			  endterm="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"/>
+			  preference for details.</para>
+			</listitem>
+		  </itemizedlist>
+		</note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.tools.match.statistics">
-      <term id="menus.tools.match.statistics.title">Match Statistics</term>
+      <term id="menus.tools.match.statistics.title"><guimenuitem>Match
+      Statistics</guimenuitem></term>
       <listitem>
         <para>Displays the Match Statistics for the project: the number of
         repetitions, exact matches, fuzzy matches and no-matches for segments,
         words and characters.</para>
-		<para>The data is also saved as a text file in <link
+
+		<para>The data is saved in the <link
+		linkend="project.folder.omegat.project.stats.match"
+		endterm="project.folder.omegat.project.stats.match.title"/> file located in the <link
 		linkend="project.folder.omegat.folder"
-		endterm="project.folder.omegat.folder.title"/>.</para>
+		endterm="project.folder.omegat.folder.title"/> folder of the
+		project.</para>
       </listitem>
     </varlistentry>
 	
     <varlistentry id="menus.tools.match.statistics.per.file">
-      <term id="menus.tools.match.statistics.per.file.title">Match Statistics per File</term>
+      <term id="menus.tools.match.statistics.per.file.title"><guimenuitem>Match
+      Statistics per File</guimenuitem></term>
       <listitem>
         <para>Displays the Match Statistics for each file of the project: the
         number of repetitions, exact matches, fuzzy matches and no-matches for
         segments, words and characters.</para>
-		<para>The data is also saved as a text file in <link
+
+		<para>The data is saved in the <link
+		linkend="project.folder.omegat.project.stats.match.per.file"
+		endterm="project.folder.omegat.project.stats.match.per.file.title"/> file located in the <link
 		linkend="project.folder.omegat.folder"
-		endterm="project.folder.omegat.folder.title"/>.</para>
+		endterm="project.folder.omegat.folder.title"/> folder of the
+		project.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.tools.align.files">
-      <term id="menus.tools.align.files.title">Align Files...</term>
+      <term id="menus.tools.align.files.title"><guimenuitem>Align
+      Files...</guimenuitem></term>
       <listitem>
         <para>Select the two files to align (the source file and its
         translation) and click <guibutton>OK</guibutton> to open the <link
-        linkend="windows.aligner" endterm="windows.aligner.title"/> window.</para>
-        <para>The supported file formats depend on your project setting. See <link
-        linkend="file.filters"
-        endterm="file.filters.title"/> for details.</para>
+        linkend="windows.aligner" endterm="windows.aligner.title"/>
+        window.</para>
+
+        <para>The supported file formats depend on your project setting. See the
+        <link linkend="file.filters" endterm="file.filters.title"/> appendix for
+        details.</para>
         <para>The source and target files can have different formats (for
         example, a <filename>.docx</filename> file can be aligned with a
         <filename>.pdf</filename> file).</para>
@@ -155,24 +223,29 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.scripting">
-      <term id="menus.tools.scripting.title">Scripting...</term>
+      <term
+      id="menus.tools.scripting.title"><guimenuitem>Scripting...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="windows.scripts"
         endterm="windows.scripts.title"/> window, which allows you to set the
-        location where scripts are stored, as well as write and run scripts,
-        and assign them a shortcut.</para>
+        location where scripts are stored, as well as write and run scripts, and
+        assign them a shortcut.</para>
 		<para>The list below this item displays 12 potential slots for
 		scripts. Clicking on an assigned slot launches the script assigned to
 		that slot.</para>
+
 		<note>
 		  <para>To assign a number to a script:</para>
+
           <orderedlist>
 			<listitem>
               <para>Open the Scripting window</para>
 			</listitem>
+
 			<listitem>
               <para>Select the script you want from the list on the left.</para>
 			</listitem>
+
 			<listitem>
               <para>At the bottom of the window, right-click on an unassigned
               number and select <guilabel>Add Script</guilabel>.</para>
@@ -186,9 +259,10 @@
       <term id="menus.tools.external.search.commands.title">External search
       commands</term>
       <listitem>
-        <para>If you have defined external searches in
-        <link linkend="dialogs.preferences.external.searches"
-        endterm="dialogs.preferences.external.searches.title"/>, their names are listed and accessible here.</para>
+        <para>If you have defined external searches in the <link
+        linkend="dialogs.preferences.external.searches"
+        endterm="dialogs.preferences.external.searches.title"/> preferences,
+        their names are listed and accessible here.</para>
       </listitem>
     </varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -1,165 +1,190 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.view">
-  <title id="menus.view.title">View</title>
+  <title id="menus.view.title"><guimenu>View</guimenu></title>
+
+  <para>This menu allows you to select the information you want to OmegaT to
+  display.</para>
 
   <variablelist>
     <varlistentry id="menus.view.mark.translated.segments">
-      <term id="menus.view.mark.translated.segments.title">Mark Translated
-      Segments</term>
+      <term
+		  id="menus.view.mark.translated.segments.title"><guimenuitem>Translated
+      Segments</guimenuitem></term>
       <listitem>
         <para>If checked, translated segments will be marked in yellow.</para>
-        </listitem>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.untranslated.segments">
-      <term id="menus.view.mark.untranslated.segments.title">Mark Untranslated
-      Segments</term>
+      <term
+      id="menus.view.mark.untranslated.segments.title"><guimenuitem>Untranslated
+      Segments</guimenuitem></term>
       <listitem>
         <para>If checked, untranslated segments will be marked in violet.</para>
-        </listitem>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.paragraph.delimitations">
-      <term id="menus.view.mark.paragraph.delimitations.title">Mark Paragraph
-      Delimitations</term>
+      <term
+      id="menus.view.mark.paragraph.delimitations.title"><guimenuitem>Paragraph
+      Delimitations</guimenuitem></term>
       <listitem>
         <para>If checked, separations between paragraphs in the source document
-        are indicated visually. See <link
+        are indicated visually. You can change the paragraph delimitation string
+        in the <link
         linkend="dialogs.preferences.editor.paragraph.delimitation.format"
-        endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>.</para>
-        </listitem>
+        endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>
+        preference.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.display.source.segments">
-      <term id="menus.view.display.source.segments.title">Display Source
-      Segments</term>
+      <term id="menus.view.display.source.segments.title"><guimenuitem>Source
+      Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, source segments will be shown and marked in green.
-        If not checked, source segments will not be shown.</para>      </listitem>
+        <para>If checked, all the source segments will be shown and marked in
+        green.  If not checked, only the current source segments will be
+        shown.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.unique.segments">
-      <term id="menus.view.mark.non.unique.segments.title">Mark Non-Unique
-      Segments</term>
+      <term
+      id="menus.view.mark.non.unique.segments.title"><guimenuitem>Non-Unique
+      Segments</guimenuitem></term>
       <listitem>
         <para>If checked, non-unique segments will be marked in pale
-        gray.</para>      </listitem>
+        gray.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.segments.with.notes">
-      <term id="menus.view.mark.segments.with.notes.title">Mark Segments with
-      Notes</term>
+      <term id="menus.view.mark.segments.with.notes.title"><guimenuitem>Segments
+      with Notes</guimenuitem></term>
       <listitem>
         <para>If checked, segments with notes will be marked in cyan. This
         marking has priority over <guimenuitem>Mark Translated
         Segments</guimenuitem> and <guimenuitem>Mark Untranslated
-        Segments</guimenuitem>.</para>      </listitem>
+        Segments</guimenuitem>.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.breakable.space">
-      <term id="menus.view.mark.non.breakable.space.title">Mark Non-Breakable
-      Spaces</term>
+      <term
+      id="menus.view.mark.non.breakable.space.title"><guimenuitem>Non-Breakable
+      Spaces</guimenuitem></term>
       <listitem>
         <para>If checked, non-breakable spaces will be displayed with a gray
-        background.</para>      </listitem>
+        background.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.white.space">
-      <term id="menus.view.mark.white.space.title">Mark Whitespace</term>
+      <term
+      id="menus.view.mark.white.space.title"><guimenuitem>Whitespace</guimenuitem></term>
       <listitem>
         <para>If checked, white spaces will be displayed with a small
-        dot.</para>      </listitem>
+        dot.</para>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.bidirectional.algorithm.control.character">
       <term
-      id="menus.view.mark.bidirectional.algorithm.control.character.title">Mark
-      Bidirectional Algorithm Control Characters</term>
+      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>BiDi
+      Control Characters</guimenuitem></term>
       <listitem>
         <para>This option displays <ulink
-        url="http://www.w3.org/International/questions/qa-bidi-controls">bidirectional
-        control characters</ulink></para> </listitem>
+        url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
+        Algorithm</ulink></para>
+	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.auto.populated.segments">
-      <term id="menus.view.mark.auto.populated.segments.title">Mark
-      Auto-Populated Segments</term>
+      <term
+      id="menus.view.mark.auto.populated.segments.title"><guimenuitem>Auto-Populated
+      Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, segments that have been auto-populated (from TMXs
-        placed in <link linkend="project.folder.tm.auto"
-        endterm="project.folder.tm.auto.title"/> for example) are marked in
+        <para>If checked, segments that have been auto-populated are marked in
         various colors.</para>
-		<para>That color marking is shown as long as 
-        <link linkend="dialogs.preferences.editor.save.auto-populated.status"
-        endterm="dialogs.preferences.editor.save.auto-populated.status.title"/>
-        is checked.</para>
-		<para>Normal translations inserted from the <filename
-        class="directory">tm/auto</filename> folder are marked in orange. Other
-        translations specifically identified in the TMX, can be marked in
-        different colors. See the <ulink
-        url="http://sourceforge.net/p/omegat/feature-requests/963/">Request For
-        Enhancement</ulink> for technical details.</para>
+
+		<para>See the <link
+		linkend="dialogs.preferences.editor.save.auto-populated.status"
+		endterm="dialogs.preferences.editor.save.auto-populated.status.title"/>
+		preference for details.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.glossary.matches">
-      <term id="menus.view.mark.glossary.matches.title">Mark Glossary
-      Matches</term>
+      <term id="menus.view.mark.glossary.matches.title"><guimenuitem>Glossary
+      Matches</guimenuitem></term>
       <listitem>
         <para>Underlines source terms that have a match in the
         glossaries. Hovering on an underlined term displays the matching target
         term. Right-clicking on an underlined term displays the matching target
         term, which can be selected and inserted at the cursor position in the
-        target text.</para> </listitem>
+        target text.</para>
+	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.language.checker">
-      <term id="menus.view.mark.language.checker.title">Language Checker</term>
+      <term id="menus.view.mark.language.checker.title"><guimenuitem>Language
+      Checker</guimenuitem></term>
       <listitem>
         <para>Underlines parts of the target where LanguageTool has found
-        errors. See <link linkend="dialog.preferences.languagetool.plugin"
-        endterm="dialog.preferences.languagetool.plugin.title"/> for
-        details.</para> </listitem>
+        errors. See the <link linkend="dialog.preferences.languagetool.plugin"
+        endterm="dialog.preferences.languagetool.plugin.title"/> preferences for
+        details.</para>
+	  </listitem>
     </varlistentry>
 	
     <varlistentry id="menus.view.aggressive.font.fallback">
-      <term id="menus.view.aggressive.font.fallback.title">Aggressive Font Fallback</term>
+      <term
+      id="menus.view.aggressive.font.fallback.title"><guimenuitem>Aggressive
+      Font Fallback</guimenuitem></term>
       <listitem>
         <para>Check this option in case OmegaT does not display certain glyphs
         properly (even if the fonts containing the relevant glyphs are installed
-        on your machine).</para> <note><para>On Windows this manual font
-        fallback mechanism has been known to interfere with the standard font
-        fallback, causing undesirable font substitutions. For that reason, it is
-        OFF by default.</para></note>
+        on your machine).</para>
+
+		<note>
+		  <para>On Windows this manual font fallback mechanism has been known to
+		  interfere with the standard font fallback, causing undesirable font
+		  substitutions. For that reason, it is OFF by default.</para>
+		</note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.modification.info">
-      <term id="menus.view.modification.info.title">Modification Info</term>
+      <term id="menus.view.modification.info.title"><guisubmenu>Modification
+      Info</guisubmenu></term>
       <listitem>
-        <para>Setting the Display Modification option to <guimenuitem>Current
-        segment</guimenuitem> will display the time and the author of the last
-        change made to the current segment. Setting it to <guimenuitem>All
-        segments</guimenuitem> shows this information for all segments, while
-        <guimenuitem>None</guimenuitem> turns this option off.</para>
-		<para>You can adapt the displayed information to your needs. See <link
+        <para>Displays the time and the author of the last change made to a
+        segment.</para>
+		
+		<para>The default value is <guimenuitem>Current segment</guimenuitem>
+		and it can be set to <guimenuitem>All segments</guimenuitem> or to
+		<guimenuitem>None</guimenuitem>.</para>
+
+		<para>You can modify the displayed information. See the <link
 		linkend="dialog.preferences.view.use.custom.templates.for.modification.info"
 		endterm="dialog.preferences.view.use.custom.templates.for.modification.info.title"/>
-		for details.</para>
-        </listitem>
+		preferences for details.</para>
+      </listitem>
     </varlistentry>
 	
 	<varlistentry id="menus.view.restore.main.window">
-      <term id="menus.view.restore.main.window.title">Restore Main Window</term>
+      <term id="menus.view.restore.main.window.title"><guimenuitem>Restore Main
+      Window</guimenuitem></term>
       <listitem>
-        <para>Restores the OmegaT main window layout to its default values, with
-        the <guilabel>Editor</guilabel> pane on the left, the <guilabel>Fuzzy
-        Matches</guilabel> pane at the top right and the
-        <guilabel>Glossary</guilabel> pane at the bottom right. All other panes
-        are minimized.</para>
-		<note><para>Use this function when you run into problems while
-        rearranging the window layout.</para></note> </listitem>
+        <para>Restores the OmegaT main window layout to its default
+        values.</para>
+
+		<note>
+		  <para>Use this function when you run into problems while
+		  rearranging the window layout.</para>
+		</note>
+	  </listitem>
     </varlistentry>
   </variablelist>
 </section>

--- a/doc_src/en/OmegaT5_Appendices.xml
+++ b/doc_src/en/OmegaT5_Appendices.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="appendices">
-  <title id="appendices.title">Appendices</title>
+<chapter id="chapter.appendices">
+  <title id="chapter.appendices.title">Appendices</title>
 
   <xi:include href="App_FileFilters.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/doc_src/en/OmegaT5_EditorsPanes.xml
+++ b/doc_src/en/OmegaT5_EditorsPanes.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="panes">
-  <title id="panes.title">Panes</title>
+<chapter id="chapter.panes">
+  <title id="chapter.panes.title">Panes</title>
 
   <section id="panes.principles">
     <title id="panes.principles.title">Principles</title>
@@ -12,11 +12,12 @@
         <term id="panes.manipulation.title">Manipulation</term>
 
         <listitem>
-          <para>The main window consists of several panes, described here, the
-          main <link endterm="menus.title" linkend="menus"/>, and a <link
-          endterm="panes.statusbar.title" linkend="panes.statusbar"/>. You can
-          change the position of a pane, or even undock it as a separate
-          window, by clicking and holding its name and dragging it.</para>
+          <para>The main window consists of several panes, described here, menus
+          described in the <link linkend="chapter.menus"
+          endterm="chapter.menus.title"/> chapter, and a status bar described
+          <link linkend="panes.statusbar">below</link>. You can change the
+          position of a pane, or even undock it as a separate window, by
+          clicking and holding its name and dragging it.</para>
 
           <para>The top right corner of a pane will show different icons
           depending on the type of pane and its current status:</para>
@@ -37,8 +38,8 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry>Lists the various extra <emphasis role="bold">actions</emphasis> available in the
-                  pane.</entry>
+                  <entry>Lists the various extra <emphasis
+                  role="bold">actions</emphasis> available in the pane.</entry>
                 </row>
 
                 <row>
@@ -52,8 +53,9 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry><emphasis role="bold">Minimizes</emphasis> the pane, so that it only shows as a tab at
-                  the bottom of the window.</entry>
+                  <entry><emphasis role="bold">Minimizes</emphasis> the pane, so
+                  that it only shows as a tab at the bottom of the
+                  window.</entry>
                 </row>
 
                 <row>
@@ -81,8 +83,8 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry><emphasis role="bold">Restores</emphasis> a maximized pane to its previous
-                  layout.</entry>
+                  <entry><emphasis role="bold">Restores</emphasis> a maximized
+                  pane to its previous layout.</entry>
                 </row>
 
                 <row>
@@ -96,7 +98,8 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry><emphasis role="bold">Undocks</emphasis> the pane from the main window.</entry>
+                  <entry><emphasis role="bold">Undocks</emphasis> the pane from
+                  the main window.</entry>
                 </row>
 
                 <row>
@@ -110,7 +113,8 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry><emphasis role="bold">Returns</emphasis> the pane to the main window.</entry>
+                  <entry><emphasis role="bold">Returns</emphasis> the pane to
+                  the main window.</entry>
                 </row>
               </tbody>
             </tgroup>
@@ -121,12 +125,12 @@
           can be resized by dragging the separators between them.</para>
 
           <note>
-            <para>If you lost track of the changes you made to the user
-            interface, and cannot see some panes, use <link
+            <para>Use <link endterm="menus.view.title"
+            linkend="menus.view"/><link
             endterm="menus.view.restore.main.window.title"
-            linkend="menus.view.restore.main.window"/> in the <link
-            endterm="menus.view.title" linkend="menus.view"/> menu any time to
-            go back to the default layout.</para>
+            linkend="menus.view.restore.main.window"/> to go back to the default
+            layout if you lost track of the changes you made to the user
+            interface, and cannot see some panes.</para>
           </note>
         </listitem>
       </varlistentry>
@@ -206,37 +210,74 @@
 		
         <listitem>
           <para>If a pane is closed but has contents to display, OmegaT can
-		  temporarily highlight the pane tab in orange when you enter the segment.</para>
+          temporarily highlight the pane tab in orange when you enter the
+          segment.</para>
+		  
 		  <para>By default, the <guilabel>Comments</guilabel> and
 		  <guilabel>Notes</guilabel> panes have notifications enabled.</para>
-		  <para>To enable or disable notifications,
+		  
+		  <para>To enable or disable notifications,</para>
+		  
 		  <itemizedlist>
-			<listitem><para>enter the pane,</para></listitem>
-			<listitem><para>click on the
-			<guilabel>Action</guilabel> widget in the top right,</para></listitem>
-			<listitem><para>and select <guilabel>Notify
-		  Me When a Segment Has...</guilabel> (the ... contents depends on the pane that
-			you want notifications from).</para></listitem>
+			<listitem>
+			  <para>enter the pane,</para>
+			</listitem>
+
+			<listitem>
+			  <para>click on the <guilabel>Action</guilabel> widget in the top
+			  right,</para>
+			</listitem>
+			
+			<listitem>
+			  <para>and select <guilabel>Notify Me When a Segment
+			  Has...</guilabel> (the ... contents depends on the pane that you
+			  want notifications from).</para>
+			</listitem>
 		  </itemizedlist>
-		  </para>
+
 		  <para>Notifications are available from the following panes:</para>
+
 		  <itemizedlist>
-			<listitem><para>Comments</para></listitem>
-			<listitem><para>Dictionary</para></listitem>
-			<listitem><para>Fuzzy Matches</para></listitem>
-			<listitem><para>Glossary</para></listitem>
-			<listitem><para>Multiple Translations</para></listitem>
-			<listitem><para>Notes</para></listitem>
-			<listitem><para>Segment Properties</para>
-			<para>The <guilabel>Segment Properties</guilabel> pane allows
-			notification settings for each of its item.</para>
-			<para>In <guilabel>Table View</guilabel>, right click on the item
-			and select <guilabel>Notify Me When a Segment Has...</guilabel> (the
-			... contents depends on the item that you want notifications from).</para>
-			<para>In <guilabel>List View</guilabel>, right click on the
-			<guilabel>Action</guilabel> widget at the right-end of the selected property
-			lineand select <guilabel>Notify Me When a Segment Has...</guilabel> (the
-			... contents depends on the item that you want notifications from).</para>
+			<listitem>
+			  <para>Comments</para>
+			</listitem>
+
+			<listitem>
+			  <para>Dictionary</para>
+			</listitem>
+
+			<listitem>
+			  <para>Fuzzy Matches</para>
+			</listitem>
+
+			<listitem>
+			  <para>Glossary</para>
+			</listitem>
+
+			<listitem>
+			  <para>Multiple Translations</para>
+			</listitem>
+
+			<listitem>
+			  <para>Notes</para>
+			</listitem>
+
+			<listitem>
+			  <para>Segment Properties</para>
+
+			  <para>The <guilabel>Segment Properties</guilabel> pane allows
+			  notification settings for each of its item.</para>
+
+			  <para>In <guilabel>Table View</guilabel>, right click on the item
+			  and select <guilabel>Notify Me When a Segment Has...</guilabel>
+			  (the ... contents depends on the item that you want notifications
+			  from).</para>
+
+			  <para>In <guilabel>List View</guilabel>, right click on the
+			  <guilabel>Action</guilabel> widget at the right-end of the
+			  selected property lineand select <guilabel>Notify Me When a
+			  Segment Has...</guilabel> (the ... contents depends on the item
+			  that you want notifications from).</para>
 			</listitem>
 		  </itemizedlist>
 		</listitem>
@@ -245,18 +286,18 @@
   </section>
 
   <section id="panes.editor">
-    <title id="panes.editor.title">Editor</title>
+    <title id="panes.editor.title"><guilabel>Editor</guilabel></title>
 
     <para>This is where you type and edit your translations.</para>
 
     <para>The text is split into numbered segments. You can scroll through the
     document and double-click on any segment to open and edit it.</para>
 
-  <example id="panes.editor.default.editor.writing.space">
-	<title id="panes.editor.default.editor.writing.space.title">Default editor writing
-      space</title>
-	<para>
-	  <programlisting>— ¶ —————————————————————
+	<example id="panes.editor.default.editor.writing.space">
+	  <title id="panes.editor.default.editor.writing.space.title">Default editor
+	  writing space</title>
+	  <para>
+		<programlisting>— ¶ —————————————————————
 
 <token>Remove Tags</token>
 |Supprimer les balises<token>&lt;segment 2148 ¶></token>
@@ -264,7 +305,7 @@
 — ¶ —————————————————————
 
 When enabled, all the formatting tags are removed from source segments.</programlisting></para>
-  </example>
+	</example>
 
     <itemizedlist>
       <listitem>
@@ -303,94 +344,121 @@ When enabled, all the formatting tags are removed from source segments.</program
       </listitem>
 
       <listitem>
-        <para>Use <link endterm="menus.goto.next.segment.title"
+        <para>Use <link  linkend="menus.goto" endterm="menus.goto.title"/><link
+        endterm="menus.goto.next.segment.title"
         linkend="menus.goto.next.segment"/> or other navigation commands
-        to:<itemizedlist>
-            <listitem>
-              <para>register the translation field contents in the project
-              translation memory, and</para>
-            </listitem>
+        to:</para>
 
-            <listitem>
-              <para>enter the next segment to translate.</para>
-            </listitem>
-          </itemizedlist> See the <link endterm="menus.goto.title"
-        linkend="menus.goto"/> menu for details.</para>
+		<itemizedlist>
+          <listitem>
+            <para>register the translation field contents in the project
+            translation memory, and</para>
+          </listitem>
+
+          <listitem>
+            <para>enter the next segment to translate.</para>
+          </listitem>
+        </itemizedlist>
+
+		<para>See the <link endterm="menus.goto.title" linkend="menus.goto"/>
+		menu for details.</para>
       </listitem>
     </itemizedlist>
 
     <note>
-      <para>Modify the Editor display to suit your workflow. See the <link linkend="dialogs.preferences.editor" endterm="dialogs.preferences.editor.title"/> preferences for details.</para>
+      <para>Modify the Editor display to suit your workflow.</para>
 
-<!--   <example id="panes.editor.modified.editor.target.field"> -->
-<!-- 	<title id="panes.editor.modified.editor.target.field.title">Example of modified -->
-<!--         editor writing space</title> -->
-<!-- 	<para> -->
-<!-- 	  <programlisting>— ¶ ————————————————————— -->
+	  <!--   <example id="panes.editor.modified.editor.target.field"> -->
+	  <!-- 	<title id="panes.editor.modified.editor.target.field.title">Example of modified -->
+	  <!--         editor writing space</title> -->
+	  <!-- 	<para> -->
+	  <!-- 	  <programlisting>— ¶ ————————————————————— -->
 
-<!-- Translation last modified by Didier on Sep 4, 2012 at 9:16:52 PM -->
-<!-- <token>Remove Ta&amp;gs</token> -->
-<!-- <token>Su&amp;pprimer les balises</token> -->
+	  <!-- Translation last modified by Didier on Sep 4, 2012 at 9:16:52 PM -->
+	  <!-- <token>Remove Ta&amp;gs</token> -->
+	  <!-- <token>Su&amp;pprimer les balises</token> -->
 
-<!-- — ¶ ————————————————————— -->
+	  <!-- — ¶ ————————————————————— -->
 
-<!-- <token>External Post-processing Command:</token> -->
-<!-- <token>[fuzzy]</token>Commande de post-traitement externe<token>&lt;segment 3644 ¶></token> -->
+	  <!-- <token>External Post-processing Command:</token> -->
+	  <!-- <token>[fuzzy]</token>Commande de post-traitement externe<token>&lt;segment 3644 ¶></token> -->
 
-<!-- — ¶ —————————————————————</programlisting></para> -->
-<!--   </example> -->
+	  <!-- — ¶ —————————————————————</programlisting></para> -->
+	  <!--   </example> -->
 
-  <para>Modifications can include:<itemizedlist>
-          <listitem>
-            <para><link endterm="dialogs.preferences.fonts.title"
-            linkend="dialogs.preferences.fonts"/></para>
-          </listitem>
+	  <para>Modifications can include:</para>
+	  
+	  <itemizedlist>
+		<listitem>
+		  <para>Font modifications, defined in the <link
+		  endterm="dialogs.preferences.fonts.title"
+		  linkend="dialogs.preferences.fonts"/> preference</para>
+		</listitem>
 
-          <listitem>
-            <para><link
-            endterm="menus.view.mark.paragraph.delimitations.title"
-            linkend="menus.view.mark.paragraph.delimitations"/></para>
-          </listitem>
+		<listitem>
+		  <para>Paragraph delimitation display, enabled by using <link
+		  endterm="menus.view.title" linkend="menus.view"/><link
+		  endterm="menus.view.mark.paragraph.delimitations.title"
+		  linkend="menus.view.mark.paragraph.delimitations"/></para>
+		</listitem>
 
-          <listitem>
-            <para><link
-            endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"
-            linkend="dialogs.preferences.editor.paragraph.delimitation.format"/></para>
-          </listitem>
+		<listitem>
+		  <para>The paragraph delimitation format, defined in the <link
+		  endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"
+		  linkend="dialogs.preferences.editor.paragraph.delimitation.format"/>
+		  preference</para>
+		</listitem>
 
-          <listitem>
-            <para><link endterm="menus.view.modification.info.title"
-            linkend="menus.view.modification.info"/></para>
-          </listitem>
+		<listitem>
+		  <para>Segment modification info display, enabled by using <link
+		  endterm="menus.view.title" linkend="menus.view"/><link
+		  endterm="menus.view.modification.info.title"
+		  linkend="menus.view.modification.info"/></para>
+		</listitem>
 
-          <listitem>
-            <para><link endterm="menus.view.display.source.segments.title"
-            linkend="menus.view.display.source.segments"/></para>
-          </listitem>
+		<listitem>
+		  <para>Source segments display, enabled by using <link
+		  endterm="menus.view.title" linkend="menus.view"/><link
+		  endterm="menus.view.display.source.segments.title"
+		  linkend="menus.view.display.source.segments"/></para>
+		</listitem>
 
-          <listitem>
-            <para><link endterm="menus.view.mark.translated.segments.title"
-            linkend="menus.view.mark.translated.segments"/></para>
-          </listitem>
+		<listitem>
+		  <para>Translated segments highlighting, enabled by using <link
+		  endterm="menus.view.title" linkend="menus.view"/><link
+		  endterm="menus.view.mark.translated.segments.title"
+		  linkend="menus.view.mark.translated.segments"/></para>
+		</listitem>
 
-          <listitem>
-            <para><link
-            endterm="dialogs.preferences.editor.leave.the.segment.empty.title"
-            linkend="dialogs.preferences.editor.leave.the.segment.empty"/></para>
-          </listitem>
+		<listitem>
+		  <para>Do not insert the source text in the translation field, enabled
+		  by the <link
+		  endterm="dialogs.preferences.editor.leave.the.segment.empty.title"
+		  linkend="dialogs.preferences.editor.leave.the.segment.empty"/>
+		  preference</para>
+		</listitem>
 
-          <listitem>
-            <para><link
-            endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"
-            linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"/></para>
-          </listitem>
+		<listitem>
+		  <para>Insert the best fuzzy match above a given threshold, enabled by
+		  the <link
+		  endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"
+		  linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"/>
+		  preference</para>
+		</listitem>
 
-          <listitem>
-            <para><link
-            endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"
-            linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"/></para>
-          </listitem>
-        </itemizedlist></para>
+		<listitem>
+		  <para>Define text that you do not want to remain in the translation,
+		  enabled by the <link
+		  endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"
+		  linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"/>
+		  preference</para>
+		</listitem>
+	  </itemizedlist>
+
+	  <para>See the <link linkend="dialogs.preferences.editor"
+	  endterm="dialogs.preferences.editor.title"/> preferences and the <link
+	  endterm="menus.view.title" linkend="menus.view"/> menu for details.
+	  </para>
     </note>
 
     <variablelist>
@@ -398,9 +466,9 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term>Empty translations</term>
 
         <listitem>
-          <para>If you leave the translation field empty, OmegaT will treat
-          the segment as untranslated and keep it in the original language
-          when it creates the translated documents.</para>
+          <para>If you leave the translation field empty, OmegaT will treat the
+          segment as untranslated and keep it in the original language when it
+          creates the translated documents.</para>
         </listitem>
       </varlistentry>
 
@@ -409,9 +477,9 @@ When enabled, all the formatting tags are removed from source segments.</program
 
         <listitem>
           <para>OmegaT can store translations that are identical to the source
-          text. This can be useful for documents that contain trademarks,
-          names or other proper nouns, or sections in a third language that do
-          not require translation.</para>
+          text. This can be useful for documents that contain trademarks, names
+          or other proper nouns, or sections in a third language that do not
+          require translation.</para>
         </listitem>
       </varlistentry>
 
@@ -419,9 +487,9 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term>Dragging text</term>
 
         <listitem>
-          <para>It is possible to drag text from anywhere in the main window
-          and drop it into the translation field. Text dragged from outside
-          the translation field is copied, while text dragged from within the
+          <para>It is possible to drag text from anywhere in the main window and
+          drop it into the translation field. Text dragged from outside the
+          translation field is copied, while text dragged from within the
           translation field is moved.</para>
         </listitem>
       </varlistentry>
@@ -430,24 +498,26 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term id="panes.editor.overwriting.title">Overwriting</term>
 
         <listitem>
-          <para>By default, typing text inserts the new text after the cursor
-          in the typing direction. To overwrite the existing text, use the
-          following keys: <itemizedlist>
-              <listitem>
-                <para>On Windows and Linux: <keycombo>
-                    <keycap>INSERT</keycap>
-                  </keycombo></para>
-              </listitem>
+          <para>By default, typing text inserts the new text after the cursor in
+          the typing direction. To overwrite the existing text, use the
+          following keys:</para>
 
-              <listitem>
-                <para>On macOS: <keycap>F3</keycap></para>
-              </listitem>
-            </itemizedlist></para>
+		  <itemizedlist>
+            <listitem>
+              <para>On Windows and Linux: <keycombo>
+              <keycap>INSERT</keycap>
+              </keycombo></para>
+            </listitem>
 
-          <para>The writing mode (overwrite - <guilabel>OVR</guilabel> or
-          insert - <guilabel>INS</guilabel>) is shown at the right of the
-          <link endterm="panes.statusbar.title" linkend="panes.statusbar"/>.
-          Use the same key to switch back and forth between each mode.</para>
+            <listitem>
+              <para>On macOS: <keycap>F3</keycap></para>
+            </listitem>
+          </itemizedlist>
+
+          <para>The writing mode (overwrite - <guilabel>OVR</guilabel> or insert
+          - <guilabel>INS</guilabel>) is shown at the right of the <link
+          linkend="panes.statusbar">status bar</link>. Use the same key to
+          switch back and forth between each mode.</para>
         </listitem>
       </varlistentry>
 
@@ -455,18 +525,18 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term id="panes.editor.cursor.lock.title">Cursor lock</term>
 
         <listitem>
-          <para>By default, the cursor is locked into the translation field,
-          and the arrow keys cannot be used to move in the source text.</para>
+          <para>By default, the cursor is locked into the translation field, and
+          the arrow keys cannot be used to move in the source text.</para>
 
           <para>Pressing <keycap>F2</keycap> unlocks the cursor and makes it
-          possible to use the arrow keys to move in the source text (or
-          anywhere else in the editor). This allows you to select text using
-          the keyboard.</para>
+          possible to use the arrow keys to move in the source text (or anywhere
+          else in the editor). This allows you to select text using the
+          keyboard.</para>
 
-          <para>The cursor status (locked - <guilabel>LCK</guilabel> or
-          unlocked - <guilabel>UNL</guilabel>) is shown at the right of the
-          <link endterm="panes.statusbar.title" linkend="panes.statusbar"/>.
-          Use the same key to lock the cursor again.</para>
+          <para>The cursor status (locked - <guilabel>LCK</guilabel> or unlocked
+          - <guilabel>UNL</guilabel>) is shown at the right of the <link
+          linkend="panes.statusbar">status bar</link>. Use the same key to lock
+          the cursor again.</para>
         </listitem>
       </varlistentry>
 
@@ -474,50 +544,57 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term id="panes.editor.context.menu.title">Context menu</term>
 
         <listitem>
-          <para>Default shortcut: <itemizedlist>
-              <listitem>
-                <para>On Windows and Linux: <keycap>Menu</keycap></para>
-              </listitem>
+          <para>Default shortcut:</para>
 
-              <listitem>
-                <para>On macOS: <keycombo>
-                    <keycap>S</keycap>
+		  <itemizedlist>
+			<listitem>
+              <para>On Windows and Linux: <keycap>Menu</keycap></para>
+			</listitem>
 
-                    <keycap>Esc</keycap>
-                  </keycombo></para>
-              </listitem>
-            </itemizedlist> You can also bring up the menu by right-clicking
-          the mouse (<keycap>C</keycap> + <keycap>click</keycap> on
-          macOS).</para>
+			<listitem>
+              <para>On macOS:
+              <keycombo><keycap>S</keycap><keycap>Esc</keycap></keycombo></para>
+			</listitem>
+          </itemizedlist>
 
-          <para>The Editor pane context menu offers: <itemizedlist>
-              <listitem>
-                <para><emphasis role="bold">Cut, Copy, Paste</emphasis>
-                functions,</para>
-              </listitem>
+		  <para>You can also bring up the menu by right-clicking the mouse
+		  (<keycap>C</keycap> + <keycap>click</keycap> on macOS).</para>
 
-              <listitem>
-                <para><guilabel>Go To Segment</guilabel> (to jump to the
-                segment under the pointer),</para>
-              </listitem>
+          <para>The Editor pane context menu offers:</para>
 
-              <listitem>
-                <para><guilabel>Search Dictionaries</guilabel> (to search for
-                the selected term in an installed dictionary),</para>
-              </listitem>
+		  <itemizedlist>
+            <listitem>
+              <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
+              <guilabel>Paste</guilabel> functions,</para>
+            </listitem>
 
-              <listitem>
-                <para><guilabel>Add Glossary Entry</guilabel> (equivalent to
-                <link endterm="menus.edit.create.glossary.entry.title"
-                linkend="menus.edit.create.glossary.entry"/>),</para>
-              </listitem>
-            </itemizedlist>and other functions available from the <link
-          endterm="menus.edit.title" linkend="menus.edit"/> menu.</para>
+            <listitem>
+              <para><guilabel>Go To Segment</guilabel> (to jump to the segment
+              under the pointer),</para>
+            </listitem>
 
-          <para>If you have selected text and defined entries in <link
+            <listitem>
+              <para><guilabel>Search Dictionaries</guilabel> (to search for the
+              selected term in an installed dictionary),</para>
+            </listitem>
+
+            <listitem>
+              <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
+              <link endterm="menus.edit.title" linkend="menus.edit"/><link
+              endterm="menus.edit.create.glossary.entry.title"
+              linkend="menus.edit.create.glossary.entry"/>),</para>
+            </listitem>
+
+          </itemizedlist>
+
+		  <para>and other functions available from the <link
+		  endterm="menus.edit.title" linkend="menus.edit"/> menu.</para>
+
+          <para>If you have selected text and defined entries in the <link
           endterm="dialogs.preferences.external.searches.title"
-          linkend="dialogs.preferences.external.searches"/>, they will also be
-          displayed in the menu.</para>
+          linkend="dialogs.preferences.external.searches"/> preferences, they
+          will also be displayed in the menu (local searches will also be
+          displayed).</para>
         </listitem>
       </varlistentry>
 
@@ -526,56 +603,69 @@ When enabled, all the formatting tags are removed from source segments.</program
         menu</term>
 
         <listitem>
-          <para>Default shortcut: <itemizedlist>
-              <listitem>
-                <para>On Windows and Linux: <keycombo>
-                    <keycap>C</keycap>
+          <para>Default shortcut:</para>
+		  
+		  <itemizedlist>
+			<listitem>
+              <para>On Windows and Linux:
+              <keycombo><keycap>C</keycap><keycap>Space</keycap></keycombo></para>
+			</listitem>
 
-                    <keycap>Space</keycap>
-                  </keycombo></para>
-              </listitem>
-
-              <listitem>
-                <para>On macOS: <keycap>Esc</keycap></para>
-              </listitem>
-            </itemizedlist></para>
-
-          <para>This menu offers the auto-completion options set in <link
+			<listitem>
+              <para>On macOS: <keycap>Esc</keycap></para>
+			</listitem>
+          </itemizedlist>
+		  			
+          <para>This menu offers the auto-completion options set in the <link
           endterm="dialog.preferences.auto.completion.title"
-          linkend="dialog.preferences.auto.completion"/>.</para>
+          linkend="dialog.preferences.auto.completion"/> preferences.</para>
         </listitem>
       </varlistentry>
+
+      <varlistentry id="panes.editor.navigation">
+        <term id="panes.editor.navigation.title">Navigation</term>
+        <listitem>
+		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.notes.pane"
+		  endterm="menus.goto.notes.pane.title"/> to enter the pane and add or
+		  modify a note.</para>
+
+		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.editor.pane"
+		  endterm="menus.goto.editor.pane.title"/> to go back to the
+		  Editor.</para>
+        </listitem>
+	  </varlistentry>
     </variablelist>
   </section>
 
   <section id="panes.fuzzy.matches">
-    <title id="panes.fuzzy.matches.title">Fuzzy Matches</title>
+    <title id="panes.fuzzy.matches.title"><guilabel>Fuzzy Matches</guilabel></title>
 
     <para>The match viewer shows segments from your translation memories that
     are the most similar to the segment you are currently translating.</para>
 
-    <para>Matches are found both in the internal project translation memory
-    that you create in real time as you translate the project, and in external
+    <para>Matches are found both in the internal project translation memory that
+    you create in real time as you translate the project, and in external
     memories you have imported from previous projects or received from third
-    parties. See <link endterm="how.to.use.tm.title" linkend="how.to.use.tm"/>
-    for details.</para>
+    parties. See the <link endterm="how.to.use.tm.title"
+    linkend="how.to.use.tm"/> how-to for details.</para>
 
     <para>When you enter a segment, the first fuzzy match (the one with the
     highest match percentage) is automatically selected. You can press
-    <keycombo>
-        <keycap>C</keycap>
+    <keycombo><keycap>C</keycap><keycap>2, 3, 4, 5</keycap></keycombo> to select
+    a different match or use <link linkend="menus.edit"
+    endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
+    endterm="menus.edit.select.match.title"/>.</para>
 
-        <keycap>2, 3, 4, 5</keycap>
-      </keycombo> to select a different match.</para>
-
-	  <example id="the.first.match">
-		<title id="the.first.match.title">The first match</title>
-		<para>
-		  <programlisting>1. <token>Configuration</token> Folder
+	<example id="the.first.match">
+	  <title id="the.first.match.title">The first match</title>
+	  <para>
+		<programlisting>1. <token>Configuration</token> Folder
 Dossier de configuration
 &lt;50/50/66% &gt;</programlisting>
-		</para>
-	  </example>
+	  </para>
+	</example>
 
     <para>The selected fuzzy match is highlighted in bold, with words missing
     from the segment you are translating shown in blue, and adjacent words
@@ -584,49 +674,52 @@ Dossier de configuration
     <para>The match also displays three percentages.</para>
 
     <para>The three matching percentages have the following meaning, in
-    order:<itemizedlist>
-        <listitem>
-          <para>Percentage calculated with stemming based on the source
-          language tokenizer, and ignoring tags and numbers (generally the
-          highest).</para>
-        </listitem>
+    order:</para>
 
-        <listitem>
-          <para>Percentage calculated without stemming, and still ignoring
-          tags and numbers (generally slightly lower).</para>
-        </listitem>
+	<itemizedlist>
+      <listitem>
+        <para>Percentage calculated with stemming based on the source language
+        tokenizer, and ignoring tags and numbers (generally the highest).</para>
+      </listitem>
 
-        <listitem>
-          <para>Percentage calculated on the entire text, including tags and
-          numbers (generally the lowest).</para>
-        </listitem>
-    </itemizedlist></para>
+      <listitem>
+        <para>Percentage calculated without stemming, and still ignoring tags
+        and numbers (generally slightly lower).</para>
+      </listitem>
 
+      <listitem>
+        <para>Percentage calculated on the entire text, including tags and
+        numbers (generally the lowest).</para>
+      </listitem>
+    </itemizedlist>
+  
     <para>You can change how matches are displayed or sorted. See the <link
     endterm="dialog.preferences.tm.matches.title"
     linkend="dialog.preferences.tm.matches"/> preferences for details.</para>
 
-    <para>Use <link endterm="menus.edit.replace.with.match.or.selection.title"
+    <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+    endterm="menus.edit.replace.with.match.or.selection.title"
     linkend="menus.edit.replace.with.match.or.selection"/> to replace the
-    translation field with the match, or <link
+    translation field with the match, or <link linkend="menus.edit"
+    endterm="menus.edit.title"/><link
     endterm="menus.edit.insert.match.or.selection.title"
-    linkend="menus.edit.insert.match.or.selection"/> to insert it at the
-    cursor position.</para>
+    linkend="menus.edit.insert.match.or.selection"/> to insert it at the cursor
+    position.</para>
   </section>
 
   <section id="panes.glossary">
-    <title id="panes.glossary.title">Glossary</title>
+    <title id="panes.glossary.title"><guilabel>Glossary</guilabel></title>
 
-    <para>The Glossary pane shows terms from your glossary files that
-    correspond to terms in the current segment. The glossary files are located
-    in the project’s <link endterm="project.folder.glossary.title"
+    <para>The Glossary pane shows terms from your glossary files that correspond
+    to terms in the current segment. The glossary files are located in the
+    project’s <link endterm="project.folder.glossary.title"
     linkend="project.folder.glossary"/> folder.</para>
 
-    <para>The source term is displayed before the “=” sign and the target
-    terms after it. If the entry contains comments, they are numbered and
-    displayed on separate lines below the terms. Terms found in the writable
-    glossary are shown in bold, while those from other glossaries are
-    presented as regular text.</para>
+    <para>The source term is displayed before the “=” sign and the target terms
+    after it. If the entry contains comments, they are numbered and displayed on
+    separate lines below the terms. Terms found in the writable glossary are
+    shown in bold, while those from other glossaries are presented as regular
+    text.</para>
 
 	<example id="glossary.matches">
 	  <title id="glossary.matches.title">Glossary matches</title>
@@ -641,75 +734,80 @@ Folder = <token>Dossier</token></programlisting>
     <para>The glossary file name is shown as a tooltip when hovering over the
     terms.</para>
 
-    <para>Hyperlinks can be present in the comment field of an entry and can be clicked
-    upon for further reference.</para>
-	<para>Links to local files
-    (<filename>file:///PATH/filename</filename>) open in the associated
-    program. Web addresses (<filename>http://...</filename>) open in the
-    default browser.</para>
+    <para>Hyperlinks can be present in the comment field of an entry and can be
+    clicked upon for further reference.</para>
+
+	<para>Links to local files (<filename>file:///PATH/filename</filename>) open
+	in the associated program. Web addresses (<filename>http://...</filename>)
+	open in the default browser.</para>
 
     <para>You can select a term in the glossary pane and right click on it to
     insert it into the translation.</para>
 
-    <para>If you have activated <link
+    <para>Use <link endterm="menus.view.title" linkend="menus.view"/><link
     endterm="menus.view.mark.glossary.matches.title"
-    linkend="menus.view.mark.glossary.matches"/> in the <link
-    endterm="menus.view.title" linkend="menus.view"/> menu, you can
-    right-click on the highlighted word in the source segment to open a pop-up
-    menu listing the translations available in your glossaries. Selecting one
-    will insert it in the segment at the current cursor position.</para>
+    linkend="menus.view.mark.glossary.matches"/> to underline glossary
+    matches.</para>
+
+	<para>You can then right-click on the underlined word in the source segment
+	to open a pop-up menu listing the translations available in your
+	glossaries. Selecting one will insert it in the segment at the current
+	cursor position.</para>
 
     <para>You can use the glossary preferences to fine-tune how the glossaries
-    are displayed. See the <link
-    endterm="dialogs.preferences.glossary.title"
+    are displayed. See the <link endterm="dialogs.preferences.glossary.title"
     linkend="dialogs.preferences.glossary"/> preferences for details.</para>
 
     <para>Modifications to any glossary file in the glossary folder are
-    immediately recognized by OmegaT and displayed in the glossary
-    pane.</para>
+    immediately recognized by OmegaT and displayed in the glossary pane.</para>
 
     <para>OmegaT includes one writable glossary file per project. Use <link
+    endterm="menus.edit.title" linkend="menus.edit"/><link
     endterm="menus.edit.create.glossary.entry.title"
-    linkend="menus.edit.create.glossary.entry"/> in the <link
-    endterm="menus.edit.title" linkend="menus.edit"/> menu to add terms to
-    that file.</para>
+    linkend="menus.edit.create.glossary.entry"/> to add terms to that
+    file.</para>
 
 	<para>See the <link linkend="app.glossaries"
 	endterm="app.glossaries.title"/> appendix for details.</para>
   </section>
 
   <section id="panes.dictionary">
-    <title id="panes.dictionary.title">Dictionary</title>
+    <title id="panes.dictionary.title"><guilabel>Dictionary</guilabel></title>
+
 	<para>The Dictionary pane shows terms from your dictionary files that
 	correspond to terms in the current segment. The dictionary files are located
-	in the project’s <link linkend="project.folder.dictionary" endterm="project.folder.dictionary.title"/> folder. See the <link
-    endterm="dialogs.preferences.dictionary.title"
-    linkend="dialogs.preferences.dictionary"/> preferences for details.</para>
+	in the project’s <link linkend="project.folder.dictionary"
+	endterm="project.folder.dictionary.title"/> folder. See the <link
+	endterm="dialogs.preferences.dictionary.title"
+	linkend="dialogs.preferences.dictionary"/> preferences for details.</para>
   </section>
   
   <section id="panes.machinetranslation">
-    <title id="panes.machinetranslation.title">Machine Translation</title>
+    <title id="panes.machinetranslation.title"><guilabel>Machine
+    Translation</guilabel></title>
 
     <para>The machine translation pane, when opened, contains the suggestions
     produced for the current segment by one or more enabled translation
-    engines. When suggestions from more than one engine are available,
+    engines. When suggestions from more than one engine are available,</para>
+	
     <itemizedlist>
-        <listitem>
-          <para>the name of the engine will appear after the translated
-          text,</para>
-        </listitem>
+      <listitem>
+        <para>the name of the engine will appear after the translated
+        text,</para>
+      </listitem>
 
-        <listitem>
-          <para>the results are sorted in alphabetical order of engine
-          names,</para>
-        </listitem>
+      <listitem>
+        <para>the results are sorted in alphabetical order of engine
+        names,</para>
+      </listitem>
 
-        <listitem>
-          <para>and the currently selected translation is highlighted.</para>
-        </listitem>
-      </itemizedlist></para>
+      <listitem>
+        <para>and the currently selected translation is highlighted.</para>
+      </listitem>
+    </itemizedlist>
 
-    <para>Use <link linkend="menus.edit.replace.with.mt.title"
+    <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+    linkend="menus.edit.replace.with.mt.title"
     endterm="menus.edit.replace.with.mt.title"/> to replace the translation of
     the current segment with the selected translation engine.</para>
 
@@ -722,55 +820,66 @@ Folder = <token>Dossier</token></programlisting>
 
     <para>Make sure the service is enabled and your credentials are entered
     correctly. If they are, you may need to contact the service provider for
-    assistance. Similarly, an error such as <literal>Unable to parse
-    translation service response</literal> suggests that there may be a
-    communication problem between your system and the provider's
-    server.</para>
+    assistance. Similarly, an error such as <literal>Unable to parse translation
+    service response</literal> suggests that there may be a communication
+    problem between your system and the provider's server.</para>
 
-	<para>See the <link linkend="dialogs.preferences.mt" endterm="dialogs.preferences.mt.title"/> preferences for details.</para>
+	<para>See the <link linkend="dialogs.preferences.mt"
+	endterm="dialogs.preferences.mt.title"/> preferences for details.</para>
   </section>
 
   <section id="panes.multipletranslations">
-    <title id="panes.multipletranslations.title">Multiple Translations</title>
+    <title id="panes.multipletranslations.title"><guilabel>Multiple
+    Translations</guilabel></title>
 
     <para>A source segment that appears in multiple locations in the project may
     require several different translations depending on context.</para>
 
-	<para>If the current
-    translation of the segment is not suitable, you can use the <link
-    endterm="menus.edit.create.alternative.translation.title"
-    linkend="menus.edit.create.alternative.translation"/> command in the <link
-    endterm="menus.edit.title" linkend="menus.edit"/> menu to specify an
-    alternative translation. The entered translation will then be treated as an
-    alternative translation of the source segment.</para>
+	<para>Use <link endterm="menus.edit.title" linkend="menus.edit"/><link
+	endterm="menus.edit.create.alternative.translation.title"
+	linkend="menus.edit.create.alternative.translation"/> to register an
+	alternative translation if the current translation of the segment is not
+	suitable. The entered translation will then be treated as an alternative
+	translation of the source segment.</para>
 
-    <para>You can define one of the alternatives—the most common or likely,
-    for instance—as the default translation with the <link
+    <para>Use <link endterm="menus.edit.title" linkend="menus.edit"/><link
     endterm="menus.edit.use.as.default.translation.title"
-    linkend="menus.edit.use.as.default.translation"/> command.</para>
+    linkend="menus.edit.use.as.default.translation"/> to define one of the
+    alternatives—the most common or likely, for instance—as the default
+    translation.</para>
   </section>
 
   <section id="panes.notes">
-    <title id="panes.notes.title">Notes</title>
+    <title id="panes.notes.title"><guilabel>Notes</guilabel></title>
 
-    <para>The Notes pane is an <emphasis>editable</emphasis> space where you can add notes to the currently active segment.</para>
+    <para>The Notes pane is an <emphasis>editable</emphasis> space where you can
+    add notes to the currently active segment.</para>
 
 	<para>This lets you come back to it later to review the translation, check
-	that alternative translations are correct or, in shared projects, ask colleagues for their
-	opinion, for example.</para>
+	that alternative translations are correct or, in shared projects, ask
+	colleagues for their opinion, for example.</para>
 
-	<para>You can browse through the notes using <link
+	<para>Use <link endterm="menus.goto.title" linkend="menus.goto"/><link
 	endterm="menus.goto.next.note.title" linkend="menus.goto.next.note"/> and
-	<link endterm="menus.goto.previous.note.title"
-		  linkend="menus.goto.previous.note"/>.</para>
+	<link endterm="menus.goto.title" linkend="menus.goto"/><link
+	endterm="menus.goto.previous.note.title"
+	linkend="menus.goto.previous.note"/> to browse through the notes.</para>
 
-	<note><para>The notes are stored in the translation memory of the
-	project. They are <emphasis>not</emphasis> stored in the translated
-	files.</para></note>
+	<para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+	linkend="menus.goto.notes.pane" endterm="menus.goto.notes.pane.title"/> to
+	enter the pane and add or modify a note.</para>
+	<para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
+	linkend="menus.goto.editor.pane" endterm="menus.goto.editor.pane.title"/> to
+	go back to the Editor.</para>
+
+	<note>
+	  <para>The notes are stored in the translation memory of the project. They
+	  are <emphasis>not</emphasis> stored in the translated files.</para>
+	</note>
   </section>
 
   <section id="panes.comments">
-    <title id="panes.comments.title">Comments</title>
+    <title id="panes.comments.title"><guilabel>Comments</guilabel></title>
 
     <para>Some file formats, such as the PO format, can provide the translator
     with comments to add context to the translation. Such comments are displayed
@@ -781,30 +890,34 @@ Folder = <token>Dossier</token></programlisting>
       displays information that is included in the file.</para>
 
 	  <para>To write your own comments about a translation, use the <link
-      endterm="panes.notes.title" linkend="panes.notes"/> pane instead.</para>
+	  endterm="panes.notes.title" linkend="panes.notes"/> pane instead.</para>
     </note>
   </section>
 
   <section id="panes.segment.properties">
-    <title id="panes.segment.properties.title">Segment properties</title>
+    <title id="panes.segment.properties.title"><guilabel>Segment
+    properties</guilabel></title>
 
-    <para>All segments have properties. The properties are displayed in this pane.</para>
-	<para>Common properties include:
+    <para>All segments have properties. The properties are displayed in this
+    pane.</para>
+	<para>Common properties include:</para>
+	
 	<variablelist>
 	  <varlistentry>
 		<term>Is duplicate</term>
 		<listitem>
-	  <para>indicates that a segment is a duplicate and specifies whether the segment is the FIRST or not.</para>
+		  <para>indicates that a segment is a duplicate and specifies whether
+		  the segment is the FIRST or not.</para>
 		</listitem>
 	  </varlistentry>
 	  <varlistentry>
 		<term>File</term>
 		<listitem>
-		<para>indicates the file where the segment is stored.</para>
+		  <para>indicates the file where the segment is stored.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
-</para>
+
     <note>
       <para>The Properties pane is <emphasis>not</emphasis> editable. It only
       displays information that is related to the segment.</para>
@@ -812,39 +925,61 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.statusbar">
-    <title id="panes.statusbar.title">Status bar</title>
+    <title id="panes.statusbar.title"><guilabel>Status bar</guilabel></title>
 
     <para>The bottom of the main window is the status bar.</para>
 
-	<para>The left side displays information about actions taken in the project
-	or error messages.</para>
+	<para>The left side of the status bar displays information about actions
+	taken in the project or error messages.</para>
 
 	<example id="panes.statusbar.messages">
       <title id="panes.statusbar.messages.title">Status bar messages examples</title>
 	  <para><literal>Synchronization of repositories</literal></para>
-	  <para>→ OmegaT is opening a team project and synchronizes with the remote repository.</para>
+
+	  <para>→ OmegaT is opening a team project and synchronizes with the remote
+	  repository.</para>
+
 	  <para><literal>Jumping to last edited segment...</literal></para>
+
 	  <para>→ OmegaT opens the last edited segment from the last session.</para>
+
 	  <para><literal>Project autosaved at 10:48 PM</literal></para>
+
 	  <para>→ OmegaT has recently saved the project.</para>
+
 	  <para><literal>Translated files created</literal></para>
+
 	  <para>→ Files were created by the user.</para>
 	</example>
 
-    <para>The right side displays the <link
+    <para>The right side of the status bar indicates whether the cursor is
+    locked withing the segment (see the <link
     endterm="panes.editor.cursor.lock.title"
-    linkend="panes.editor.cursor.lock"/> and the <link linkend="panes.editor.overwriting" endterm="panes.editor.overwriting.title"/> status followed by progress
-    information.</para>
+    linkend="panes.editor.cursor.lock"/> setting), whether the cursor overwrites
+    the existing text (see the <link linkend="panes.editor.overwriting"
+    endterm="panes.editor.overwriting.title"/> setting), and also displays
+    progress information.</para>
 
     <para>Click on the figures to alternate between displaying progress as numbers or
     percentages.</para>
 
-
 	<example id="panes.statusbar.widgets">
-      <title id="panes.statusbar.widgets.title">Status bar progress
-      information</title>
-	  <para><literal>LCK  |  OVR <token>257/271 (12292/154896, 177692)</token><token> 35/0 </token></literal></para>
+      <title id="panes.statusbar.widgets.title">Status bar information</title>
+	  <para><literal>LCK | OVR <token>257/271 (12292/154896,
+	  177692)</token><token> 35/0 </token></literal></para>
+
 	  <variablelist>
+		<varlistentry>
+		  <term>Cursor status</term>
+		  <listitem>
+			<para><literal>LCK</literal> indicates that the cursor is locked
+			inside the segment.</para>
+
+			<para><literal>OVR</literal> indicates that the cursor overwrites
+			the existing text.</para>
+		  </listitem>
+		</varlistentry>
+		
 		<varlistentry>
 		  <term>In the file</term>
 		  <listitem>
@@ -853,6 +988,7 @@ Folder = <token>Dossier</token></programlisting>
 			= total number of segments</para>
 		  </listitem>
 		</varlistentry>
+
 		<varlistentry>
 		  <term>In the project</term>
 		  <listitem>
@@ -863,23 +999,36 @@ Folder = <token>Dossier</token></programlisting>
 			total number of segments</para>
 		  </listitem>
 		</varlistentry>
+
 		<varlistentry>
 		  <term>In the segment</term>
 		  <listitem>
-			<para><emphasis role="bold">35</emphasis> = number of
-			characters in the source / <emphasis
-			role="bold">0</emphasis> = number of characters in the
-			target area so far</para>
+			<para><emphasis role="bold">35</emphasis> = number of characters in
+			the source / <emphasis role="bold">0</emphasis> = number of
+			characters in the target area so far</para>
 		  </listitem>
 		</varlistentry>
 	  </variablelist>
 	</example>
 	
 	<example id="panes.statusbar.widgets.percentage">
-      <title id="panes.statusbar.widgets.percentage.title">Status bar progress
+      <title id="panes.statusbar.widgets.percentage.title">Status bar
       information, percentage mode</title>
-	  <para><literal>LCK  |  OVR <token>94.8% (14 left) / 7.9% (142,604 left), 177,692</token> <token>35/0</token></literal></para>
+	  <para><literal>UNL | INS <token>94.8% (14 left) / 7.9% (142,604 left),
+	  177,692</token> <token>35/0</token></literal></para>
 	  <variablelist>
+		<varlistentry>
+		  <term>Cursor status</term>
+		  <listitem>
+			<para><literal>UNL</literal> indicates that the cursor is not locked
+			inside the segment and can navigate around the editor window with
+			standard navigation commands.</para>
+
+			<para><literal>INS</literal> indicates that the cursor inserts
+			text.</para>
+		  </listitem>
+		</varlistentry>
+
 		<varlistentry>
 		  <term>In the file</term>
 		  <listitem>
@@ -888,6 +1037,7 @@ Folder = <token>Dossier</token></programlisting>
 			= number of untranslated segments</para>
 		  </listitem>
 		</varlistentry>
+
 		<varlistentry>
 		  <term>In the project</term>
 		  <listitem>
@@ -898,6 +1048,7 @@ Folder = <token>Dossier</token></programlisting>
 			total number of segments</para>
 		  </listitem>
 		</varlistentry>
+
 		<varlistentry>
 		  <term>In the segment</term>
 		  <listitem>

--- a/doc_src/en/OmegaT5_HowTo.xml
+++ b/doc_src/en/OmegaT5_HowTo.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="how.to">
-  <title id="how.to.title">How To...</title>
+<chapter id="chapter.how.to">
+  <title id="chapter.how.to.title">How To...</title>
 
   <xi:include href="HowTo_RestoreYourData.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/doc_src/en/OmegaT5_Menus.xml
+++ b/doc_src/en/OmegaT5_Menus.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="menus">
-  <title id="menus.title">Menus</title>
-  <para>Menus are where you access most of OmegaT's functions. Most of the menu items are associated with a keyboard shortcut.</para>
-  <para>Menu items that do not have a shortcut indicated next to them have no default shortcut assigned by default. See <link linkend="app.shortcuts.customization" endterm="app.shortcuts.customization.title"/> if you want to modify or add shortcuts.</para>
+<chapter id="chapter.menus">
+  <title id="chapter.menus.title">Menus</title>
+
+  	<para>OmegaT looks a bit stern, if not outright unfriendly, to people who
+  	are used to button based interfaces. Buttons are very few in OmegaT. Most of
+  	the action takes place with the help of shortcuts associated to menu
+  	items.</para>
+
+	<para>Shortcuts are ubiquitous in this manual and you should be able very
+	shortly to remember the few that are useful in the course of a standard
+	translation day.</para>
+
+	<para>Menus are where you access most of OmegaT's functions. Most of the
+	menu items are associated with a keyboard shortcut.</para>
+
+	<para>Menu items that do not have a shortcut indicated next to them have no
+	default shortcut assigned by default. See the <link
+	linkend="app.shortcuts.customization"
+	endterm="app.shortcuts.customization.title"/> appendix if you want to modify
+	or add shortcuts.</para>
 
   <note><para>Key shortcut description reminder:
     <table id="menus.shortcut.description">
@@ -51,16 +67,23 @@
 
   <xi:include href="Menus_Project.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  
   <xi:include href="Menus_Edit.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="Menus_GoTo.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="Menus_View.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="Menus_Tools.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="Menus_Options.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="Menus_Help.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
 </chapter>

--- a/doc_src/en/OmegaT5_Preferences.xml
+++ b/doc_src/en/OmegaT5_Preferences.xml
@@ -3,48 +3,54 @@
 "../../../docbook-xml-4.5/docbookx.dtd"
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
-<chapter id="dialogs.preferences">
-  <title id="dialogs.preferences.title">Preferences</title>
+<chapter id="chapter.dialogs.preferences">
+  <title
+  id="chapter.dialogs.preferences.title"><guilabel>Preferences</guilabel></title>
 
-  <para>This dialog is accessible by selecting <link
+  <para>Use <link endterm="menus.options.title" linkend="menus.options"/><link
   endterm="menus.options.preferences.title"
-  linkend="menus.options.preferences"/> in the <link
-  endterm="menus.options.title" linkend="menus.options"/> menu (the <literal>OmegaT</literal> menu on macOS).</para>
+  linkend="menus.options.preferences"/> to access this dialog (the
+  <literal>OmegaT</literal> menu on macOS).</para>
 
-  <para>Use the search field at the top of the preferences list to look for specific items.</para>
+  <para>Use the search field at the top of the preferences list to look for
+  specific items.</para>
   
-  <para>Preferences set in this dialog are saved to the default <link linkend="configuration.folder" endterm="configuration.folder.title"/> and apply to all translation projects unless you have specified a different configuration folder.</para>
+  <para>Preferences set in this dialog are saved to the default <link
+  linkend="configuration.folder">configuration folder</link> and apply to all
+  translation projects unless you have specified a different configuration
+  folder.</para>
 
   <note>
-    <para>It is possible to have OmegaT use a different configuration folder
-    to define project-specific configurations. See <link
-    endterm="launch.with.command.line.omegat.terminal.command.syntax.title"
-    linkend="launch.with.command.line.omegat.terminal.command.syntax"/> for
-    details. If you specify such a configuration folder, all modifications made
-    in this dialog will be stored there.</para>
+    <para>It is possible to have OmegaT use a different configuration folder to
+    define project-specific configurations. See the <link
+    endterm="launch.with.command.line.title"
+    linkend="launch.with.command.line"/> section for details. If you specify
+    such a configuration folder, all modifications made in this dialog will be
+    stored there.</para>
   </note>
 
   <section id="dialogs.preferences.general">
-    <title id="dialogs.preferences.general.title">General</title>
+    <title id="dialogs.preferences.general.title"><guilabel>General</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.general.use.tab.to.advance">
-        <term id="dialogs.preferences.general.use.tab.to.advance.title">Use TAB
-        to Advance</term>
+        <term id="dialogs.preferences.general.use.tab.to.advance.title"><option>Use TAB
+        to Advance</option></term>
 
         <listitem>
 		  <para>The default key to validate and leave a segment is
 		  <keycap>Enter</keycap>.</para>
           <para>This option sets the segment validation key to
           <keycap>Tab</keycap> instead.</para>
+
 		  <para>This option is useful with some Chinese,
           Japanese or Korean character input systems.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.always.confirm.quit">
-        <term id="dialogs.preferences.general.always.confirm.quit.title">Always
-        Confirm Quit</term>
+        <term id="dialogs.preferences.general.always.confirm.quit.title"><option>Always
+        Confirm Quit</option></term>
 
         <listitem>
           <para>The program will ask for confirmation before closing.</para>
@@ -52,42 +58,46 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.access.configuration.folder">
-        <term id="dialogs.preferences.general.access.configuration.folder.title">Access Configuration Folder</term>
-
-      <listitem>
-        <para>Opens the local folder where OmegaT configuration files are
-        stored.</para>
-		<note><para>The location depends on the operating system and launch
-		options. See <link linkend="configuration.folder"
-		endterm="configuration.folder.title"/> for details.</para></note>
-      </listitem>
+        <term
+			id="dialogs.preferences.general.access.configuration.folder.title"><option>Access
+        Configuration Folder</option></term>
+		<listitem>
+          <para>Opens the local folder where OmegaT configuration files are
+          stored.</para>
+		  <note>
+			<para>The location depends on the operating system and launch
+			options. See the <link linkend="configuration.folder"
+			endterm="configuration.folder.title"/> appendix for details.</para>
+		  </note>
+		</listitem>
       </varlistentry>
 
 	</variablelist>
   </section>
 
   <section id="dialogs.preferences.mt">
-    <title id="dialogs.preferences.mt.title">Machine Translation</title>
+    <title id="dialogs.preferences.mt.title"><guilabel>Machine Translation</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.mt.automatically.fetch.translations">
         <term
-			id="dialogs.preferences.mt.automatically.fetch.translations.title">Automatically
-        fetch translations</term>
+			id="dialogs.preferences.mt.automatically.fetch.translations.title"><option>Automatically
+        fetch translations</option></term>
 
         <listitem>
-          <para>If you disable this
-          option, machine translations will only be fetched when you use
-          <link linkend="menus.edit.replace.with.mt" endterm="menus.edit.replace.with.mt.title"/> in the
-          current segment. You will then have to press that combination again to
-          insert the suggestion.</para>
+          <para>If you disable this option, machine translations will only be
+          fetched when you use <link linkend="menus.edit"
+          endterm="menus.edit.title"/><link linkend="menus.edit.replace.with.mt"
+          endterm="menus.edit.replace.with.mt.title"/> in the current
+          segment. You will then have to press that combination again to insert
+          the suggestion.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.untranslated.segments.only">
         <term
-			id="dialogs.preferences.mt.untranslated.segments.only.title">Untranslated
-        segments only</term>
+			id="dialogs.preferences.mt.untranslated.segments.only.title"><option>Untranslated
+        segments only</option></term>
 
         <listitem>
           <para>Check this box to send only untranslated segments to the machine
@@ -96,20 +106,25 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.provider.list">
-        <term id="dialogs.preferences.mt.provider.list.title">Provider list</term>
+        <term id="dialogs.preferences.mt.provider.list.title"><option>Provider
+        list</option></term>
 
         <listitem>
           <para>In the list of machine translation available in OmegaT, check
-          the <guilabel>Enabled</guilabel> box for each provider you want
-          to access. Use the <guibutton>Configure</guibutton> button to manage
-          your authentication credentials for that provider.</para>
+          the <guilabel>Enabled</guilabel> box for each provider you want to
+          access. Use the <guibutton>Configure</guibutton> button to manage your
+          authentication credentials for that provider.</para>
 
-		  <note><para>Most providers require some kind of registration before
-		  using their services. Make sure you have the proper credentials before
-		  using this function.</para></note>
+		  <note>
+			<para>Most providers require some kind of registration before using
+			their services. Make sure you have the proper credentials before
+			using this function.</para>
+		  </note>
 
 		  <table id="dialogs.preferences.mt.provider.list.configuration">
-			<title id="dialogs.preferences.mt.provider.list.configuration.title">Required credentials</title>
+			<title
+			id="dialogs.preferences.mt.provider.list.configuration.title"><option>Required
+			credentials</option></title>
 
 			<tgroup align="left" cols="3" rowsep="1">
 			  <colspec align="left" colnum="1"/>
@@ -128,23 +143,28 @@
 				</row>
 				<row>
 				  <entry>DeepL</entry>
-				  <entry>Requires a Deepl Pro Advanced plan available only in some countries</entry>
-				  <entry><ulink url="https://www.deepl.com/en/pro">https://www.deepl.com/en/pro</ulink></entry>
+				  <entry>Requires a Deepl Pro Advanced plan available only in
+				  some countries</entry>
+				  <entry><ulink
+				  url="https://www.deepl.com/en/pro">https://www.deepl.com/en/pro</ulink></entry>
 				</row>
 				<row>
 				  <entry>Microsoft translator</entry>
 				  <entry>API client ID</entry>
-				  <entry><ulink url="https://www.microsoft.com/en-us/translator/">https://www.microsoft.com/en-us/translator/</ulink></entry>
+				  <entry><ulink
+				  url="https://www.microsoft.com/en-us/translator/">https://www.microsoft.com/en-us/translator/</ulink></entry>
 				</row>
 				<row>
 				  <entry>MyMemory (machine translation)</entry>
 				  <entry></entry>
-				  <entry><ulink url="https://mymemory.translated.net/doc/cat.php">https://mymemory.translated.net/</ulink></entry>
+				  <entry><ulink
+				  url="https://mymemory.translated.net/doc/cat.php">https://mymemory.translated.net/</ulink></entry>
 				</row>
 				<row>
 				  <entry>Apertium</entry>
 				  <entry>URL, key</entry>
-				  <entry><ulink url="http://www.apertium.org">http://www.apertium.org</ulink></entry>
+				  <entry><ulink
+				  url="http://www.apertium.org">http://www.apertium.org</ulink></entry>
 				</row>
 				<row>
 				  <entry>MyMemory (human translation)</entry>
@@ -154,17 +174,20 @@
 				<row>
 				  <entry>IBM Watson</entry>
 				  <entry>URL, Model ID, Login ID, Password</entry>
-				  <entry><ulink url="https://www.ibm.com/watson">https://www.ibm.com/watson</ulink></entry>
+				  <entry><ulink
+				  url="https://www.ibm.com/watson">https://www.ibm.com/watson</ulink></entry>
 				</row>
 				<row>
 				  <entry>Google Translate v2</entry>
 				  <entry>API key</entry>
-				  <entry><ulink url="https://cloud.google.com/translate/docs/reference/rest/">https://cloud.google.com/translate/</ulink></entry>
+				  <entry><ulink
+				  url="https://cloud.google.com/translate/docs/reference/rest/">https://cloud.google.com/translate/</ulink></entry>
 				</row>
 				<row>
 				  <entry>Yandex</entry>
 				  <entry>API key</entry>
-				  <entry><ulink url="https://yandex.com/dev/dictionary/keys/get/">https://yandex.com/</ulink></entry>
+				  <entry><ulink
+				  url="https://yandex.com/dev/dictionary/keys/get/">https://yandex.com/</ulink></entry>
 				</row>
 			  </tbody>
 			</tgroup>
@@ -175,13 +198,13 @@
   </section>
 
   <section id="dialogs.preferences.glossary">
-    <title id="dialogs.preferences.glossary.title">Glossary</title>
+    <title id="dialogs.preferences.glossary.title"><guilabel>Glossary</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries">
         <term
-			id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title">Display
-        TBX glossaries context description</term>
+        id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title"><option>Display
+        TBX glossaries context description</option></term>
 
         <listitem>
           <para>Uncheck this option if the context description shown for each
@@ -191,7 +214,8 @@
 
       <varlistentry id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text">
         <term
-			id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title">Match term groups even if the terms appear separately</term>
+			id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title"><option>Match
+        term groups even if the terms appear separately</option></term>
 
         <listitem>
           <para>When a glossary term is a compound word, the term will match
@@ -201,8 +225,8 @@
 
       <varlistentry id="dialogs.preferences.glossary.use.stemming.for.glossary.entries">
         <term
-			id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title">Use
-        stemming</term>
+			id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title"><option>Use
+        stemming</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -211,30 +235,42 @@
 
       <varlistentry id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text">
         <term
-			id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title">Replace matches when inserting source text</term>
+        id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title"><option>Replace
+        matches when inserting source text</option></term>
         <listitem>
-          <para>When OmegaT inserts the source contents, with
+          <para>When you use</para>
+		  
 		  <itemizedlist>
-			<listitem><para><link
-          linkend="menus.edit.replace.with.source"
-          endterm="menus.edit.replace.with.source.title"/>,</para></listitem>
-			<listitem><para><link
-          linkend="menus.edit.insert.source"
-          endterm="menus.edit.insert.source.title"/> or</para></listitem>
-			<listitem><para><link
-          linkend="dialogs.preferences.editor.insert.the.source.text"
-          endterm="dialogs.preferences.editor.insert.the.source.text.title"/>,
-			etc.</para></listitem>
+			<listitem>
+			  <para><link linkend="menus.edit"
+			  endterm="menus.edit.title"/><link linkend="menus.edit.replace.with.source"
+			  endterm="menus.edit.replace.with.source.title"/>,</para>
+			</listitem>
+
+			<listitem>
+			  <para><link linkend="menus.edit" endterm="menus.edit.title"/><link
+			  linkend="menus.edit.insert.source"
+			  endterm="menus.edit.insert.source.title"/> or</para>
+			</listitem>
+
+			<listitem>
+			  <para>the <link
+			  linkend="dialogs.preferences.editor.insert.the.source.text"
+			  endterm="dialogs.preferences.editor.insert.the.source.text.title"/>
+			  preference, etc.</para>
+			</listitem>
 		  </itemizedlist>
-		  words with a glossary entry are automatically replaced by their
+
+		  <para>to insert the source content in the target segment, words with a
+		  glossary entry will automatically be replaced by their
 		  translation.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.ignore.hits.with.very.different.case">
         <term
-			id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title">Ignore
-        matches with very different case (e.g., FOO vs foo)</term>
+        id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title"><option>Ignore
+        matches with very different case (e.g., USER vs user)</option></term>
 
         <listitem>
           <para>Matches with very different case are not displayed.</para>
@@ -242,7 +278,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.glossary.layout">
-        <term id="dialogs.preferences.glossary.glossary.layout.title">Layout</term>
+        <term id="dialogs.preferences.glossary.glossary.layout.title"><option>Layout</option></term>
 
         <listitem>
           <para>Select a layout for the glossary pane contents. Additional
@@ -252,8 +288,8 @@
 
       <varlistentry id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term">
         <term
-			id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title">Merge
-        alternate definition of the same term</term>
+        id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title"><option>Merge
+        alternate definition of the same term</option></term>
 
         <listitem>
           <para>If a glossary item has multiple definitions, they will be
@@ -264,23 +300,34 @@
   </section>
 
   <section id="dialogs.preferences.dictionary">
-    <title id="dialogs.preferences.dictionary.title">Dictionary</title>
+    <title id="dialogs.preferences.dictionary.title"><guilabel>Dictionary</guilabel></title>
 
-	<para>Preferences here define how the contents of the <link linkend="project.folder.dictionary" endterm="project.folder.dictionary.title"/> folder are displayed in the <link linkend="panes.dictionary" endterm="panes.dictionary.title"/> pane.</para>
+	<para>Preferences here define how the contents of the <link
+	linkend="project.folder.dictionary"
+	endterm="project.folder.dictionary.title"/> folder are displayed in the
+	<link linkend="panes.dictionary" endterm="panes.dictionary.title"/>
+	pane.</para>
+	
     <variablelist>
       <varlistentry id="dialogs.preferences.dictionary.automatically.search.segment">
         <term
-			id="dialogs.preferences.dictionary.automatically.search.segment.title">Search automatically</term>
+			id="dialogs.preferences.dictionary.automatically.search.segment.title"><option>Search
+        automatically</option></term>
 
         <listitem>
-          <para>If you disable this function you will need to use <link linkend="menus.edit.search.dictionaries" endterm="menus.edit.search.dictionaries.title"/> to search for dictionary matches.</para>
+          <para>If you disable this function you will need to use <link
+          linkend="menus.edit"
+          endterm="menus.edit.title"/><link
+          linkend="menus.edit.search.dictionaries"
+          endterm="menus.edit.search.dictionaries.title"/> to search for
+          dictionary matches.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries">
         <term
-			id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title">Use
-        fuzzy matching</term>
+			id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"><option>Use
+        fuzzy matching</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -288,82 +335,89 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.condensed.view">
-        <term id="dialogs.preferences.dictionary.use.condensed.view.title">Use
-        condensed view</term>
+        <term id="dialogs.preferences.dictionary.use.condensed.view.title"><option>Use
+        condensed view</option></term>
 
         <listitem>
-          <para>Some dictionary drivers provided as plugins do not support this feature. </para>
+          <para>Some dictionary drivers provided as plugins do not support this
+          feature. </para>
         </listitem>
       </varlistentry>
     </variablelist>
   </section>
 
   <section id="dialogs.preferences.appearance">
-    <title id="dialogs.preferences.appearance.title">Appearance</title>
+    <title id="dialogs.preferences.appearance.title"><guilabel>Appearance</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.appearance.theme">
-        <term id="dialogs.preferences.appearance.theme.title">Theme</term>
+        <term id="dialogs.preferences.appearance.theme.title"><option>Theme</option></term>
 
         <listitem>
           <para>Select a theme for the OmegaT user interface.</para>
-          <para>Additional themes can be added as plugins. The themes also provide
-          predefined set of default colors.</para>
-		  <para>Not all natively provided Java themes are compatible with OmegaT operation.</para>
+
+          <para>Additional themes can be added as plugins. The themes also
+          provide predefined set of default colors.</para>
+
+		  <para>Not all natively provided Java themes are compatible with OmegaT
+		  operation.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.appearance.restore.main.window">
         <term
-			id="dialogs.preferences.appearance.restore.main.window.title">Restore
-        Main Window</term>
+			id="dialogs.preferences.appearance.restore.main.window.title"><option>Restore
+        Main Window</option></term>
 
         <listitem>
-          <para>Restores the OmegaT window panes to their
-          default arrangement.</para>
-		  <para>Use this feature when you are unable to restore
-          the desired arrangement after undocking, moving, or hiding one or more
-          panes. You can use it when panes do not appear as expected after an
-          OmegaT upgrade.</para>
+          <para>Restores the OmegaT window panes to their default
+          arrangement.</para>
+
+		  <para>Use this feature when you are unable to restore the desired
+		  arrangement after undocking, moving, or hiding one or more panes. You
+		  can use it when panes do not appear as expected after an OmegaT
+		  upgrade.</para>
         </listitem>
       </varlistentry>
     </variablelist>
 	
 	<section id="dialogs.preferences.fonts">
-      <title id="dialogs.preferences.fonts.title">Font</title>
+      <title id="dialogs.preferences.fonts.title"><guilabel>Font</guilabel></title>
 
       <para>Select the font and font size used to display the text in the main
       window panes.</para>
 
-		<note><para>OmegaT uses the same font for both the source and target
+	  <note>
+		<para>OmegaT uses the same font for both the source and target
 		languages. If you work in a language pair that uses different writing
 		systems, make sure you choose a font that can display both languages
 		correctly. Characters that are not supported will appear as
-		squares.</para></note>
+		squares.</para>
+	  </note>
 
-		<variablelist>
-		  <varlistentry>
-		  <term>Apply this font to tabular data (project files,
-          statistics, etc.)</term>
+	  <variablelist>
+		<varlistentry>
+		  <term><option>Apply this font to tabular data (project files, statistics,
+		  etc.)</option></term>
 		  <listitem>
 			<para>Tabular data is by default displayed in a monospaced font that
 			keeps columns properly aligned. Using a proportional font will break
 			that layout.</para>
 		  </listitem>
-		  </varlistentry>
-		  <varlistentry>
-			<term>Apply a different font size to the dictionary pane</term>
+		</varlistentry>
 
-			<listitem>
-			  <para>By default, the dictionary pane uses the same font size as the main window
-			  panes.</para>
-			</listitem>
-		  </varlistentry>
-		</variablelist>
+		<varlistentry>
+		  <term><option>Apply a different font size to the dictionary pane</option></term>
+		  <listitem>
+			<para>By default, the dictionary pane uses the same font size as
+			the main window panes.</para>
+		  </listitem>
+		</varlistentry>
+	  </variablelist>
 	</section>
 
 	<section id="dialogs.preferences.colours">
-      <title id="dialogs.preferences.colours.title">Colors</title>
+      <title id="dialogs.preferences.colours.title"><guilabel>Colors</guilabel></title>
 
       <para>You can assign different colors for the various parts of the user
       interface.</para>
@@ -372,1043 +426,1262 @@
       a script called <link
       linkend="windows.scripts.distribution.switch.colour.theme"
       endterm="windows.scripts.distribution.switch.colour.theme.title"/> that
-      provides a default dark theme. See <link linkend="windows.scripts"
-      endterm="windows.scripts.title"/> for details.</para>
+      provides a default dark theme. See the <link linkend="windows.scripts"
+      endterm="windows.scripts.title"/> window for details.</para>
 	</section>
   </section>
 
   <section id="dialogs.preferences.file.filters">
-	<title id="dialogs.preferences.file.filters.title">Global File Filters</title>
+	<title id="dialogs.preferences.file.filters.title"><guilabel>Global File
+	Filters</guilabel></title>
 
-	<para>This dialog lists the file filters available to projects that do
-	not use local file filters.</para>
+	<para>This dialog lists the file filters available to projects that do not
+	use local file filters.</para>
 
 	<para>The contents of this preference are identical to the contents of the
-	<link linkend="dialogs.project.properties.filters"
-	endterm="dialogs.project.properties.filters.title"/> dialog. See <link
-	linkend="file.filters" endterm="file.filters.title"/> for details.</para>
+	<link linkend="dialogs.project.properties.filters">local file filters</link>
+	dialog. See the <link linkend="file.filters" endterm="file.filters.title"/>
+	appendix for details.</para>
 
-	<note><para>If local file filters are used, modifying global file filters
-	will have no effect on the project.</para></note>
-</section>
-
-
-<section id="dialogs.preferences.segmentation.setup">
-  <title id="dialogs.preferences.segmentation.setup.title">Global Segmentation Rules</title>
-
-  <para>See <link linkend="app.segmentation"
-  endterm="app.segmentation.title"/> for a general explanation of
-  segmentation (global or local, paragraph or sentence, etc.)</para>
-
-  <warning><para>This dialog only accesses the global segmentation rules. If you have set local rules  in <link linkend="dialogs.project.properties" endterm="dialogs.project.properties.title"/>, modifications here will not be taken into account.</para></warning>
-  
-  <section id="dialogs.preferences.segmentation.setup.scope">
-	<title id="dialogs.preferences.segmentation.setup.scope.title">Language
-	sets</title>
-
-	<para>Only the rules associated to language patterns that correspond to
-	the source language of your project are applied. See <link
-	linkend="dialogs.project.properties.languages"
-	endterm="dialogs.project.properties.languages.title"/> in <link
-	linkend="dialogs.project.properties"
-	endterm="dialogs.project.properties.title"/>.</para>
-
-	<example id="dialogs.preferences.segmentation.setup.scope.example">
-	  <title id="dialogs.preferences.segmentation.setup.scope.example.title">Rules for Japanese</title>
-	  <para>For a translation from Japanese, <emphasis>only</emphasis> the rule
-	  set associated to the <code>JA.*</code> pattern and the generic rule sets
-	  associated to the <code>.*</code> will be taken into account.</para>
-	</example>
-
-	<para>When you click on a language pattern in the top half of the dialog,
-	a list of associated rules will be displayed in the bottom half of the
-	dialog.</para>
-
-	<para>All segmentation rule sets for a matching language pattern are
-	active and are applied in order. Rules for specific language regions
-	should be higher than default ones.</para>
-
-	<example id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example">
-	  <title id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example.title">Cascading priorities</title>
-	<para>The rules for
-	<emphasis>FR-CA</emphasis> should be set higher than those for
-	<emphasis>FR.*</emphasis>, which should themselves be higher than the
-	generic <emphasis>.*</emphasis> set.</para>
-	<para>Thus, when translating from Canadian
-	French the rules for Canadian French—if any—will apply first, followed by
-	the rules for French and lastly, by the generic rules.</para>
-	</example>
-	
-	<para>To create a new rule set:
-	<orderedlist>
-	  <listitem>
-		<para>Click <guibutton>Add</guibutton>. An empty line will appear at the bottom of the table.</para>
-	  </listitem>
-	  <listitem>
-		<para>Change the name of the rule set and the language pattern to the
-		desired label and corresponding pattern. The language pattern is a
-		regular expression.</para>
-	  </listitem>
-	  <listitem>
-		<para>Use the <guibutton>Move Up</guibutton> button to set the rule set
-		priority.</para>
-	  </listitem>
-	</orderedlist>
-	</para>
+	<note>
+	  <para>If local file filters are used, modifying global file filters will
+	  have no effect on the project.</para>
+	</note>
   </section>
 
-  <section id="segmentation.rules">
-	<title id="segmentation.rules.title">Set contents</title>
 
-	<warning><para>Exception rules should be listed
-	<emphasis>above</emphasis> break rules.</para>
-	<para>When OmegaT reads files, it puts a non-breaking marker at every exception location. Places that do not have such markers and that match break rules will be break locations.</para></warning>
+  <section id="dialogs.preferences.segmentation.setup">
+	<title id="dialogs.preferences.segmentation.setup.title"><guilabel>Global
+	Segmentation Rules</guilabel></title>
+
+	<para>See the <link linkend="app.segmentation"
+	endterm="app.segmentation.title"/> appendix for a general explanation of
+	segmentation (global or local, paragraph or sentence, etc.)</para>
+
+	<warning>
+	  <para>This dialog only accesses the global segmentation rules. If you have
+	  set local rules in the <link linkend="dialogs.project.properties"
+	  endterm="dialogs.project.properties.title"/> dialog, modifications here
+	  will not be taken into account.</para>
+	</warning>
 	
-	<variablelist>
-	  <varlistentry id="segmentation.rules.exceptionrule">
-		<term id="segmentation.rules.exceptionrule.title">Exceptions</term>
+	<section id="dialogs.preferences.segmentation.setup.scope">
+	  <title id="dialogs.preferences.segmentation.setup.scope.title">Language
+	  sets</title>
 
+	  <para>Only the rules associated to language patterns that correspond to
+	  the source language of your project are applied. See the <link
+	  linkend="dialogs.project.properties.languages"
+	  endterm="dialogs.project.properties.languages.title"/> project
+	  properties.</para>
+
+	  <example id="dialogs.preferences.segmentation.setup.scope.example">
+		<title
+		id="dialogs.preferences.segmentation.setup.scope.example.title">Rules
+		for Japanese</title>
+		<para>For a translation from Japanese, <emphasis>only</emphasis> the
+		rule set associated to the <code>JA.*</code> pattern and the generic
+		rule sets associated to the <code>.*</code> will be taken into
+		account.</para>
+	  </example>
+
+	  <para>When you click on a language pattern in the top half of the dialog,
+	  a list of associated rules will be displayed in the bottom half of the
+	  dialog.</para>
+
+	  <para>All segmentation rule sets for a matching language pattern are
+	  active and are applied in order. Rules for specific language regions
+	  should be higher than default ones.</para>
+
+	  <example id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example">
+		<title
+			id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example.title">Cascading
+		priorities</title>
+		<para>The rules for <emphasis>FR-CA</emphasis> should be set higher than
+		those for <emphasis>FR.*</emphasis>, which should themselves be higher
+		than the generic <emphasis>.*</emphasis> set.</para>
+
+		<para>Thus, when translating from Canadian French the rules for Canadian
+		French—if any—will apply first, followed by the rules for French and
+		lastly, by the generic rules.</para>
+	  </example>
+	  
+	  <para>To create a new rule set:</para>
+	  <orderedlist>
 		<listitem>
-		  <para>To define an exception rule, leave the <guilabel>Break/Exception
-		  </guilabel>check box unchecked.</para>
-
-		  <para>Specify text combinations that are exceptions to a break
-		  rule. For example, <emphasis>Mrs. Dalloway</emphasis> should not be
-		  split in two segments even though a break rule for <emphasis>period
-		  followed by a space</emphasis> generally defines a sentence.</para>
-		 
+		  <para>Click <guibutton>Add</guibutton>. An empty line will appear at
+		  the bottom of the table.</para>
 		</listitem>
-	  </varlistentry>
-
-	  <varlistentry id="segmentation.rules.breakrule">
-		<term id="segmentation.rules.breakrule.title">Breaks</term>
-
-		<listitem>
-		  <para>To define a break rule, check the
-		  <guilabel>Break/Exception</guilabel> box.</para>
-
-		  <para>Separates the source text into segments. For example,
-		  <emphasis>period followed by a space</emphasis> generally defines a
-		  sentence end in English.</para>
-		</listitem>
-	  </varlistentry>
-
-  <varlistentry id="creating.new.rule">
-	<term id="creating.new.rule.title"><guibutton>Add</guibutton></term>
-	<listitem>
-	  <para>The <emphasis role="bold">Before</emphasis> pattern identifies the parts that are before the break or exception point.</para>
-	  <para>The <emphasis role="bold"> After</emphasis> pattern identifies the parts that are after the break or exception point.</para>
-
-	<para>The <emphasis role="bold">Before</emphasis> and<emphasis
-	role="bold"> After</emphasis> patterns are regular expressions. See
-	<link linkend="app.regex" endterm="app.regex.title"/>
-	for details.</para>
-	</listitem>
-  </varlistentry>
-	</variablelist>
-	
-	<para>The existing rules always provide a good starting point. See also
-	<link linkend="segmentation.simple.examples"
-		  endterm="segmentation.simple.examples.title"/>.</para>
-  </section>
-</section>
-
-<section id="dialog.preferences.auto.completion">
-  <title id="dialog.preferences.auto.completion.title">Auto-Completion</title>
-
-  <para>Click on <guilabel>Glossary</guilabel> to configure the
-  auto-completer glossary view.</para>
-
-  <para>Click on <guilabel>Autotext</guilabel> to configure the Autotext
-  options, and to add or remove entries.</para>
-
-  <para>Click on <guilabel>Character Table</guilabel> to set the Character
-  table auto-completer options.</para>
-
-  <para>Click on <guilabel>Enable history completion</guilabel> or
-  <guilabel>Enable history prediction</guilabel> to set history based
-  completions.</para>
-
-  <note>
-	<para>Absolutely none of your data (history, etc.) is
-	<emphasis>ever</emphasis> sent to an external server by OmegaT for
-	processing. All prediction/completion results are computed
-	locally.</para>
-  </note>
-
-  <para>If the <guilabel>Show Relevant Suggestions Automatically</guilabel>
-  option is checked, typing the first letter of a translated glossary entry,
-  or <literal>&lt;</literal> for a tag, automatically launches the
-  auto-completer.</para>
-</section>
-
-<section id="dialog.preferences.spellchecker">
-  <title id="dialog.preferences.spellchecker.title">Spellchecker</title>
-
-  <para>OmegaT has a built-in spellchecker but requires you to install spellchecking dictionaries based on your target languages.</para>
-
-  <warning><para>OmegaT will use the language dictionary that has the same name
-  as the target language code set in <link
-  linkend="dialogs.project.properties.languages"
-  endterm="dialogs.project.properties.languages.title"/>. An
-  <emphasis>FR-FR</emphasis> dictionary will not spellcheck
-  <emphasis>FR</emphasis> target segments. If necessary, modify the name of the
-  dictionary or change your project’s language settings.</para></warning>
-
-  <variablelist>
-	<varlistentry id="dialog.preferences.spellchecker.automatic.check">
-	  <term id="dialog.preferences.spellchecker.automatic.check.title">Spellcheck the translation</term>
-	  <listitem><para>Enable after installing a spellchecking dictionary. OmegaT will underline spelling mistakes with red wavy-lines.</para>
-	  <para>Use the <link linkend="panes.editor.context.menu" endterm="panes.editor.context.menu.title"/> to correct the mistake, to <guimenuitem>Ignore All</guimenuitem> or to <guimenuitem>Add to Dictionary</guimenuitem>. See <link linkend="project.folder.omegat.spellcheck">spellchecker files</link> for details.</para>
-	  </listitem>
-	</varlistentry>
-	<varlistentry id="dialog.preferences.spellchecker.dictionary.folder">
-	  <term id="dialog.preferences.spellchecker.dictionary.folder.title">Spellchecking dictionaries location</term>
-	  <listitem><para>The folder where OmegaT will install and search for spelling dictionaries. It is generally in the <link linkend="configuration.folder" endterm="configuration.folder.title"/> folder.</para></listitem>
-	</varlistentry>
-	<varlistentry id="dialog.preferences.spellchecker.already.installed">
-	  <term id="dialog.preferences.spellchecker.already.installed.title">Available languages</term>
-	  <listitem><para>The list of dictionaries that are present in the above folder.</para>
-	  <para>If none are displayed it either means that you have not yet installed a spelling dictionary, or that your project uses a specific configuration folder that does not contain yet a spelling dictionary.</para></listitem>
-	</varlistentry>
-	<varlistentry id="dialog.preferences.spellchecker.url">
-	  <term id="dialog.preferences.spellchecker.url.title">URL of downloadable spellchecking dictionaries</term>
-	  <listitem><para>The default URL where OmegaT will look for dictionaries to install.</para>
-	  <para>You can also download dictionaries from other locations, or copy dictionaries installed locally.</para></listitem>
-	</varlistentry>
-	<varlistentry id="dialog.preferences.spellchecker.install.new">
-	  <term id="dialog.preferences.spellchecker.install.new.title">Install new language...</term>
-	  <listitem><para>Displays the list of available dictionaries from the above URL.</para>
-	  <warning><para>This action requires an internet connection</para></warning>
-	  <para>Select the dictionaries that you want to install and click <guibutton>Install</guibutton>. Depending on your internet connection it may take a while before the dictionary is installed.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-
-  
-</section>
-
-<section id="dialog.preferences.languagetool.plugin">
-  <title id="dialog.preferences.languagetool.plugin.title">LanguageTool</title>
-
-  <variablelist>
-	<varlistentry id="dialog.preferences.languagetool.plugin.servicetype">
-	  <term
-		  id="dialog.preferences.languagetool.plugin.servicetype.title">Service
-	  type</term>
-
-	  <listitem>
-		<para>Select the location of the language checker.</para>
-
-		<para>Using a different language checker on your local machine than
-		the one supplied with OmegaT allows you to customize the
-		verification rules.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialog.preferences.languagetool.plugin.rules">
-	  <term id="dialog.preferences.languagetool.plugin.rules.title">Rules</term>
-
-	  <listitem>
-		<para>Select the rules depending on whether they are
-		relevant to the type of text you are translating.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
-
-<section id="dialogs.preferences.external.searches">
-  <title id="dialogs.preferences.external.searches.title">Global External
-  Searches</title>
-  <para>External searches are either web searches or local commands that
-  take the string selected in the Editor as a parameter. The web searches
-  are opened in the default browser and the commands are equivalent to items
-  launched on the command line.</para>
-  <variablelist>
-	<varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
-	  <term
-		  id="dialogs.preferences.external.search.enable.project.specific.commands.title">Allow local external search commands</term>
-
-	  <listitem>
-		<warning><para>For security reasons, <link
-		linkend="dialogs.project.properties.external.searches"
-		endterm="dialogs.project.properties.external.searches.title"/>
-		are disabled by default.</para></warning>
-
-		<para>Local external search commands are saved in <link
-		linkend="project.folder.omegat.filters"
-		endterm="project.folder.omegat.filters.title"/>. Only activate this
-		option if you trust the source of that file.</para>
-
 		
-	  </listitem>
-	</varlistentry>
+		<listitem>
+		  <para>Change the name of the rule set and the language pattern to the
+		  desired label and corresponding pattern. The language pattern is a
+		  regular expression.</para>
+		</listitem>
 
-	<varlistentry id="dialogs.preferences.external.search.context.menu.priority">
-	  <term
-		  id="dialogs.preferences.external.search.context.menu.priority.title">Context
-	  Menu Priority</term>
+		<listitem>
+		  <para>Use the <guibutton>Move Up</guibutton> button to set the rule
+		  set priority.</para>
+		</listitem>
+	  </orderedlist>
+	</section>
 
-	  <listitem>
-		<para>This option enables you to change the order of the commands in
-		the Editor pane <link linkend="panes.editor.context.menu" endterm="panes.editor.context.menu.title"/>. Values around 100 display commands
-		at the top, and values around 900 display them at the bottom.</para>
+	<section id="segmentation.rules">
+	  <title id="segmentation.rules.title"><guilabel>Set contents</guilabel></title>
+	  <warning>
+		<para>Exception rules should be listed <emphasis>above</emphasis> break
+		rules.</para>
 
-		<warning><para>Restart OmegaT to apply this change.</para></warning>
-	  </listitem>
-	</varlistentry>
-	<varlistentry  id="dialogs.preferences.external.search.items">
-	  <term id="dialogs.preferences.external.search.items.title">Sets</term>
-	  <listitem>
-		<para>Each set represents a group of web searches or local commands
-		that are launched simultaneously.</para>
-		<para>A set must be given a name. The name will be displayed
-		at the bottom of the <link linkend="menus.tools"
-		endterm="menus.tools.title"/> menu.</para>
-		<para>If you check <guilabel>Show
-		in Editor context menu</guilabel>, the set name will also be
-		displayed in the <link linkend="panes.editor.context.menu"
-		endterm="panes.editor.context.menu.title"/> if a string is selected.</para>
-		<para>URL searches as well as commands must contain the string
-		<literal>{target}</literal> to be accepted. The <literal>{target}</literal>
-		placeholder will be replaced by the string that was selected in the
-		Editor.</para>
-		<para>URLs are opened with the default web browser, one per tab.</para>
-		<example id="dialogs.preferences.external.search.items.url.search.example"><title id="dialogs.preferences.external.search.items.url.search.example.title">URL search example</title>
-		<programlisting>https://duckduckgo.com/?q=%22{target}%22+site%3A.fr+-linguee</programlisting>
-		<para>This opens a search for the {target} term on DuckDuckGo with a
-		number of search parameters.</para></example>
-		<para>Commands are opened on the command line. The
-		<guilabel>Delimiter</guilabel>defines the delimiter between command
-		parameters. The default delimiter is <code>|</code>.</para>
-		<example id="dialogs.preferences.external.search.items.command.example"><title id="dialogs.preferences.external.search.items.command.example.title">Command example</title>
-		<programlisting>/usr/bin/open|dict://{target}</programlisting>
-		<para>This opens the dictionary application that implements the
-		<code>dict</code> protocol on your machine looking for the
-		{target} term.</para></example>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
-
-<section id="dialogs.preferences.editor">
-  <title id="dialogs.preferences.editor.title">Editor</title>
-
-  <para>When entering an empty segment:
-  <variablelist>
-	<varlistentry id="dialogs.preferences.editor.insert.the.source.text">
-	  <term
-		  id="dialogs.preferences.editor.insert.the.source.text.title">Insert
-	  the source text</term>
-
-	  <listitem>
-		<para>Use this option temporarily for parts of the translation that
-		do not require much transformation.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.leave.the.segment.empty">
-	  <term
-		  id="dialogs.preferences.editor.leave.the.segment.empty.title">Leave
-	  the segment empty</term>
-
-	  <listitem>
-		<para>You can  enter your translation right away.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.insert.the.best.fuzzy.match">
-	  <term
-		  id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title">Insert
-	  the best fuzzy match</term>
-
-	  <listitem>
-		<para>OmegaT inserts the translation with the highest match percentage above
-		the value you set in this dialog.</para>
-		<para>The prefix identifies translations inserted as fuzzy matches. You can
-		also define the prefix to as <link
-		linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
-		endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/>
-		to include it in the tag issues checking process and make sure you do not forget it in your translation.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-  </para>
-  
-  <variablelist>
-	<varlistentry id="dialogs.preferences.editor.attempt.to.convert.numbers.when.inserting.a.fuzzy.match">
-	  <term
-		  id="dialogs.preferences.editor.attempt.to.convert.numbers.when.inserting.a.fuzzy.match.title">Attempt to convert fuzzy match numbers</term>
-
-	  <listitem>
-		<para>When a fuzzy match is inserted, OmegaT tries to adapt the
-		numbers in the fuzzy match to the numbers in the source.</para>
-
-		<note><para>Only integers and simple floats (e.g., 5.4) are
-			considered.</para></note>
-
-		<example id="convert.match.numbers">
-		  <title>Fuzzy match number conversion</title>
-
-		  <para><token>2001</token> in the source:</para>
-		  <para><programlisting>
-[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
-		  
-		  <para><token>2003</token> in the fuzzy match:</para>
-		  <para><programlisting>[[<token>2003</token>年]]、ドイツの永住権を取得。
-[[<token>2003</token>]], elle acquiert la nationalité allemande.</programlisting></para>
-
-<para>When the match is inserted, OmegaT will convert <token>2003</token> to <token>2001</token>:</para>
-<para><programlisting>[[<token>2001</token>]], elle acquiert la nationalité allemande.</programlisting></para>
-
-		</example>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source">
-	  <term
-		  id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title">Allow
-	  translation to be equal to source</term>
-
-	  <listitem>
-		<para>A translation that is
-		identical to the source text is not recognized as a translation by default. OmegaT will erase it and will count the segment as not translated.</para>
-
-		<para>Use this option to force OmegaT to register such
-		entries and count them as translated.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.export.the.segment.to.text.files">
-	  <term
-		  id="dialogs.preferences.editor.export.the.segment.to.text.files.title">Export
-	  the segment to a text file</term>
-
-	  <listitem>
-		<para>When OmegaT enters a segment,
-
-		<itemizedlist>
-		  <listitem>
-			<para>the content of the source part is copied to <link
-			linkend="configuration.folder.default.contents.script.source"
-			endterm="configuration.folder.default.contents.script.source.title"/>,</para>
-		  </listitem>
-		  <listitem>
-			<para>the content of the target part (if any) is copied to <link
-			linkend="configuration.folder.default.contents.script.target"
-			endterm="configuration.folder.default.contents.script.target.title"/>,</para>
-		  </listitem>
-		</itemizedlist>
-		both located in the <link linkend="windows.scripts.folder">scripting folder</link>.
-		</para>
-	
-		<para>The files are overwritten when OmegaT enters a new
-		segment.</para>
-
-		<para>The <link
-		linkend="windows.scripts.distribution.extract.text.content"
-		endterm="windows.scripts.distribution.extract.text.content.title"/>
-		script does something similar but for the whole project at once. See
-		<link linkend="windows.scripts"
-			  endterm="windows.scripts.title"/>.</para>
-
-		<note><para>This function has
-		no relation to the <link linkend="windows.scripts"
-		endterm="windows.scripts.title"/> function.</para></note>
-
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation">
-	  <term
-	  id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title">Stop at untranslated and alternatives translations</term>
-
-	  <listitem>
-		<para><link
-		linkend="menus.goto.next.untranslated.segment"
-		endterm="menus.goto.next.untranslated.segment.title"/> also stops at
-		segments with alternative translations.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.allow.tag.editing">
-	  <term id="dialogs.preferences.editor.allow.tag.editing.title">Allow tag
-	  editing</term>
-
-	  <listitem>
-		<para>Tags should generally not be modified, but that is possible when this option is enabled.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment">
-	  <term
-		  id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title">Check
-	  issues when leaving a segment</term>
-
-	  <listitem>
-		<para>OmegaT runs an issues check on the segment as you leave it. See <link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.save.auto-populated.status">
-	  <term id="dialogs.preferences.editor.save.auto-populated.status.title">Save
-	  auto-populated status</term>
-
-	  <listitem>
-		<para>Translation memories in <link linkend="project.folder.tm.auto"
-		endterm="project.folder.tm.auto.title"/> and <link
-		linkend="project.folder.tm.enforce"
-		endterm="project.folder.tm.enforce.title"/> can auto-populate the
-		project memory. Segments that receive automated translation at that time
-		can be marked in the <guilabel>Editor</guilabel> pane with <link
-		linkend="menus.view.mark.auto.populated.segments"
-		endterm="menus.view.mark.auto.populated.segments.title"/>.</para>
-	  </listitem>
-	</varlistentry>
-
-    <varlistentry id="dialogs.preferences.editor.save.orgin.of.translation">
-	  <term
-		  id="dialogs.preferences.editor.save.orgin.of.translation.title">Save
-	  origin of translation</term>
-
-	  <listitem>
-        <para>When machine translation is enabled, OmegaT registers
-        the name of the engine that was used to populate a given segment.</para>
-	  </listitem>
-    </varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.initially.load.this.many.segments">
-	  <term
-		  id="dialogs.preferences.editor.initially.load.this.many.segments.title">Initial number of loaded segments</term>
-
-	  <listitem>
-		<para>The editor initially loads and displays 2,000 segments, and
-		progressively loads more as you scroll up or down. Change this number according to your machine performance.</para>
-	  </listitem>
-	</varlistentry>
-
-	<varlistentry id="dialogs.preferences.editor.paragraph.delimitation.format">
-	  <term
-		  id="dialogs.preferences.editor.paragraph.delimitation.format.title">Paragraph
-	  delimitation format</term>
-
-	  <listitem>
-		<para>To identify segments that belong to the same paragraph, use <link linkend="menus.view.mark.paragraph.delimitations" endterm="menus.view.mark.paragraph.delimitations.title"/>.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
-
-<section id="dialogs.preferences.tag.processing">
-  <title id="dialogs.preferences.tag.processing.title">Tag Processing</title>
-
-  <variablelist>
-	<varlistentry id="dialogs.preferences.tag.processing.programming.variables">
-	  <term id="dialogs.preferences.tag.processing.programming.variables.title">Check printf function variables</term>
-	  <listitem>
-		<para>Check printf variables in file formats other than the PO format. The PO filter already handles variables marked with <literal>%</literal>.</para>
-		<para>You can select
+		<para>When OmegaT reads files, it puts a non-breaking marker at every
+		exception location. Places that do not have such markers and that match
+		break rules will be break locations.</para>
+	  </warning>
+	  
 	  <variablelist>
-		<varlistentry>
-		  <term>None</term>
-		  <listitem><para>None of the variable patterns are checked.</para></listitem>
+		<varlistentry id="segmentation.rules.exceptionrule">
+		  <term id="segmentation.rules.exceptionrule.title"><option>Exceptions</option></term>
+
+		  <listitem>
+			<para>To define an exception rule, leave the <guilabel>Break/Exception
+			</guilabel>check box unchecked.</para>
+
+			<para>Specify text combinations that are exceptions to a break
+			rule. For example, <emphasis>Mrs. Dalloway</emphasis> should not be
+			split in two segments even though a break rule for <emphasis>period
+			followed by a space</emphasis> generally defines a sentence.</para>
+			
+		  </listitem>
 		</varlistentry>
-		<varlistentry>
-		  <term>Simple variables (e.g., %s, %d)</term>
-		  <listitem><para>Only the simple variable patterns are checked.</para></listitem>
+
+		<varlistentry id="segmentation.rules.breakrule">
+		  <term id="segmentation.rules.breakrule.title"><option>Breaks</option></term>
+
+		  <listitem>
+			<para>To define a break rule, check the
+			<guilabel>Break/Exception</guilabel> box.</para>
+
+			<para>Separates the source text into segments. For example,
+			<emphasis>period followed by a space</emphasis> generally defines a
+			sentence end in English.</para>
+		  </listitem>
 		</varlistentry>
-		<varlistentry>
-		  <term>All variables (e.g., %s, %-s)</term>
-		  <listitem><para>This can result in false positives in some files.</para></listitem>
+
+		<varlistentry id="creating.new.rule">
+		  <term id="creating.new.rule.title"><guibutton>Add</guibutton></term>
+		  <listitem>
+			<para>The <emphasis role="bold">Before</emphasis> pattern identifies
+			the parts that are before the break or exception point.</para>
+
+			<para>The <emphasis role="bold"> After</emphasis> pattern identifies
+			the parts that are after the break or exception point.</para>
+
+			<para>The <emphasis role="bold">Before</emphasis> and<emphasis
+			role="bold"> After</emphasis> patterns are regular expressions. See
+			the <link linkend="app.regex" endterm="app.regex.title"/> appendix
+			for details.</para>
+		  </listitem>
 		</varlistentry>
 	  </variablelist>
-	</para>
-	</listitem>
-	</varlistentry>
+	  
+	  <para>The existing rules always provide a good starting point.</para>
+	</section>
+  </section>
+
+  <section id="dialog.preferences.auto.completion">
+	<title
+	id="dialog.preferences.auto.completion.title"><guilabel>Auto-Completion</guilabel></title>
+
+	<para>Click on <guilabel>Glossary</guilabel> to configure the auto-completer
+	glossary view.</para>
+
+	<para>Click on <guilabel>Autotext</guilabel> to configure the Autotext
+	options, and to add or remove entries.</para>
+
+	<para>Click on <guilabel>Character Table</guilabel> to set the Character
+	table auto-completer options.</para>
+
+	<para>Click on <guilabel>Enable history completion</guilabel> or
+	<guilabel>Enable history prediction</guilabel> to set history based
+	completions.</para>
+
+	<note>
+	  <para>Absolutely none of your data (history, etc.) is
+	  <emphasis>ever</emphasis> sent to an external server by OmegaT for
+	  processing. All prediction/completion results are computed locally.</para>
+	</note>
+
+	<para>If the <guilabel>Show Relevant Suggestions Automatically</guilabel>
+	option is checked, typing the first letter of a translated glossary entry,
+	or <literal>&lt;</literal> for a tag, automatically launches the
+	auto-completer.</para>
+  </section>
+
+  <section id="dialog.preferences.spellchecker">
+	<title
+	id="dialog.preferences.spellchecker.title"><guilabel>Spellchecker</guilabel></title>
+
+	<para>OmegaT has a built-in spellchecker but requires you to install
+	spellchecking dictionaries based on your target languages.</para>
+
+	<warning>
+	  <para>OmegaT will use the language dictionary that has the same name as
+	  the target language code set in the <link
+	  linkend="dialogs.project.properties.languages"
+	  endterm="dialogs.project.properties.languages.title"/> project
+	  property. An <emphasis>FR-FR</emphasis> dictionary will not spellcheck
+	  <emphasis>FR</emphasis> target segments. If necessary, modify the name of
+	  the dictionary or change your project’s language settings.</para>
+	</warning>
+
+	<variablelist>
+	  <varlistentry id="dialog.preferences.spellchecker.automatic.check">
+		<term
+		id="dialog.preferences.spellchecker.automatic.check.title"><option>Spellcheck
+		the translation</option></term>
+		<listitem>
+		  <para>Enable after installing a spellchecking dictionary. OmegaT will
+		  underline spelling mistakes with red wavy-lines.</para>
+		  <para>Use the <link linkend="panes.editor.context.menu">editor context
+		  menu</link> to correct the mistake, to <guimenuitem>Ignore
+		  All</guimenuitem> or to <guimenuitem>Add to
+		  Dictionary</guimenuitem>. See <link
+		  linkend="project.folder.omegat.spellcheck">spellchecker files</link>
+		  for details.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialog.preferences.spellchecker.dictionary.folder">
+		<term
+		id="dialog.preferences.spellchecker.dictionary.folder.title"><option>Spellchecking
+		dictionaries location</option></term>
+		<listitem>
+		  <para>The folder where OmegaT will install and search for spelling
+		  dictionaries. It is generally in the <link
+		  linkend="configuration.folder" endterm="configuration.folder.title"/>
+		  folder.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialog.preferences.spellchecker.already.installed">
+		<term
+		id="dialog.preferences.spellchecker.already.installed.title"><option>Available
+		languages</option></term>
+		<listitem>
+		  <para>The list of dictionaries that are present in the above
+		  folder.</para>
+
+		  <para>If none are displayed it either means that you have not yet
+		  installed a spelling dictionary, or that your project uses a specific
+		  configuration folder that does not contain yet a spelling
+		  dictionary.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialog.preferences.spellchecker.url">
+		<term id="dialog.preferences.spellchecker.url.title"><option>URL of
+		downloadable spellchecking dictionaries</option></term>
+		<listitem>
+		  <para>The default URL where OmegaT will look for dictionaries to
+		  install.</para>
+
+		  <para>You can also download dictionaries from other locations, or copy
+		dictionaries installed locally.</para></listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.spellchecker.install.new">
+		<term
+		id="dialog.preferences.spellchecker.install.new.title"><option>Install
+		new language...</option></term>
+		<listitem>
+		  <para>Displays the list of available dictionaries from the above
+		  URL.</para>
+
+		  <warning>
+			<para>This action requires an internet connection</para>
+		  </warning>
+
+		  <para>Select the dictionaries that you want to install and click
+		  <guibutton>Install</guibutton>. Depending on your internet connection
+		  it may take a while before the dictionary is installed.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
+  
+  <section id="dialog.preferences.languagetool.plugin">
+	<title
+	id="dialog.preferences.languagetool.plugin.title"><guilabel>LanguageTool</guilabel></title>
+
+	<variablelist>
+	  <varlistentry id="dialog.preferences.languagetool.plugin.servicetype">
+		<term
+		id="dialog.preferences.languagetool.plugin.servicetype.title"><option>Service
+		type</option></term>
+
+		<listitem>
+		  <para>Select the location of the language checker.</para>
+
+		  <para>Using a different language checker on your local machine than
+		  the one supplied with OmegaT allows you to customize the verification
+		  rules.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.languagetool.plugin.rules">
+		<term
+		id="dialog.preferences.languagetool.plugin.rules.title"><option>Rules</option></term>
+
+		<listitem>
+		  <para>Select the rules depending on whether they are relevant to the
+		  type of text you are translating.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
+
+  <section id="dialogs.preferences.external.searches">
+	<title id="dialogs.preferences.external.searches.title"><guilabel>Global External
+	Searches</guilabel></title>
+	<para>External searches are either web searches or local commands that take
+	the string selected in the Editor as a parameter. The web searches are
+	opened in the default browser and the commands are equivalent to items
+	launched on the command line.</para>
+
+	<variablelist>
+	  <varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
+		<term
+		id="dialogs.preferences.external.search.enable.project.specific.commands.title"><option>Allow
+		local external search commands</option></term>
+
+		<listitem>
+		  <warning>
+			<para>For security reasons, <link
+			linkend="dialogs.project.properties.external.searches">local
+			externam searches</link> are disabled by default.</para>
+		  </warning>
+
+		  <para>Local external search commands are saved in the <link
+		  linkend="project.folder.omegat.filters"
+		  endterm="project.folder.omegat.filters.title"/> file. Only activate
+		  this option if you trust the source of that file.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialogs.preferences.external.search.context.menu.priority">
+		<term
+		id="dialogs.preferences.external.search.context.menu.priority.title"><option>Context
+		Menu Priority</option></term>
+
+		<listitem>
+		  <para>This option enables you to change the order of the commands in
+		  the Editor pane <link linkend="panes.editor.context.menu">context
+		  menu</link>. Values around 100 display commands at the top, and values
+		  around 900 display them at the bottom.</para>
+
+		  <warning>
+			<para>Restart OmegaT to apply this change.</para>
+		  </warning>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry  id="dialogs.preferences.external.search.items">
+		<term id="dialogs.preferences.external.search.items.title"><option>Sets</option></term>
+		<listitem>
+		  <para>Each set represents a group of web searches or local commands
+		  that are launched simultaneously.</para>
+
+		  <para>A set must be given a name. The name will be displayed at the
+		  bottom of the <link linkend="menus.tools"
+		  endterm="menus.tools.title"/> menu.</para>
+
+		  <para>If you check <guilabel>Show in Editor context menu</guilabel>,
+		  the set name will also be displayed in the <link
+		  linkend="panes.editor.context.menu">context menu</link> if a string is
+		  selected.</para>
+
+		  <para>URL searches as well as commands must contain the string
+		  <literal>{target}</literal> to be accepted. The
+		  <literal>{target}</literal> placeholder will be replaced by the string
+		  that was selected in the Editor.</para>
+
+		  <para>URLs are opened with the default web browser, one per
+		  tab.</para>
+
+		  <example
+			  id="dialogs.preferences.external.search.items.url.search.example">
+			<title
+			id="dialogs.preferences.external.search.items.url.search.example.title">URL
+			search example</title>
+			<programlisting>https://duckduckgo.com/?q=%22{target}%22+site%3A.fr+-linguee</programlisting>
+
+			<para>This opens a search for the {target} term on DuckDuckGo with a
+			number of search parameters.</para></example>
+
+			<para>Commands are opened on the command line. The
+			<guilabel>Delimiter</guilabel>defines the delimiter between command
+			parameters. The default delimiter is <code>|</code>.</para>
+
+		  <example
+			  id="dialogs.preferences.external.search.items.command.example">
+			<title
+			id="dialogs.preferences.external.search.items.command.example.title">Command
+			example</title>
+			<programlisting>/usr/bin/open|dict://{target}</programlisting>
+
+			<para>This opens the dictionary application that implements the
+			<code>dict</code> protocol on your machine looking for the {target}
+			term.</para></example>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
+
+  <section id="dialogs.preferences.editor">
+	<title id="dialogs.preferences.editor.title"><guilabel>Editor</guilabel></title>
+
+	<para>When entering an empty segment:</para>
+	<variablelist>
+	  <varlistentry id="dialogs.preferences.editor.insert.the.source.text">
+		<term
+		id="dialogs.preferences.editor.insert.the.source.text.title"><option>Insert the
+		source text</option></term>
+
+		<listitem>
+		  <para>Use this option temporarily for parts of the translation that do
+		  not require much transformation.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialogs.preferences.editor.leave.the.segment.empty">
+		<term
+		id="dialogs.preferences.editor.leave.the.segment.empty.title"><option>Leave the
+		segment empty</option></term>
+
+		<listitem>
+		  <para>You can enter your translation right away.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialogs.preferences.editor.insert.the.best.fuzzy.match">
+		<term
+		id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"><option>Insert
+		the best fuzzy match</option></term>
+
+		<listitem>
+		  <para>OmegaT inserts the translation with the highest match percentage
+		  above the value you set in this dialog.</para>
+
+		  <para>The prefix identifies translations inserted as fuzzy
+		  matches. You can also register the prefix in the <link
+		  linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
+		  endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"/>
+		  preference to include it in the tag issues checking process and make
+		  sure you do not forget it in your translation.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
 	
-	<varlistentry id="dialogs.preferences.tag.processing.simple.java.messageformat">
-	  <term
-		  id="dialogs.preferences.tag.processing.simple.java.messageformat.title">Check
-	  simple Java MessageFormat placeholders</term>
-	  <listitem><para>Check  Java MessageFormat placeholders in file formats other than the Java Bundles format. The Java Bundles filter already handles placeholders marked with <literal>{#}</literal> where <literal>#</literal> is a number.</para>
-</listitem>
-	</varlistentry>
+	<variablelist>
+	  <varlistentry id="dialogs.preferences.editor.attempt.to.convert.numbers.when.inserting.a.fuzzy.match">
+		<term
+		id="dialogs.preferences.editor.attempt.to.convert.numbers.when.inserting.a.fuzzy.match.title"><option>Attempt
+		to convert fuzzy match numbers</option></term>
 
-	<varlistentry id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order">
-	  <term
-		  id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title">Allow
-	  translated tags to be in a different order</term>
-	  <listitem>
-		<para>Tags in a different order than the source will not appear in the list of tag issues. See <link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
+		<listitem>
+		  <para>When a fuzzy match is inserted, OmegaT tries to adapt the numbers
+		  in the fuzzy match to the numbers in the source.</para>
 
-	<varlistentry id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues">
-	  <term
-		  id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title">Block the creation of translated files with tag issues</term>
-	  <listitem><para>If you try to create the translated files, OmegaT will display the issues dialog until no issues are found. See <link linkend="menus.tools.check.issues" endterm="menus.tools.check.issues.title"/> for details.</para></listitem>
-	</varlistentry>
+		  <note>
+			<para>Only integers and simple floats (e.g., 5.4) are
+			considered.</para>
+		  </note>
 
-	<varlistentry id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics">
-	  <term
-	  id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title">Count
-	  flagged text and custom tags in statistics</term>
-	  <listitem>
-		<para>Unlike OmegaT tags, flagged text and custom tags are by default counted in the statistics. See <link linkend="menus.tools.statistics" endterm="menus.tools.statistics.title"/> for details.</para>
-	  </listitem>
-	</varlistentry>
+		  <example id="convert.match.numbers">
+			<title>Fuzzy match number conversion</title>
+			<para><token>2001</token> in the source:</para>
+			<para>
+			  <programlisting>[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
+			
+			<para><token>2003</token> in the fuzzy match:</para>
+			<para><programlisting>[[<token>2003</token>年]]、ドイツの永住権を取得。
+[[<token>2003</token>]], elle acquiert la nationalité allemande.</programlisting></para>
 
-	<varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags">
-	  <term
-		  id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title">Custom tags</term>
+			<para>When the match is inserted, OmegaT will convert
+			<token>2003</token> to <token>2001</token>:</para>
 
-	  <listitem><para>Use regular expressions to define custom tags. To define a list of tags, group each tag between parentheses and separate the groups with <literal>|</literal> (equivalent to "OR" in regular expressions).</para>
+			<para><programlisting>[[<token>2001</token>]], elle acquiert la nationalité allemande.</programlisting></para>
+		  </example>
+		</listitem>
+	  </varlistentry>
 
-	  <para>For example, use <userinput>\d+</userinput> to treat all numbers as
-	  tags, enabling you to check that numbers have not been accidentally
-	  changed in the translation.</para>
+	  <varlistentry id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source">
+		<term
+		id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"><option>Allow
+		translation to be equal to source</option></term>
 
-	  <para>Similarly, use <userinput>&lt;/?[^>]+&gt;</userinput> to
-	  make sure that HTML (or similar) tags entered into the source text are
-	  preserved without modification in the translation.</para>
+		<listitem>
+		  <para>A translation that is identical to the source text is not
+		  recognized as a translation by default. OmegaT will erase it and will
+		  count the segment as not translated.</para>
 
-	  <para>Use parentheses and <literal>|</literal> to have OmegaT consider the two tags: <userinput>(\d+)|(&lt;/?[^>]+&gt;)</userinput>.</para>
+		  <para>Use this option to force OmegaT to register such entries and
+		  count them as translated.</para>
+		</listitem>
+	  </varlistentry>
 
-	  <para>See <link linkend="app.regex" endterm="app.regex.title" /> for details.</para>
-	  </listitem>
-	</varlistentry>
-	
-	<varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation">
-	  <term
-		  id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title">Flagged text</term>
-	  <listitem><para>Text in the target segment matching this expression is marked
-	  in red and identified as an extraneous tag for issue checking purposes. See
-		<link linkend="menus.tools.check.issues"
-	  endterm="menus.tools.check.issues.title"/> for details.</para></listitem>
-	</varlistentry>
+	  <varlistentry id="dialogs.preferences.editor.export.the.segment.to.text.files">
+		<term
+		id="dialogs.preferences.editor.export.the.segment.to.text.files.title"><option>Export
+		the segment to a text file</option></term>
 
-  </variablelist>
-</section>
+		<listitem>
+		  <para>When OmegaT enters a segment,</para>
 
-<section id="dialog.preferences.team">
-  <title id="dialog.preferences.team.title">Team</title>
+		  <itemizedlist>
+			<listitem>
+			  <para>the content of the source part is copied to the <link
+			  linkend="configuration.folder.default.contents.script.source"
+			  endterm="configuration.folder.default.contents.script.source.title"/> file,</para>
+			</listitem>
+			<listitem>
+			  <para>the content of the target part (if any) is copied to the <link
+			  linkend="configuration.folder.default.contents.script.target"
+			  endterm="configuration.folder.default.contents.script.target.title"/> file,</para>
+			</listitem>
+		  </itemizedlist>
+		  
+		  <para>both located in the <link
+		  linkend="windows.scripts.folder">scripting folder</link>.
+		  </para>
+		  
+		  <note>
+			<para>This function has no relation to the <link
+			linkend="windows.scripts" endterm="windows.scripts.title"/>
+			function.</para>
+		  </note>
 
-  <para>The name you enter here will be attached to all the segments you
-  translate.</para>
+		  <para>The files are overwritten when OmegaT enters a new
+		  segment.</para>
 
-  <variablelist>
-	<varlistentry id="dialog.preferences.team.title.repository.credentials">
-	  <term
-		  id="dialog.preferences.team.title.repository.credentials.title">Repository
-	  Credentials</term>
+		  <para>The <link
+		  linkend="windows.scripts.distribution.extract.text.content"
+		  endterm="windows.scripts.distribution.extract.text.content.title"/>
+		  script does something similar but for the whole project at once. See
+		  the <link linkend="windows.scripts" endterm="windows.scripts.title"/>
+		  window.</para>
 
-	  <listitem>
-		<para>List of projects for which login details have been stored in
-		OmegaT. Remove a project from this list if you want OmegaT to ask
-		you for its credentials the next time you access it.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
+		</listitem>
+	  </varlistentry>
 
-<section id="dialog.preferences.tm.matches">
-  <title id="dialog.preferences.tm.matches.title">TM Matches</title>
+	  <varlistentry id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation">
+		<term
+		id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title"><option>Stop
+		at untranslated and alternatives translations</option></term>
 
-  <variablelist>
-	<varlistentry id="dialog.preferences.tm.matches.sort.fuzzy.matches.by">
-	  <term
-		  id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title">Sort
-	  fuzzy matches by:</term>
+		<listitem>
+		  <para><link linkend="menus.goto" endterm="menus.goto.title"/><link
+		  linkend="menus.goto.next.untranslated.segment"
+		  endterm="menus.goto.next.untranslated.segment.title"/> also stops at
+		  segments with alternative translations.</para>
+		</listitem>
+	  </varlistentry>
 
-	  <listitem>
-		<para>By default, stemming is used to determine the closest matches
-		displayed in the <guilabel>Fuzzy Matches</guilabel> panel.</para>
+	  <varlistentry id="dialogs.preferences.editor.allow.tag.editing">
+		<term id="dialogs.preferences.editor.allow.tag.editing.title"><option>Allow tag
+		editing</option></term>
 
-		<para>To obtain more literal matches closer to 100%, select the
-		<guilabel>Full text, including tags and numbers</guilabel>
-		option.</para>
-	  </listitem>
-	</varlistentry>
+		<listitem>
+		  <para>Tags should generally not be modified, but that is possible when
+		  this option is enabled.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="dialog.preferences.tm.matches.minimum.threshold">
-	  <term id="dialog.preferences.tm.matches.minimum.threshold.title">Minimal threshold to show a fuzzy match</term>
-	  <listitem><para>OmegaT displays the 5 best fuzzy matches above 30% by default. You can change the threshold here.</para></listitem>
-	</varlistentry>
+	  <varlistentry id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment">
+		<term
+		id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"><option>Check
+		issues when leaving a segment</option></term>
 
-	<varlistentry id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs">
-	  <term
-		  id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title">Select how tags of non-OmegaT TMXs should be displayed</term>
+		<listitem>
+		  <para>OmegaT runs an issues check on the segment as you leave it. The
+		  option is equivalent to using <link linkend="menus.tools"
+		  endterm="menus.tools.title"/><link linkend="menus.tools.check.issues"
+		  endterm="menus.tools.check.issues.title"/>.</para>
+		</listitem>
+	  </varlistentry>
 
-	  <listitem>
-		<para>Determine how to handle tags in TMX files generated by other
-		tools.</para>
+	  <varlistentry id="dialogs.preferences.editor.save.auto-populated.status">
+		<term id="dialogs.preferences.editor.save.auto-populated.status.title"><option>Save
+		auto-populated status</option></term>
 
-		<para>You can choose whether to display them and whether to use standard XML notation for standalone tags (e.g. &lt;i/&gt;).</para>
-	  </listitem>
-	</varlistentry>
+		<listitem>
+		  <para>Translation memories located in <link
+		  linkend="project.folder.tm.auto"
+		  endterm="project.folder.tm.auto.title"/> and <link
+		  linkend="project.folder.tm.enforce"
+		  endterm="project.folder.tm.enforce.title"/> can auto-populate the
+		  project memory. Segments that receive automated translation at that
+		  time can be marked in the <guilabel>Editor</guilabel> pane by using
+		  <link linkend="menus.view" endterm="menus.view.title"/>.<link
+		  linkend="menus.view.mark.auto.populated.segments"
+		  endterm="menus.view.mark.auto.populated.segments.title"/>.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="dialog.preferences.tm.matches.other.languages">
-	  <term id="dialog.preferences.tm.matches.other.languages.title">Include matches from other languages</term>
-	  <listitem><para>Segments that have matches in different target languages can also be displayed in the <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/> pane. You can apply a penalty to such matches.</para></listitem>
-	</varlistentry>
+      <varlistentry id="dialogs.preferences.editor.save.orgin.of.translation">
+		<term
+		id="dialogs.preferences.editor.save.orgin.of.translation.title"><option>Save
+		origin of translation</option></term>
 
-	
-	<varlistentry id="dialog.preferences.tm.matches.match.display.template">
-	  <term
-		  id="dialog.preferences.tm.matches.match.display.template.title">Match
-	  display template</term>
+		<listitem>
+          <para>When machine translation is enabled, OmegaT registers the name
+          of the engine that was used to populate a given segment.</para>
+		</listitem>
+      </varlistentry>
 
-	  <listitem>
-		<para>Change how fuzzy matches are displayed, through the use of
-		pre-configured variables:</para>
+	  <varlistentry id="dialogs.preferences.editor.initially.load.this.many.segments">
+		<term
+		id="dialogs.preferences.editor.initially.load.this.many.segments.title"><option>Initial
+		number of loaded segments</option></term>
 
-		<para>The default is:</para>
-		<para><programlisting>${id}. ${fuzzyFlag}${sourceText}
-${targetText}
-&lt;${score}/${noStemScore}/${adjustedScore}% ${filePath}></programlisting></para>
-		<para>Here is a possible alternative:</para>
-		<para><programlisting>⥤ ${id}. &lt;${score}/${noStemScore}/${adjustedScore}%> ${fuzzyFlag} ${fileNameOnly}
-[NEW]▷ ${diff}
+		<listitem>
+		  <para>The editor initially loads and displays 2,000 segments, and
+		  progressively loads more as you scroll up or down. Change this number
+		  according to your machine performance.</para>
+		</listitem>
+	  </varlistentry>
 
-[OLD]◀ ${diffReversed}
-     ◀ ${targetText}</programlisting></para>
+	  <varlistentry id="dialogs.preferences.editor.paragraph.delimitation.format">
+		<term
+		id="dialogs.preferences.editor.paragraph.delimitation.format.title"><option>Paragraph
+		delimitation format</option></term>
 
+		<listitem>
+		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
+		  linkend="menus.view.mark.paragraph.delimitations"
+		  endterm="menus.view.mark.paragraph.delimitations.title"/> to identify
+		  segments that belong to the same paragraph.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 
-		<para>The template variables are also available from a drop-down menu
-		and can be inserted with a button.</para>
+  <section id="dialogs.preferences.tag.processing">
+	<title id="dialogs.preferences.tag.processing.title"><guilabel>Tag Processing</guilabel></title>
 
-		<table id="table.match.pane.setup" colsep="0" rowsep="0">
-		  <title id="table.match.pane.setup.title">Match template variables</title>
+	<variablelist>
+	  <varlistentry id="dialogs.preferences.tag.processing.programming.variables">
+		<term
+		id="dialogs.preferences.tag.processing.programming.variables.title"><option>Check
+		printf function variables</option></term>
+		<listitem>
+		  <para>Check printf variables in file formats other than the PO
+		  format. The PO filter already handles variables marked with
+		  <literal>%</literal>.</para>
 
-		  <tgroup cols="2" colsep="1" rowsep="1">
-			<colspec align="left"/>
+		  <para>You can select</para>
+		  
+		  <variablelist>
+			<varlistentry>
+			  <term><option>None</option></term>
+			  <listitem>
+				<para>None of the variable patterns are checked.</para>
+			  </listitem>
+			</varlistentry>
+			
+			<varlistentry>
+			  <term><option>Simple variables (e.g., %s, %d)</option></term>
+			  <listitem>
+				<para>Only the simple variable patterns are checked.</para>
+			  </listitem>
+			</varlistentry>
 
-			<colspec align="left"/>
+			<varlistentry>
+			  <term><option>All variables (e.g., %s, %-s)</option></term>
+			  <listitem>
+				<para>This can result in false positives in some files.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialogs.preferences.tag.processing.simple.java.messageformat">
+		<term
+		id="dialogs.preferences.tag.processing.simple.java.messageformat.title"><option>Check
+		simple Java MessageFormat placeholders</option></term>
+		<listitem>
+		  <para>Check Java MessageFormat placeholders in file formats other than
+		  the Java Bundles format. The Java Bundles filter already handles
+		  placeholders marked with <literal>{#}</literal> where
+		  <literal>#</literal> is a number.</para>
+		</listitem>
+	  </varlistentry>
 
-			<tbody>
-			  <row>
-				<entry>
-				  <literal>${id}</literal>
-				</entry>
-				<entry>Number of the match from 1 to 5</entry>
-			  </row>
+	  <varlistentry id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order">
+		<term
+		id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title"><option>Allow
+		translated tags to be in a different order</option></term>
+		<listitem>
+		  <para>Tags in a different order than the source will not appear in the
+		  list of tag issues. See the <link linkend="menus.tools"
+		  endterm="menus.tools.title"/><link linkend="menus.tools.check.issues"
+		  endterm="menus.tools.check.issues.title"/> menu for details.</para>
+		</listitem>
+	  </varlistentry>
 
-			  <row>
-				<entry>
-				  <literal>${sourceText}</literal>
-				</entry>
-				<entry>The source text of the match</entry>
-			  </row>
+	  <varlistentry id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues">
+		<term
+		id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"><option>Block
+		the creation of translated files with tag issues</option></term>
+		<listitem>
+		  <para>If you try to create the translated files, OmegaT will display
+		  the issues dialog until no issues are found. See the <link
+		  linkend="menus.tools" endterm="menus.tools.title"/><link
+		  linkend="menus.tools.check.issues"
+		  endterm="menus.tools.check.issues.title"/> menu for details.</para>
+		</listitem>
+	  </varlistentry>
 
-			  <row>
-				<entry>
-				  <literal>${diff}</literal>
-				</entry>
-				<entry>A string that shows the differences between the
-				source and the match.</entry>
-			  </row>
+	  <varlistentry id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics">
+		<term
+		id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"><option>Count
+		flagged text and custom tags in statistics</option></term>
+		<listitem>
+		  <para>Unlike OmegaT tags, flagged text and custom tags are by default
+		  counted in the statistics. See the <link
+		  linkend="menus.tools"
+		  endterm="menus.tools.title"/><link
+		  linkend="menus.tools.statistics"
+		  endterm="menus.tools.statistics.title"/> menu for details.</para>
+		</listitem>
+	  </varlistentry>
 
-			  <row>
-				<entry>
-				  <literal>${diffReversed}</literal>
-				</entry>
-				<entry>Same as ${diff}, but with the differences (what is to
-				be inserted and deleted) inverted.</entry>
-			  </row>
+	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags">
+		<term
+		id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"><option>Custom
+		tags</option></term>
+		<listitem>
+		  <para>Use regular expressions to define custom tags. To define a list
+		  of tags, group each tag between parentheses and separate the groups
+		  with <literal>|</literal> (equivalent to "OR" in regular
+		  expressions).</para>
 
-			  <row>
-				<entry>
-				  <literal>${targetText}</literal>
-				</entry>
-				<entry>The target text of the match</entry>
-			  </row>
+		  <para>For example, use <userinput>\d+</userinput> to treat all numbers
+		  as tags, enabling you to check that numbers have not been accidentally
+		  changed in the translation.</para>
 
-			  <row>
-				<entry>
-				  <literal>${score}</literal>
-				</entry>
-				<entry>Percentage calculated with the <guilabel>Stemming, no
-				tags and no numbers</guilabel> option.</entry>
-			  </row>
+		  <para>Similarly, use <userinput>&lt;/?[^>]+&gt;</userinput> to make
+		  sure that HTML (or similar) tags entered into the source text are
+		  preserved without modification in the translation.</para>
 
-			  <row>
-				<entry>
-				  <literal>${noStemScore}</literal>
-				</entry>
-				<entry>Percentage calculated with the <guilabel>No tags and
-				no numbers</guilabel> option.</entry>
-			  </row>
+		  <para>Use parentheses and <literal>|</literal> to have OmegaT consider
+		  the two tags: <userinput>(\d+)|(&lt;/?[^>]+&gt;)</userinput>.</para>
 
-			  <row>
-				<entry>
-				  <literal>${adjustedScore}</literal>
-				</entry>
-				<entry>Percentage calculated with the <guilabel>Full text,
-				including tags and numbers</guilabel> option.</entry>
-			  </row>
+		  <para>See the <link linkend="app.regex" endterm="app.regex.title" />
+		  appendix for details.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation">
+		<term
+		id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"><option>Flagged
+		text</option></term>
+		<listitem>
+		  <para>Text in the target segment matching this expression is marked in
+		  red and identified as an extraneous tag for issue checking
+		  purposes. See the <link
+		  linkend="menus.tools"
+		  endterm="menus.tools.title"/><link linkend="menus.tools.check.issues"
+		  endterm="menus.tools.check.issues.title"/> menu for details.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 
-			  <row>
-				<entry>
-				  <literal>${fileNameOnly}</literal>
-				</entry>
-				<entry>The TM filename, without the extension.</entry>
-			  </row>
+  <section id="dialog.preferences.team">
+	<title id="dialog.preferences.team.title"><guilabel>Team</guilabel></title>
 
-			  <row>
-				<entry>
-				  <literal>${filePath}</literal>
-				</entry>
-				<entry>The TM file full path.</entry>
-			  </row>
+	<para>The name you enter here will be attached to all the segments you
+	translate.</para>
 
-			  <row>
-				<entry>
-				  <literal>${fileShortPath}</literal>
-				</entry>
-				<entry>The TM file relative path.</entry>
-			  </row>
+	<variablelist>
+	  <varlistentry id="dialog.preferences.team.title.repository.credentials">
+		<term
+		id="dialog.preferences.team.title.repository.credentials.title"><option>Repository
+		Credentials</option></term>
+		<listitem>
+		  <para>List of projects for which login details have been stored in
+		  OmegaT. Remove a project from this list if you want OmegaT to ask you
+		  for its credentials the next time you access it.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 
-			  <row>
-				<entry>
-				  <literal>${initialCreationID}</literal>
-				</entry>
-				<entry>The ID of the translator who created the segment.</entry>
-			  </row>
+  <section id="dialog.preferences.tm.matches">
+	<title id="dialog.preferences.tm.matches.title"><option>TM Matches</option></title>
 
-			  <row>
-				<entry>
-				  <literal>${initialCreationDate}</literal>
-				</entry>
-				<entry>The date when the segment was created.</entry>
-			  </row>
+	<variablelist>
+	  <varlistentry id="dialog.preferences.tm.matches.sort.fuzzy.matches.by">
+		<term
+		id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title"><option>Sort
+		fuzzy matches by:</option></term>
 
-			  <row>
-				<entry>
-				  <literal>${changeID}</literal>
-				</entry>
-				<entry>The ID of the translator who last changed the segment.</entry>
-			  </row>
+		<listitem>
+		  <para>By default, stemming is used to determine the closest matches
+		  displayed in the <guilabel>Fuzzy Matches</guilabel> panel.</para>
 
-			  <row>
-				<entry>
-				  <literal>${changeDate}</literal>
-				</entry>
-				<entry>The date when the segment was last changed.</entry>
-			  </row>
+		  <para>To obtain more literal matches closer to 100%, select the
+		  <guilabel>Full text, including tags and numbers</guilabel>
+		  option.</para>
+		</listitem>
+	  </varlistentry>
 
-			  <row>
-				<entry>
-				  <literal>${fuzzyFlag}</literal>
-				</entry>
-				<entry>Indicate that this match is fuzzy (currently only for
-				translations from PO files with the #fuzzy mark).</entry>
-			  </row>
+	  <varlistentry id="dialog.preferences.tm.matches.minimum.threshold">
+		<term id="dialog.preferences.tm.matches.minimum.threshold.title"><option>Minimal threshold to show a fuzzy match</option></term>
+		<listitem>
+		  <para>OmegaT displays the 5 best fuzzy matches above 30% by
+		  default. You can change the threshold here.</para>
+		</listitem>
+	  </varlistentry>
 
-			  <row>
-				<entry>
-				  <literal>${sourceLanguage}</literal>
-				</entry>
-				<entry>The segment source language.</entry>
-			  </row>
+	  <varlistentry id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs">
+		<term
+		id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title"><option>Select
+		how tags of non-OmegaT TMXs should be displayed</option></term>
 
-			  <row>
-				<entry>
-				  <literal>${targetLanguage}</literal>
-				</entry>
-				<entry>The segment target language.</entry>
-			  </row>
+		<listitem>
+		  <para>Determine how to handle tags in TMX files generated by other
+		  tools.</para>
 
-			</tbody>
-		  </tgroup>
-		</table>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
+		  <para>You can choose whether to display them and whether to use
+		  standard XML notation for standalone tags (e.g. &lt;i/&gt;).</para>
+		</listitem>
+	  </varlistentry>
 
-<section id="dialog.preferences.view">
-  <title id="dialog.preferences.view.title">View</title>
+	  <varlistentry id="dialog.preferences.tm.matches.other.languages">
+		<term
+		id="dialog.preferences.tm.matches.other.languages.title"><option>Include
+		matches from other languages</option></term>
+		<listitem>
+		  <para>Segments that have matches in different target languages can
+		  also be displayed in the <link linkend="panes.fuzzy.matches"
+		  endterm="panes.fuzzy.matches.title"/> pane. You can apply a penalty to
+		  such matches.</para>
+		</listitem>
+	  </varlistentry>
 
-  <variablelist>
-	<varlistentry id="dialog.preferences.view.display.all.source.segments.in.bold">
-	  <term id="dialog.preferences.view.display.all.source.segments.in.bold.title">Display all source segments in bold</term>
-	  <listitem>
-		<para>By default, only the current segment is displayed in bold face.</para>
-	  </listitem>
-	</varlistentry>
+	  
+	  <varlistentry id="dialog.preferences.tm.matches.match.display.template">
+		<term
+		id="dialog.preferences.tm.matches.match.display.template.title"><option>Match
+		display template</option></term>
 
-	<varlistentry id="dialog.preferences.view.display.active.source.segment.in.bold">
-	  <term id="dialog.preferences.view.display.active.source.segment.in.bold.title">Display active source segment in bold</term>
-	  <listitem>
-		<para>If source segments are displayed in normal face, you can use this
-		option to display only the current source segment in bold.</para>
-	  </listitem>
-</varlistentry>
+		<listitem>
+		  <para>Change how fuzzy matches are displayed, through the use of
+		  pre-configured variables:</para>
 
-	<varlistentry id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments">
-	  <term
-		  id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title">Mark all non-unique segments</term>
-	  <listitem>
-		<para>By default, only the second and subsequent non-unique segments are
-		marked when <link linkend="menus.view.mark.non.unique.segments"
-		endterm="menus.view.mark.non.unique.segments.title"/> is enabled. Use this
-		option to also mark the first such segment.</para>
-	  </listitem>
-	</varlistentry>
+		  <para>The default is:</para>
+		  
+		  <para><programlisting>${id}. ${fuzzyFlag}${sourceText} ${targetText}
+&lt;${score}/${noStemScore}/${adjustedScore}%
+${filePath}></programlisting></para>
 
-	<varlistentry id="dialog.preferences.view.simplify.tooltip.on.protected.parts">
-	  <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title">Simplify tag tooltips</term>
-	  <listitem>
-		<para>Tags are protected text. Tag tooltips display the actual content of the tag. For content with paired tags (as in HTML) the tooltips can be simplified when you hover on them.</para>
-	  </listitem>
-	</varlistentry>
+		  <para>Here is a possible alternative:</para>
 
-	<varlistentry id="dialog.preferences.view.use.custom.templates.for.modification.info">
-	  <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title">Customize segment modification information</term>
-	  <listitem>
-		<para>Segment modification information is displayed over the segment. the
-		default setting shows who last modified the translation and when:</para>
-
-		<example id="dialog.preferences.view.use.custom.templates.for.modification.info.example">
-		  <title id="dialog.preferences.view.use.custom.templates.for.modification.info.example.title">Default display</title>
 		  <para>
-		  <programlisting>Translation last modified by suzume on Oct 6, 2022 at 2:18:27 PM
+			<programlisting>⥤ ${id}. &lt;${score}/${noStemScore}/${adjustedScore}%> ${fuzzyFlag} ${fileNameOnly}
+[NEW]▷ ${diff}
+			
+[OLD]◀ ${diffReversed}
+◀ ${targetText}</programlisting></para>
+
+
+		  <para>The template variables are also available from a drop-down menu
+		  and can be inserted with a button.</para>
+
+		  <table id="table.match.pane.setup" colsep="0" rowsep="0">
+			<title id="table.match.pane.setup.title">Match template variables</title>
+
+			<tgroup cols="2" colsep="1" rowsep="1">
+			  <colspec align="left"/>
+			  <colspec align="left"/>
+			  <tbody>
+				<row>
+				  <entry>
+					<literal>${id}</literal>
+				  </entry>
+				  <entry>Number of the match from 1 to 5</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${sourceText}</literal>
+				  </entry>
+				  <entry>The source text of the match</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${diff}</literal>
+				  </entry>
+				  <entry>A string that shows the differences between the
+				  source and the match.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${diffReversed}</literal>
+				  </entry>
+				  <entry>Same as ${diff}, but with the differences (what is to
+				  be inserted and deleted) inverted.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${targetText}</literal>
+				  </entry>
+				  <entry>The target text of the match</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${score}</literal>
+				  </entry>
+				  <entry>Percentage calculated with the <guilabel>Stemming, no
+				  tags and no numbers</guilabel> option.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${noStemScore}</literal>
+				  </entry>
+				  <entry>Percentage calculated with the <guilabel>No tags and
+				  no numbers</guilabel> option.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${adjustedScore}</literal>
+				  </entry>
+				  <entry>Percentage calculated with the <guilabel>Full text,
+				  including tags and numbers</guilabel> option.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${fileNameOnly}</literal>
+				  </entry>
+				  <entry>The TM filename, without the extension.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${filePath}</literal>
+				  </entry>
+				  <entry>The TM file full path.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${fileShortPath}</literal>
+				  </entry>
+				  <entry>The TM file relative path.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${initialCreationID}</literal>
+				  </entry>
+				  <entry>The ID of the translator who created the segment.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${initialCreationDate}</literal>
+				  </entry>
+				  <entry>The date when the segment was created.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${changeID}</literal>
+				  </entry>
+				  <entry>The ID of the translator who last changed the segment.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${changeDate}</literal>
+				  </entry>
+				  <entry>The date when the segment was last changed.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${fuzzyFlag}</literal>
+				  </entry>
+				  <entry>Indicate that this match is fuzzy (currently only for
+				  translations from PO files with the #fuzzy mark).</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${sourceLanguage}</literal>
+				  </entry>
+				  <entry>The segment source language.</entry>
+				</row>
+
+				<row>
+				  <entry>
+					<literal>${targetLanguage}</literal>
+				  </entry>
+				  <entry>The segment target language.</entry>
+				</row>
+
+			  </tbody>
+			</tgroup>
+		  </table>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
+
+  <section id="dialog.preferences.view">
+	<title id="dialog.preferences.view.title"><guilabel>View</guilabel></title>
+
+	<variablelist>
+	  <varlistentry id="dialog.preferences.view.display.all.source.segments.in.bold">
+		<term
+		id="dialog.preferences.view.display.all.source.segments.in.bold.title"><option>Display
+		all source segments in bold</option></term>
+		<listitem>
+		  <para>By default, only the current segment is displayed in bold
+		  face.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.view.display.active.source.segment.in.bold">
+		<term
+		id="dialog.preferences.view.display.active.source.segment.in.bold.title"><option>Display
+		active source segment in bold</option></term>
+		<listitem>
+		  <para>If source segments are displayed in normal face, you can use
+		  this option to display only the current source segment in bold.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments">
+		<term
+		id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title"><option>Mark
+		all non-unique segments</option></term>
+		<listitem>
+		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
+		  linkend="menus.view.mark.non.unique.segments"
+		  endterm="menus.view.mark.non.unique.segments.title"/> to mark the
+		  second and subsequent non-unique segments. Use this option to also
+		  mark the first such segment.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.view.simplify.tooltip.on.protected.parts">
+		<term
+		id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title"><option>Simplify
+		tag tooltips</option></term>
+		<listitem>
+		  <para>Tags are protected text. Tag tooltips display the actual content
+		  of the tag. For content with paired tags (as in HTML) the tooltips can
+		  be simplified when you hover on them.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="dialog.preferences.view.use.custom.templates.for.modification.info">
+		<term
+		id="dialog.preferences.view.use.custom.templates.for.modification.info.title"><option>Customize
+		segment modification information</option></term>
+		<listitem>
+		  <para>Segment modification information is displayed over the
+		  segment. the default setting shows who last modified the translation
+		  and when:</para>
+
+		  <example id="dialog.preferences.view.use.custom.templates.for.modification.info.example">
+			<title
+			id="dialog.preferences.view.use.custom.templates.for.modification.info.example.title">Default
+			display</title>
+			<para>
+			  <programlisting>Translation last modified by suzume on Oct 6, 2022 at 2:18:27 PM
 [[チューリッヒ大学]]大学院博士課程修了。
 [[Université de Zurich]] Elle finit sa thèse de doctorat.&lt;segment 0178></programlisting>
+			</para>
+		  </example>
+
+		  <para>Use <link
+		  linkend="menus.view"
+		  endterm="menus.view.title"/><link
+		  linkend="menus.view.modification.info"
+		  endterm="menus.view.modification.info.title"/> to display segment modification information.
 		  </para>
-		</example>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="dialog.preferences.view.modification.info.template">
+		<term
+		id="dialog.preferences.view.modification.info.template.title"><option>Standard
+		template</option></term>
+		<listitem>
+		  <para>Use the template variables to adapt this template to your
+		  needs.</para>
+		</listitem>
+	  </varlistentry>
 
-		<para>Segment modification information is displayed with <link linkend="menus.view.modification.info" endterm="menus.view.modification.info.title"/>.
-		</para>
-	  </listitem>
-	</varlistentry>
-	
-	<varlistentry id="dialog.preferences.view.modification.info.template">
-	  <term id="dialog.preferences.view.modification.info.template.title">Standard template</term>
-	  <listitem>
-		<para>Use the template variables to adapt this template to your needs.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="dialog.preferences.view.modification.info.template.for.segments.without.date">
+		<term
+		id="dialog.preferences.view.modification.info.template.for.segments.without.date.title"><option>Template
+		for segments without date</option></term>
+		<listitem>
+		  <para>Use the template variables to adapt this template to your
+		  needs.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 
-	<varlistentry id="dialog.preferences.view.modification.info.template.for.segments.without.date">
-	  <term
-	  id="dialog.preferences.view.modification.info.template.for.segments.without.date.title">Template
-	  for segments without date</term>
-	  <listitem>
-		<para>Use the template variables to adapt this template to your needs.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
+  <section id="dialogs.preferences.saving.and.output">
+	<title id="dialogs.preferences.saving.and.output.title"><guilabel>Saving and
+	Output</guilabel></title>
 
-<section id="dialogs.preferences.saving.and.output">
-  <title id="dialogs.preferences.saving.and.output.title">Saving and
-  Output</title>
+	<variablelist>
+	  <varlistentry id="dialog.preferences.saving.and.output.interval">
+		<term id="dialog.preferences.saving.and.output.interval.title"><option>Project
+		data saving interval</option></term>
+		<listitem>
+		  <para>Allows the user to select the interval between automatic project
+		  data saves.  See the <link
+		  linkend="how.to.restore.your.data.automatic.backup"
+		  endterm="how.to.restore.your.data.automatic.backup.title"/> section
+		  for details.</para>
 
-  <variablelist>
-	<varlistentry id="dialog.preferences.saving.and.output.interval">
-	  <term id="dialog.preferences.saving.and.output.interval.title">Project data saving
-	  interval</term>
-	  <listitem>
-		<para>Allows the user to select the interval between automatic project data saves.  See <link linkend="how.to.restore.your.data.automatic.backup" endterm="how.to.restore.your.data.automatic.backup.title"/> for details.</para>
+		  <para>Change the default interval (3 minutes) depending on the
+		  characteristics of the project:</para>
 
-		<para>Change the default interval (3 minutes) depending on the
-		characteristics of the project:</para>
+		  <itemizedlist>
+			<listitem>
+			  <para>Short intervals (10 seconds minimum) for projects
+			  synchronized on an internal server.</para>
+			</listitem>
 
-		<itemizedlist>
-		  <listitem>
-			<para>Short intervals (10 seconds minimum) for projects
-			synchronized on an internal server.</para>
-		  </listitem>
+			<listitem>
+			  <para>Longer intervals for team projects hosted on external
+			  servers.</para>
+			</listitem>
+		  </itemizedlist>
+		</listitem>
+	  </varlistentry>
 
-		  <listitem>
-			<para>Longer intervals for team projects hosted on external servers.</para>
-		  </listitem>
-		</itemizedlist>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
+		<term
+		id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>Global
+		post-processing commands</option></term>
 
-	<varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
-	  <term
-		  id="dialogs.preferences.saving.and.output.external.post-processing.command.title">Global
-	  post-processing commands</term>
+		<listitem>
+		  <para>OmegaT can automatically run commands after you use <link
+		  linkend="menus.project" endterm="menus.project.title"/><link
+		  linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project" endterm="menus.project.title"/><link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/>. You
+		  can define such commands here.</para>
 
-	  <listitem>
-		  <para>Specify commands to run automatically after using <link
-		linkend="menus.project.create.translated.documents"
-		endterm="menus.project.create.translated.documents.title"/> or <link linkend="menus.project.create.current.translated.document" endterm="menus.project.create.current.translated.document.title"/>.</para>
+		  <para>Commands specified here are available to all the projects that
+		  use the same configuration folder. They are saved in the <link
+		  linkend="configuration.folder.default.contents.omegat.prefs"
+		  endterm="configuration.folder.default.contents.omegat.prefs.title"/>
+		  file.</para>
 
-		<para>Commands specified here are available to all the projects that use
-		the same configuration folder. They are saved in <link
-		linkend="configuration.folder.default.contents.omegat.prefs"
-		endterm="configuration.folder.default.contents.omegat.prefs.title"/>.</para>
+		  <para>The template variables list gives you access to various project
+		  data and system variables. See the <link
+		  linkend="post.processing.commands.template.variables"
+		  endterm="post.processing.commands.template.variables.title"/> section
+		  for details.</para>
+		  
+		</listitem>
+	  </varlistentry>
 
-		<para>The template variables list gives you access to various project
-		data and system variables. See <link linkend="post.processing.commands.template.variables" endterm="post.processing.commands.template.variables.title"/> for details.</para>
-		
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
+		<term
+		id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><option>Allow
+		local post-processing commands</option></term>
 
-	<varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
-	  <term
-		  id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title">Allow local post-processing commands</term>
+		<listitem>
+		  <warning>
+			<para>For security reasons, the <link
+			linkend="dialogs.project.properties.external.processing.command">local
+			post-processing commands</link> are disabled by default.</para>
+		  </warning>
 
-	  <listitem>
-		<warning><para>For security reasons, <link linkend="dialogs.project.properties.external.processing.command" endterm="dialogs.project.properties.external.processing.command.title"/> are
-		  disabled by default.</para></warning>
-
-		  <para>You can also define local post-processing commands
-		  available only to a given project. Such commands are defined in <link
+		  <para>You can also define local post-processing commands available
+		  only to a given project. Such commands are defined in the <link
 		  linkend="dialogs.project.properties.external.processing.command"
-		  endterm="dialogs.project.properties.external.processing.command.title"/>.</para>
+		  endterm="dialogs.project.properties.external.processing.command.title"/>
+		  window.</para>
 
-		<para>Local post-processing commands are saved in <link linkend="project.folder.omegat.project.file" endterm="project.folder.omegat.project.file.title"/>. Only activate this option if you trust the source of that file.</para>
+		  <para>Local post-processing commands are saved in the <link
+		  linkend="project.folder.omegat.project.file"
+		  endterm="project.folder.omegat.project.file.title"/> file. Only
+		  activate this option if you trust the source of that file.</para>
 
-	  	<note><para>Local commands are run before global commands.</para></note>
+	  	  <note>
+			<para>Local commands are run before global commands.</para>
+		  </note>
 
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-</section>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </section>
 
-<section id="dialogs.preferences.proxy.login">
-  <title id="dialogs.preferences.proxy.login.title">Proxy Login</title>
+  <section id="dialogs.preferences.proxy.login">
+	<title id="dialogs.preferences.proxy.login.title"><guilabel>Proxy Login</guilabel></title>
 
-  <para>If you use an authenticated proxy server to access the
-  Internet, enter your credentials here.</para>
-</section>
+	<para>If you use an authenticated proxy server to access the Internet, enter
+	your credentials here.</para>
+  </section>
 
-<section id="dialogs.preferences.secure.store">
-  <title id="dialogs.preferences.secure.store.title">Secure store</title>
+  <section id="dialogs.preferences.secure.store">
+	<title id="dialogs.preferences.secure.store.title"><guilabel>Secure store</guilabel></title>
 
-  <para>Define or reset the master password used to
-  protect login credentials as well as access keys for machine translation
-  services.</para>
+	<para>Define or reset the master password used to protect login credentials
+	as well as access keys for machine translation services.</para>
 
-  <para>Before resetting the master password, always make a backup of that
-  information, because it will be deleted and will have to be re-entered.</para>
-</section>
+	<para>Before resetting the master password, always make a backup of that
+	information, because it will be deleted and will have to be
+	re-entered.</para>
+  </section>
 
-<section id="dialogs.preferences.plugins">
-  <title id="dialogs.preferences.plugins.title">Plugins</title>
+  <section id="dialogs.preferences.plugins">
+	<title id="dialogs.preferences.plugins.title"><guilabel>Plugins</guilabel></title>
 
-  <para>Displays the list of all the installed plugins.</para>
+	<para>Displays the list of all the installed plugins.</para>
 
-  <para>Plugins are installed
-  either in the <link linkend="application.folder.plugins" endterm="application.folder.plugins.title"/> folder under
-  the <link linkend="application.folder" endterm="application.folder.title"/>, or in the platform-specific
-  <link linkend="configuration.folder" endterm="configuration.folder.title"/>.</para>
-  <para>Additional plugins can be found on the <ulink
-  url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT development
-  site</ulink>.</para>
-</section>
+	<para>Plugins are installed either in the <link
+	linkend="application.folder.plugins"
+	endterm="application.folder.plugins.title"/> folder under the <link
+	linkend="application.folder">application folder</link>, or in the
+	platform-specific <link linkend="configuration.folder">configuration folder</link></para>
 
-<section id="dialogs.preferences.updates">
-  <title id="dialogs.preferences.updates.title">Updates</title>
+	<para>Additional plugins can be found on the <ulink
+	url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT development
+	site</ulink>.</para>
+  </section>
 
-  <para>Use this option to choose whether to be automatically notified of
-  updates to OmegaT.</para>
+  <section id="dialogs.preferences.updates">
+	<title id="dialogs.preferences.updates.title"><guilabel>Updates</guilabel></title>
 
-  <para>If OmegaT detects an update, it will display a link to the download page. See <link linkend="update.and.delete.omegat" endterm="update.and.delete.omegat.title"/> for details.</para>
-</section>
+	<para>Use this option to choose whether to be automatically notified of
+	updates to OmegaT.</para>
+
+	<para>If OmegaT detects an update, it will display a link to the download
+	page. See the <link linkend="update.and.delete.omegat"
+	endterm="update.and.delete.omegat.title"/> section for details.</para>
+  </section>
 </chapter>

--- a/doc_src/en/OmegaT5_ProjectFolder.xml
+++ b/doc_src/en/OmegaT5_ProjectFolder.xml
@@ -1,66 +1,133 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="project.folder">
-  <title id="project.folder.title">Project Folder</title>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
+<chapter id="chapter.project.folder">
+  <title id="chapter.project.folder.title">Project Folder</title>
 
-  <para>An OmegaT project consists of a set of folders and files that contain the resources used for translating.</para>
+  <para>An OmegaT project consists of a set of folders and files that contain
+  the resources used for translating.</para>
+
   <para>A project is a folder containing, at a minimum, the following:</para>
   
   <variablelist>
 	<varlistentry id="project.folder.omegat">
 	  <term id="project.folder.omegat.title">omegat</term>
-	  <listitem><para>This is the project folder that always contains <link linkend="project.folder.project.save.tmx" endterm="project.folder.project.save.tmx.title"/>, the project translation memory, and <link linkend="project.folder.project.stats" endterm="project.folder.project.stats.title"/>, the statistics data file for the project.</para>
-	  <para>Other files will be added over the course of the translation.</para>
+	  <listitem>
+		<para>This is the project folder that always contains <link
+		linkend="project.folder.project.save.tmx"
+		endterm="project.folder.project.save.tmx.title"/>, the project
+		translation memory, and <link linkend="project.folder.project.stats"
+		endterm="project.folder.project.stats.title"/>, the statistics data file
+		for the project.</para>
+		<para>Other files will be added over the course of the
+		translation.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="project.folder.omegat.project.file">
 	  <term id="project.folder.omegat.project.file.title">omegat.project</term>
-	  <listitem><para>This file contains the properties of the project (source and target languages, their respective tokenizers, the type of segmentation used, etc.) and also acts as an <emphasis>address book</emphasis> that specifies where project resources are located.</para>
-	  <para>By default, a newly created project will contain all the required resources within its folder, and those resources are assigned the default names below.
-	  
-	  <itemizedlist>
-		<listitem><para><link linkend="project.folder.source" endterm="project.folder.source.title"/> contains the source files</para></listitem>
+	  <listitem>
+		<para>This file contains the properties of the project (source and
+		target languages, their respective tokenizers, the type of segmentation
+		used, etc.) and also acts as an <emphasis>address book</emphasis> that
+		specifies where project resources are located.</para>
 
-		<listitem><para><link linkend="project.folder.target" endterm="project.folder.target.title"/> is the location where the target files are created</para></listitem>
+		<para>By default, a newly created project will contain all the required
+		resources within its folder, and those resources are assigned the
+		default names below.</para>
+		
+		<itemizedlist>
+		  <listitem>
+			<para><link linkend="project.folder.source"
+			endterm="project.folder.source.title"/> contains the source
+			files</para>
+		  </listitem>
 
-		<listitem><para><link linkend="project.folder.glossary" endterm="project.folder.glossary.title"/> contains the glossaries</para></listitem>
+		  <listitem>
+			<para><link linkend="project.folder.target"
+			endterm="project.folder.target.title"/> is the location where the
+			target files are created</para>
+		  </listitem>
 
-		<listitem><para><link linkend="project.folder.glossary.txt" endterm="project.folder.glossary.txt.title"/> is the project writable glossary</para></listitem>
+		  <listitem>
+			<para><link linkend="project.folder.glossary"
+			endterm="project.folder.glossary.title"/> contains the
+			glossaries</para>
+		  </listitem>
 
-		<listitem><para><link linkend="project.folder.tm" endterm="project.folder.tm.title"/> contains the reference translation memories</para></listitem>
+		  <listitem>
+			<para><link linkend="project.folder.glossary.txt"
+			endterm="project.folder.glossary.txt.title"/> is the project
+			writable glossary</para>
+		  </listitem>
 
-		<listitem><para><link linkend="project.folder.dictionary" endterm="project.folder.dictionary.title"/> contains the reference dictionaries</para></listitem>
-	  </itemizedlist>
-	  </para></listitem>
+		  <listitem>
+			<para><link linkend="project.folder.tm"
+			endterm="project.folder.tm.title"/> contains the reference
+			translation memories</para>
+		  </listitem>
+
+		  <listitem>
+			<para><link linkend="project.folder.dictionary"
+			endterm="project.folder.dictionary.title"/> contains the reference
+			dictionaries</para>
+		  </listitem>
+		</itemizedlist>
+	  </listitem>
 	</varlistentry>
   </variablelist>
 
-  <para>You can access the project folder and its folders with the <link linkend="menus.project.access.project.contents" endterm="menus.project.access.project.contents.title"/> command in the <link linkend="menus.project" endterm="menus.project.title"/> menu.</para>
+  <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
+  linkend="menus.project.access.project.contents"
+  endterm="menus.project.access.project.contents.title"/> to access the project
+  folder and its subfolders.</para>
 
-  <para>You can use <link linkend="menus.project.properties" endterm="menus.project.properties.title"/>, to easily assign locations other than the default ones to the various resources either when you create the project, or later on.</para>
+  <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
+  linkend="menus.project.properties" endterm="menus.project.properties.title"/>,
+  to easily assign locations other than the default ones to the various
+  resources either when you create the project, or later on.</para>
 
-  <para>For example, you can
+  <para>For example, you can</para>
 
-  <itemizedlist>
-	<listitem><para>create the translated files in a shared folder outside the project folder, in a location easily accessible to your reviewer, or</para></listitem>
-
-	<listitem><para>use a glossary folder from a separate but related project, or</para></listitem>
-
-	<listitem><para>use a reference translation memory folder that you have set up for related projects,</para></listitem>
-  </itemizedlist>
-  and so on.</para>
-
-  <para>Creating a project gives it a core hierarchy, but its final structure is not fixed. You can always remove or add files and folders to the project.</para>
-
-  <note><para>You can also create OmegaT projects either manually or with scripts by copying a set of prewritten files to a new folder:</para>
   <itemizedlist>
 	<listitem>
-	  <para>Any given folder that contains a valid <filename>omegat.project</filename> file will be recognized as a translation project by OmegaT (even if it later needs manual adjustments).</para>
+	  <para>create the translated files in a shared folder outside the project
+	  folder, in a location easily accessible to your reviewer, or</para>
 	</listitem>
+
 	<listitem>
-  <para>If the folder is an empty repository and the <filename>omegat.project</filename> file contains remote repository information, the project will be recognized as a team project by OmegaT:
-	<programlisting>...
+	  <para>use a glossary folder from a separate but related project, or</para>
+	</listitem>
+
+	<listitem>
+	  <para>use a reference translation memory folder that you have set up for
+	  related projects, and so on.</para>
+	</listitem>
+  </itemizedlist>
+  
+  <para>Creating a project gives it a core hierarchy, but its final structure is
+  not fixed. You can always remove or add files and folders to the
+  project.</para>
+
+  <note>
+	<para>You can also create OmegaT projects either manually or with scripts by
+	copying a set of prewritten files to a new folder:</para>
+	
+	<itemizedlist>
+	  <listitem>
+		<para>Any given folder that contains a valid
+		<filename>omegat.project</filename> file will be recognized as a
+		translation project by OmegaT (even if it later needs manual
+		adjustments).</para>
+	  </listitem>
+
+	  <listitem>
+		<para>If the folder is an empty repository and the
+		<filename>omegat.project</filename> file contains remote repository
+		information, the project will be recognized as a team project by
+		OmegaT:</para>
+		
+		<programlisting>...
     &lt;external_command&gt;&lt;/external_command&gt;
     &lt;repositories&gt;
         &lt;repository type="git" url="https://URL/OF/THE/REMOTE/PROJECT/REPOSITORY"&gt;
@@ -68,157 +135,274 @@
         &lt;/repository&gt;
     &lt;/repositories&gt;
 &lt;/project&gt;</programlisting>
-  See <link linkend="how.to.setup.team.project" endterm="how.to.setup.team.project.title"/> for details.</para>
-	</listitem>
-  </itemizedlist></note>
+
+		<para>See the <link linkend="how.to.setup.team.project"
+		endterm="how.to.setup.team.project.title"/> how-to for details.</para>
+	  </listitem>
+	</itemizedlist>
+  </note>
   
   <section id="project.folder.source">
     <title id="project.folder.source.title">source</title>
     <para>The source folder contains the files to translate.</para>
-	<para>Use <link linkend="menus.project.copy.files.to.source.folder" endterm="menus.project.copy.files.to.source.folder.title"/> or drop files on the <link linkend="panes.editor" endterm="panes.editor.title"/> pane to add files any time you want.</para>
-	<para>The contents of the files in a format that OmegaT supports will be displayed in the <link linkend="panes.editor" endterm="panes.editor.title"/> pane for translation.</para>
+
+	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
+	linkend="menus.project.copy.files.to.source.folder"
+	endterm="menus.project.copy.files.to.source.folder.title"/> or drop files on
+	the <link linkend="panes.editor" endterm="panes.editor.title"/> pane to add
+	files any time you want.</para>
+
+	<para>The contents of the files in a format that OmegaT supports will be
+	displayed in the <link linkend="panes.editor" endterm="panes.editor.title"/>
+	pane for translation.</para>
 
 	<para>You can add folders or remove files with your file manager.</para>
-	<para>If your translation project involves a number of folders and you feel like working on one folder at a time, change the <link linkend="dialogs.project.properties.file.locations.source.files" endterm="dialogs.project.properties.file.locations.source.files.title"/> as you wish.</para>
+
+	<para>If your translation project involves a number of folders and you feel
+	like working on one folder at a time, use <link linkend="menus.project"
+	endterm="menus.project.title"/><link linkend="menus.project.properties"
+	endterm="menus.project.properties.title"/> to access the project properties
+	and change the assigned <link
+	linkend="dialogs.project.properties.file.locations.source.files">source
+	folder</link> as you wish.</para>
   </section>
 
   <section id="project.folder.target">
     <title id="project.folder.target.title">target</title>
     <para>This folder is initially empty.</para>
-	<para>It will be populated with the translated files every time you use <link linkend="menus.project.create.translated.documents" endterm="menus.project.create.translated.documents.title"/> or <link linkend="menus.project.create.current.translated.document" endterm="menus.project.create.current.translated.document.title"/>.</para>
-	<para>The translated files that correspond to the contents of the <link linkend="project.folder.source" endterm="project.folder.source.title"/> folder, whether fully translated or not, are then created here, using the same hierarchy as in the source folder.</para>
-	<para>The files created here will reflect the current state of the translation. Untranslated segments will remain in the source language.</para>
+
+	<para>It will be populated with the translated files every time you use
+	<link linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/>.</para>
+
+	<para>The translated files that correspond to the contents of the <link
+	linkend="project.folder.source" endterm="project.folder.source.title"/>
+	folder, whether fully translated or not, are then created here, using the
+	same hierarchy as in the source folder.</para>
+
+	<para>The files created here will reflect the current state of the
+	translation. Untranslated segments will remain in the source
+	language.</para>
   </section>
 
   <section id="project.folder.tm">
     <title id="project.folder.tm.title">tm</title>
-    <para>This folder can contain any number of bilingual reference documents (TMX files, but also any file in a bilingual format supported by OmegaT, including PO files, etc.) and the TMX files can also be compressed in the gzip format.</para>
+    <para>This folder can contain any number of bilingual reference documents
+    (TMX files, but also any file in a bilingual format supported by OmegaT,
+    including PO files, etc.) and the TMX files can also be compressed in the
+    gzip format.</para>
 	
-	<para>OmegaT can be instructed to automatically insert matches. To remind you that a match was inserted by OmegaT and not by you, OmegaT adds the prefix set in <link linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match" endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"/>.</para>
+	<para>OmegaT can be instructed to automatically insert matches. To remind
+	you that a match was inserted by OmegaT and not by you, OmegaT adds the
+	prefix set in the <link
+	linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"
+	endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"/>
+	preference.</para>
 	
-    <para>Matches from the reference memories are displayed in the <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/> pane, just like matches from <link linkend="project.folder.project.save.tmx" endterm="project.folder.project.save.tmx.title"/>, the project translation memory.</para>
+    <para>Matches from the reference memories are displayed in the <link
+    linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/> pane,
+    just like matches from <link linkend="project.folder.project.save.tmx"
+    endterm="project.folder.project.save.tmx.title"/>, the project translation
+    memory.</para>
 
-  <para>Such matches are by default
-  limited to the source and target languages defined in <link
-  linkend="dialogs.project.properties"
-  endterm="dialogs.project.properties.title"/>, but you can also add matches in languages that are not the target language. See <link linkend="dialog.preferences.tm.matches.other.languages" endterm="dialog.preferences.tm.matches.other.languages.title"/> for details.</para>
+	<para>Such matches are by default limited to the source and target languages
+	defined in the <link linkend="dialogs.project.properties"
+	endterm="dialogs.project.properties.title"/> dialog, but you can also add
+	matches in languages that are not the target language. See the <link
+	linkend="dialog.preferences.tm.matches.other.languages"
+	endterm="dialog.preferences.tm.matches.other.languages.title"/> preferences
+	for details.</para>
 
-  <para>The folder can contain any number of subfolders, including some that have special functions:
-<variablelist>
-    <varlistentry id="project.folder.tm.auto">
-      <term id="project.folder.tm.auto.title">tm/auto</term>
-	  <listitem>
-	  <para>This folder is intended for reliable references files that can automatically fill exactly matching and not yet translated segments.</para>
-      <para>Translations from TMX files placed in this folder are automatically inserted in matching segments without the automatic prefix, making it unnecessary to confirm these segments.</para>
-	  <para>Translations coming from this folder are considered to be <emphasis>as</emphasis> reliable as the project memory.</para>
+	<para>The folder can contain any number of subfolders, including some that
+	have special functions:</para>
 
-	  <note><para>Only the <filename>tm/auto</filename> folder is automatically generated at project creation. You must manually create and fill any other <filename>tm</filename> folder that you want to use.</para></note>
+	<variablelist>
+      <varlistentry id="project.folder.tm.auto">
+		<term id="project.folder.tm.auto.title">tm/auto</term>
+		<listitem>
+		  <para>This folder is intended for reliable references files that can
+		  automatically fill exactly matching and not yet translated
+		  segments.</para>
 
-	  <orderedlist>
-        <listitem>
-          <para>Put the applicable memories in the <filename class="directory">tm/auto</filename> folder.</para>
-        </listitem>
+		  <para>Translations from TMX files placed in this folder are
+		  automatically inserted in matching segments without the automatic
+		  prefix, making it unnecessary to confirm these segments.</para>
 
-        <listitem>
-          <para>Open the project. You will see that segments identical to source segments in those memories are already filled in. They will be highlighted in orange if you have checked the <link linkend="menus.view.mark.auto.populated.segments" endterm="menus.view.mark.auto.populated.segments.title"/> option in the <link linkend="menus.view" endterm="menus.view.title"/> menu.</para>
-        </listitem>
+		  <para>Translations coming from this folder are considered to be
+		  <emphasis>as</emphasis> reliable as the project memory.</para>
 
-        <listitem>
-          <para>Make a minor change anywhere in the project and save it. This will add the translations loaded from the tm/auto folder to the project translation memory.</para>
-        </listitem>
-      </orderedlist>
-	  
-      <warning><para>If you remove a TMX file from <filename class="directory">tm/auto</filename> before Step 3, its content will not be kept.</para></warning>
-	  </listitem>
-	</varlistentry>
+		  <note>
+			<para>Only the <filename>tm/auto</filename> folder is automatically
+			generated at project creation. You must manually create and fill any
+			other <filename>tm</filename> folder that you want to
+			use.</para>
+		  </note>
 
-    <varlistentry id="project.folder.tm.enforce">
-      <term id="project.folder.tm.enforce.title">tm/enforce</term>
-	  <listitem>
-	  <para>This folder is made for reliable references files that are also meant to automatically overwrite previously translated contents.</para>
-
-      <para>Translations from TMX files placed in this folder are automatically inserted in matching segments without the automatic prefix, making it unnecessary to confirm these segments. Translations coming from this folder are considered to be <emphasis>more</emphasis> reliable than the current project memory.</para>
-
-      <para>If you have no doubt that a given TMX contains more accurate translations than the current <filename>project_save.tmx</filename> file, put that TMX in the <filename class="directory">tm/enforce</filename> folder to overwrite the existing translations unconditionally.</para>
-
-      <orderedlist>
-        <listitem>
-          <para>Put the applicable memories in the <filename class="directory">tm/enforce</filename> folder.</para>
-        </listitem>
-
-        <listitem>
-          <para>Open the project. You will see that segments identical to source segments in those memories are already filled in.</para>
-        </listitem>
-
-        <listitem>
-          <para>Make a minor change anywhere in the project and save. This updates the project translation memory.</para>
-        </listitem>
-
-        <listitem>
-          <para>Make a decision about the immutability of the enforced segments:
-		  <itemizedlist>
+		  <orderedlist>
 			<listitem>
-              <para>If they <emphasis>don't need</emphasis> to remain immutable to further changes,  remove the TMX from <filename class="directory">tm/enforce</filename>.</para>
+			  <para>Put the applicable memories in the <filename
+			  class="directory">tm/auto</filename> folder.</para>
+			</listitem>
+			
+			<listitem>
+			  <para>Open the project. You will see that segments identical to
+			  source segments in those memories are already filled in. Use <link
+			  linkend="menus.view" endterm="menus.view.title"/><link
+			  linkend="menus.view.mark.auto.populated.segments"
+			  endterm="menus.view.mark.auto.populated.segments.title"/> to
+			  highlight them.</para>
 			</listitem>
 
 			<listitem>
-              <para>If they <emphasis>do need</emphasis> to remain immutable to further changes, leave the TMX in <filename class="directory">tm/enforce</filename>. Any modification to the segments that come from these memories will <emphasis>not</emphasis> be taken into account.</para>
+			  <para>Make a minor change anywhere in the project and save it. This
+			  will add the translations loaded from the tm/auto folder to the
+			  project translation memory.</para>
 			</listitem>
-          </itemizedlist></para>
-        </listitem>
-      </orderedlist>
+		  </orderedlist>
+		  
+		  <warning>
+			<para>If you remove a TMX file from <filename
+			class="directory">tm/auto</filename> before Step 3, its content will
+			not be kept.</para>
+		  </warning>
+		</listitem>
+	  </varlistentry>
+
+      <varlistentry id="project.folder.tm.enforce">
+		<term id="project.folder.tm.enforce.title">tm/enforce</term>
+		<listitem>
+		  <para>This folder is made for reliable references files that are also
+		  meant to automatically overwrite previously translated contents.</para>
+
+		  <para>Translations from TMX files placed in this folder are
+		  automatically inserted in matching segments without the automatic
+		  prefix, making it unnecessary to confirm these segments. Translations
+		  coming from this folder are considered to be <emphasis>more</emphasis>
+		  reliable than the current project memory.</para>
+
+		  <para>If you have no doubt that a given TMX contains more accurate
+		  translations than the current <filename>project_save.tmx</filename>
+		  file, put that TMX in the <filename
+		  class="directory">tm/enforce</filename> folder to overwrite the existing
+		  translations unconditionally.</para>
+
+		  <orderedlist>
+			<listitem>
+			  <para>Put the applicable memories in the <filename
+			  class="directory">tm/enforce</filename> folder.</para>
+			</listitem>
+
+			<listitem>
+			  <para>Open the project. You will see that segments identical to
+			  source segments in those memories are already filled in.</para>
+			</listitem>
+			
+			<listitem>
+			  <para>Make a minor change anywhere in the project and save. This
+			  updates the project translation memory.</para>
+			</listitem>
+
+			<listitem>
+			  <para>Make a decision about the immutability of the enforced
+			  segments:</para>
+			  
+			  <itemizedlist>
+				<listitem>
+				  <para>If they <emphasis>don't need</emphasis> to remain
+				  immutable to further changes, remove the TMX from <filename
+				  class="directory">tm/enforce</filename>.</para>
+				</listitem>
+
+				<listitem>
+				  <para>If they <emphasis>do need</emphasis> to remain immutable
+				  to further changes, leave the TMX in <filename
+				  class="directory">tm/enforce</filename>. Any modification to the
+				  segments that come from these memories will
+				  <emphasis>not</emphasis> be taken into account.</para>
+				</listitem>
+			  </itemizedlist>
+			</listitem>
+		  </orderedlist>
+		  
+		  <warning>
+			<para>If you remove a TMX file from <filename
+			class="directory">tm/enforce</filename> before Step 3, none of the
+			enforced translations will be kept.</para>
+		  </warning>
+		</listitem>
+	  </varlistentry>
+
+      <varlistentry id="project.folder.tm.mt">
+		<term id="project.folder.tm.mt.title">tm/mt</term>
+		<listitem>
+		  <para>When a match is inserted from a TMX contained in this folder, the
+		  background color of the active segment changes to red.</para>
+
+		  <para>The background color is restored to normal when you leave the
+		  segment or when you modify the segment.</para>
+		</listitem>
+	  </varlistentry>
 	  
-      <warning><para>If  you remove a TMX file from <filename class="directory">tm/enforce</filename> before Step 3, none of the enforced translations will be kept.</para></warning>
-	  </listitem>
-	</varlistentry>
+      <varlistentry id="project.folder.tm.penalty">
+		<term id="project.folder.tm.penalty.title">tm/penalty-xxx</term>
+		<listitem>
+		  <para><literal>xxx</literal> is a number from 0 to 100 that will act as
+		  a penalty subtracted from the match percentage of segments coming from
+		  this folder.</para>
 
-    <varlistentry id="project.folder.tm.mt">
-      <term id="project.folder.tm.mt.title">tm/mt</term>
-	  <listitem>
-		<para>When a match is inserted from a TMX contained in this folder, the background color of the active segment changes to red.</para>
-		<para>The background color is restored to normal when you leave the segment or when you modify the segment.</para>
-	  </listitem>
-	</varlistentry>
-	
-    <varlistentry id="project.folder.tm.penalty">
-      <term id="project.folder.tm.penalty.title">tm/penalty-xxx</term>
-	  <listitem>
-		<para><literal>xxx</literal> is a number from 0 to 100 that will act as a penalty subtracted from the match percentage of segments coming from this folder.</para>
-		<para>For example, a 100% match in a TMX, stored in a folder called <filename class="directory">penalty-30</filename> becomes a 70% match. The penalty applies to all three match percentages. Scores of 75, 80 and 90 for a match are lowered to 45, 50 and 60.</para>
-	  </listitem>
-	</varlistentry>
+		  <para>For example, a 100% match in a TMX, stored in a folder called
+		  <filename class="directory">penalty-30</filename> becomes a 70%
+		  match. The penalty applies to all three match percentages. Scores of 75,
+		  80 and 90 for a match are lowered to 45, 50 and 60.</para>
+		</listitem>
+	  </varlistentry>
 
-    <varlistentry id="project.folder.tm.tmx2source">
-      <term id="project.folder.tm.tmx2source.title">tm/tmx2source</term>
-	  <listitem>
+      <varlistentry id="project.folder.tm.tmx2source">
+		<term id="project.folder.tm.tmx2source.title">tm/tmx2source</term>
+		<listitem>
+		  <para>You can display a third language <emphasis>right
+		  under</emphasis> the source segment to use as a third language
+		  reference. See the <link linkend="how.to.tm.bridge.two.languages"
+		  endterm="how.to.tm.bridge.two.languages.title"/> how-to for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
 
-  <para>You can display a third language <emphasis>right
-  under</emphasis> the source segment to use as a third language reference. See
-  <link linkend="how.to.tm.bridge.two.languages"
-  endterm="how.to.tm.bridge.two.languages.title"/> for details.</para>
-      </listitem>
-	</varlistentry>
-</variablelist>
-</para>	
-	<note><para>You can combine folders to create new functions. For example, a 10% penalty folder within the machine translation folder: <filename>tm/mt/penalty-010</filename> would never generate 100% matches that could otherwise be automatically inserted by OmegaT, and would always set a red background to the match whenever it is inserted.</para></note>
+	<note>
+	  <para>You can combine folders to create new functions. For example, a 10%
+	  penalty folder within the machine translation folder:
+	  <filename>tm/mt/penalty-010</filename> would never generate 100% matches
+	  that could otherwise be automatically inserted by OmegaT, and would always
+	  set a red background to the match whenever it is inserted.</para>
+	</note>
   </section>
 
   <section id="project.folder.exported.tm">
 	<title id="project.folder.exported.tm.title">exported tms folder</title>
-	<para>By default, that folder is the project folder itself but you can change its location to make it more practical to share exported TM files. See <link linkend="how.to.tm.share.translation.memories" endterm="how.to.tm.share.translation.memories.title"/> for details.</para>
+	<para>By default, that folder is the project folder itself but you can
+	change its location to make it more practical to share exported TM
+	files. See the <link linkend="how.to.tm.share.translation.memories"
+	endterm="how.to.tm.share.translation.memories.title"/> how-to for
+	details.</para>
   </section>
 
   <section id="project.folder.dictionary">
     <title id="project.folder.dictionary.title">dictionary</title>
-    <para>This folder is initially empty, and is used to store any dictionaries you add to the project.</para>
+    <para>This folder is initially empty, and is used to store any dictionaries
+    you add to the project.</para>
 
 	<para>Dictionary terms that match parts of the segment are displayed in the
-	<link linkend="panes.dictionary" endterm="panes.dictionary.title"/> pane. See
-	<link linkend="dialogs.preferences.dictionary"
-	endterm="dialogs.preferences.dictionary.title"/> for details.</para>
+	<link linkend="panes.dictionary" endterm="panes.dictionary.title"/>
+	pane. See the <link linkend="dialogs.preferences.dictionary"
+	endterm="dialogs.preferences.dictionary.title"/> preferences for
+	details.</para>
 
     <para>OmegaT supports dictionaries in the StarDict or in the Lingvo DSL
-    format. You can find some dictionaries on the <ulink url="https://sourceforge.net/p/omegat/wiki/Reference%20Material/">OmegaT
+    format. You can find some dictionaries on the <ulink
+    url="https://sourceforge.net/p/omegat/wiki/Reference%20Material/">OmegaT
     Wiki</ulink>.</para>
 
 	<para>To install dictionaries:</para>
@@ -228,12 +412,14 @@
         <para>download the file - it should be a tarball archive (extension
         <filename>tar.bz</filename> or <filename>tar.bz2</filename>),</para>
       </listitem>
+	  
       <listitem>
         <para>extract its contents into this folder. There should be three files
         per dictionary, with extensions <filename>dz</filename>,
         <filename>idx</filename> and <filename>ifo</filename>.</para>
       </listitem>
     </orderedlist>
+
 	<para>If you want to remove words from potential dictionary matches, add an
 	<filename>ignore.txt</filename> encoded in UTF-8 to the folder. The file
 	must have one word per line. All the words contained in that list will be
@@ -242,10 +428,13 @@
 
   <section id="project.folder.glossary">
     <title id="project.folder.glossary.title">glossary</title>
-    <para>This folder is initially empty. It is used to store the default writable glossary and any other glossaries you use in the project.</para>
+    <para>This folder is initially empty. It is used to store the default
+    writable glossary and any other glossaries you use in the project.</para>
 
-		<para>Glossary terms that match parts of the segment are displayed in the
-	<link linkend="panes.glossary" endterm="panes.glossary.title"/> pane. See <link linkend="app.glossaries" endterm="app.glossaries.title"/> for details.</para>
+	<para>Glossary terms that match parts of the segment are displayed in the
+	<link linkend="panes.glossary" endterm="panes.glossary.title"/> pane. See
+	the <link linkend="app.glossaries" endterm="app.glossaries.title"/> appendix
+	for details.</para>
 
 	<variablelist>
       <varlistentry id="project.folder.glossary.txt">
@@ -254,6 +443,7 @@
           <para>This is the project writable glossary. It is created the first
           time you use <link linkend="menus.edit.create.glossary.entry"
           endterm="menus.edit.create.glossary.entry.title"/>.</para>
+
 		  <para>You can access it with <link
 		  linkend="menus.project.access.project.contents.title"
 		  endterm="menus.project.access.project.contents.title"/>, open it in a
@@ -266,66 +456,109 @@
 
   <section id="project.folder.omegat.folder">
     <title id="project.folder.omegat.folder.title">omegat</title>
-    <para>The <filename class="directory">omegat</filename> folder contains, at a minimum, the <link linkend="project.folder.project.save.tmx" endterm="project.folder.project.save.tmx.title"/> and <link linkend="project.folder.project.stats" endterm="project.folder.project.stats.title"/> files. It may also include several other files.</para>
+    <para>The <filename class="directory">omegat</filename> folder contains, at
+    a minimum, the <link linkend="project.folder.project.save.tmx"
+    endterm="project.folder.project.save.tmx.title"/> and <link
+    linkend="project.folder.project.stats"
+    endterm="project.folder.project.stats.title"/> files. It may also include
+    several other files.</para>
 
     <variablelist>
       <varlistentry id="project.folder.project.save.tmx">
         <term id="project.folder.project.save.tmx.title">project_save.tmx</term>
         <listitem>
-          <para>This is the most important file in the project. When you
-          create a new project, the file is  empty and is gradually
-          filled with the translations of the text in files located in the <link
+          <para>This is the most important file in the project. When you create
+          a new project, the file is empty and is gradually filled with the
+          translations of the text in files located in the <link
           linkend="project.folder.source"
           endterm="project.folder.source.title"/> folder.</para>
-		  <para>It constitutes the working translation memory of the project.</para>
-		  <para>OmegaT regularly backs-up that file. See <link linkend="how.to.restore.your.data" endterm="how.to.restore.your.data.title"/> for details.</para>
-		          </listitem>
+
+		  <para>It constitutes the working translation memory of the
+		  project.</para>
+
+		  <para>OmegaT regularly backs-up that file. See the <link
+		  linkend="how.to.restore.your.data"
+		  endterm="how.to.restore.your.data.title"/> how-to for details.</para>
+		</listitem>
       </varlistentry>
 	  
-	<varlistentry id="project.folder.project.save.tmx.bak">
-	  <term id="project.folder.project.save.tmx.bak.title">project_save.tmx.bak</term>
-	  <listitem><para>This file is a backup of <filename>project_save.tmx</filename> and is automatically recreated every time <filename>project_save.tmx</filename> has been modified: either after using <link linkend="menus.project.save" endterm="menus.project.save.title"/>, or as a regular backup every 3 minutes by default. See <link linkend="dialog.preferences.saving.and.output.interval" endterm="dialog.preferences.saving.and.output.interval.title"/> for details.</para></listitem>
-	</varlistentry>
-	
-	<varlistentry id="project.folder.project.save.tmx.timestamp.bak">
-	  <term id="project.folder.project.save.tmx.timestamp.bak.title">project_save.tmx.timestamp.bak</term>
-	  <listitem><para>Every time a project is loaded, OmegaT creates a backup of <filename>project_save.tmx</filename> with the name <filename>project_save.tmx.[time stamp].bak</filename>. OmegaT keeps up to 10 of those files.</para></listitem>
-	</varlistentry>
+	  <varlistentry id="project.folder.project.save.tmx.bak">
+		<term id="project.folder.project.save.tmx.bak.title">project_save.tmx.bak</term>
+		<listitem>
+		  <para>This file is a backup of <filename>project_save.tmx</filename>
+		  and is automatically recreated every time
+		  <filename>project_save.tmx</filename> has been modified: either after
+		  using <link linkend="menus.project"
+		  endterm="menus.project.title"/><link linkend="menus.project.save"
+		  endterm="menus.project.save.title"/>, or as a regular backup every 3
+		  minutes by default. See the <link
+		  linkend="dialog.preferences.saving.and.output.interval"
+		  endterm="dialog.preferences.saving.and.output.interval.title"/>
+		  preference for details.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="project.folder.project.save.tmx.timestamp.bak">
+		<term id="project.folder.project.save.tmx.timestamp.bak.title">project_save.tmx.timestamp.bak</term>
+		<listitem>
+		  <para>Every time a project is loaded, OmegaT creates a backup of
+		  <filename>project_save.tmx</filename> with the name
+		  <filename>project_save.tmx.[time stamp].bak</filename>. OmegaT keeps
+		  up to 10 of those files.</para>
+		</listitem>
+	  </varlistentry>
 
       <varlistentry id="project.folder.project.stats">
         <term id="project.folder.project.stats.title">project_stats.txt</term>
         <listitem>
-          <para>This is the statistics file for the whole project. It is updated each time the project is reloaded.</para>
-		  <para>You can also update it with the <link linkend="menus.tools.statistics" endterm="menus.tools.statistics.title"/> command in the <link linkend="menus.tools" endterm="menus.tools.title"/> menu.</para>
+          <para>This is the statistics file for the whole project. It is updated
+          each time the project is reloaded.</para>
+
+		  <para>Use <link linkend="menus.tools"
+		  endterm="menus.tools.title"/><link linkend="menus.tools.statistics"
+		  endterm="menus.tools.statistics.title"/> to update it.</para>
         </listitem>
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.project.stats.match">
         <term id="project.folder.omegat.project.stats.match.title">project_stats_match.txt</term>
         <listitem>
-          <para>This file contains the latest project match statistics, which are generated by the <link linkend="menus.tools.match.statistics" endterm="menus.tools.match.statistics.title"/> command in the <link linkend="menus.tools" endterm="menus.tools.title"/> menu.</para>
+          <para>This file contains the latest project match statistics. Use
+          <link linkend="menus.tools" endterm="menus.tools.title"/><link
+          linkend="menus.tools.match.statistics"
+          endterm="menus.tools.match.statistics.title"/> to generate it.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.project.stats.match.per.file">
-        <term id="project.folder.omegat.project.stats.match.per.file.title">project_stats_match_per_file.txt</term>
+        <term
+        id="project.folder.omegat.project.stats.match.per.file.title">project_stats_match_per_file.txt</term>
         <listitem>
-          <para>This file contains the latest project match statistics by file, which are generated by the <link linkend="menus.tools.match.statistics.per.file" endterm="menus.tools.match.statistics.per.file.title"/> command in the <link linkend="menus.tools" endterm="menus.tools.title"/> menu.</para>
+          <para>This file contains the latest project match statistics by file.
+          Use <link linkend="menus.tools" endterm="menus.tools.title"/><link
+          linkend="menus.tools.match.statistics.per.file"
+          endterm="menus.tools.match.statistics.per.file.title"/> to generate
+          it.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="
 						project.folder.omegat.spellcheck">
-        <term id="project.folder.omegat.ignored.words.title">ignored_words.txt</term>
+        <term
+        id="project.folder.omegat.ignored.words.title">ignored_words.txt</term>
         <term id="project.folder.omegat.learned.words">learned_words.txt</term>
         <listitem>
           <para>These files are created and used by the spellchecker. You can
-          add terms in the <link linkend="panes.editor" endterm="panes.editor.title"/> pane  by right-clicking on a word marked as incorrect and
-          selecting <guimenuitem>Ignore All</guimenuitem> (for words to skip
-          during spellchecking), or <guimenuitem>Add to Dictionary</guimenuitem>
-          (for words to accept as correct), respectively, from the <link
-          linkend="panes.editor.context.menu"
-          endterm="panes.editor.context.menu.title"/>. See <link linkend="dialog.preferences.spellchecker" endterm="dialog.preferences.spellchecker.title"/> for details.</para>
+          add terms in the <link linkend="panes.editor"
+          endterm="panes.editor.title"/> pane by right-clicking on a word marked
+          as incorrect and selecting <guimenuitem>Ignore All</guimenuitem> (for
+          words to skip during spellchecking), or <guimenuitem>Add to
+          Dictionary</guimenuitem> (for words to accept as correct),
+          respectively, from the <link
+          linkend="panes.editor.context.menu">context menu</link>. See the <link
+          linkend="dialog.preferences.spellchecker"
+          endterm="dialog.preferences.spellchecker.title"/> preferences for
+          details.</para>
 
 		  <para>If you already have a collection of words you want the
 		  spellchecker to ignore or accept, simply save them in text files with
@@ -339,7 +572,8 @@
       <varlistentry id="project.folder.omegat.segmentation">
         <term id="project.folder.omegat.segmentation.title">segmentation.conf</term>
         <listitem>
-          <para>This file contains the project-specific segmentation rules.</para>
+          <para>This file contains the project-specific segmentation
+          rules.</para>
         </listitem>
       </varlistentry>
 
@@ -367,14 +601,19 @@
       <varlistentry id="project.folder.omegat.file.order">
         <term id="project.folder.omegat.file.order.title">files_order.txt</term>
         <listitem>
-          <para>This file is created if you manually change the order of the files in the <link linkend="windows.source.files.list" endterm="windows.source.files.list.title"/> window.</para>
+          <para>This file is created if you manually change the order of the
+          files in the <link linkend="windows.source.files.list"
+          endterm="windows.source.files.list.title"/> window.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.last.entry">
         <term id="project.folder.omegat.last.entry.title">last_entry.properties</term>
         <listitem>
-          <para>This file keeps a record of the last segment you visited, including its number, its source contents, the file name and the date, so that you can come back to it when you reload/relaunch the project.</para>
+          <para>This file keeps a record of the last segment you visited,
+          including its number, its source contents, the file name and the date,
+          so that you can come back to it when you reload/relaunch the
+          project.</para>
         </listitem>
       </varlistentry>	  
     </variablelist>
@@ -382,14 +621,22 @@
 
   <section id="project.folder.omegat.project">
     <title id="project.folder.omegat.project.title">omegat.project</title>
-    <para>This file contains the project parameters defined in the <link linkend="dialogs.project.properties" endterm="dialogs.project.properties.title"/>.</para>
+    <para>This file contains the project parameters defined in the <link
+    linkend="dialogs.project.properties">project properties</link>.</para>
   </section>
 
   <section id="project.folder.repositories">
     <title id="project.folder.repositories.title">.repositories</title>
     <para>In a team project, this folder contains a versioned copy of the
     project tree structure linked directly to the remote server.</para>
-    <para>You can make changes to the remote files (such as deleting or replacing them) by making your changes in this folder and using a Git or SVN client to synchronize them with the remote server. See <link linkend="how.to.setup.team.project" endterm="how.to.setup.team.project.title"/> for details.</para>
-    <para>In some operating systems, this folder is hidden by default. Turn on the option to show hidden files in your system to make it visible.</para>
+
+    <para>You can make changes to the remote files (such as deleting or
+    replacing them) by making your changes in this folder and using a Git or SVN
+    client to synchronize them with the remote server. See the <link
+    linkend="how.to.setup.team.project"
+    endterm="how.to.setup.team.project.title"/> how-to for details.</para>
+
+    <para>In some operating systems, this folder is hidden by default. Turn on
+    the option to show hidden files in your system to make it visible.</para>
   </section>
 </chapter>

--- a/doc_src/en/OmegaT5_WindowsAndDialogs.xml
+++ b/doc_src/en/OmegaT5_WindowsAndDialogs.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
-<chapter id="windows.and.dialogs">
-  <title id="windows.and.dialogs.title">Windows and Dialogs</title>
-
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
+<chapter id="chapter.windows.and.dialogs">
+  <title id="chapter.windows.and.dialogs.title">Windows and Dialogs</title>
   
-  <para>A <emphasis>window</emphasis> can be kept open next to the editor and lets you interact with both.</para>
-  <para>A <emphasis>dialog</emphasis> requires you to take action and close it before you can go back to translating.</para>
+  <para>A <emphasis>window</emphasis> can be kept open next to the editor and
+  lets you interact with both.</para>
+  <para>A <emphasis>dialog</emphasis> requires you to take action and close it
+  before you can go back to translating.</para>
 
   <xi:include href="Dialogs_ProjectProperties.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 

--- a/doc_src/en/OmegaTUsersManual_xinclude full.xml
+++ b/doc_src/en/OmegaTUsersManual_xinclude full.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd"
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
-<book lang="en" id="book.user.guide">
+<book lang="en" id="book.user.manual">
   <bookinfo>
-    <title id="book.user.guide.title">OmegaT &vernb; - User Guide</title>
+    <title id="book.user.manual.title">OmegaT &vernb; - User Manual</title>
     <pubdate>@timestamp@</pubdate>
 	<!-- TODO automate date insertion -->
     <abstract>
-      <para>This document is the official user guide to OmegaT, the free
+      <para>This document is the official user manual to OmegaT, the free
       Computer-Assisted Translation tool.</para>
     </abstract>
   </bookinfo>

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -2,91 +2,101 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.aligner">
-  <title id="windows.aligner.title">Align Files</title>
+  <title id="windows.aligner.title"><guilabel>Align Files</guilabel></title>
 
-  <para>Select
-  <link endterm="menus.tools.align.files.title"
-  linkend="menus.tools.align.files"/> in the <link endterm="menus.tools.title"
-  linkend="menus.tools"/> menu to access this tool.</para>
+  <para>Use <link endterm="menus.tools.title"
+  linkend="menus.tools"/><link endterm="menus.tools.align.files.title"
+  linkend="menus.tools.align.files"/> to access this tool.</para>
 
-    <para>OmegaT also offers a command line based alignment mode for key-based
-    formats. See <link linkend="launch.with.command.line.mode.console.align"
-    endterm="launch.with.command.line.mode.console.align.title"/> for
-    details.</para>
+  <para>OmegaT also offers a command line based alignment mode for key-based
+  formats. See the <link linkend="launch.with.command.line.mode.console.align"
+  endterm="launch.with.command.line.mode.console.align.title"/> option for
+  details.</para>
 
-	<warning>
-      <para>The aligner does not allow you to save your work partway through an
-      alignment. Therefore, it is recommended that you divide the files to align
-      into shorter files that you can comfortably align in a single
-      session. Doing so has the added benefit of reducing mismatches in the
-      initial automatic alignment, making the manual correction step
-      smoother.</para>
-    </warning>
+  <warning>
+    <para>The aligner does not allow you to save your work partway through an
+    alignment. Therefore, it is recommended that you divide the files to align
+    into shorter files that you can comfortably align in a single session. Doing
+    so has the added benefit of reducing mismatches in the initial automatic
+    alignment, making the manual correction step smoother.</para>
+  </warning>
 
 
-  <para>Alignment is the process of creating a bilingual translation memory
-  from a pair of already translated monolingual documents. Aligning the
-  contents of the files is a four-step process:</para>
+  <para>Alignment is the process of creating a bilingual translation memory from
+  a pair of already translated monolingual documents. Aligning the contents of
+  the files is a four-step process:</para>
+
   <orderedlist>
-	<listitem><para>specify the source and target languages and select the two
-	files you want to align.</para></listitem>
-	<listitem><para>the files are read by the aligner,
-	which attempts to match the segments that correspond to one another in the
-	original and translated texts,</para></listitem> <listitem><para>the
-	translator reviews the results and makes any necessary manual
-	adjustments,</para></listitem>
-	<listitem><para>save the result to TMX</para></listitem>
+	<listitem>
+	  <para>specify the source and target languages and select the two files you
+	  want to align.</para>
+	</listitem>
+
+	<listitem>
+	  <para>the files are read by the aligner, which attempts to match the
+	  segments that correspond to one another in the original and translated
+	  texts,</para>
+	</listitem>
+
+	<listitem>
+	  <para>the translator reviews the results and makes any necessary manual
+	  adjustments,</para>
+	</listitem>
+
+	<listitem>
+	  <para>save the result to TMX</para>
+	</listitem>
   </orderedlist>
 
   <para>The aligner can read all the file formats supported by OmegaT.</para>
   
   <note>
-    <para>If you have a translation project open, the aligner will
-    automatically use the languages from that project, as well the
-    project-specific segmentation rules, if any.</para>
+    <para>If you have a translation project open, the aligner will automatically
+    use the languages from that project, as well the project-specific
+    segmentation rules, if any.</para>
   </note>
 
-  <para>After selecting the language and files, click <guibutton>OK</guibutton> button to  bring up the <guilabel>Align</guilabel> window,
-  which shows the results of the automatic alignment.</para>
+  <para>After selecting the language and files, click <guibutton>OK</guibutton>
+  button to bring up the <guilabel>Align</guilabel> window, which shows the
+  results of the automatic alignment.</para>
 
-  <para>The main part of the window is divided into three columns:
+  <para>The main part of the window is divided into three columns:</para>
+  
   <itemizedlist>
-      <listitem>
-        <para><guilabel>Keep</guilabel>: The segment pairs in rows that have
-        this box checked are saved to the translation memory file.
-        Unchecked rows are discarded.</para>
-      </listitem>
+    <listitem>
+      <para><guilabel>Keep</guilabel>: The segment pairs in rows that have this
+      box checked are saved to the translation memory file.  Unchecked rows are
+      discarded.</para>
+    </listitem>
 
-      <listitem>
-        <para><guilabel>Source</guilabel>: The segments from the original
-        text.</para>
-      </listitem>
+    <listitem>
+      <para><guilabel>Source</guilabel>: The segments from the original
+      text.</para>
+    </listitem>
 
-      <listitem>
-        <para><guilabel>Target</guilabel>: The segments from the translated
-        text.</para>
-      </listitem>
-    </itemizedlist></para>
+    <listitem>
+      <para><guilabel>Target</guilabel>: The segments from the translated
+      text.</para>
+    </listitem>
+  </itemizedlist>
 
   <section id="windows.aligner.adjust">
     <title id="windows.aligner.adjust.title">Settings</title>
 
     <para>In this step, the bottom part of the window presents various
-    parameters and options you can change if the initial alignment looks like
-    it could be improved. It also shows an <guilabel>Average score</guilabel>
-    result for the alignment. As a rule of thumb, the lower that score, the
-    more accurate the alignment. Changing a parameter immediately recalculates
-    the alignment, allowing you to quickly try different combinations to
-    obtain the best results.</para>
+    parameters and options you can change if the initial alignment looks like it
+    could be improved. It also shows an <guilabel>Average score</guilabel>
+    result for the alignment. As a rule of thumb, the lower that score, the more
+    accurate the alignment. Changing a parameter immediately recalculates the
+    alignment, allowing you to quickly try different combinations to obtain the
+    best results.</para>
 
     <para>The available parameters and options are:</para>
 
     <variablelist>
 	  <title>Parameters</title>
-
-      <varlistentry>
+	  <varlistentry>
         <term>Comparison mode</term>
-
         <listitem>
           <itemizedlist>
             <listitem>
@@ -113,12 +123,11 @@
 
       <varlistentry>
         <term>Algorithm:</term>
-
         <listitem>
           <itemizedlist>
             <listitem>
-              <para><guilabel>Viterbi</guilabel>: The default algorithms used
-              to align the documents.</para>
+              <para><guilabel>Viterbi</guilabel>: The default algorithms used to
+              align the documents.</para>
             </listitem>
 
             <listitem>
@@ -127,15 +136,14 @@
             </listitem>
           </itemizedlist>
 
-          <para>There is no hard-and-fast rule on which algorithm you
-          should choose. Try both, and use the one that yields the better
-          result for your files.</para>
+          <para>There is no hard-and-fast rule on which algorithm you should
+          choose. Try both, and use the one that yields the better result for
+          your files.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Calculator:</term>
-
         <listitem>
           <itemizedlist>
             <listitem>
@@ -149,15 +157,14 @@
             </listitem>
           </itemizedlist>
 
-          <para>As with the algorithms, there is no hard-and-fast rule on
-          which statistical distribution you should choose. Try both and use
-          the one that yields the better result for your files.</para>
+          <para>As with the algorithms, there is no hard-and-fast rule on which
+          statistical distribution you should choose. Try both and use the one
+          that yields the better result for your files.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Counter:</term>
-
         <listitem>
           <itemizedlist>
             <listitem>
@@ -167,9 +174,9 @@
             </listitem>
 
             <listitem>
-              <para><guilabel>Word</guilabel>: The basic unit used to
-              determine the size of segments in languages that use a space to
-              delimit words.</para>
+              <para><guilabel>Word</guilabel>: The basic unit used to determine
+              the size of segments in languages that use a space to delimit
+              words.</para>
             </listitem>
           </itemizedlist>
 
@@ -186,21 +193,18 @@
 
     <variablelist>
 	  <title>Options</title>
-
       <varlistentry>
         <term>Segment</term>
-
         <listitem>
           <para>The aligner uses sentence segmentation by default. Uncheck the
-          check box to use paragraph segmentation (see <link
+          check box to use paragraph segmentation. See the <link
           endterm="dialogs.preferences.segmentation.setup.title"
-          linkend="dialogs.preferences.segmentation.setup"/>)</para>
+          linkend="dialogs.preferences.segmentation.setup"/> preferences.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Remove Tags</term>
-
         <listitem>
           <para>The aligner includes tags in the segments by default. Uncheck
           the check box to apply the <link
@@ -209,56 +213,55 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Highlight</term>
-
+      <varlistentry id="windows.aligner.adjust.highlight">
+        <term id="windows.aligner.adjust.highlight.title">Highlight</term>
         <listitem>
-          <para>By default, the aligner highlights all numbers in the source
-          and target segments. Uncheck the check box to turn off
-          highlighting.</para>
+		  <para>Uncheck the check box to turn off highlighting.</para>
+
+          <para>The aligner uses the regular expression <code>\d+</code>
+          to highlight all numbers in the source and target segments.</para>
+		  <para>You can modify the regular expression to add highlighted
+		  parts. See the <link linkend="app.regex" endterm="app.regex.title"/>
+		  chapter for details.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Rules...</term>
-
         <listitem>
           <para>Clicking this button lets you edit the segmentation rules that
-          apply to this project. See <link linkend="app.segmentation"
-          endterm="app.segmentation.title"/> for details.</para>
+          apply to this project. See the <link linkend="app.segmentation"
+          endterm="app.segmentation.title"/> appendix for details.</para>
 
           <warning>
-            <para>If you modify the segmentation rules, you will be asked if
-            you want to save those changes when you exit the aligner. The
-            default choice is <guibutton>Yes</guibutton>, which may not be
-            what you want if you edited the general OmegaT segmentation
-            rules.</para>
+            <para>If you modify the segmentation rules, you will be asked if you
+            want to save those changes when you exit the aligner. The default
+            choice is <guibutton>Yes</guibutton>, which may not be what you want
+            if you edited the general OmegaT segmentation rules.</para>
           </warning>
-
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Filters...</term>
-
         <listitem>
-          <para>Clicking this button lets you edit the file filters that
-          apply to this project. See <link linkend="dialogs.preferences.file.filters"
-          endterm="dialogs.preferences.file.filters.title"/> for details.</para>
-
+          <para>Clicking this button lets you edit the file filters that apply
+          to this project. See the <link
+          linkend="dialogs.preferences.file.filters"
+          endterm="dialogs.preferences.file.filters.title"/> preferences for
+          details.</para>
 
           <warning>
-            <para>If you modify the file filters, you will be asked if you
-            want to save those changes when you exit the aligner. The default
-            choice is <guibutton>Yes</guibutton>, which may not be what you
-            want if you edited the general OmegaT file filters.</para>
+            <para>If you modify the file filters, you will be asked if you want
+            to save those changes when you exit the aligner. The default choice
+            is <guibutton>Yes</guibutton>, which may not be what you want if you
+            edited the general OmegaT file filters.</para>
           </warning>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>Pattern...</term>
-
         <listitem>
           <para>This option lets you enter a regular expression to define the
           pattern used for highlighting text in the source and target
@@ -276,11 +279,13 @@
 
     <para>In addition, the <guimenu>File</guimenu> menu provides the following
     commands:</para>
+	
     <itemizedlist>
       <listitem>
         <para><guimenuitem>Save TMX...</guimenuitem>: This item is grayed out
         until the next step is complete.</para>
       </listitem>
+	  
       <listitem>
         <para><guimenuitem>Reset</guimenuitem>: This command restores all
         parameters to their default value. It can also be called by clicking the
@@ -288,11 +293,13 @@
         pressing
         <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo></para>
       </listitem>
+
       <listitem>
         <para><guimenuitem>Reload</guimenuitem>: This command reloads the file
         from the disk. You can use this command to parse and align the files
         again if you had to modify their contents.</para>
       </listitem>
+
       <listitem>
         <para><guimenuitem>Close</guimenuitem>: This closes the
         <guilabel>Align</guilabel> dialog. Doing so in this step cancels the
@@ -333,6 +340,7 @@
     the arrow keys. Segment blocks can be selected with the mouse by clicking
     the first segment, and holding the <keycap>Shift</keycap> key while clicking
     the last segment.</para>
+
 	<para>Alternatively, you can press the arrow keys while holding
 	<keycap>Shift</keycap> to select consecutive segments. The available actions
 	are presented below.</para>
@@ -347,15 +355,18 @@
           the main window pane.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Move Down (<keycap>D</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments,
           down one row.</para>
+
           <para>This command is also available from the button to the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Split (<keycap>S</keycap>)</term>
         <listitem>
@@ -364,15 +375,18 @@
           place the cursor at the location where you want to split the text, and
           click <guibutton>OK</guibutton> or press
           <keycap>Enter</keycap>.</para>
+
           <para>If two or more segments occupying separate cells in the same row
           (segments that do not have a <guilabel>Keep</guilabel> check box on
           the same line as their cell) are selected, this command will split
           them the selected cells back into separate rows (with a
           <guilabel>Keep</guilabel> check box).</para>
-          <para>This command is also available from the button to the right of
+
+		  <para>This command is also available from the button to the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Merge (<keycap>M</keycap>)</term>
         <listitem>
@@ -381,10 +395,12 @@
           all be merged, but remain in separate cells. Calling the command on
           the same selection one more time merges the contents of all selected
           cells into a single cell.</para>
+
 		  <para>This command is also available from the button to the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Edit (<keycap>E</keycap>)</term>
         <listitem>
@@ -394,31 +410,34 @@
           <guibutton>OK</guibutton> button to close the dialog when
           finished. In this dialog, the <keycap>Enter</keycap> enters a line
           break in the text.</para>
+
 		  <para>Use
 		  <keycombo><keycap>C</keycap><keycap>Enter</keycap></keycombo> to close
 		  it without using the mouse.</para>
-          <para>This command is also available from the button to the right of
+
+		  <para>This command is also available from the button to the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
-      <varlistentry>
-        <term>Mark Accepted
-        (<keycap>A</keycap>)</term>
+
+	  <varlistentry>
+        <term>Mark Accepted (<keycap>A</keycap>)</term>
         <listitem>
           <para>Use this command to confirm that the alignment of the segments
           in the selected row or block of rows is correct. This highlights the
           corresponding <guilabel>Keep</guilabel> column in green.</para>
         </listitem>
       </varlistentry>
-      <varlistentry>
-        <term>Mark Needs Review
-        (<keycap>R</keycap>)</term>
+
+	  <varlistentry>
+        <term>Mark Needs Review (<keycap>R</keycap>)</term>
         <listitem>
           <para>Use this command to identify a row or block of rows for which
           the alignment of the segments is in doubt. This highlights the
           corresponding <guilabel>Keep</guilabel> column in red.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Clear Mark (<keycap>C</keycap>)</term>
         <listitem>
@@ -427,6 +446,7 @@
           Review</guilabel> commands.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Realign Pending
         (<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>)</term>
@@ -435,13 +455,15 @@
           update the alignment for the remaining rows.</para>
         </listitem>
       </varlistentry>
-      <varlistentry>
+
+	  <varlistentry>
         <term>Keep All</term>
         <listitem>
-          <para>Use this command to check the <guilabel>Keep</guilabel> box
-          for all rows.</para>
+          <para>Use this command to check the <guilabel>Keep</guilabel> box for
+          all rows.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
         <term>Keep None</term>
         <listitem>
@@ -449,28 +471,31 @@
           box for all rows.</para>
         </listitem>
       </varlistentry>
-      <varlistentry>
-        <term>Toggle Selected
-        (<keycap>K</keycap>)</term>
+
+	  <varlistentry>
+        <term>Toggle Selected (<keycap>K</keycap>)</term>
         <listitem>
           <para>Use this command to switch the <guilabel>Keep</guilabel> check
           box of the selected row or block of rows from checked to unchecked, or
           vice versa.</para>
         </listitem>
       </varlistentry>
+
       <varlistentry>
-        <term>Start Pinpoint Align
-        (<keycap>Space</keycap>)</term>
+        <term>Start Pinpoint Align (<keycap>Space</keycap>)</term>
         <listitem>
           <para>If the corresponding segments are several rows apart and you
           want to quickly align them, use this command to set the first segment
           and then click on the corresponding segment in the other
           column.</para>
+		  
 		  <para>You can also use the arrow keys and press <keycap>Space</keycap>
 		  in the corresponding segment.</para>
+		  
           <para>Segments aligned with this method are automatically marked as
           accepted.</para>
-          <para>It can be helpful to run the <guimenuitem>Realign
+
+		  <para>It can be helpful to run the <guimenuitem>Realign
           Pending</guimenuitem> command after using pinpoint align a few
           times.</para>
         </listitem>
@@ -481,22 +506,22 @@
     TMX...</guibutton> button to create the translation memory.</para>
 
     <note>
-      <para>Only rows with a checked <guilabel>Keep</guilabel> box in the
-      first column are saved to the translation memory.</para>
+      <para>Only rows with a checked <guilabel>Keep</guilabel> box in the first
+      column are saved to the translation memory.</para>
     </note>
 
 
     <para>In addition to the <guibutton>Save TMX...</guibutton> button, the
     bottom part of the <guilabel>Align</guilabel> window in the manual
     correction step features the same <guilabel>Highlight</guilabel> check box
-    and <guibutton>Pattern...</guibutton> button as in the first step. This option is
-    also accessible from the <guimenu>View</guimenu> menu.</para>
+    and <guibutton>Pattern...</guibutton> button as in the first step. This
+    option is also accessible from the <guimenu>View</guimenu> menu.</para>
 
     <warning>
       <para>There is also a <guibutton>Reset</guibutton> button at the bottom of
       the window. <emphasis role="bold">Use it with caution!</emphasis> Clicking
-      this button will discard all your changes and bring you back to
-      the first step.</para>
+      this button will discard all your changes and bring you back to the first
+      step.</para>
     </warning>    
     
   </section>

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.scripts">
-  <title id="windows.scripts.title">Scripting</title>
+  <title id="windows.scripts.title"><guilabel>Scripting</guilabel></title>
 
   <para>Scripts are short programs (similar to macros in office applications)
   that can be used to automate tasks as well as to extend or customize OmegaT
@@ -10,136 +10,173 @@
   underlying Java virtual machine.</para>
 
 
-  <para>The Scripting window allows you to load an existing script and run it
-  on the current project.</para>
+  <para>The Scripting window allows you to load an existing script and run it on
+  the current project.</para>
 
-  <para>You can access the window from <link
-  endterm="menus.tools.scripting.title" linkend="menus.tools.scripting"/>
-  in the <link endterm="menus.tools.title" linkend="menus.tools"/>
-  menu.</para>
+  <para>Use <link endterm="menus.tools.title" linkend="menus.tools"/><link
+  endterm="menus.tools.scripting.title" linkend="menus.tools.scripting"/> to
+  access the window.</para>
 
   <section id="windows.scripts.folder">
 	<title id="windows.scripts.folder.title">The script folder</title>
 	
-  <para>By default, scripts are stored in the <link
-  linkend="application.folder.scripts"
-  endterm="application.folder.scripts.title"/> folder of the OmegaT
-  application folder.</para>
+	<para>By default, scripts are stored in the <link
+	linkend="application.folder.scripts"
+	endterm="application.folder.scripts.title"/> folder of the OmegaT
+	application folder.</para>
 
-  <para>New scripts added there will appear in the list of available scripts
-  in the left-hand panel of the window.</para>
+	<para>New scripts added there will appear in the list of available scripts
+	in the left-hand panel of the window.</para>
 
-  <warning><para>If a list of scripts is not displayed on the left side of the
-  script editor window, use the Scripting window <guimenu>File</guimenu> > <guimenuitem>Set Scripts Folder...</guimenuitem> menu to locate the place where scripts are stored.</para>
-  </warning>
+	<warning>
+	  <para>If a list of scripts is not displayed on the left side of the script
+	  editor window, use the Scripting window <guimenu>File</guimenu> >
+	  <guimenuitem>Set Scripts Folder...</guimenuitem> menu to locate the place
+	  where scripts are stored.</para>
+	</warning>
 
-  <para>Additional scripts can be found here: <ulink
-  url="https://sourceforge.net/projects/omegatscripts/">OmegaT
-  Scripts</ulink>. Just copy the file and put it in the <link
-  linkend="application.folder.scripts"
-  endterm="application.folder.scripts.title"/> folder.</para>
+	<para>Additional scripts can be found here: <ulink
+	url="https://sourceforge.net/projects/omegatscripts/">OmegaT
+	Scripts</ulink>. Just copy the file and put it in the <link
+	linkend="application.folder.scripts"
+	endterm="application.folder.scripts.title"/> folder.</para>
 
-  <para>Some scripts are <emphasis>event</emphasis> based and can be made to be
-  triggered automatically when a given event takes place. Each event corresponds
-  to a subfolder under <link
-  linkend="application.folder.scripts"
-  endterm="application.folder.scripts.title"/>:
+	<para>Some scripts are <emphasis>event</emphasis> based and can be made to
+	be triggered automatically when a given event takes place. Each event
+	corresponds to a subfolder under the <link
+	linkend="application.folder.scripts"
+	endterm="application.folder.scripts.title"/> folder:</para>
 
-  <variablelist>
-	<varlistentry id="application.folder.scripts.application.shutdown">
-	  <term id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
-	  <listitem><para>Scripts in this folder will be launched before OmegaT shuts down.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.application.startup">
-	  <term id="application.folder.scripts.application.startup.title">application_startup</term>
-	  <listitem><para>Scripts in this folder will be launched when the scripting engine is available, shortly after OmegaT is launched.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.entry.activated">
-	  <term id="application.folder.scripts.entry.activated.title">entry_activated</term>
-	  <listitem><para>Scripts in this folder will be launched when editing a new segment. The segment is in the "newEntry" binding.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.new.file">
-	  <term id="application.folder.scripts.new.file.title">new_file</term>
-	  <listitem><para>Scripts in the folder will be launched when the editor switches to the next file in the project. The new filename is in the "activeFileName" binding.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.new.word">
-	  <term id="application.folder.scripts.new.word.title">new_word</term>
-	  <listitem><para>Scripts in the folder will be launched when a new word is edited in the Editor window. The new word is available with "newWord".</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.project.changed">
-	  <term id="application.folder.scripts.project.changed.title">project_changed</term>
-	  <listitem><para>Scripts in the folder will be launched when the state of the project changes. An "eventType" object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, SAVE.</para></listitem>
-	</varlistentry>
-  </variablelist>
-  </para>
-	<warning><para>Scripts are also launched when you are executing other scripts. That means
-that on a large project, an "entry_activated" script will be called a lot of time when using a search/replace type of script that loops through all the segments, rendering the application unresponsive. </para></warning>
+	<variablelist>
+	  <varlistentry id="application.folder.scripts.application.shutdown">
+		<term
+		id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
+		<listitem>
+		  <para>Scripts in this folder will be launched before OmegaT shuts
+		  down.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="application.folder.scripts.application.startup">
+		<term
+		id="application.folder.scripts.application.startup.title">application_startup</term>
+		<listitem>
+		  <para>Scripts in this folder will be launched when the scripting
+		  engine is available, shortly after OmegaT is launched.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="application.folder.scripts.entry.activated">
+		<term
+		id="application.folder.scripts.entry.activated.title">entry_activated</term>
+		<listitem>
+		  <para>Scripts in this folder will be launched when editing a new
+		  segment. The segment is in the "newEntry" binding.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="application.folder.scripts.new.file">
+		<term id="application.folder.scripts.new.file.title">new_file</term>
+		<listitem>
+		  <para>Scripts in the folder will be launched when the editor switches
+		  to the next file in the project. The new filename is in the
+		  "activeFileName" binding.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="application.folder.scripts.new.word">
+		<term id="application.folder.scripts.new.word.title">new_word</term>
+		<listitem>
+		  <para>Scripts in the folder will be launched when a new word is edited
+		  in the Editor window. The new word is available with "newWord".</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry id="application.folder.scripts.project.changed">
+		<term
+		id="application.folder.scripts.project.changed.title">project_changed</term>
+		<listitem>
+		  <para>Scripts in the folder will be launched when the state of the
+		  project changes. An "eventType" object is bound and can take the
+		  following values: CLOSE, COMPILE, CREATE, LOAD, SAVE.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+
+	<warning>
+	  <para>Scripts are also launched when you are executing other scripts. That
+	  means that on a large project, an "entry_activated" script will be called
+	  a lot of time when using a search/replace type of script that loops
+	  through all the segments, rendering the application unresponsive. </para>
+	</warning>
   </section>
   
 
-<section id="windows.scripts.usage">
-  <title id="windows.scripts.usage.title">Usage</title>
+  <section id="windows.scripts.usage">
+	<title id="windows.scripts.usage.title">Usage</title>
 
-  
-  <itemizedlist>
-    <listitem>
-      <para>Click the name of a script in the list in the left-hand panel. The
-      script is loaded in the editor.</para>
-    </listitem>
+	<itemizedlist>
+      <listitem>
+		<para>Click the name of a script in the list in the left-hand panel. The
+		script is loaded in the editor.</para>
+      </listitem>
 
-    <listitem>
-      <para>Click <guibutton>Run</guibutton> at the bottom of the window, or
-      press <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo> to
-      launch the script immediately.</para>
-    </listitem>
+      <listitem>
+		<para>Click <guibutton>Run</guibutton> at the bottom of the window, or
+		press <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo> to
+		launch the script immediately.</para>
+      </listitem>
 
-    <listitem>
-      <para>To create a shortcut to a script that you use frequently, right-click one of the
-      <guibutton>&lt;1&gt;</guibutton> to <guibutton>&lt;12&gt;</guibutton>
-      buttons at the bottom of the window and select <guilabel>Add
-      Script</guilabel> to assign the script to that number.</para>
+      <listitem>
+		<para>To create a shortcut to a script that you use frequently,
+		right-click one of the <guibutton>&lt;1&gt;</guibutton> to
+		<guibutton>&lt;12&gt;</guibutton> buttons at the bottom of the window
+		and select <guilabel>Add Script</guilabel> to assign the script to that
+		number.</para>
 
-	  <para>If you want to detach the script from the shortcut, right-click on its button and select <guilabel>Remove Script</guilabel></para>
-    </listitem>
+		<para>If you want to detach the script from the shortcut, right-click on
+		its button and select <guilabel>Remove Script</guilabel></para>
+      </listitem>
 
-    <listitem>
-      <para>You can then click on the number to run its assigned script. You
-      can also run the script from the <link linkend="menus.tools.scripting"
-      endterm="menus.tools.scripting.title"/> menu by selecting the applicable
-      menu item or by pressing the associated shortcut
-      (<keycombo><keycap>C</keycap><keycap>A</keycap><keycap>F1 to
-      F12</keycap></keycombo>).</para>
-    </listitem>
-  </itemizedlist>
+      <listitem>
+		<para>You can then click on the number to run its assigned script. You
+		can also run the script from the <link linkend="menus.tools"
+		endterm="menus.tools.title"/><link linkend="menus.tools.scripting"
+		endterm="menus.tools.scripting.title"/> menu by selecting the applicable
+		menu item or by pressing the associated shortcut
+		(<keycombo><keycap>C</keycap><keycap>A</keycap><keycap>F1 to
+		F12</keycap></keycombo>).</para>
+      </listitem>
+	</itemizedlist>
 
+	<warning>
+      <para>Linux users: depending on the configuration of your operating
+      system, you may not have permission to write to the default scripts folder
+      location.</para>
 
-  <warning>
-    <para>Linux users: depending on the configuration of your operating
-    system, you may not have permission to write to the default scripts folder
-    location.</para>
+      <para>In such cases, you will have to copy or move the script folder to a
+      location for which you have write permissions, such as the <link
+      linkend="configuration.folder.location">configuration folder</link>, if
+      you want to write your own scripts, add new ones, or modify existing
+      ones.</para>
 
-    <para>In such cases, you will have to copy or move the script folder to
-    a location for which you have write permissions, such as the <link
-    endterm="configuration.folder.location.title"
-    linkend="configuration.folder.location"/>, if you want to write your own
-    scripts, add new ones, or modify existing ones.</para>
+      <para>If you do have permission to write to the default folder, make sure
+      you change the name, or make a backup, of any scripts you modify, as they
+      will be overwritten when OmegaT is updated.</para>
+	</warning>
+  </section>
 
-    <para>If you do have permission to write to the default folder, make sure
-    you change the name, or make a backup, of any scripts you modify, as they
-    will be overwritten when OmegaT is updated.</para>
-  </warning>
-</section>
-
-  
   <section id="windows.scripts.distribution">
     <title id="windows.scripts.distribution.title">Distributed scripts</title>
 
     <para>OmegaT comes with a number of scripts developed by OmegaT
-	contributors. Use the script editor to open, run, or modify scripts directly,
-	or to write new scripts for your own use.</para>
+    contributors. Use the script editor to open, run, or modify scripts
+    directly, or to write new scripts for your own use.</para>
 
-	<note><para>The scripts distributed with OmegaT are here for your convenience
-	but are not supported by the OmegaT development team.</para></note>
+	<note>
+	  <para>The scripts distributed with OmegaT are here for your convenience
+	  but are not supported by the OmegaT development team.</para>
+	</note>
 	
 	<para>Follow the instructions provided in the script itself.</para>
 
@@ -156,7 +193,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.auto.open.last.project">
         <term
-			id="windows.scripts.distribution.auto.open.last.project.title">Auto Open
+        id="windows.scripts.distribution.auto.open.last.project.title">Auto Open
         Last Project</term>
 
         <listitem>
@@ -175,7 +212,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.currency.translator">
         <term
-			id="windows.scripts.distribution.currency.translator.title">Currency
+        id="windows.scripts.distribution.currency.translator.title">Currency
         Translator</term>
 
         <listitem>
@@ -189,7 +226,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.example.gui.scripting">
         <term
-			id="windows.scripts.distribution.example.gui.scripting.title">Example -
+        id="windows.scripts.distribution.example.gui.scripting.title">Example -
         GUI Scripting</term>
 
         <listitem>
@@ -199,7 +236,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.example.key.binding">
         <term
-			id="windows.scripts.distribution.example.key.binding.title">Example -
+        id="windows.scripts.distribution.example.key.binding.title">Example -
         Key Binding</term>
 
         <listitem>
@@ -209,7 +246,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.example.modify.segment">
         <term
-			id="windows.scripts.distribution.example.modify.segment.title">Example -
+        id="windows.scripts.distribution.example.modify.segment.title">Example -
         Modify Segment</term>
 
         <listitem>
@@ -219,7 +256,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.example.search.and.replace">
         <term
-			id="windows.scripts.distribution.example.search.and.replace.title">Example
+        id="windows.scripts.distribution.example.search.and.replace.title">Example
         - Search and Replace</term>
 
         <listitem>
@@ -229,7 +266,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.external.spellcheck">
         <term
-			id="windows.scripts.distribution.external.spellcheck.title">External
+        id="windows.scripts.distribution.external.spellcheck.title">External
         spellcheck</term>
 
         <listitem>
@@ -243,7 +280,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.extract.text.content">
         <term
-			id="windows.scripts.distribution.extract.text.content.title">Extract
+        id="windows.scripts.distribution.extract.text.content.title">Extract
         Text Content</term>
 
         <listitem>
@@ -256,7 +293,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.non.breaking.space">
         <term
-			id="windows.scripts.distribution.non.breaking.space.title">Non-breaking
+        id="windows.scripts.distribution.non.breaking.space.title">Non-breaking
         space</term>
 
         <listitem>
@@ -349,7 +386,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.spellcheck">
         <term
-			id="windows.scripts.distribution.spellcheck.title">Spellcheck</term>
+        id="windows.scripts.distribution.spellcheck.title">Spellcheck</term>
 
         <listitem>
           <para>Global spell checking.</para>
@@ -402,7 +439,7 @@ that on a large project, an "entry_activated" script will be called a lot of tim
 
       <varlistentry id="windows.scripts.distribution.issue.provider.sample.groovy">
         <term
-			id="windows.scripts.distribution.issue.provider.sample.groovy.title">issue_provider_sample.groovy</term>
+        id="windows.scripts.distribution.issue.provider.sample.groovy.title">issue_provider_sample.groovy</term>
 
         <listitem>
           <para>(no description)</para>
@@ -410,7 +447,8 @@ that on a large project, an "entry_activated" script will be called a lot of tim
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.toolbar.groovy">
-        <term id="windows.scripts.distribution.toolbar.groovy.title">toolbar.groovy</term>
+        <term
+        id="windows.scripts.distribution.toolbar.groovy.title">toolbar.groovy</term>
         <listitem>
           <para>(no description)</para>
         </listitem>

--- a/doc_src/en/Windows_SourceFilesList.xml
+++ b/doc_src/en/Windows_SourceFilesList.xml
@@ -2,26 +2,31 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.source.files.list">
-  <title id="windows.source.files.list.title">Source Files</title>
+  <title id="windows.source.files.list.title"><guilabel>Source
+  Files</guilabel></title>
 
-  <para>This window is displayed automatically when OmegaT loads a project,
-  and at any time by using <link linkend="menus.project.source.files.list" endterm="menus.project.source.files.list.title"/>.</para>
+  <para>This window is displayed automatically when OmegaT loads a project, and
+  at any time by using <link linkend="menus.project"
+  endterm="menus.project.title"/><link linkend="menus.project.source.files.list"
+  endterm="menus.project.source.files.list.title"/>.</para>
 
   <para>The window displays the following information:</para>
 
   <itemizedlist>
     <listitem>
-      <para>in the window title: the total number of translatable files in the project.</para>
-	  <para>These are the
-      files present in the <link linkend="project.folder.source"
-      endterm="project.folder.source.title"/> folder in a format that OmegaT is
-      able to recognize.</para>
+      <para>in the window title: the total number of translatable files in the
+      project.</para>
+
+	  <para>These are the files present in the <link
+	  linkend="project.folder.source" endterm="project.folder.source.title"/>
+	  folder in a format that OmegaT is able to recognize.</para>
     </listitem>
 
     <listitem>
       <para>as a list: all the translatable files in the project.</para>
+
 	  <para>Clicking on any file will open it in the <link
-	  linkend="panes.editor" endterm="panes.editor.title"/> for
+	  linkend="panes.editor" endterm="panes.editor.title"/> pane for
 	  translation.</para>
     </listitem>
 
@@ -42,10 +47,12 @@
   arrows to select a file, and open it for translation by pressing
   <keycap>Enter</keycap>.</para>
 
-  <note><para>Filenames (in the first column) can be sorted alphabetically by
-  clicking in the header. It is also possible to change the position of a
-  filename, by clicking on it and pressing the <guibutton>Move ...</guibutton>
-  button on the right.</para></note>
+  <note>
+	<para>Filenames (in the first column) can be sorted alphabetically by
+	clicking in the header. It is also possible to change the position of a
+	filename, by clicking on it and pressing the <guibutton>Move ...</guibutton>
+	button on the right.</para>
+  </note>
 
   <para>Right-clicking on a filename opens a popup that allows opening the
   source file and (if it exists) the target file.</para>
@@ -56,33 +63,52 @@
 
   <para>The difference between &quot;Number of segments&quot; and &quot;Number
   of unique segments&quot; provides an approximate idea of the number of
-  repetitions in the text. The <link linkend="menus.tools.statistics"
-  endterm="menus.tools.statistics.title"/> item in the <link linkend="menus.tools"
-  endterm="menus.tools.title"/> menu will give you more information.</para>
+  repetitions in the text. Use <link linkend="menus.tools"
+  endterm="menus.tools.title"/><link linkend="menus.tools.statistics"
+  endterm="menus.tools.statistics.title"/> to obtain more information.</para>
 
-  <para>Modifying the segmentation rules may alter the number of
-  segments/unique segments. This, however, should generally be avoided
-  once you have started translating the project. See <link
-  linkend="app.segmentation" endterm="app.segmentation.title"/> for
-  details.</para>
+  <para>Modifying the segmentation rules may alter the number of segments/unique
+  segments. This, however, should generally be avoided once you have started
+  translating the project. See the <link linkend="app.segmentation"
+  endterm="app.segmentation.title"/> appendix for details.</para>
 
-  <para>The buttons at the bottom can be used to add files to your project:
+  <para>The buttons at the bottom can be used to add files to your project:</para>
+  
   <variablelist>
-	<varlistentry id="windows.source.files.list.copy.files"><term
-	id="windows.source.files.list.copy.files.title">Add Files...</term>
-	<listitem><para>Copies the selected files to the <link
-  linkend="project.folder.source" endterm="project.folder.source.title"/>
-  folder and reloads the project to take the new files into account.</para></listitem>
+	<varlistentry id="windows.source.files.list.copy.files">
+	  <term id="windows.source.files.list.copy.files.title"><guibutton>Add
+	  Files...</guibutton></term>
+	<listitem>
+	  <para>Copies the selected files to the <link
+	  linkend="project.folder.source" endterm="project.folder.source.title"/>
+	  folder and reloads the project to take the new files into account.</para>
+	</listitem>
 	</varlistentry>
-	<varlistentry id="windows.source.files.list.download.page"><term
-	id="windows.source.files.list.download.page.title">Add Online MediaWiki Page...</term>
-	<listitem><para>Asks for the page URL and downloads it into the <link
-  linkend="project.folder.source" endterm="project.folder.source.title"/> folder.</para></listitem>
+	
+	<varlistentry id="windows.source.files.list.download.page">
+	  <term id="windows.source.files.list.download.page.title"><guibutton>Add
+	  Online MediaWiki Page...</guibutton></term>
+	  <listitem>
+		<para>Asks for the page URL and downloads it into the <link
+		linkend="project.folder.source" endterm="project.folder.source.title"/>
+		folder.</para>
+	  </listitem>
 	</varlistentry>
   </variablelist>
-  The two actions are equivalent to using the <link linkend="menus.project" endterm="menus.project.title"/> menu commands <link linkend="menus.project.copy.files.to.source.folder" endterm="menus.project.copy.files.to.source.folder.title"/> and <link linkend="menus.project.download.mediawiki.page" endterm="menus.project.download.mediawiki.page.title"/>.
-  </para>
   
-  <note><para>To keep the Source Files list window to automatically open when a project is loaded, manually change <token>project_files_show_on_load</token> to
-  <token>false</token> in the <link linkend="configuration.folder.default.contents.omegat.prefs" endterm="configuration.folder.default.contents.omegat.prefs.title"/> configuration file.</para></note>
+  <para>The two actions are equivalent to using the <link
+  linkend="menus.project" endterm="menus.project.title"/><link
+  linkend="menus.project.copy.files.to.source.folder"
+  endterm="menus.project.copy.files.to.source.folder.title"/> and <link
+  linkend="menus.project" endterm="menus.project.title"/><link
+  linkend="menus.project.download.mediawiki.page"
+  endterm="menus.project.download.mediawiki.page.title"/> menu items.</para>
+  
+  <note>
+	<para>To keep the Source Files list window to automatically open when a
+	project is loaded, you can manually change the <link
+	linkend="configuration.folder.default.contents.omegat.prefs"
+	endterm="configuration.folder.default.contents.omegat.prefs.title"/>
+	configuration file.</para>
+  </note>
 </section>

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.replace">
-  <title id="windows.text.replace.title">Text Replace</title>
+  <title id="windows.text.replace.title"><guilabel>Text
+  Replace</guilabel></title>
 
-  <para>Use <link linkend="menus.edit.search.and.replace"
-  endterm="menus.edit.search.and.replace.title"/> to open a new replace window and
-  enter the word or phrase you wish to search for in the search field.</para>
+  <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+  linkend="menus.edit.search.and.replace"
+  endterm="menus.edit.search.and.replace.title"/> to open a new replace window
+  and enter the word or phrase you wish to search for in the search
+  field.</para>
   
   <para>Alternatively, select a word or phrase in the <link
   linkend="panes.editor" endterm="panes.editor.title"/>, <link
   linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>, or <link
-  linkend="panes.glossary" endterm="panes.glossary.title"/> pane and use <link linkend="menus.edit.search.and.replace"
+  linkend="panes.glossary" endterm="panes.glossary.title"/> pane and use <link
+  linkend="menus.edit" endterm="menus.edit.title"/><link
+  linkend="menus.edit.search.and.replace"
   endterm="menus.edit.search.and.replace.title"/>. The selection is
   automatically entered in the search field.</para>
 
@@ -24,7 +30,8 @@
   <guibutton>Search</guibutton>, or hit <keycap>Enter</keycap> if the cursor is
   still in the field.</para>
 
-  <para>Search matches are displayed in bold blue characters, and the modified strings are displayed in orange to show the result of the replacement.</para>
+  <para>Search matches are displayed in bold blue characters, and the modified
+  strings are displayed in orange to show the result of the replacement.</para>
 
 
   <example id="replace.with.allemand">
@@ -37,75 +44,120 @@
 ---------</programlisting></para>
   </example>
   
-  <note><para>At this stage, no replacements have been made yet.</para></note>
+  <note>
+	<para>At this stage, no replacements have been made yet.</para>
+  </note>
 
-  <para>Click one of the following options: <itemizedlist>
-      <listitem>
-        <para><guibutton>Replace All</guibutton>: replace every occurrence (after displaying a confirmation window showing the number of occurrences).</para>
-      </listitem>
-      <listitem>
-        <para><guibutton>Replace:</guibutton> replaces each entry one at a time in the Editor pane.</para>
-		<para>Click <guibutton>Replace Next</guibutton> or <guibutton>Skip</guibutton>, to move to the next entry, and click <guibutton>Finish</guibutton> to end the replacement operation.</para>
-      </listitem>
-    </itemizedlist><itemizedlist>
-      <listitem>
-        <para><guibutton>Close</guibutton>: close the window without making any changes.</para>
-      </listitem>
-    </itemizedlist></para>
-
-  
-  <para>The replace window has its own menus:</para>
+  <para>Click one of the following options:</para>
 
   <itemizedlist>
     <listitem>
-      <para><guimenu>File</guimenu> &gt; <guimenuitem>Search for Selection</guimenuitem> (<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>): the current selection is inserted in the search field.</para>
+      <para><guibutton>Replace All</guibutton>: replace every occurrence (after
+      displaying a confirmation window showing the number of
+      occurrences).</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>File</guimenu> &gt; <guimenuitem>Close</guimenuitem> (<keycombo><keycap>C</keycap><keycap>W</keycap></keycombo>): close the search window.</para>
+        <para><guibutton>Replace:</guibutton> replaces each entry one at a time
+        in the Editor pane.</para>
+		<para>Click <guibutton>Replace Next</guibutton> or
+		<guibutton>Skip</guibutton>, to move to the next entry, and click
+		<guibutton>Finish</guibutton> to end the replacement operation.</para>
+    </listitem>
+  </itemizedlist>
+
+  <itemizedlist>
+    <listitem>
+      <para><guibutton>Close</guibutton>: close the window without making any
+      changes.</para>
+    </listitem>
+  </itemizedlist>
+
+  <para>The replace window has its own menus:</para>
+ 
+  <itemizedlist>
+    <listitem>
+      <para><guimenu>File</guimenu> &gt; <guimenuitem>Search for
+      Selection</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>): the current
+      selection is inserted in the search field.</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Insert Source</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>): insert the content of the current source segment.</para>
+      <para><guimenu>File</guimenu> &gt; <guimenuitem>Close</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>W</keycap></keycombo>): close the
+      search window.</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Replace with Source</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>): replace the contents of the search field with those of the  current source segment.</para>
+      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Insert
+      Source</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>):
+      insert the content of the current source segment.</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Create Glossary Entry</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>): add a new glossary item. See <link linkend="menus.edit.create.glossary.entry" endterm="menus.edit.create.glossary.entry.title"/> for details.</para>
+      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Replace with
+      Source</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>):
+      replace the contents of the search field with those of the current source
+      segment.</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Reset Options</guimenuitem>: reset the search window options.</para>
+      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Create Glossary
+      Entry</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>):
+      add a new glossary item. See <link linkend="menus.edit"
+      endterm="menus.edit.title"/><link
+      linkend="menus.edit.create.glossary.entry"
+      endterm="menus.edit.create.glossary.entry.title"/> for details.</para>
+    </listitem>
+
+    <listitem>
+      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Reset
+      Options</guimenuitem>: reset the search window options.</para>
     </listitem>
   </itemizedlist>
 
   <section id="windows.text.replace.methods">
     <title id="windows.text.replace.methods.title">Search type</title>
 
-    <para>Use the  radio buttons to select the type of search.</para>
+    <para>Use the radio buttons to select the type of search.</para>
+
 	<para>The following search types are available:</para>
 
     <variablelist>
       <varlistentry id="windows.text.replace.methods.exact">
         <term id="windows.text.replace.methods.exact.title">Exact search</term>
         <listitem>
-          <para>Search for the string exactly as it was entered in the search field.</para>
+          <para>Search for the string exactly as it was entered in the search
+          field.</para>
+
 		  <para>It is equivalent to a web search enclosed in quotation marks.</para>
 
-		  <note><para>The <code>*</code> and <code>?</code> wild card search characters can be used in exact searches:</para>
+		  <note>
+			<para>The <code>*</code> and <code>?</code> wild card search
+			characters can be used in exact searches:</para>
 
-    <itemizedlist>
-      <listitem>
-        <para>'*' matches zero or more characters, from the current position up to the end of a word. The search term <literal>'run*'</literal>, for example, matches <literal>'run'</literal>, <literal>'runs'</literal> and <literal>'running'</literal>.</para>
-      </listitem>
+			<itemizedlist>
+			  <listitem>
+				<para>'*' matches zero or more characters, from the current
+				position up to the end of a word. The search term
+				<literal>'run*'</literal>, for example, matches
+				<literal>'run'</literal>, <literal>'runs'</literal> and
+				<literal>'running'</literal>.</para>
+			  </listitem>
 
-      <listitem>
-        <para>'?' matches any single character. For instance, <literal>'run?'</literal> matches <literal>'runs'</literal>, as well as the <literal>'runn'</literal> portion of <literal>'running'</literal> or <literal>'runner'</literal>.</para>
-      </listitem>
-    </itemizedlist></note>
+			  <listitem>
+				<para>'?' matches any single character. For instance,
+				<literal>'run?'</literal> matches <literal>'runs'</literal>, as
+				well as the <literal>'runn'</literal> portion of
+				<literal>'running'</literal> or
+				<literal>'runner'</literal>.</para>
+			  </listitem>
+			</itemizedlist>
+		  </note>
         </listitem>
       </varlistentry>
 
@@ -113,10 +165,17 @@
         <term id="windows.text.replace.methods.regex.title">Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
-		  <para>Regular expressions are a very powerful way to search for general or  complex patterns rather than exact strings. See <link linkend="app.regex" endterm="app.regex.title"/> for details.</para>
-		    <note><para>The replacement string supports references to groups defined in
-  the search string. Use <code>$n</code> in the replacement field to refer to
-  the <code>nth</code> group in the search field.</para></note>
+
+		  <para>Regular expressions are a very powerful way to search for
+		  general or complex patterns rather than exact strings. See the <link
+		  linkend="app.regex" endterm="app.regex.title"/> appendix for
+		  details.</para>
+
+		  <note>
+			<para>The replacement string supports references to groups defined
+			in the search string. Use <code>$n</code> in the replacement field
+			to refer to the <code>nth</code> group in the search field.</para>
+		  </note>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -125,70 +184,109 @@
   <section id="windows.text.replace.options">
 	<title id="windows.text.replace.options.title">Options</title>
 	
-  <variablelist>
-	<varlistentry><term>Case sensitive</term><listitem><para>Only returns results with the same letter case as the search terms.</para></listitem></varlistentry>
-	
-	<varlistentry><term>Space matches nbsp</term><listitem><para>Space characters in search terms will match both a normal space and a non-breaking space (\u00A) character.</para></listitem></varlistentry>
-
-	<varlistentry><term>Untranslated</term><listitem><para>Also  search in untranslated segments.</para></listitem></varlistentry>
- 
-  <varlistentry>
-    <term><guibutton>Show Advanced Options</guibutton></term>
-	<listitem>
-	  <para>Select additional criteria such as the person who authored or
-    changed the translation, the date and time of translation (modification), or
-    whether to exclude orphan segments.
-
 	<variablelist>
 	  <varlistentry>
-		<term>Full/Half-width char insensitive</term>
-		<listitem><para>returns results that match both the full- and half-width forms
-		(CJK characters) of the characters in the search terms.</para>
+		<term>Case sensitive</term>
+		<listitem>
+		  <para>Only returns results with the same letter case as the search
+		  terms.</para>
+		</listitem>
+	  </varlistentry>
+	
+	  <varlistentry>
+		<term>Space matches nbsp</term>
+		<listitem>
+		  <para>Space characters in search terms will match both a normal space
+		  and a non-breaking space (\u00A) character.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Untranslated</term>
+		<listitem>
+		  <para>Also search in untranslated segments.</para>
+		</listitem>
+	  </varlistentry>
+ 
+	  <varlistentry>
+		<term><guibutton>Show Advanced Options</guibutton></term>
+		<listitem>
+		  <para>Select additional criteria such as the person who authored or
+		  changed the translation, the date and time of translation
+		  (modification), or whether to exclude orphan segments.</para>
+
+		  <variablelist>
+			<varlistentry>
+			  <term>Full/Half-width char insensitive</term>
+			  <listitem>
+				<para>returns results that match both the full- and half-width
+				forms (CJK characters) of the characters in the search
+				terms.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		  <para>Hide the advanced options with <guibutton>Hide Advanced
+		  Options</guibutton></para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
-	Hide the advanced options with <guibutton>Hide Advanced Options</guibutton></para>
-	</listitem>
-  </varlistentry>
-  </variablelist>
   </section>
 
   <section id="windows.text.replace.result.display">
     <title id="windows.text.replace.result.display.title">Results display</title>
 
-    <para>Matches are displayed in their order of appearance in the project. For translated segments, the original text is displayed above the translated text. Only the source text is displayed for untranslated segments.</para>
+    <para>Matches are displayed in their order of appearance in the project. For
+    translated segments, the original text is displayed above the translated
+    text. Only the source text is displayed for untranslated segments.</para>
 
-	<para>Double-click on a segment to open it in the <link linkend="panes.editor" endterm="panes.editor.title"/>.</para>
+	<para>Double-click on a segment to open it in the <link
+	linkend="panes.editor" endterm="panes.editor.title"/> pane.</para>
 
-    <para>You can use the following shortcuts in the search results:
+    <para>You can use the following shortcuts in the search results:</para>
+	
 	<variablelist>
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
-		<listitem><para>Move to the next segment</para></listitem>
+		<listitem>
+		  <para>Move to the next segment</para>
+		</listitem>
 	  </varlistentry>
+
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
-		<listitem><para>Move to the preceding segment</para></listitem>
+		<listitem>
+		  <para>Move to the preceding segment</para>
+		</listitem>
+
 	  </varlistentry>
+
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
-		<listitem><para>Jump to the current segment in the editor.</para></listitem>
+		<listitem>
+		  <para>Jump to the current segment in the editor.</para>
+		</listitem>
 	  </varlistentry>
 	</variablelist>
-		The selected segment is highlighted in green.
-	</para>
+
+	<para>The selected segment is highlighted in green.</para>
 	
 	<variablelist>
 	  <varlistentry>
 		<term>Auto-sync with editor</term>
 		<listitem>
-		  <para>the <link linkend="panes.editor" endterm="panes.editor.title"/> pane synchronizes its display with the selection in the search results</para>
+		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
+		  pane synchronizes its display with the selection in the search
+		  results</para>
 		</listitem>
 	  </varlistentry>
+	  
 	  <varlistentry>
 		<term>Back to the initial segment on close</term>
 		<listitem>
-		  <para>when you close the search windows, the <link linkend="panes.editor" endterm="panes.editor.title"/> pane automatically goes back to the segment that it displayed before the search was started</para>
+		  <para>When you close the search windows, the <link
+		  linkend="panes.editor" endterm="panes.editor.title"/> pane
+		  automatically goes back to the segment that it displayed before the
+		  search was started</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.search">
-  <title id="windows.text.search.title">Text Search</title>
+  <title id="windows.text.search.title"><guilabel>Text Search</guilabel></title>
 
-  <para>Use <link linkend="menus.edit.search.project"
+  <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+  linkend="menus.edit.search.project"
   endterm="menus.edit.search.project.title"/> to open a new search window and
   enter the word or phrase you wish to search for in the search field.</para>
   
@@ -14,37 +16,39 @@
   <para>Alternatively, select a word or phrase in the <link
   linkend="panes.editor" endterm="panes.editor.title"/>, <link
   linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>, or <link
-  linkend="panes.glossary" endterm="panes.glossary.title"/> pane and use <link linkend="menus.edit.search.project"
-  endterm="menus.edit.search.project.title"/>. The selection is
-  automatically entered in the search field.</para>
+  linkend="panes.glossary" endterm="panes.glossary.title"/> pane and use <link
+  linkend="menus.edit" endterm="menus.edit.title"/><link
+  linkend="menus.edit.search.project"
+  endterm="menus.edit.search.project.title"/>. The selection is automatically
+  entered in the search field.</para>
 
 
   <para>Click the drop-down arrow of the <guilabel>Search for:</guilabel> field
   to access the last ten searches.</para>
 
-  <para>Click on <guibutton>Search</guibutton> or hit <keycap>Enter</keycap> when
-  the search field is selected to start the search.</para>
+  <para>Click on <guibutton>Search</guibutton> or hit <keycap>Enter</keycap>
+  when the search field is selected to start the search.</para>
   
   <para>Matches will be displayed in bold blue characters.</para>
 
-  	  <example id="search.for.doitsu">
-		<title id="search.for.doitsu.title">Search for ドイツ</title>
-		<para>
-		  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
+  <example id="search.for.doitsu">
+	<title id="search.for.doitsu.title">Search for ドイツ</title>
+	<para>
+	  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
 -- 177> [[2001年]]、<token>ドイツ</token>の永住権を取得。
 ---------</programlisting>
-		</para>
-	  </example>
+	</para>
+  </example>
 
-  
   <para>The search window has its own menus:</para>
 
   <itemizedlist>
     <listitem>
       <para><guimenu>File</guimenu> &gt; <guimenuitem>Search for
-      Selection</guimenuitem> (<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>): the current selection is inserted in the search
-      field.</para>
+      Selection</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>): the current
+      selection is inserted in the search field.</para>
     </listitem>
 
     <listitem>
@@ -55,20 +59,27 @@
 
     <listitem>
       <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Insert
-      Source</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>): insert the content of the current source
-      segment.</para>
+      Source</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>):
+      insert the content of the current source segment.</para>
     </listitem>
 
     <listitem>
       <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Replace with
-      Source</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>): replace the contents of
-      the search field with those of the current source segment.</para>
+      Source</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>):
+      replace the contents of the search field with those of the current source
+      segment.</para>
     </listitem>
 
     <listitem>
-      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Create Glossary Entry</guimenuitem> (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>): add a new glossary item. See <link
-          linkend="menus.edit.create.glossary.entry"
-          endterm="menus.edit.create.glossary.entry.title"/> for details.</para>
+      <para><guimenu>Edit</guimenu> &gt; <guimenuitem>Create Glossary
+      Entry</guimenuitem>
+      (<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>):
+      add a new glossary item. See <link linkend="menus.edit"
+      endterm="menus.edit.title"/><link
+      linkend="menus.edit.create.glossary.entry"
+      endterm="menus.edit.create.glossary.entry.title"/> for details.</para>
     </listitem>
 
     <listitem>
@@ -82,8 +93,7 @@
 
     <para>Use the radio buttons to select the type of search.</para>
 
-	<para>The following
-    search types are available:</para>
+	<para>The following search types are available:</para>
 
     <variablelist>
       <varlistentry id="windows.text.search.methods.exact">
@@ -91,6 +101,7 @@
         <listitem>
           <para>Search for the string exactly as it was entered in the search
           field.</para>
+
 		  <para>It is equivalent to a web search enclosed in quotation marks.</para>
         </listitem>
       </varlistentry>
@@ -101,30 +112,35 @@
         <listitem>
           <para>Search for segments containing each of the search terms
           separated by a space.</para>
+
 		  <para>It is equivalent to a web search without quotation marks.</para>
 
-	<note><para>The <code>*</code> and <code>?</code> characters can be used in
-	both exact and keyword searches:</para>
+		  <note>
+			<para>The <code>*</code> and <code>?</code> characters can be used
+			in both exact and keyword searches:</para>
 
-    <itemizedlist>
-      <listitem>
-        <para><code>*</code> matches zero or more characters, from the current
-        position up to the end of a word.</para>
-		<para>The search term <literal>run*</literal>, for example, matches
-		<literal>run</literal>, <literal>runs</literal> and
-		<literal>running</literal>.</para>
-      </listitem>
-    </itemizedlist>
+			<itemizedlist>
+			  <listitem>
+				<para><code>*</code> matches zero or more characters, from the
+				current position up to the end of a word.</para>
 
-    <itemizedlist>
-      <listitem>
-        <para><code>?</code> matches any single character.</para>
-		<para>For instance, <literal>run?</literal> matches
-		<literal>runs</literal>, as well as the <literal>runn</literal> portion
-		of <literal>running</literal> or <literal>runner</literal>.</para>
-      </listitem>
-    </itemizedlist>
-	</note>
+				<para>The search term <literal>run*</literal>, for example,
+				matches <literal>run</literal>, <literal>runs</literal> and
+				<literal>running</literal>.</para>
+			  </listitem>
+			</itemizedlist>
+
+			<itemizedlist>
+			  <listitem>
+				<para><code>?</code> matches any single character.</para>
+
+				<para>For instance, <literal>run?</literal> matches
+				<literal>runs</literal>, as well as the <literal>runn</literal>
+				portion of <literal>running</literal> or
+				<literal>runner</literal>.</para>
+			  </listitem>
+			</itemizedlist>
+		  </note>
         </listitem>
       </varlistentry>
 	</variablelist>
@@ -136,13 +152,15 @@
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 		  <para>Regular expressions are a very powerful way to search for
-		  general or complex patterns rather than exact strings. See <link
-		  linkend="app.regex" endterm="app.regex.title"/> for
+		  general or complex patterns rather than exact strings. See the <link
+		  linkend="app.regex" endterm="app.regex.title"/> appendix for
 		  details.</para>
 
-	<warning><para>The <code>*</code> and <code>?</code> characters have a special
-meaning in regular expressions. Therefore, the wild card searches described
-above only apply to exact and keyword searches.</para></warning>
+		  <warning>
+			<para>The <code>*</code> and <code>?</code> characters have a special
+			meaning in regular expressions. Therefore, the wild card searches described
+			above only apply to exact and keyword searches.</para>
+		  </warning>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -151,107 +169,174 @@ above only apply to exact and keyword searches.</para></warning>
   <section id="windows.text.search.options">
 	<title id="windows.text.search.options.title">Options</title>
 	
-  <variablelist>
-	<varlistentry><term>Case sensitive</term><listitem><para>Only returns
-	results with the same letter case as the search
-	terms.</para></listitem></varlistentry>
-	
-	<varlistentry><term>Space matches nbsp</term><listitem><para>Space
-	characters in search terms will match both a normal space and a non-breaking
-	space (\u00A) character.</para></listitem></varlistentry>
-
-	<varlistentry><term>In source</term><listitem><para>Search in the source
-	segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>In translation</term><listitem><para>Search in the
-	target segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>In notes</term><listitem><para>Search in notes attached
-	to segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>In comments</term><listitem><para>Search in comments
-	attached to segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>Translated or untranslated</term><listitem><para>Search
-	in both translated and untranslated
-	segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>Translated</term><listitem><para>Search only in
-	translated segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>Untranslated</term><listitem><para>Search only in
-	untranslated segments.</para></listitem></varlistentry>
-
-	<varlistentry><term>Display: all matching
-	segments</term><listitem><para>Every segment is displayed individually, even
-	if it is a duplicate found in either the same document or a different
-	document in the project.</para></listitem></varlistentry>
-
-	<varlistentry><term>Display: file names</term><listitem><para>The name of
-	the file containing the segment is found is displayed above each
-	result.</para></listitem></varlistentry>
-
-	<varlistentry><term>Search in: Project</term>
-	<listitem><para>Search in the various bilingual resources of the project.</para>
-	<para>Select the scope of the search:
 	<variablelist>
 	  <varlistentry>
-		<term>Memory</term>
-		<listitem><para>include the project memory (<link
-	linkend="project.folder.project.save.tmx"
-	endterm="project.folder.project.save.tmx.title"/>)</para>
-		</listitem>
-	  </varlistentry>
-	  <varlistentry>
-		<term>TMs</term>
-		<listitem><para>include the translation memories located in the <link
-		linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder</para>
-		</listitem>
-	  </varlistentry>
-	  <varlistentry>
-		<term>Glossaries</term>
-		<listitem><para>include the glossaries located in the
-	<link linkend="project.folder.glossary"
-		  endterm="project.folder.glossary.title"/> folder</para>
-		</listitem>
-	  </varlistentry>
-	</variablelist>
-  </para>
-	</listitem>
-	</varlistentry>
-	
-	<varlistentry><term>Search in: Files</term><listitem><para>Search in reference files not included in the project resources.</para>
-	<para>OmegaT can conduct searches in any file that it can read as source file. See <link linkend="file.filters" endterm="file.filters.title"/> for details.</para>
-	<para>TMX files are excluded from file searches since OmegaT
-	does not recognize them as a source file format despite supporting them as
-	translation memories.</para></listitem></varlistentry>
-
-  <varlistentry>
-    <term><guibutton>Show Advanced Options</guibutton></term>
-	<listitem>
-	  <para>Select additional criteria such as the person who authored or
-    changed the translation, the date and time of translation (modification), or
-    whether to exclude orphan segments.
-
-	<variablelist>
-	  <varlistentry>
-		<term>Full/Half-width char insensitive</term>
-		<listitem><para>returns results that match both the full- and half-width forms
-		(CJK characters) of the characters in the search terms.</para>
-		</listitem>
-	  </varlistentry>
-	  <varlistentry>
-		<term>Number of matching segments</term>
+		<term>Case sensitive</term>
 		<listitem>
-		  <para>sets the maximum
-		  number of matches displayed in the search result area.</para>
+		  <para>Only returns results with the same letter case as the search
+		  terms.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry>
+		<term>Space matches nbsp</term>
+		<listitem>
+		  <para>Space characters in search terms will match both a normal space
+		  and a non-breaking space (\u00A)
+		  character.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>In source</term>
+		<listitem>
+		  <para>Search in the source segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>In translation</term>
+		<listitem>
+		  <para>Search in the target segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>In notes</term>
+		<listitem>
+		  <para>Search in notes attached to segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>In comments</term>
+		<listitem>
+		  <para>Search in comments attached to segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Translated or untranslated</term>
+		<listitem>
+		  <para>Search in both translated and untranslated segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Translated</term>
+		<listitem>
+		  <para>Search only in translated segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Untranslated</term>
+		<listitem>
+		  <para>Search only in untranslated segments.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Display: all matching segments</term>
+		<listitem>
+		  <para>Every segment is displayed individually, even if it is a
+		  duplicate found in either the same document or a different document in
+		  the project.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Display: file names</term>
+		<listitem>
+		  <para>The name of the file containing the segment is found is
+		  displayed above each result.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term>Search in: Project</term>
+		<listitem>
+		  <para>Search in the various bilingual resources of the project.</para>
+
+		  <para>Select the scope of the search:</para>
+		  
+		  <variablelist>
+			<varlistentry>
+			  <term>Memory</term>
+			  <listitem>
+				<para>include the project memory (<link
+				linkend="project.folder.project.save.tmx"
+				endterm="project.folder.project.save.tmx.title"/>)</para>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>TMs</term>
+			  <listitem>
+				<para>include the translation memories located in the <link
+				linkend="project.folder.tm" endterm="project.folder.tm.title"/>
+				folder</para>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>Glossaries</term>
+			  <listitem>
+				<para>include the glossaries located in the <link
+				linkend="project.folder.glossary"
+				endterm="project.folder.glossary.title"/> folder</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry>
+		<term>Search in: Files</term>
+		<listitem>
+		  <para>Search in reference files not included in the project
+		  resources.</para>
+
+		  <para>OmegaT can conduct searches in any file that it can read as
+		  source file. See the <link linkend="file.filters"
+		  endterm="file.filters.title"/> chapter for details.</para>
+
+		  <para>TMX files are excluded from file searches since OmegaT does not
+		  recognize them as a source file format despite supporting them as
+		  translation memories.</para>
+		</listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+		<term><guibutton>Show Advanced Options</guibutton></term>
+		<listitem>
+		  <para>Select additional criteria such as the person who authored or
+		  changed the translation, the date and time of translation
+		  (modification), or whether to exclude orphan segments.</para>
+
+		  <variablelist>
+			<varlistentry>
+			  <term>Full/Half-width char insensitive</term>
+			  <listitem>
+				<para>returns results that match both the full- and half-width
+				forms (CJK characters) of the characters in the search
+				terms.</para>
+			  </listitem>
+			</varlistentry>
+
+			<varlistentry>
+			  <term>Number of matching segments</term>
+			  <listitem>
+				<para>sets the maximum number of matches displayed in the search
+				result area.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+
+		  <para>Hide the advanced options with <guibutton>Hide Advanced Options</guibutton></para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
-	Hide the advanced options with <guibutton>Hide Advanced Options</guibutton></para>
-	</listitem>
-  </varlistentry>
-  </variablelist>
   </section>
 
   <section id="windows.text.search.result.display">
@@ -262,58 +347,73 @@ above only apply to exact and keyword searches.</para></warning>
     text. Only the source text is displayed for untranslated segments.</para>
 
     <para>Double-click on a segment to open it in the <link
-    linkend="panes.editor" endterm="panes.editor.title"/>.</para>
+    linkend="panes.editor" endterm="panes.editor.title"/> pane.</para>
 
-    <para>You can also use the following shortcuts in the search results:
+    <para>You can also use the following shortcuts in the search results:</para>
+	
 	<variablelist>
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
-		<listitem><para>Move to the next segment</para></listitem>
+		<listitem>
+		  <para>Move to the next segment</para>
+		</listitem>
 	  </varlistentry>
+	  
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
-		<listitem><para>Move to the preceding segment</para></listitem>
+		<listitem>
+		  <para>Move to the preceding segment</para>
+		</listitem>
 	  </varlistentry>
 	  <varlistentry>
 		<term><keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
-		<listitem><para>Jump to the current segment in the editor.</para></listitem>
+		<listitem>
+		  <para>Jump to the current segment in the editor.</para>
+		</listitem>
 	  </varlistentry>
 	</variablelist>
-	The selected segment is highlighted in green:
+	
+	<para>The selected segment is highlighted in green:</para>
 
   	<example id="select.second.match">
-		<title id="select.second.match.title">Select the second match</title>
-		<para>
-		  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
+	  <title id="select.second.match.title">Select the second match</title>
+	  <para>
+		<programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
 <action>-- 177> [[2001年]]、<token>ドイツ</token>の永住権を取得。</action>
 ---------</programlisting>
-		</para>
-	  </example>
-	</para>
-	
+	  </para>
+	</example>
+
 	<variablelist>
 	  <varlistentry>
 		<term>Auto-sync with editor</term>
 		<listitem>
-		  <para>the <link linkend="panes.editor" endterm="panes.editor.title"/> pane synchronizes its display with the selection in the search results</para>
+		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
+		  pane synchronizes its display with the selection in the search
+		  results</para>
 		</listitem>
 	  </varlistentry>
 	  <varlistentry>
 		<term>Back to the initial segment on close</term>
 		<listitem>
-		  <para>when you close the search windows, the <link linkend="panes.editor" endterm="panes.editor.title"/> pane automatically goes back to the segment that it displayed before the search was started</para>
+		  <para>When you close the search windows, the <link
+		  linkend="panes.editor" endterm="panes.editor.title"/> pane
+		  automatically goes back to the segment that it displayed before the
+		  search was started</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
   </section>
-	
+  
   <section id="windows.text.search.filter">
     <title id="windows.text.search.filter.title">Filter</title>
 
-	<para>Click on <guibutton>Filter</guibutton> to show only the matching search result
-	segments in the <link linkend="panes.editor"
-	endterm="panes.editor.title"/>. To remove the filter, click
-	on <guibutton>Remove Filter</guibutton> at the top of the <link linkend="panes.editor" endterm="panes.editor.title"/> pane or reload the project.</para>
+	<para>Click on <guibutton>Filter</guibutton> to show only the matching
+	search result segments in the <link linkend="panes.editor"
+	endterm="panes.editor.title"/> pane. To remove the filter, click on
+	<guibutton>Remove Filter</guibutton> at the top of the <link
+	linkend="panes.editor" endterm="panes.editor.title"/> pane or reload the
+	project.</para>
   </section>
 </section>


### PR DESCRIPTION
The localization process identified issues with the way the manual was written.

There are *very* few  additions in terms of information.
Most of the modifications are regarding links to other parts of the manual.

→ I've tried to systematically include the target type into the sentence.

`See <l1/> for details.`
is now:
`See the <l1/> chapter for details.`

etc.

I've also tried to homogenize wordings. For ex.

`To achieve this and that, you can use <m1/> in the <m2/> menu.`

is now:

`Use <m2/><m1/> to achieve this.`

where menu items are systematically in pairs with <root menu name><menu item name> and in 95% of the case they are prefixed with the verb "use".

Buttons are "click on ..."

Preferences are either "enable" or "see".

Etc.