### PR TITLE
Add PDFs to generated "User Manual" index.html - POC for documentation

### DIFF
--- a/doc_src/index_template.html
+++ b/doc_src/index_template.html
@@ -14,7 +14,11 @@
 <table>
 <% languages.each { lang -> %>
     <tr>
-        <td><a href="${lang.code}/index.html">${lang.name}</a></td>
+        <td>
+            <p>${lang.name}:</p>
+        </td>
+        <td><a href="${lang.code}/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%20${lang.version}/OmegaT_documentation_${lang.code}.PDF/download">PDF</a></td>
         <td>(<span class="${lang.status}">${lang.version}</span>)</td>
     </tr>
 <% } %>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,97 +14,173 @@
 <table>
 
     <tr>
-        <td><a href="be/index.html">беларускі</a></td>
+        <td>
+            <p>беларускі:</p>
+        </td>
+        <td><a href="be/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_be.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="cs/index.html">čeština</a></td>
+        <td>
+            <p>čeština:</p>
+        </td>
+        <td><a href="cs/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.0/OmegaT_documentation_cs.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="de/index.html">Deutsch</a></td>
+        <td>
+            <p>Deutsch:</p>
+        </td>
+        <td><a href="de/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_de.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="el/index.html">Ελληνικά</a></td>
+        <td>
+            <p>Ελληνικά:</p>
+        </td>
+        <td><a href="el/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.9.9/OmegaT_documentation_el.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">2.9.9</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="en/index.html">English</a></td>
-        <td>(<span class="out-of-date">4.3.1</span>)</td>
+        <td>
+            <p>English:</p>
+        </td>
+        <td><a href="en/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%205.8.0/OmegaT_documentation_en.PDF/download">PDF</a></td>
+        <td>(<span class="up-to-date">5.8.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="es/index.html">español</a></td>
+        <td>
+            <p>español:</p>
+        </td>
+        <td><a href="es/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_es.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">2.3.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="fi/index.html">suomi</a></td>
+        <td>
+            <p>suomi:</p>
+        </td>
+        <td><a href="fi/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_fi.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="fr/index.html">français</a></td>
+        <td>
+            <p>français:</p>
+        </td>
+        <td><a href="fr/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_fr.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="gl/index.html">galego</a></td>
+        <td>
+            <p>galego:</p>
+        </td>
+        <td><a href="gl/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.0.2/OmegaT_documentation_gl.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">3.0.2</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="hr/index.html">hrvatski</a></td>
+        <td>
+            <p>hrvatski:</p>
+        </td>
+        <td><a href="hr/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.6.0/OmegaT_documentation_hr.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">3.6.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="ia/index.html">Interlingua</a></td>
+        <td>
+            <p>Interlingua:</p>
+        </td>
+        <td><a href="ia/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.6.0/OmegaT_documentation_ia.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">3.6.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="it/index.html">italiano</a></td>
+        <td>
+            <p>italiano:</p>
+        </td>
+        <td><a href="it/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_it.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="ja/index.html">日本語</a></td>
+        <td>
+            <p>日本語:</p>
+        </td>
+        <td><a href="ja/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_ja.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="nl/index.html">Nederlands</a></td>
+        <td>
+            <p>Nederlands:</p>
+        </td>
+        <td><a href="nl/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_nl.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="pt/index.html">português</a></td>
+        <td>
+            <p>português:</p>
+        </td>
+        <td><a href="pt/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_pt.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="pt_BR/index.html">português (Brasil)</a></td>
+        <td>
+            <p>português (Brasil):</p>
+        </td>
+        <td><a href="pt_BR/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.6.0/OmegaT_documentation_pt_BR.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">3.6.0</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="ru/index.html">русский</a></td>
+        <td>
+            <p>русский:</p>
+        </td>
+        <td><a href="ru/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.0.2/OmegaT_documentation_ru.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">3.0.2</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="uk/index.html">українська</a></td>
+        <td>
+            <p>українська:</p>
+        </td>
+        <td><a href="uk/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_uk.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 
     <tr>
-        <td><a href="zh_CN/index.html">中文 (中国)</a></td>
+        <td>
+            <p>中文 (中国):</p>
+        </td>
+        <td><a href="zh_CN/index.html">HTML/Web</a></td>
+        <td><a href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.3.1/OmegaT_documentation_zh_CN.PDF/download">PDF</a></td>
         <td>(<span class="out-of-date">4.3.1</span>)</td>
     </tr>
 


### PR DESCRIPTION
## Pull request type
[documentation]

## Which ticket is resolved?

- SourceForge Documentation task 379 The localized site documentation page does not link to the correct PDF
  * https://sourceforge.net/p/omegat/documentation/379/

<!-- 
 Above block is used for changelog. 
-->


## What does this PR change?

This PR tries to address the lack of links for the most recent localised PDFs on the OmegaT website by adding a PDF link to the HTML page that can be generated using Gradle to get the latest version: 
[ SF Doc 379 The localized site documentation page does not link to the correct PDF](https://sourceforge.net/p/omegat/documentation/379/)

This is more of a proof of concept/work in progress than a real solution at the moment.
It adds a link to the PDF of the User Manual on [the page that links to its most recent HTML version](https://omegat.sourceforge.io/manual-standard/) which would then look like the attached screenshot. 
This implementation assumes that the most recent PDF version should be the same as the HTML, which does not seem to be the case.

## Other information

![Screenshot 2022-12-20 at 18 44 57](https://user-images.githubusercontent.com/11940280/208745669-d2327aca-4056-483e-9418-d88b93f5c4d5.png)
