### PR TITLE
Bump dependency stardict4j@0.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ dependencies {
         // Dictionary
         implementation 'com.github.takawitter:trie4j:0.9.8'
         implementation 'io.github.eb4j:dsl4j:0.5.3'
-        implementation 'tokyo.northside:stardict4j:0.4.1'
+        implementation 'tokyo.northside:stardict4j:0.5.0'
 
         // Encoding detections
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'


### PR DESCRIPTION
Stardict4j Changes on v0.5.0
  - Drop dependency for Caffeine cache library
  - Use internal cache code based on LinkedHashMap
  - Can disable drivers cache by setting cacheSize as 0

## Pull request type

- Other (describe below)


## Which ticket is resolved?

No ticket but it is related to #373


## What does this PR change?

- Bump stardict4j@0.5.0

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
