### PR TITLE
Gradle: add jacoco verification rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -911,6 +911,34 @@ tasks.jacocoTestReport {
         xml.required = true  // coveralls plugin depends on xml format report
         html.required = true
     }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ["gen/core/**/*", "org/omegat/**/gui/*", "org/omegat/**/data/*"])
+        }))
+    }
+}
+
+// check.dependsOn jacocoTestCoverageVerification
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.test)
+    violationRules {
+        rule {
+            element = 'CLASS'
+            includes = ['org.omegat.core.machinetranslators.*', 'org.omegat.core.dictionaries.*']
+            excludes = ['**.*.1', '**.*.2', '**.*.3']  // ignore inner classes
+            limit { minimum = 0.20 }
+        }
+        rule {
+            element = 'PACKAGE'
+            includes = ['org.omegat.filters?.*',
+                        'org.omegat.externalfinder', 'org.omegat.languagetools', 'org.omegat.util',
+                        'org.omegat.core.events', 'org.omegat.core.matching', 'org.omegat.core.search',
+                        'org.omegat.core.segmentation', 'org.omegat.core.spellchecker', 'org.omegat.core.statistics',
+                        'org.omegat.core.tagvalidation', 'org.omegat.core.team2.*']
+            excludes = ['org.omegat.core.team2.gui', 'org.omegat.util.xml.*']
+            limit { minimum = 0.60 }
+        }
+    }
 }
 
 task manualPdfs {


### PR DESCRIPTION

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

N.A.

## What does this PR change?

- Add Jacoco configurations to detect  packages/classes without unit test
  - Set minimum coverage to 20%
  - Exclude generated code, data class, gui classes
- It is not mandatory; comment out check dependency

## Other information

[What is a reasonable code coverage?](https://stackoverflow.com/a/90021/4467057)
