### PR TITLE
Add a GH action to use Sonar on the codebase and PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,48 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew jar --info
+      - name: Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test jacocoTestReport --info -Pheadless
+      - name: Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube --info

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.0.0'
     id 'com.github.ben-manes.versions' version '0.39.0'
     id 'ru.vyarus.mkdocs' version '3.0.0'
+    id "org.sonarqube" version "3.5.0.2730"
 }
 
 apply from: 'gradle/utils.gradle'
@@ -1123,6 +1124,14 @@ task publishVersion {
 python.docker.use = true
 mkdocs {
     sourcesDir = 'docs_devel'
+}
+
+sonarqube {
+  properties {
+    property "sonar.projectKey", "damien-rembert_omegat"
+    property "sonar.organization", "damien-rembert-all"
+    property "sonar.host.url", "https://sonarcloud.io"
+  }
 }
 
 // Allow setting the max heap size for the run task from the command line, e.g.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
- Provide more information on the codebase
  * [https://sourceforge.net/p/omegat/feature-requests/1660/](https://sourceforge.net/p/omegat/feature-requests/1660/)

## What does this PR change?

I have set up [a SonarCloud instance](https://sonarcloud.io/summary/overall?id=omegat-sonar_omegat) to watch my master branch and I think it provides a lot of useful information. 

## Other information

SonarCloud can be used with Azure rather than GitHub, if that's the preferred option.
It can be set to use reports from other tools that are already integrated to OmegaT (Jacoco, Checkstyle, SpotBugs).
I think I have only managed to add Jacoco, which provides the test coverage graph.

The properties "sonar.projectKey" and "sonar.organization" would need to be changed.
To set this up on my repo, I have added a SONAR_TOKEN to the GH Actions of my repo.

