### PR TITLE
Check and fine-tune the remaining chapters.

### DIFF
--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -9,8 +9,8 @@
   linkend="menus.project.properties" endterm="menus.project.properties.title"/>
   to open the dialog.</para>
   
-  <para>The dialog is used to set the initial project properties when creating a
-  new project and also to modify them later, after the project has been
+  <para>This dialog is used to set the initial project properties when creating 
+  a new project or to modify them later, after the project has been
   created.</para>
 
   <para>See the <link linkend="introduction.create.and.open.new.project"
@@ -30,37 +30,38 @@
 	  or from not matching it in other preferences.</para>
 	</warning>
 
-	<para>Language codes are used in various places in OmegaT:</para>
+	<para>Language codes are used in various places in OmegaT to:</para>
 	
 	<itemizedlist>
 	  <listitem>
-		<para>to get results in the <link linkend="panes.fuzzy.matches"
+		<para>get results in the <link linkend="panes.fuzzy.matches"
 		endterm="panes.fuzzy.matches.title"/> pane,</para>
 	  </listitem>
 
 	  <listitem>
-		<para>to apply the segmentation rules defined in the <link
+		<para>apply the segmentation rules defined in the <link
 		linkend="dialogs.preferences.segmentation.setup"
 		endterm="dialogs.preferences.segmentation.setup.title"/>
 		preferences,</para>
 	  </listitem>
 
 	  <listitem>
-		<para>to find spelling mistakes from the dictionaries installed in the
+		<para>find spelling mistakes from the dictionaries installed in the
 		<link linkend="dialog.preferences.spellchecker"
 		endterm="dialog.preferences.spellchecker.title"/> preferences,</para>
 	  </listitem>
 
 	  <listitem>
-		<para>to find grammatical and typographical mistakes from the rules set
+		<para>find grammatical and typographical mistakes from the rules set
 		in the <link linkend="dialog.preferences.languagetool.plugin"
 		endterm="dialog.preferences.languagetool.plugin.title"/>
-		preferences, etc.</para>
+		preferences,</para>
 	  </listitem>
 	</itemizedlist>
-	
+
+	  <para>and so on.</para>
     <para>OmegaT automatically selects the tokenizers that correspond to the
-    source and target languages but you can manually modify the
+    source and target languages but you can manually modify those
     settings. Tokenizers allow OmegaT to provide better matches.</para>
   </section>
 
@@ -75,8 +76,9 @@
         segmenting</option></term>
 
 		<listitem>		  
-          <para>Sentence-level segmentation splits the source file “paragraphs”
-          into segments based on segmentation rules.</para>
+          <para>Sentence-level segmentation splits paragraphs or other text
+          blocks in the source file into segments based on segmentation
+					rules.</para>
 
 		  <para>Disable this option if you prefer not to further segment the
 		  paragraphs.</para>
@@ -93,7 +95,7 @@
 		  <para>Click on <link
 		  linkend="dialogs.project.properties.local.segmentation"
 		  endterm="dialogs.project.properties.local.segmentation.title"/> to use
-		  project specific segmentation rules (local rules) and not the global
+		  project-specific (local) segmentation rules rather than the global
 		  rules. You can also start OmegaT from the command line with a project
 		  specific configuration setting to achieve a similar result.</para>
 
@@ -119,13 +121,13 @@
 		  <para>If you change the segmentation while translating, you will have
 		  to reload the project for the new segmentation to take effect. This
 		  will split or merge some previously translated segments, which will
-		  therefore no longer be considered translated. Nonetheless, their
-		  original translation will still be in the project memory.</para>
+		  therefore no longer be translated. However, their original translation
+		  will still be in the project memory.</para>
 
 		  <para>See the <link linkend="app.segmentation"
 		  endterm="app.segmentation.title"/> appendix for general explanations about
-		  segmentation (global or local, paragraph or sentence, setting,
-		  etc.)</para>
+		  segmentation (global or local, paragraph or sentence, settings,
+		  and so on).</para>
         </listitem>
       </varlistentry>
 
@@ -138,14 +140,14 @@
 		  <para>By default, segmentation rules are global and apply to all
 		  projects.</para>
 		  
-          <para>Segmentation rules found when you open the <link
-          linkend="dialogs.preferences.segmentation.setup"
-          endterm="dialogs.preferences.segmentation.setup.title"/> preferences
-          (use <link linkend="menus.options"
-          endterm="menus.options.title"/><link
-          linkend="menus.options.segmentation"
-          endterm="menus.options.segmentation.title"/>) are the global
-          rules.</para>
+			<para>The segmentation rules presented when you open the <link
+			linkend="dialogs.preferences.segmentation.setup"
+			endterm="dialogs.preferences.segmentation.setup.title"/> preferences
+			(using <link linkend="menus.options"
+			endterm="menus.options.title"/><link
+			linkend="menus.options.segmentation"
+			endterm="menus.options.segmentation.title"/>) are the global
+			rules.</para>
 
 		  <para>Use this button to create local rules specific to your
 		  project. Check the <option>Use local segmentation rules</option>
@@ -155,7 +157,7 @@
 		  linkend="project.folder.omegat.segmentation"
 		  endterm="project.folder.omegat.segmentation.title"/> file located in
 		  its <link linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder, and the rules
+		  endterm="project.folder.omegat.folder.title"/> folder. These rules
 		  will supersede the global segmentation rules.</para>
 		  
 		  <para>To disable local segmentation rules, disable this option or
@@ -168,8 +170,8 @@
 
 		  <para>See the <link linkend="app.segmentation"
 		  endterm="app.segmentation.title"/> appendix for general explanations
-		  about segmentation (global or local, paragraph or sentence, setting,
-		  etc.)</para>
+		  about segmentation (global or local, paragraph or sentence, settings,
+		  and so on).</para>
         </listitem>
       </varlistentry>
 	  
@@ -203,7 +205,7 @@
 
 		<listitem>
           <para>Tags are generally useful to reproduce specific layouts or
-          characteristics of the source text into the translated text.</para>
+          characteristics of the source text in the translated text.</para>
 
 		  <para>If you activate this function, no tag will be displayed in the
 		  source segments.</para>
@@ -216,12 +218,13 @@
 			<para>The tags are not really removed from the document, but rather
 			stacked at the end of the segment. In most cases, this should not
 			keep the translated file from opening. If you just need to reduce
-			the number of tags, you can use the <link
+			the number of tags in a <application>Microsoft Word</application>
+			(2007 and later) document, you can use the <link
 			linkend="windows.scripts.distribution.tagwipe"
 			endterm="windows.scripts.distribution.tagwipe.title"/> script.</para>
 
 			<para>See the <link linkend="windows.scripts"
-			endterm="windows.scripts.title"/> window for details.</para>
+			endterm="windows.scripts.title"/> section for details.</para>
 		  </note>
         </listitem>
       </varlistentry>
@@ -245,7 +248,7 @@
 		  <para>OmegaT can automatically run commands after the target files
 		  have been created.</para>
 
-		  <para>Specify here the commands that will be run.</para>
+		  <para>Enter the commands you want to run in this field.</para>
 
 		  <para>Use <link linkend="menus.project"
 		  endterm="menus.project.title"/><link
@@ -254,7 +257,7 @@
 		  linkend="menus.project" endterm="menus.project.title"/><link
 		  linkend="menus.project.create.current.translated.document"
 		  endterm="menus.project.create.current.translated.document.title"/> to
-		  create the target files and trigger the command launch.</para>
+		  create the target files and trigger the command.</para>
 
 		  <para>Commands specified here are only available to this project. They
 		  are saved in the <link linkend="project.folder.omegat.project.file"
@@ -299,11 +302,12 @@
 		  <para>The project will store the new set of file filters in the <link
 		  linkend="project.folder.omegat.filters"
 		  endterm="project.folder.omegat.filters.title"/> file located in its
-		  omegat folder, and the settings will supersede the global file filter
+		  <link linkend="project.folder.omegat.folder"
+		  endterm="project.folder.omegat.folder.title"/> folder. These settings will supersede the global file filter
 		  settings.</para>
 
 		  <note>
-			<para>To disable project specific file filters, uncheck the
+			<para>To disable project-specific file filters, uncheck the
 			box or remove that file.</para>
 		  </note>
 		  
@@ -348,11 +352,11 @@
 		  <link linkend="project.folder.omegat.finder"
 		  endterm="project.folder.omegat.finder.title"/> file located in its
 		  <link linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder, and the
+		  endterm="project.folder.omegat.folder.title"/> folder. These
 		  settings will supersede the global external searches settings.</para>
 
-		  <para>To delete project specific external searches, click on
-		  <guibutton>Remove</guibutton> or remove that file.</para>
+		  <para>To delete project specific external searches, click on the
+		  <guibutton>Remove</guibutton> button or remove that file.</para>
 		  
 		  <para>See the <link linkend="dialogs.preferences.external.searches"
 		  endterm="dialogs.preferences.external.searches.title"/> preferences
@@ -379,24 +383,24 @@
 	<para>An OmegaT translation project consists of a number of resources in
 	separate folders.</para>
 
-	<para>When a new project is created, OmegaT proposes to create a default
-	project folder that contains all the resources used in the translation, but
+	<para>When a new project is created, OmegaT proposes a default project folder
+	structure that contains all the resources used in the translation, but
 	that structure is not compulsory.</para>
 
-	<para>Resource folders can be located anywhere on your machine, including on
+	<para>Resource folders can be located anywhere on your system, including on
 	shared disks.</para>
 
 	<para>See the <link linkend="chapter.project.folder"
 	endterm="chapter.project.folder.title"/> chapter for details.</para>
 
 	<para>You can modify the structure of your project by adding or removing
-	files from the folders, or even by changing the folders the project
-	will use, at will, even during the course of the translation.</para>
+	files from the folders, or even by changing the folders used by the project
+	at any time, even during the course of the translation.</para>
 
 	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
 	linkend="menus.project.access.project.contents"
 	endterm="menus.project.access.project.contents.title"/> and its submenus to
-	access all the project ressource locations.</para>
+	access the locations of the project resources.</para>
 
 	<variablelist>
 	  <varlistentry id="dialogs.project.properties.file.locations.browse">
@@ -405,12 +409,12 @@
 
 		<listitem>
 		  <para>The <guibutton>Browse</guibutton> button is available for all
-		  the user-defined project resources.</para>
+		  user-definable project resources.</para>
 
 		  <note>
-			<para>Resources do not have to be contained in the default project
-			folder that OmegaT creates. You can select any folder that you want
-			to hold your resources, even folders located on shared disks.</para>
+			<para>Resources do not have to be stored in the default project
+			folder that OmegaT creates. You can select any folder you want
+			to hold your resources, including folders on shared disks.</para>
 		  </note>
 
 		  <para>Click on the button to select the folder that you want to use
@@ -425,14 +429,14 @@
 
 		<listitem>
 		  <para>This folder contains the files that you want to
-		  translate. OmegaT will try to read all the files at once, and will
-		  display in the editor the translatable contents that it has found.</para>
+		  translate. OmegaT tries to read all the files at once, and displays
+		  the translatable contents it finds in the editor.</para>
 
 		  <para>See the <link linkend="project.folder.source"
 		  endterm="project.folder.source.title"/> section for details.</para>
 
-		  <para>If the folder is empty, if none of the files contain
-		  translatable contents, or if there are no files supported by OmegaT’s
+		  <para>If the folder is empty, none of the files contain translatable
+		  content, or there are no files supported by the available
 		  file filters, OmegaT will tell you that the folder is empty.</para>
 
 		  <variablelist>
@@ -441,26 +445,26 @@
 			  id="dialogs.project.properties.file.locations.exclusions.title"><guibutton>Exclusions...</guibutton></term>
 
 			  <listitem>
-				<para>Click <guibutton>Exclusions...</guibutton> to define the
-				files or folders that will be ignored by OmegaT. An ignored file
-				or folder:</para>
+				<para>Click the <guibutton>Exclusions...</guibutton> button to specify 
+				files or folders that should be ignored by OmegaT. An ignored file
+				or folder is:</para>
 		  
 				<itemizedlist>
 				  <listitem>
-					<para>is not displayed in the <link linkend="panes.editor"
+					<para>not displayed in the <link linkend="panes.editor"
 					endterm="panes.editor.title"/> pane,</para>
 				  </listitem>
 
 				  <listitem>
-					<para>is not taken into account in the various statistics
-					reports (use <link linkend="menus.tools"
+					<para>not taken into account in the various statistics
+					reports (such as the <link linkend="menus.tools"
 					endterm="menus.tools.title"/><link
 					linkend="menus.tools.statistics"
-					endterm="menus.tools.statistics.title"/>, etc.), and</para>
+					endterm="menus.tools.statistics.title"/> command), and</para>
 				  </listitem>
 
 				  <listitem>
-					<para>is not copied to the <link
+					<para>not copied to the <link
 					linkend="project.folder.target"
 					endterm="project.folder.target.title"/> folder when the
 					translated files are created.</para>
@@ -468,11 +472,11 @@
 				</itemizedlist>
 
 				<para>The Exclusion patterns dialog allows you to add or remove
-				a pattern or to edit one by double-clicking it, or selecting it
-				and pressing <keycap>F2</keycap>. To define exclusions, use the
+				a pattern, or edit one either by double-clicking it or selecting it
+				and pressing <keycap>F2</keycap>. Use the
 				<ulink
 				url="https://ant.apache.org/manual/dirtasks.html#patterns">Apache
-				ant syntax</ulink>.</para>
+				ant syntax</ulink> to define exclusions.</para>
 			  </listitem>
 			</varlistentry>
 		  </variablelist>
@@ -485,13 +489,13 @@
 		memories folder</option></term>
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
-		  translation memories. OmegaT will try to read all the files at once,
-		  and will match their contents to the segment you are translating.</para>
+		  translation memories. OmegaT tries to read all the files at once,
+		  and compares their contents to the segment you are translating.</para>
 
 		  <para>See the <link linkend="project.folder.tm"
 		  endterm="project.folder.tm.title"/> section for details.</para>
 
-		  <para>If matches are found, they will be displayed in the <link
+		  <para>If matches are found, they are displayed in the <link
 		  linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>
 		  pane.</para>
 		</listitem>
@@ -504,13 +508,13 @@
 
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
-		  glossaries. OmegaT will try to read all the files at once, and will
-		  match their contents to the segment you are translating.</para>
+		  glossaries. OmegaT tries to read all the files at once, and compares
+			their contents to the segment you are translating.</para>
 
 		  <para>See the <link linkend="project.folder.glossary"
 		  endterm="project.folder.glossary.title"/> section for details.</para>
 		  
-		  <para>If matches are found, they will be displayed in the <link
+		  <para>If matches are found, they are displayed in the <link
 		  linkend="panes.glossary" endterm="panes.glossary.title"/> pane.</para>
 
 		  <para>See the <link linkend="app.glossaries"
@@ -529,13 +533,13 @@
 		  linkend="menus.edit"
 		  endterm="menus.edit.title"/><link
 		  linkend="menus.edit.create.glossary.entry"
-		  endterm="menus.edit.create.glossary.entry.title"/> menu.</para>
+		  endterm="menus.edit.create.glossary.entry.title"/> command.</para>
 
 		  <para>It is automatically created the first time a term is
 		  added.</para>
 
-		  <para>Added items are automatically recognized and displayed if they
-		  match terms in the current segment.</para>
+		  <para>Newly added entries are automatically recognized and displayed if 
+		  they match terms in the current segment.</para>
 
 		  <para>This file is <emphasis>always</emphasis> located in the <link
 		  linkend="project.folder.glossary"
@@ -576,13 +580,15 @@
 		  located in the <link linkend="project.folder.source"
 		  endterm="project.folder.source.title"/> folder.</para>
 
-		  <para>Segments that have been translated will be replaced by their
-		  translation and untranslated segments will remain in the source
+		  <para>Segments that have been translated are replaced by their
+		  translation and untranslated segments remain in the source
 		  language.</para>
 		
-		  <para>The folder structure reflects the copied contents and files that
-		  are not supported by OmegaT’s file filters will be copied without
-		  modifications.</para>
+		  <para>The folder structure mirrors that of the
+			<link linkend="project.folder.source"
+		  endterm="project.folder.source.title"/> folder. Files that
+		  are not supported by OmegaT’s file filters are copied without
+		  modification.</para>
 
 		  <para>Use <link linkend="menus.project.create.translated.documents"
 		  endterm="menus.project.create.translated.documents.title"/> or <link
@@ -604,16 +610,6 @@
 		  <para>This is the folder where OmegaT copies the current state of the
 		  translation in the form of TMX files when you create the translated
 		  files.</para>
-		
-		  <para>The TMX files will contain only the segments that correspond to
-		  the current contents of the <link linkend="project.folder.source"
-		  endterm="project.folder.source.title"/> folder.</para>
-
-		  <para>Use <link linkend="menus.project.create.translated.documents"
-		  endterm="menus.project.create.translated.documents.title"/> or <link
-		  linkend="menus.project.create.current.translated.document"
-		  endterm="menus.project.create.current.translated.document.title"/> to
-		  create the translated files and the exported TMX files.</para>
 
 		  <note>
 			<para>By default, that folder is the project folder itself but you
@@ -624,6 +620,16 @@
 			endterm="how.to.tm.share.translation.memories.title"/> how-to for
 			details.</para>
 		  </note>
+		
+		  <para>The TMX files contain only the segments from the files currently
+			stored in the <link linkend="project.folder.source"
+		  endterm="project.folder.source.title"/> folder.</para>
+
+		  <para>Use <link linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/> or <link
+		  linkend="menus.project.create.current.translated.document"
+		  endterm="menus.project.create.current.translated.document.title"/> to
+		  create the translated files and the exported TMX files.</para>
 
 		  <variablelist>
 			<varlistentry id="dialogs.project.properties.file.locations.tms.to.export">
@@ -631,7 +637,7 @@
 			  id="dialogs.project.properties.file.locations.tms.to.export.title"><option>Translation
 			  memories to export</option></term>
 			  <listitem>
-				<para>This checkbox lets you choose in which format you want
+				<para>This checkbox lets you choose the formats in which you want
 				OmegaT to create the above TMX files.</para>
 
 				<para>See the <link linkend="how.to.use.tm"
@@ -641,8 +647,8 @@
 				  <varlistentry>
 					<term><option>OmegaT</option></term>
 					<listitem>
-					  <para>An “OmegaT” TMX contains the tags that OmegaT
-					  created, in a form that can only be properly used by an
+					  <para>An “OmegaT” TMX contains the tags created by OmegaT
+						in a form that can only be used properly by an
 					  OmegaT project.</para>
 					</listitem>
 				  </varlistentry>
@@ -650,8 +656,8 @@
 				  <varlistentry>
 					<term><option>TMX Level 1</option></term>
 					<listitem>
-					  <para>A “level 1” TMX contains only textual data and has
-					  removed all tag information.</para>
+					  <para>A “level 1” TMX removes all tag information and contains only
+						textual data.</para>
 					</listitem>
 				  </varlistentry>
 				
@@ -659,7 +665,7 @@
 					<term><option>TMX Level 2</option></term>
 					<listitem>
 					  <para>A “level 2” TMX contains textual data along with
-					  tags encapsulated in a way that is compatible with other
+					  tags encapsulated in a form compatible with other
 					  CAT tools.</para>
 					</listitem>
 				  </varlistentry>

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -24,9 +24,8 @@
       Action</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></term>
       <listitem>
-        <para>Cancels the modifications made to the segment while the segment is
-        current. Once the segment is left, the modification history is
-        lost.</para>
+        <para>Cancels modifications made to the segment while it is
+        current. Modification history is lost upon leaving the segment.</para>
       </listitem>
     </varlistentry>
 
@@ -35,9 +34,8 @@
 	  <keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Reapplies the modifications that were cancelled while the segment
-        is current. Once the segment is left, the modification history is
-        lost.</para>
+        <para>Reapplies modifications that were cancelled while the segment
+        is current. Modification history is lost upon leaving the segment.</para>
       </listitem>
     </varlistentry>
 
@@ -47,11 +45,11 @@
 	  </term>
       <listitem>
         <para>Replaces the target segment with the currently selected fuzzy
-        match (by default the first match is selected) or with the text selected
+        match (the first match by default) or with the text selected
         in the <link linkend="panes.fuzzy.matches"
         endterm="panes.fuzzy.matches.title"/> pane.</para>
 
-        <para>The selected text has priority over the selected match.</para>
+        <para>Selected text has priority over the selected match.</para>
 
 		<para>See the <link linkend="panes.fuzzy.matches"
 		endterm="panes.fuzzy.matches.title"/> pane description for
@@ -68,7 +66,7 @@
         the <link linkend="panes.fuzzy.matches"
         endterm="panes.fuzzy.matches.title"/> pane at the cursor position. If a
         part of the target segment has been selected, that part will be
-        overwriten.</para>
+        overwritten.</para>
 
         <para>The selected text has priority over the selected match.</para>
 
@@ -94,7 +92,7 @@
       <listitem>
         <para>Inserts the segment source at the cursor position. If a part of
         the target segment has been selected, that part will be
-        overwriten.</para>
+        overwritten.</para>
       </listitem>
     </varlistentry>
 
@@ -105,13 +103,13 @@
       <listitem>
         <para>Selects the source text.</para>
 
-		<para>The selection can be directly used in OmegaT for <link
+		<para>The selection can be used directly in OmegaT for <link
 		linkend="windows.text.search">internal searches</link>, <link
 		linkend="windows.text.replace">replacements</link>, <link
-		linkend="menus.edit.create.glossary.entry">glossary term entry</link>,
+		linkend="menus.edit.create.glossary.entry">entering glossary terms</link>,
 		<link linkend="dialogs.preferences.external.searches">external
-		searches</link>, etc. Once copied to the OS clipboard, it can also be
-		used in web searches and otherwise.</para>
+		searches</link>, and so on. Once copied to the OS clipboard, it can also be
+		used in web searches and elsewhere.</para>
       </listitem>
     </varlistentry>
 
@@ -120,13 +118,13 @@
 	  <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
 	  </term>
       <listitem>
-        <para>Replaces the target segment with the translation, provided by the
-        selected Machine Translation service.</para>
+        <para>Replaces the target segment with the translation provided by the
+        selected machine translation service.</para>
 		<para>If the <link
 		linkend="dialogs.preferences.mt.automatically.fetch.translations"
 		endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/>
-		preference is disabled, use this action a first time to fetch the
-		translation and a second time to insert it.</para>
+		preference is disabled, use this action once to fetch the
+		translation, and a second time to insert it.</para>
 		
 		<para>No action is taken if no machine translation service has been
 		activated in the <link linkend="menus.options"
@@ -179,8 +177,8 @@
 	  </term>
       <listitem>
         <para>Allows the user to create an entry in the project writable
-        glossary (<link linkend="project.folder.glossary.txt"
-        endterm="project.folder.glossary.txt.title"/>).</para>
+        glossary (the <link linkend="project.folder.glossary.txt"
+        endterm="project.folder.glossary.txt.title"/> file).</para>
 
 		<para>There are two ways to use this function.</para>
 
@@ -204,7 +202,7 @@
 				<para>Press
 				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
 				
-				<para>The selection will be entered in the <guilabel>Source
+				<para>The selection is entered in the <guilabel>Source
 				term</guilabel> field.</para>
 			  </listitem>
 
@@ -216,7 +214,7 @@
 				<para>Press
 				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
 
-				<para>The selection will be entered in the <guilabel>Target
+				<para>The selection is entered in the <guilabel>Target
 				term</guilabel> field.</para>
 			  </listitem>
 
@@ -228,7 +226,7 @@
 				<para>[Optional] Press
 				<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></para>
 
-				<para>The selection will be entered in the
+				<para>The selection is entered in the
 				<guilabel>Comment</guilabel> field.</para>
 			  </listitem>
 
@@ -254,9 +252,9 @@
         function, the text will be pasted by default in the <guilabel>Search
         for:</guilabel> field.</para>
 
-		<para><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>F</keycap></keycombo>
-		reuses the most recent still open Search window (instead of opening a
-		new one).</para>
+		<para>The <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>F</keycap></keycombo>
+		combination reuses the most recent still open Search window instead of 
+		opening a new one.</para>
       </listitem>
     </varlistentry>
 
@@ -415,7 +413,7 @@
       <listitem>
 		<para>If several alternative translations are available for the active
 		segment, you can label the alternative selected as the default
-		translation. The entry will be greyed if only one translation is
+		translation. The entry will be grayed if only one translation is
 		available.</para>
       </listitem>
 	</varlistentry>
@@ -445,9 +443,9 @@
       <term id="menus.edit.set.empty.translation.title"><guimenuitem>Set Empty
       Translation</guimenuitem></term>
       <listitem>
-		<para>Define the translation as empty. In the target document, nothing
-		will appear for this segment. In the Editor, the translation is
-		displayed as <literal>&lt;EMPTY&gt;</literal>.</para>
+		<para>Define the translation as empty. The target document contains nothing
+		for this segment, while the Editor marks it with the
+		<literal>&lt;EMPTY&gt;</literal> identifier.</para>
       </listitem>
 	</varlistentry>
 

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -4,7 +4,7 @@
 <section id="menus.goto">
   <title id="menus.goto.title"><guimenu>Go To</guimenu></title>
 
-  <para>This menu gives you access to the segment and panes navigation commands.</para>
+  <para>This menu gives you access to the segment and pane navigation commands.</para>
 
   <example id="example.next.untranslated.segment">
 	<title id="example.next.untranslated.segment.title">Shortcut description
@@ -54,12 +54,13 @@
         file if the current segment is the last one in the file.</para>
 
         <note>
-		  <para><keycap>TAB</keycap> can be used as an alternate shortcut if the
+		  <para>You can use <keycap>TAB</keycap> as an alternative shortcut by
+		  enabling the
 		  <link linkend="dialogs.preferences.general.use.tab.to.advance"
 		  endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
-		  preference is enabled.</para>
+		  preference.</para>
 		  
-		  <para>This is useful for character entry systems that use
+		  <para>This is useful with character entry systems that use
 		  <keycap>Enter</keycap> to validate input.</para></note>
       </listitem>
     </varlistentry>
@@ -77,13 +78,13 @@
         file.</para>
 
         <note>
-		  <para><keycombo><keycap>C</keycap><keycap>TAB</keycap></keycombo> can
-		  be used as an alternate shortcut if the <link
+		  <para>You can use <keycombo><keycap>C</keycap><keycap>TAB</keycap></keycombo>
+		  as an alternative shortcut by enabling the <link
 		  linkend="dialogs.preferences.general.use.tab.to.advance"
 		  endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
-		  preference is enabled.</para>
+		  preference.</para>
 		  
-		  <para>This is useful for character entry systems that use
+		  <para>This is useful with character entry systems that use
 		  <keycap>Enter</keycap> to validate input.</para>
 		</note>
       </listitem>
@@ -191,6 +192,17 @@
 	  </listitem>
 	</varlistentry>
 
+    <varlistentry id="menus.goto.back.in.history">
+      <term id="menus.goto.back.in.history.title"><guimenuitem>Back in
+      History</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
+      <listitem>
+        <para>OmegaT remembers your segment navigation history.</para>
+        <para>This command allows you to move backward one segment at a time to
+        segments you have previously visited.</para>
+      </listitem>
+    </varlistentry>
+    
     <varlistentry id="menus.goto.forward.in.history">
       <term id="menus.goto.forward.in.history.title"><guimenuitem>Forward in
       History</guimenuitem>
@@ -199,22 +211,11 @@
         <para>OmegaT remembers your segment navigation history.</para>
 
         <para>This command allows you to move forward one segment at a time to
-        segments that you have previously visited with <link
+        segments you have previously visited with the above <link
         linkend="menus.goto"
         endterm="menus.goto.title"/><link
         linkend="menus.goto.back.in.history"
-        endterm="menus.goto.back.in.history.title"/>.</para>
-      </listitem>
-    </varlistentry>
-
-    <varlistentry id="menus.goto.back.in.history">
-      <term id="menus.goto.back.in.history.title"><guimenuitem>Back in
-      History</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
-      <listitem>
-        <para>OmegaT remembers your segment navigation history.</para>
-        <para>This command allows you to move backward one segment at a time to
-        segments that you have previously visited.</para>
+        endterm="menus.goto.back.in.history.title"/> command.</para>
       </listitem>
     </varlistentry>
 

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -31,7 +31,7 @@
 		  </listitem>
 		</itemizedlist>
 
-		<para>Allows you to activate/deactivate the available machine
+		<para>Allows you to activate or deactivate the available machine
 		translation engines.</para>
 
         <para>If several translation engines are selected, you can also use
@@ -52,7 +52,7 @@
 		  </listitem>
 		</itemizedlist>
 
-        <para>Allows you to activate/deactivate fuzzy matching for glossary
+        <para>Allows you to activate or deactivate fuzzy matching for glossary
         maches.</para>
 
 		<para>See the <link linkend="dialogs.preferences.glossary"
@@ -71,7 +71,7 @@
 		  </listitem>
 		</itemizedlist>
 
-        <para>Allows you to activate/deactivate fuzzy matching for dictionary
+        <para>Allows you to activate or deactivate fuzzy matching for dictionary
         maches.</para>
 
 		<para>See the <link linkend="dialogs.preferences.dictionary"
@@ -84,7 +84,7 @@
       <term
       id="menus.options.autocompletion.title"><guisubmenu>Auto-Completion</guisubmenu></term>
       <listitem>
-		<para>Select the various options to activate/deactivate them. See the
+		<para>Select the various options to activate or deactivate them. See the
 		<link linkend="dialog.preferences.auto.completion"
 		endterm="dialog.preferences.auto.completion.title"/> preferences for
 		details.</para>

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -58,7 +58,7 @@
       <listitem>
         <para>Gives access to the last ten edited projects. Clicking one will
         save the current project, close it and open the selected project.</para>
-        <para>Use <guimenuitem>Clear Menu</guimenuitem> function to delete
+        <para>Use the <guimenuitem>Clear Menu</guimenuitem> function to delete
         the list of recent projects.</para>
       </listitem>
     </varlistentry>
@@ -78,8 +78,8 @@
 		  endterm="project.folder.glossary.title"/> folder are automatically
 		  recognized and do not require reloading the project.</para>
 		</note>
-		<para>When reloading a team project, OmegaT reloads the remote
-		properties, not the local properties.</para>
+		<para>When reloading a team project, OmegaT reloads the remote,
+		rather than the local, properties.</para>
       </listitem>
     </varlistentry>
 
@@ -101,8 +101,8 @@
         <para>Saves the project translation memory (<link
         linkend="project.folder.project.save.tmx"
         endterm="project.folder.project.save.tmx.title"/>).</para>
-		<para>OmegaT automatically saves translations every 3 minutes as well as
-		when you close the project or quit OmegaT. See the <link
+		<para>OmegaT automatically saves translations every three minutes as well as
+		when you close the project or quit the program. See the <link
 		linkend="dialog.preferences.saving.and.output.interval"
 		endterm="dialog.preferences.saving.and.output.interval.title"/>
 		preference for details.</para>
@@ -128,7 +128,7 @@
 		<para>Opens a dialog where you can paste the URL of the Mediawiki page
 		you want to translate. The source data of the page will be copied into
 		the <link linkend="project.folder.source"
-		endterm="project.folder.source.title"/> folder, as a text file, with the
+		endterm="project.folder.source.title"/> folder, as a text file with the
 		<filename>.utf8</filename> extension.</para>
       </listitem>
     </varlistentry>
@@ -152,10 +152,10 @@
       Target Files</guimenuitem></term>
       <listitem>
         <warning><para>This function is specific to team projects. <emphasis>Use
-        this function only if the team project manager requested
-        so</emphasis>. See the <link linkend="how.to.use.team.project"
+        this function only if the team project manager asked you to
+        do so</emphasis>. See the <link linkend="how.to.use.team.project"
         endterm="how.to.use.team.project.title"/> how-to for details.</para></warning>
-        <para>Uploads locally created from the <link
+        <para>Uploads locally created translated files from the <link
         linkend="project.folder.target" endterm="project.folder.target.title"/>
         folder to the team project repository.</para>
       </listitem>
@@ -170,7 +170,7 @@
         <para>Creates the target files based on your translation. The created
         target files are located in the <link linkend="project.folder.target"
         endterm="project.folder.target.title"/> folder.</para>
-		<note><para>You can block target file creation if tag issues are
+		<note><para>You can prevent the creation of target files if tag issues are
 		found. See the <link
 		linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"
 		endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/>
@@ -255,7 +255,7 @@
 			<term><link linkend="chapter.project.folder"><guimenuitem>Project
 			Folder</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -263,7 +263,7 @@
 			<term><link
 			linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -271,7 +271,7 @@
 			<term><link
 			linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -279,7 +279,7 @@
 			<term><link linkend="project.folder.source"><guimenuitem>Source
 			Files</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -287,7 +287,7 @@
 			<term><link linkend="project.folder.target"><guimenuitem>Target
 			Files</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -295,7 +295,7 @@
 			<term><link
 			linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 		  
@@ -304,7 +304,7 @@
 			linkend="project.folder.exported.tm"><guimenuitem>Exported
 			TMs</guimenuitem></link></term>
 			<listitem>
-			  <para>Opens the folder in your file management application</para>
+			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -315,7 +315,7 @@
 			  linkend="project.folder.source"
 			  endterm="project.folder.source.title"/> folder.</para>
 
-			  <para>Opens the file in its associated application.</para>
+			  <para>Opens the file in the associated application.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -326,7 +326,7 @@
 			  linkend="project.folder.target"
 			  endterm="project.folder.target.title"/> folder.</para>
 
-			  <para>Opens the file in its associated application if it exists.</para>
+			  <para>Opens the file in the associated application if the file exists.</para>
 			</listitem>
 		  </varlistentry>
 
@@ -337,7 +337,7 @@
 			  linkend="project.folder.glossary"
 			  endterm="project.folder.glossary.title"/> folder.</para>
 
-			  <para>Opens the file in its associated application, if it exists.</para>
+			  <para>Opens the file in the associated application if the file exists.</para>
 			</listitem>
 		  </varlistentry>
 		</variablelist>

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -5,7 +5,7 @@
   <title id="menus.tools.title"><guimenu>Tools</guimenu></title>
 
   <para>This menu gives you access to a number of tools, including QA
-  validation, match reports, an aligner, scripting, etc.</para>
+  validation, match reports, an aligner, and scripting.</para>
 
   <example id="example.check.issues">
 	<title id="example.check.issues.title">Shortcut description example</title>
@@ -33,7 +33,7 @@
         <itemizedlist>
           <listitem>
             <para><guilabel>Tag Issues</guilabel> (always selected): detects
-            missing or displaced tags, including custom tags and flagged
+            missing or misplaced tags, including custom tags and flagged
             text. See the <link linkend="dialogs.preferences.tag.processing"
             endterm="dialogs.preferences.tag.processing.title"/> preferences for
             details.</para>
@@ -71,18 +71,18 @@
         <para>The results are presented as a table in which:</para>
         <itemizedlist>
           <listitem>
-            <para>double-clicking a row activates the corresponding segment in
-            the Editor pane,</para>
+            <para>Double-clicking a row activates the corresponding segment in
+            the Editor pane.</para>
           </listitem>
 
           <listitem>
-            <para>clicking a column header changes the sort order for that
-            column,</para>
+            <para>Clicking a column header changes the sort order for that
+            column.</para>
           </listitem>
 
           <listitem>
-            <para>selecting a row, or moving the mouse over it, displays a
-            context menu icon in the last column; clicking that icon presents
+            <para>Selecting or mousing over a row displays a
+            context menu icon in the last column. Clicking that icon presents
             actions available to correct or ignore the error.</para>
 
 			<note>
@@ -92,8 +92,8 @@
 			  endterm="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"/>
 			  preference.</para>
 
-			  <para>To block translated files creation if tag issues are found,
-			  enable the <link
+			  <para>To prevent the creation of translated files if tag issues are 
+			  found, enable the <link
 			  linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"
 			  endterm="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"/>
 			  preference.</para>
@@ -158,7 +158,7 @@
 			</listitem>
 
 			<listitem>
-			  <para>Custom tags and flagged text: as for OmegaT tags, they are
+			  <para>Custom tags and flagged text: as with OmegaT tags, they are
 			  not counted by default in the statistics, but you can have OmegaT
 			  count them as words. See the <link
 			  linkend="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics"
@@ -174,9 +174,9 @@
       <term id="menus.tools.match.statistics.title"><guimenuitem>Match
       Statistics</guimenuitem></term>
       <listitem>
-        <para>Displays the Match Statistics for the project: the number of
-        repetitions, exact matches, fuzzy matches and no-matches for segments,
-        words and characters.</para>
+        <para>Displays the match statistics for the project, which consist of 
+        the number of repetitions, exact matches, fuzzy matches and no-matches 
+        for segments, words and characters.</para>
 
 		<para>The data is saved in the <link
 		linkend="project.folder.omegat.project.stats.match"
@@ -191,9 +191,9 @@
       <term id="menus.tools.match.statistics.per.file.title"><guimenuitem>Match
       Statistics per File</guimenuitem></term>
       <listitem>
-        <para>Displays the Match Statistics for each file of the project: the
+        <para>Displays the individual match statistics, which consist of the
         number of repetitions, exact matches, fuzzy matches and no-matches for
-        segments, words and characters.</para>
+        segments, words and characters, for each file in the project.</para>
 
 		<para>The data is saved in the <link
 		linkend="project.folder.omegat.project.stats.match.per.file"
@@ -262,7 +262,7 @@
         <para>If you have defined external searches in the <link
         linkend="dialogs.preferences.external.searches"
         endterm="dialogs.preferences.external.searches.title"/> preferences,
-        their names are listed and accessible here.</para>
+        they are listed and accessible here.</para>
       </listitem>
     </varlistentry>
   </variablelist>

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -12,7 +12,7 @@
 		  id="menus.view.mark.translated.segments.title"><guimenuitem>Translated
       Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, translated segments will be marked in yellow.</para>
+        <para>If checked, translated segments are marked in yellow.</para>
       </listitem>
     </varlistentry>
 
@@ -21,7 +21,7 @@
       id="menus.view.mark.untranslated.segments.title"><guimenuitem>Untranslated
       Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, untranslated segments will be marked in violet.</para>
+        <para>If checked, untranslated segments are marked in violet.</para>
       </listitem>
     </varlistentry>
 
@@ -43,9 +43,9 @@
       <term id="menus.view.display.source.segments.title"><guimenuitem>Source
       Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, all the source segments will be shown and marked in
-        green.  If not checked, only the current source segments will be
-        shown.</para>
+        <para>If checked, all source segments are shown and marked in
+        green.  Otherwise, only the current source segment is shown.
+        </para>
       </listitem>
     </varlistentry>
 
@@ -54,7 +54,7 @@
       id="menus.view.mark.non.unique.segments.title"><guimenuitem>Non-Unique
       Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, non-unique segments will be marked in pale
+        <para>If checked, non-unique segments are marked in pale
         gray.</para>
       </listitem>
     </varlistentry>
@@ -63,7 +63,7 @@
       <term id="menus.view.mark.segments.with.notes.title"><guimenuitem>Segments
       with Notes</guimenuitem></term>
       <listitem>
-        <para>If checked, segments with notes will be marked in cyan. This
+        <para>If checked, segments with notes are marked in cyan. This
         marking has priority over <guimenuitem>Mark Translated
         Segments</guimenuitem> and <guimenuitem>Mark Untranslated
         Segments</guimenuitem>.</para>
@@ -75,7 +75,7 @@
       id="menus.view.mark.non.breakable.space.title"><guimenuitem>Non-Breakable
       Spaces</guimenuitem></term>
       <listitem>
-        <para>If checked, non-breakable spaces will be displayed with a gray
+        <para>If checked, non-breakable spaces are displayed with a gray
         background.</para>
       </listitem>
     </varlistentry>
@@ -84,7 +84,7 @@
       <term
       id="menus.view.mark.white.space.title"><guimenuitem>Whitespace</guimenuitem></term>
       <listitem>
-        <para>If checked, white spaces will be displayed with a small
+        <para>If checked, white spaces are displayed as a small
         dot.</para>
       </listitem>
     </varlistentry>
@@ -148,7 +148,7 @@
       id="menus.view.aggressive.font.fallback.title"><guimenuitem>Aggressive
       Font Fallback</guimenuitem></term>
       <listitem>
-        <para>Check this option in case OmegaT does not display certain glyphs
+        <para>Check this option if OmegaT does not display certain glyphs
         properly (even if the fonts containing the relevant glyphs are installed
         on your machine).</para>
 

--- a/doc_src/en/OmegaT5_EditorsPanes.xml
+++ b/doc_src/en/OmegaT5_EditorsPanes.xml
@@ -12,14 +12,14 @@
         <term id="panes.manipulation.title">Manipulation</term>
 
         <listitem>
-          <para>The main window consists of several panes, described here, menus
+          <para>The main window consists of several panes, described here, menus,
           described in the <link linkend="chapter.menus"
-          endterm="chapter.menus.title"/> chapter, and a status bar described
-          <link linkend="panes.statusbar">below</link>. You can change the
-          position of a pane, or even undock it as a separate window, by
-          clicking and holding its name and dragging it.</para>
+          endterm="chapter.menus.title"/> chapter, and a status bar, described
+          <link linkend="panes.statusbar">below</link>. You can click and 
+          hold the name of a pane to drag it to a new position or even undock it
+          as a separate window.</para>
 
-          <para>The top right corner of a pane will show different icons
+          <para>The top right corner of each pane shows different icons
           depending on the type of pane and its current status:</para>
 
           <table id="table.pane.widgets">
@@ -53,9 +53,8 @@
                       </imageobject>
                     </inlinemediaobject></entry>
 
-                  <entry><emphasis role="bold">Minimizes</emphasis> the pane, so
-                  that it only shows as a tab at the bottom of the
-                  window.</entry>
+                  <entry><emphasis role="bold">Minimizes</emphasis> the
+                  pane to a tab at the bottom of the window.</entry>
                 </row>
 
                 <row>
@@ -129,8 +128,8 @@
             linkend="menus.view"/><link
             endterm="menus.view.restore.main.window.title"
             linkend="menus.view.restore.main.window"/> to go back to the default
-            layout if you lost track of the changes you made to the user
-            interface, and cannot see some panes.</para>
+            layout if you lose track of the changes you made to the user
+            interface and can no longer see certain panes.</para>
           </note>
         </listitem>
       </varlistentry>
@@ -220,22 +219,22 @@
 		  
 		  <itemizedlist>
 			<listitem>
-			  <para>enter the pane,</para>
+			  <para>Enter the pane.</para>
 			</listitem>
 
 			<listitem>
-			  <para>click on the <guilabel>Action</guilabel> widget in the top
-			  right,</para>
+			  <para>Click on the <guilabel>Action</guilabel> widget at the top
+			  right.</para>
 			</listitem>
 			
 			<listitem>
-			  <para>and select <guilabel>Notify Me When a Segment
-			  Has...</guilabel> (the ... contents depends on the pane that you
-			  want notifications from).</para>
+			  <para>Select <guilabel>Notify Me When a Segment
+			  Has...</guilabel> (where ... varies depending on the pane for which you
+			  are enabling notifications.</para>
 			</listitem>
 		  </itemizedlist>
 
-		  <para>Notifications are available from the following panes:</para>
+		  <para>The following panes can provide notifications:</para>
 
 		  <itemizedlist>
 			<listitem>
@@ -270,14 +269,12 @@
 
 			  <para>In <guilabel>Table View</guilabel>, right click on the item
 			  and select <guilabel>Notify Me When a Segment Has...</guilabel>
-			  (the ... contents depends on the item that you want notifications
-			  from).</para>
+			  (where ... varies according to the desired notification).</para>
 
 			  <para>In <guilabel>List View</guilabel>, right click on the
 			  <guilabel>Action</guilabel> widget at the right-end of the
-			  selected property lineand select <guilabel>Notify Me When a
-			  Segment Has...</guilabel> (the ... contents depends on the item
-			  that you want notifications from).</para>
+			  selected property line and select <guilabel>Notify Me When a
+			  Segment Has...</guilabel> (where ... varies according to the desired notification).</para>
 			</listitem>
 		  </itemizedlist>
 		</listitem>
@@ -330,12 +327,12 @@ When enabled, all the formatting tags are removed from source segments.</program
       </listitem>
 
       <listitem>
-        <para>The cursor is by default locked into the translation
-        field.</para>
+        <para>The cursor is locked into the translation field
+        by default.</para>
 
-        <para>Use <keycap>F2</keycap> to unlock the cursor and move it beyond
-        the translation field, and to make it come back into the translation
-        field when you are done.</para>
+        <para>Use <keycap>F2</keycap> to unlock it and freely move it
+        back and forth between the translation field and other parts of
+        the pane.</para>
       </listitem>
 
       <listitem>
@@ -351,8 +348,8 @@ When enabled, all the formatting tags are removed from source segments.</program
 
 		<itemizedlist>
           <listitem>
-            <para>register the translation field contents in the project
-            translation memory, and</para>
+            <para>register the contents of the translation field in the 
+            project translation memory, and</para>
           </listitem>
 
           <listitem>
@@ -390,68 +387,68 @@ When enabled, all the formatting tags are removed from source segments.</program
 	  
 	  <itemizedlist>
 		<listitem>
-		  <para>Font modifications, defined in the <link
+		  <para>Changing the font as described in the <link
 		  endterm="dialogs.preferences.fonts.title"
-		  linkend="dialogs.preferences.fonts"/> preference</para>
+		  linkend="dialogs.preferences.fonts"/> preference.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Paragraph delimitation display, enabled by using <link
+		  <para>Showing or hiding paragraph delimitations using <link
 		  endterm="menus.view.title" linkend="menus.view"/><link
 		  endterm="menus.view.mark.paragraph.delimitations.title"
-		  linkend="menus.view.mark.paragraph.delimitations"/></para>
+		  linkend="menus.view.mark.paragraph.delimitations"/>.</para>
 		</listitem>
 
 		<listitem>
-		  <para>The paragraph delimitation format, defined in the <link
+		  <para>Changing the paragraph delimitation format, defined in the <link
 		  endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"
 		  linkend="dialogs.preferences.editor.paragraph.delimitation.format"/>
-		  preference</para>
+		  preference.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Segment modification info display, enabled by using <link
+		  <para>Showing segment modification information using <link
 		  endterm="menus.view.title" linkend="menus.view"/><link
 		  endterm="menus.view.modification.info.title"
-		  linkend="menus.view.modification.info"/></para>
+		  linkend="menus.view.modification.info"/>.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Source segments display, enabled by using <link
+		  <para>Showing or hiding source segments using <link
 		  endterm="menus.view.title" linkend="menus.view"/><link
 		  endterm="menus.view.display.source.segments.title"
-		  linkend="menus.view.display.source.segments"/></para>
+		  linkend="menus.view.display.source.segments"/>.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Translated segments highlighting, enabled by using <link
+		  <para>Highlighting translated segments using <link
 		  endterm="menus.view.title" linkend="menus.view"/><link
 		  endterm="menus.view.mark.translated.segments.title"
-		  linkend="menus.view.mark.translated.segments"/></para>
+		  linkend="menus.view.mark.translated.segments"/>.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Do not insert the source text in the translation field, enabled
-		  by the <link
+		  <para>Automatically inserting the source text in the translation
+      field by disabling the <link
 		  endterm="dialogs.preferences.editor.leave.the.segment.empty.title"
 		  linkend="dialogs.preferences.editor.leave.the.segment.empty"/>
-		  preference</para>
+		  preference.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Insert the best fuzzy match above a given threshold, enabled by
-		  the <link
+		  <para>Inserting the best fuzzy match above the threshold defined in
+		  <link
 		  endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"
 		  linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"/>
-		  preference</para>
+		  preference.</para>
 		</listitem>
 
 		<listitem>
-		  <para>Define text that you do not want to remain in the translation,
-		  enabled by the <link
+		  <para>Defining text that you want to leave out of the translation,
+		  enabled in the <link
 		  endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"
 		  linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"/>
-		  preference</para>
+		  preference.</para>
 		</listitem>
 	  </itemizedlist>
 
@@ -516,8 +513,7 @@ When enabled, all the formatting tags are removed from source segments.</program
 
           <para>The writing mode (overwrite - <guilabel>OVR</guilabel> or insert
           - <guilabel>INS</guilabel>) is shown at the right of the <link
-          linkend="panes.statusbar">status bar</link>. Use the same key to
-          switch back and forth between each mode.</para>
+          linkend="panes.statusbar">status bar</link>. The same key toggles between each mode.</para>
         </listitem>
       </varlistentry>
 
@@ -525,7 +521,7 @@ When enabled, all the formatting tags are removed from source segments.</program
         <term id="panes.editor.cursor.lock.title">Cursor lock</term>
 
         <listitem>
-          <para>By default, the cursor is locked into the translation field, and
+          <para>By default, the cursor is locked in the translation field, and
           the arrow keys cannot be used to move in the source text.</para>
 
           <para>Pressing <keycap>F2</keycap> unlocks the cursor and makes it
@@ -535,8 +531,8 @@ When enabled, all the formatting tags are removed from source segments.</program
 
           <para>The cursor status (locked - <guilabel>LCK</guilabel> or unlocked
           - <guilabel>UNL</guilabel>) is shown at the right of the <link
-          linkend="panes.statusbar">status bar</link>. Use the same key to lock
-          the cursor again.</para>
+          linkend="panes.statusbar">status bar</link>. The same key toggles
+          between locking and unlocking the cursor.</para>
         </listitem>
       </varlistentry>
 
@@ -560,12 +556,14 @@ When enabled, all the formatting tags are removed from source segments.</program
 		  <para>You can also bring up the menu by right-clicking the mouse
 		  (<keycap>C</keycap> + <keycap>click</keycap> on macOS).</para>
 
-          <para>The Editor pane context menu offers:</para>
+          <para>The Editor pane context menu offers various functions available
+          from the <link endterm="menus.edit.title"
+          linkend="menus.edit"/> menu, notably:</para>
 
 		  <itemizedlist>
 			<listitem>
-			  <para>Matched glossary items, and their comments as a tooltip if
-			  existing. Use <link endterm="menus.view.title"
+			  <para>Matched glossary items, with comments, if any presented as a
+        tooltip. Use <link endterm="menus.view.title"
 			  linkend="menus.view"/><link
 			  endterm="menus.view.mark.glossary.matches.title"
 			  linkend="menus.view.mark.glossary.matches"/> to enable this
@@ -573,37 +571,33 @@ When enabled, all the formatting tags are removed from source segments.</program
 			</listitem>
 
 			<listitem>
-              <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
-              <guilabel>Paste</guilabel> functions,</para>
-            </listitem>
+        <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
+        <guilabel>Paste</guilabel> functions,</para>
+      </listitem>
 
-            <listitem>
-              <para><guilabel>Go To Segment</guilabel> (to jump to the segment
-              under the pointer),</para>
-            </listitem>
+      <listitem>
+        <para><guilabel>Go To Segment</guilabel> (to jump to the segment
+        under the pointer).</para>
+      </listitem>
 
-            <listitem>
-              <para><guilabel>Search Dictionaries</guilabel> (to search for the
-              selected term in an installed dictionary),</para>
-            </listitem>
+      <listitem>
+        <para><guilabel>Search Dictionaries</guilabel> (to search for the
+        selected term in an installed dictionary).</para>
+      </listitem>
 
-            <listitem>
-              <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
-              <link endterm="menus.edit.title" linkend="menus.edit"/><link
-              endterm="menus.edit.create.glossary.entry.title"
-              linkend="menus.edit.create.glossary.entry"/>),</para>
-            </listitem>
+      <listitem>
+        <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
+        <link endterm="menus.edit.title" linkend="menus.edit"/><link
+        endterm="menus.edit.create.glossary.entry.title"
+        linkend="menus.edit.create.glossary.entry"/>).</para>
+      </listitem>
 
-          </itemizedlist>
-
-		  <para>and other functions available from the <link
-		  endterm="menus.edit.title" linkend="menus.edit"/> menu.</para>
+      </itemizedlist>
 
           <para>If you have selected text and defined entries in the <link
           endterm="dialogs.preferences.external.searches.title"
           linkend="dialogs.preferences.external.searches"/> preferences, they
-          will also be displayed in the menu (local searches will also be
-          displayed).</para>
+          will also be displayed in this menu (as will local searches).</para>
         </listitem>
       </varlistentry>
 
@@ -651,21 +645,21 @@ When enabled, all the formatting tags are removed from source segments.</program
   <section id="panes.fuzzy.matches">
     <title id="panes.fuzzy.matches.title"><guilabel>Fuzzy Matches</guilabel></title>
 
-    <para>The match viewer shows segments from your translation memories that
-    are the most similar to the segment you are currently translating.</para>
+    <para>The match viewer shows the segments from your translation memories that
+    are most similar to the segment you are currently translating.</para>
 
-    <para>Matches are found both in the internal project translation memory that
-    you create in real time as you translate the project, and in external
-    memories you have imported from previous projects or received from third
-    parties. See the <link endterm="how.to.use.tm.title"
-    linkend="how.to.use.tm"/> how-to for details.</para>
+    <para>Matches are taken from both the internal project translation
+    memory created in real time as you translate the project, and
+    external memories you have imported from previous projects or
+    received from third parties. See the <link endterm="how.to.use.tm.title" linkend="how.to.use.tm"/> how-to for details.</para>
 
     <para>When you enter a segment, the first fuzzy match (the one with the
     highest match percentage) is automatically selected. You can press
-    <keycombo><keycap>C</keycap><keycap>2, 3, 4, 5</keycap></keycombo> to select
-    a different match or use <link linkend="menus.edit"
+    <keycombo><keycap>C</keycap><keycap>2, 3, 4, or 5</keycap>
+    </keycombo>, or use <link linkend="menus.edit"
     endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
-    endterm="menus.edit.select.match.title"/>.</para>
+    endterm="menus.edit.select.match.title"/>, to select
+    a different match .</para>
 
 	<example id="the.first.match">
 	  <title id="the.first.match.title">The first match</title>
@@ -676,14 +670,13 @@ Dossier de configuration
 	  </para>
 	</example>
 
-    <para>The selected fuzzy match is highlighted in bold, with words missing
-    from the segment you are translating shown in blue, and adjacent words
-    shown in green.</para>
+    <para>The selected fuzzy match is highlighted in bold. Words missing
+    from the segment you are translating are shown in blue, and adjacent words
+    in green.</para>
 
-    <para>The match also displays three percentages.</para>
+    <para>The match also displays three matching percentages.</para>
 
-    <para>The three matching percentages have the following meaning, in
-    order:</para>
+    <para>These percentages have the following meaning, in order:</para>
 
 	<itemizedlist>
       <listitem>
@@ -692,7 +685,7 @@ Dossier de configuration
       </listitem>
 
       <listitem>
-        <para>Percentage calculated without stemming, and still ignoring tags
+        <para>Percentage calculated without stemming, while still ignoring tags
         and numbers (generally slightly lower).</para>
       </listitem>
 
@@ -743,11 +736,10 @@ Folder = <token>Dossier</token></programlisting>
     <para>The glossary file name is shown as a tooltip when hovering over the
     terms.</para>
 
-    <para>Hyperlinks can be present in the comment field of an entry and can be
-    clicked upon for further reference.</para>
+    <para>The comment field of an entry can contain hyperlinks, which can be clicked for further reference.</para>
 
 	<para>Links to local files (<filename>file:///PATH/filename</filename>) open
-	in the associated program. Web addresses (<filename>http://...</filename>)
+	in the associated program. Web addresses (<filename>https://...</filename>)
 	open in the default browser.</para>
 
     <para>You can select a term in the glossary pane and right click on it to
@@ -760,8 +752,8 @@ Folder = <token>Dossier</token></programlisting>
 
 	<para>You can then right-click on the underlined word in the source segment
 	to open a pop-up menu listing the translations available in your
-	glossaries. Selecting one will insert it in the segment at the current
-	cursor position.</para>
+	glossaries. Select one to insert it at the current
+	cursor position in the segment.</para>
 
     <para>You can use the glossary preferences to fine-tune how the glossaries
     are displayed. See the <link endterm="dialogs.preferences.glossary.title"
@@ -795,23 +787,22 @@ Folder = <token>Dossier</token></programlisting>
     <title id="panes.machinetranslation.title"><guilabel>Machine
     Translation</guilabel></title>
 
-    <para>The machine translation pane, when opened, contains the suggestions
-    produced for the current segment by one or more enabled translation
-    engines. When suggestions from more than one engine are available,</para>
+    <para>The machine translation pane, when opened, shows the suggestions
+    for the current segment produced by each enabled translation
+    engine . When suggestions from more than one engine are available,</para>
 	
     <itemizedlist>
       <listitem>
-        <para>the name of the engine will appear after the translated
+        <para>the name of the engine appears after the translated
         text,</para>
       </listitem>
 
       <listitem>
-        <para>the results are sorted in alphabetical order of engine
-        names,</para>
+        <para>the results are sorted alphabetically by engine name, and</para>
       </listitem>
 
       <listitem>
-        <para>and the currently selected translation is highlighted.</para>
+        <para>the currently selected translation is highlighted.</para>
       </listitem>
     </itemizedlist>
 
@@ -820,8 +811,7 @@ Folder = <token>Dossier</token></programlisting>
     endterm="menus.edit.replace.with.mt.title"/> to replace the translation of
     the current segment with the selected translation engine.</para>
 
-    <para>The "Origin" property of the current segment is assigned the selected
-    engine name.</para>
+    <para>The selected engine name is assigned to the <parameter>Origin</parameter> property of the current segment.</para>
 
 	<para>If there is a connection or authentication error with a machine
 	translation engine, the status bar at the bottom of the window will briefly
@@ -890,16 +880,16 @@ Folder = <token>Dossier</token></programlisting>
   <section id="panes.comments">
     <title id="panes.comments.title"><guilabel>Comments</guilabel></title>
 
-    <para>Some file formats, such as the PO format, can provide the translator
-    with comments to add context to the translation. Such comments are displayed
-    here.</para>
+    <para>Some file formats, such as the PO format, can contain comments
+    for the translator to add context to the translation. Such comments
+    are displayed here.</para>
 
     <note>
-      <para>The Comments pane is <emphasis>not</emphasis> editable. It only
-      displays information that is included in the file.</para>
+      <para>The <guilabel>Comments</guilabel> pane is <emphasis>not</emphasis> editable. It only
+      displays the information contained in the file.</para>
 
-	  <para>To write your own comments about a translation, use the <link
-	  endterm="panes.notes.title" linkend="panes.notes"/> pane instead.</para>
+	  <para>Use the <link
+	  endterm="panes.notes.title" linkend="panes.notes"/> pane to enter your own comments about a translation.</para>
     </note>
   </section>
 
@@ -915,14 +905,14 @@ Folder = <token>Dossier</token></programlisting>
 	  <varlistentry>
 		<term>Is duplicate</term>
 		<listitem>
-		  <para>indicates that a segment is a duplicate and specifies whether
-		  the segment is the FIRST or not.</para>
+		  <para>Indicates that a segment is a duplicate and specifies whether
+		  it is the FIRST instance.</para>
 		</listitem>
 	  </varlistentry>
 	  <varlistentry>
 		<term>File</term>
 		<listitem>
-		  <para>indicates the file where the segment is stored.</para>
+		  <para>Indicates which file contains the segment.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
@@ -938,8 +928,7 @@ Folder = <token>Dossier</token></programlisting>
 
     <para>The bottom of the main window is the status bar.</para>
 
-	<para>The left side of the status bar displays information about actions
-	taken in the project or error messages.</para>
+	<para>The left side of the status bar displays information on project actions or error messages.</para>
 
 	<example id="panes.statusbar.messages">
       <title id="panes.statusbar.messages.title">Status bar messages examples</title>
@@ -962,11 +951,11 @@ Folder = <token>Dossier</token></programlisting>
 	</example>
 
     <para>The right side of the status bar indicates whether the cursor is
-    locked withing the segment (see the <link
+    locked within the segment (see the <link
     endterm="panes.editor.cursor.lock.title"
-    linkend="panes.editor.cursor.lock"/> setting), whether the cursor overwrites
+    linkend="panes.editor.cursor.lock"/> setting) and whether the cursor overwrites
     the existing text (see the <link linkend="panes.editor.overwriting"
-    endterm="panes.editor.overwriting.title"/> setting), and also displays
+    endterm="panes.editor.overwriting.title"/> setting). It also displays
     progress information.</para>
 
     <para>Click on the figures to alternate between displaying progress as numbers or

--- a/doc_src/en/OmegaT5_Menus.xml
+++ b/doc_src/en/OmegaT5_Menus.xml
@@ -4,8 +4,8 @@
 <chapter id="chapter.menus">
   <title id="chapter.menus.title">Menus</title>
 
-  	<para>OmegaT looks a bit stern, if not outright unfriendly, to people who
-  	are used to button based interfaces. Buttons are very few in OmegaT. Most of
+  	<para>OmegaT has very few buttons and looks a bit stern, if not outright
+    unfriendly, to people who are used to button-based interfaces. Most of
   	the action takes place with the help of shortcuts associated to menu
   	items.</para>
 
@@ -13,11 +13,10 @@
 	shortly to remember the few that are useful in the course of a standard
 	translation day.</para>
 
-	<para>Menus are where you access most of OmegaT's functions. Most of the
-	menu items are associated with a keyboard shortcut.</para>
+	<para>Menus are where you access most of OmegaT's functions. Most 
+	menu items have an associated keyboard shortcut.</para>
 
-	<para>Menu items that do not have a shortcut indicated next to them have no
-	default shortcut assigned by default. See the <link
+	<para>Menu items that do not indicate a shortcut do nothave one assigned by default. See the <link
 	linkend="app.shortcuts.customization"
 	endterm="app.shortcuts.customization.title"/> appendix if you want to modify
 	or add shortcuts.</para>

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -28,27 +28,27 @@
 
   <orderedlist>
 	<listitem>
-	  <para>specify the source and target languages and select the two files you
+	  <para>Specify the source and target languages and select the two files you
 	  want to align.</para>
 	</listitem>
 
 	<listitem>
-	  <para>the files are read by the aligner, which attempts to match the
+	  <para>The aligner reads the files and attempts to match the
 	  segments that correspond to one another in the original and translated
-	  texts,</para>
+	  texts.</para>
 	</listitem>
 
 	<listitem>
-	  <para>the translator reviews the results and makes any necessary manual
-	  adjustments,</para>
+	  <para>Review the results and makes any necessary manual
+	  adjustments.</para>
 	</listitem>
 
 	<listitem>
-	  <para>save the result to TMX</para>
+	  <para>Save the result to a TMX file.</para>
 	</listitem>
   </orderedlist>
 
-  <para>The aligner can read all the file formats supported by OmegaT.</para>
+  <para>The aligner can read all file formats supported by OmegaT.</para>
   
   <note>
     <para>If you have a translation project open, the aligner will automatically
@@ -237,7 +237,7 @@
             <para>If you modify the segmentation rules, you will be asked if you
             want to save those changes when you exit the aligner. The default
             choice is <guibutton>Yes</guibutton>, which may not be what you want
-            if you edited the general OmegaT segmentation rules.</para>
+            if you edited the global OmegaT segmentation rules.</para>
           </warning>
         </listitem>
       </varlistentry>
@@ -255,7 +255,7 @@
             <para>If you modify the file filters, you will be asked if you want
             to save those changes when you exit the aligner. The default choice
             is <guibutton>Yes</guibutton>, which may not be what you want if you
-            edited the general OmegaT file filters.</para>
+            edited the global OmegaT file filters.</para>
           </warning>
         </listitem>
       </varlistentry>
@@ -264,11 +264,12 @@
         <term>Pattern...</term>
         <listitem>
           <para>This option lets you enter a regular expression to define the
-          pattern used for highlighting text in the source and target
+          pattern used to highlight text in the source and target
           segments. By default, the aligner uses <literal>\d+</literal> to
           highlight numbers. If your texts contain other elements that would be
           useful to highlight, modify the regular expression to include those
-          elements, separated by a <literal>|</literal>.</para>
+          elements, using the <literal>|</literal> symbol to separate each
+          element.</para>
         </listitem>
       </varlistentry>      
     </variablelist>
@@ -327,7 +328,7 @@
 
     <para>All available actions can be accessed from the <guimenu>Edit</guimenu>
     menu or by pressing the corresponding shortcut key. The most common actions
-    are also accessible from the buttons to the right of the main pane.</para>
+    are also accessible from the buttons at the right of the main pane.</para>
 
     <note>
       <para>The shortcut keys are well worth remembering if you use the aligner
@@ -351,7 +352,7 @@
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments, up
           one row.</para>
-          <para>This command is also available from the button to the right of
+          <para>This command is also available from the button at the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
@@ -362,7 +363,7 @@
           <para>Moves the selected segment, or block of consecutive segments,
           down one row.</para>
 
-          <para>This command is also available from the button to the right of
+          <para>This command is also available from the button at the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
@@ -373,16 +374,15 @@
           <para>If a single segment is selected, this command opens the
           <guilabel>Split Text</guilabel> dialog. Use the mouse or arrow keys to
           place the cursor at the location where you want to split the text, and
-          click <guibutton>OK</guibutton> or press
+          click the <guibutton>OK</guibutton> button or press
           <keycap>Enter</keycap>.</para>
 
           <para>If two or more segments occupying separate cells in the same row
-          (segments that do not have a <guilabel>Keep</guilabel> check box on
-          the same line as their cell) are selected, this command will split
-          them the selected cells back into separate rows (with a
+          (multi-cell segments containing lines without a <guilabel>Keep</guilabel> check box) are selected, this command will 
+          split the selected cells back into separate rows (with a
           <guilabel>Keep</guilabel> check box).</para>
 
-		  <para>This command is also available from the button to the right of
+		  <para>This command is also available from the button at the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
@@ -396,7 +396,7 @@
           the same selection one more time merges the contents of all selected
           cells into a single cell.</para>
 
-		  <para>This command is also available from the button to the right of
+		  <para>This command is also available from the button at the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
@@ -415,7 +415,7 @@
 		  <keycombo><keycap>C</keycap><keycap>Enter</keycap></keycombo> to close
 		  it without using the mouse.</para>
 
-		  <para>This command is also available from the button to the right of
+		  <para>This command is also available from the button at the right of
           the main window pane.</para>
         </listitem>
       </varlistentry>
@@ -485,19 +485,19 @@
         <term>Start Pinpoint Align (<keycap>Space</keycap>)</term>
         <listitem>
           <para>If the corresponding segments are several rows apart and you
-          want to quickly align them, use this command to set the first segment
-          and then click on the corresponding segment in the other
+          want to quickly align them, use this command to select the first 
+          segment and then click on the corresponding segment in the other
           column.</para>
 		  
 		  <para>You can also use the arrow keys and press <keycap>Space</keycap>
 		  in the corresponding segment.</para>
 		  
-          <para>Segments aligned with this method are automatically marked as
+          <para>Segments aligned using this method are automatically marked as
           accepted.</para>
 
 		  <para>It can be helpful to run the <guimenuitem>Realign
-          Pending</guimenuitem> command after using pinpoint align a few
-          times.</para>
+          Pending</guimenuitem> command after using the pinpoint align command 
+          a few times.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -29,89 +29,63 @@
 	in the left-hand panel of the window.</para>
 
 	<warning>
-	  <para>If a list of scripts is not displayed on the left side of the script
-	  editor window, use the Scripting window <guimenu>File</guimenu> >
-	  <guimenuitem>Set Scripts Folder...</guimenuitem> menu to locate the place
-	  where scripts are stored.</para>
+	  <para>If no list of scripts is displayed on the left side of 
+	  the script editor window, use the Scripting window <guimenu>File</guimenu> >
+	  <guimenuitem>Set Scripts Folder...</guimenuitem> menu to set 
+	  the location of the scripts.</para>
 	</warning>
 
 	<para>Additional scripts can be found here: <ulink
 	url="https://sourceforge.net/projects/omegatscripts/">OmegaT
-	Scripts</ulink>. Just copy the file and put it in the <link
+	Scripts</ulink>. Just copy the file to the <link
 	linkend="application.folder.scripts"
 	endterm="application.folder.scripts.title"/> folder.</para>
 
-	<para>Some scripts are <emphasis>event</emphasis> based and can be made to
-	be triggered automatically when a given event takes place. Each event
-	corresponds to a subfolder under the <link
-	linkend="application.folder.scripts"
-	endterm="application.folder.scripts.title"/> folder:</para>
+  <para>Some scripts are <emphasis>event</emphasis>-based and can be set to
+  trigger automatically when a given event takes place. Each event corresponds
+  to a subfolder under <link
+  linkend="application.folder.scripts"
+  endterm="application.folder.scripts.title"/>:</para>
 
-	<variablelist>
-	  <varlistentry id="application.folder.scripts.application.shutdown">
-		<term
-		id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
-		<listitem>
-		  <para>Scripts in this folder will be launched before OmegaT shuts
-		  down.</para>
-		</listitem>
-	  </varlistentry>
-	  
-	  <varlistentry id="application.folder.scripts.application.startup">
-		<term
-		id="application.folder.scripts.application.startup.title">application_startup</term>
-		<listitem>
-		  <para>Scripts in this folder will be launched when the scripting
-		  engine is available, shortly after OmegaT is launched.</para>
-		</listitem>
-	  </varlistentry>
+  <variablelist>
+	<varlistentry id="application.folder.scripts.application.shutdown">
+	  <term id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
+	  <listitem><para>Scripts in this folder are launched before OmegaT shuts down.</para></listitem>
+	</varlistentry>
+	<varlistentry id="application.folder.scripts.application.startup">
+	  <term id="application.folder.scripts.application.startup.title">application_startup</term>
+	  <listitem><para>Scripts in this folder are launched as soon as the scripting engine is available, shortly after OmegaT starts.</para></listitem>
+	</varlistentry>
+	<varlistentry id="application.folder.scripts.entry.activated">
+	  <term id="application.folder.scripts.entry.activated.title">entry_activated</term>
+	  <listitem><para>Scripts in this folder are launched when editing a new segment. The segment is in the <code>newEntry></code> binding.</para></listitem>
+	</varlistentry>
+	<varlistentry id="application.folder.scripts.new.file">
+	  <term id="application.folder.scripts.new.file.title">new_file</term>
+	  <listitem><para>Scripts in this folder are launched when the editor switches to the next file in the project. The new filename is in the <code>activeFileName</code> binding.</para></listitem>
+	</varlistentry>
+	<varlistentry id="application.folder.scripts.new.word">
+	  <term id="application.folder.scripts.new.word.title">new_word</term>
+	  <listitem><para>Scripts in this folder are launched when a new word is edited in the Editor window. The new word is available from the <code>newWord</code> binding.</para></listitem>
+	</varlistentry>
+	<varlistentry id="application.folder.scripts.project.changed">
+	  <term id="application.folder.scripts.project.changed.title">project_changed</term>
+	  <listitem><para>Scripts in this folder are launched when the state of the project changes. An <code>eventType</code> object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, or SAVE.</para></listitem>
+	</varlistentry>
+  </variablelist>
 
-	  <varlistentry id="application.folder.scripts.entry.activated">
-		<term
-		id="application.folder.scripts.entry.activated.title">entry_activated</term>
-		<listitem>
-		  <para>Scripts in this folder will be launched when editing a new
-		  segment. The segment is in the "newEntry" binding.</para>
-		</listitem>
-	  </varlistentry>
-
-	  <varlistentry id="application.folder.scripts.new.file">
-		<term id="application.folder.scripts.new.file.title">new_file</term>
-		<listitem>
-		  <para>Scripts in the folder will be launched when the editor switches
-		  to the next file in the project. The new filename is in the
-		  "activeFileName" binding.</para>
-		</listitem>
-	  </varlistentry>
-
-	  <varlistentry id="application.folder.scripts.new.word">
-		<term id="application.folder.scripts.new.word.title">new_word</term>
-		<listitem>
-		  <para>Scripts in the folder will be launched when a new word is edited
-		  in the Editor window. The new word is available with "newWord".</para>
-		</listitem>
-	  </varlistentry>
-
-	  <varlistentry id="application.folder.scripts.project.changed">
-		<term
-		id="application.folder.scripts.project.changed.title">project_changed</term>
-		<listitem>
-		  <para>Scripts in the folder will be launched when the state of the
-		  project changes. An "eventType" object is bound and can take the
-		  following values: CLOSE, COMPILE, CREATE, LOAD, SAVE.</para>
-		</listitem>
-	  </varlistentry>
-	</variablelist>
-
-	<warning>
-	  <para>Scripts are also launched when you are executing other scripts. That
-	  means that on a large project, an "entry_activated" script will be called
-	  a lot of time when using a search/replace type of script that loops
-	  through all the segments, rendering the application unresponsive. </para>
-	</warning>
+  <para>The folders are already created in the script folder that comes with the
+  distribution.</para>
+  
+  <warning>
+	<para>Scripts are also launched when you are executing other scripts. 
+	Consequently, in a large project, an <code>entry_activated</code> script is
+  called frequently when a search/replace type of script that
+  loops through all segments is used, rendering the application
+  unresponsive.</para>
+  </warning>
   </section>
   
-
   <section id="windows.scripts.usage">
 	<title id="windows.scripts.usage.title">Usage</title>
 
@@ -122,7 +96,7 @@
       </listitem>
 
       <listitem>
-		<para>Click <guibutton>Run</guibutton> at the bottom of the window, or
+		<para>Click the <guibutton>Run</guibutton> button at the bottom of the window, or
 		press <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo> to
 		launch the script immediately.</para>
       </listitem>
@@ -174,7 +148,7 @@
     directly, or to write new scripts for your own use.</para>
 
 	<note>
-	  <para>The scripts distributed with OmegaT are here for your convenience
+	  <para>The scripts distributed with OmegaT are included for your convenience
 	  but are not supported by the OmegaT development team.</para>
 	</note>
 	
@@ -206,7 +180,7 @@
         Same Segment</term>
 
         <listitem>
-          <para>Check for identical segments (case sensitive)</para>
+          <para>Check for identical segments (case sensitive).</para>
         </listitem>
       </varlistentry>
 
@@ -230,7 +204,7 @@
         GUI Scripting</term>
 
         <listitem>
-          <para>Example of GUI scripting</para>
+          <para>Example of GUI scripting.</para>
         </listitem>
       </varlistentry>
 
@@ -250,7 +224,7 @@
         Modify Segment</term>
 
         <listitem>
-          <para>Example showing how to modify a segment.</para>
+          <para>Example that shows how to modify a segment.</para>
         </listitem>
       </varlistentry>
 
@@ -287,7 +261,7 @@
           <para>Extracts the content of the project to a single text file (one
           line per segment). See <ulink
           url="https://sourceforge.net/p/omegat/feature-requests/182/">RFE#182
-          Extracts the content of the projects to text file</ulink></para>
+          Extracts the content of the projects to text file</ulink>.</para>
         </listitem>
       </varlistentry>
 
@@ -325,7 +299,7 @@
         Project Folder</term>
 
         <listitem>
-          <para>Open the project folder in the operating system.</para>
+          <para>Open the project folder in the default file manager.</para>
         </listitem>
       </varlistentry>
 
@@ -334,7 +308,7 @@
         Folder</term>
 
         <listitem>
-          <para>Open the /tm folder.</para>
+          <para>Open the <filename class="directory">/tm</filename> folder.</para>
         </listitem>
       </varlistentry>
 
@@ -482,7 +456,7 @@
           programming styles. See <ulink
           url="https://developer.oracle.com/databases/nashorn-javascript-part1.html">Practical
           Nashorn, Part 1: Introducing JavaScript, ECMAScript, and
-          Nashorn</ulink></para>
+          Nashorn</ulink>.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc_src/en/Windows_SourceFilesList.xml
+++ b/doc_src/en/Windows_SourceFilesList.xml
@@ -6,7 +6,7 @@
   Files</guilabel></title>
 
   <para>This window is displayed automatically when OmegaT loads a project, and
-  at any time by using <link linkend="menus.project"
+  can be called at any time using <link linkend="menus.project"
   endterm="menus.project.title"/><link linkend="menus.project.source.files.list"
   endterm="menus.project.source.files.list.title"/>.</para>
 
@@ -14,7 +14,7 @@
 
   <itemizedlist>
     <listitem>
-      <para>in the window title: the total number of translatable files in the
+      <para>In the window title: the total number of translatable files in the
       project.</para>
 
 	  <para>These are the files present in the <link
@@ -23,7 +23,7 @@
     </listitem>
 
     <listitem>
-      <para>as a list: all the translatable files in the project.</para>
+      <para>As a list: all translatable files in the project.</para>
 
 	  <para>Clicking on any file will open it in the <link
 	  linkend="panes.editor" endterm="panes.editor.title"/> pane for
@@ -31,8 +31,8 @@
     </listitem>
 
     <listitem>
-      <para>File entries include their names, file filter types, their
-      encoding and the number of segments each file contains</para>
+      <para>Each file entry lists its name, file filter type, 
+      encoding, and the number of segments it contains</para>
     </listitem>
 
     <listitem>
@@ -42,24 +42,24 @@
     </listitem>
   </itemizedlist>
 
-  <para>Typing any text will open a <guilabel>Filter</guilabel> field at the
+  <para>Typing any text opens a <guilabel>Filter</guilabel> field at the
   bottom of the window where parts of filenames can be entered. You can use
-  arrows to select a file, and open it for translation by pressing
-  <keycap>Enter</keycap>.</para>
+  arrows to select a file, and press <keycap>Enter</keycap> to open it for 
+  translation.</para>
 
   <note>
-	<para>Filenames (in the first column) can be sorted alphabetically by
-	clicking in the header. It is also possible to change the position of a
-	filename, by clicking on it and pressing the <guibutton>Move ...</guibutton>
-	button on the right.</para>
+	<para>Filenames (the first column) can be sorted alphabetically by
+	clicking the header. You can change the position of a file by selecting it
+	and clicking one of the <guibutton>Move...</guibutton> buttons
+  on the right.</para>
   </note>
 
-  <para>Right-clicking on a filename opens a popup that allows opening the
-  source file and (if it exists) the target file.</para>
+  <para>Right-clicking a filename brings up a popup menu that lets you open the
+  source file or the target file (if it exists).</para>
 
   <para>The number of <emphasis role="bold">Unique</emphasis> segments is
-  calculated by removing the number of duplicate segments from the total segment
-  number.</para>
+  calculated by removing the number of duplicate segments from the total
+  number of segments.</para>
 
   <para>The difference between &quot;Number of segments&quot; and &quot;Number
   of unique segments&quot; provides an approximate idea of the number of
@@ -68,11 +68,11 @@
   endterm="menus.tools.statistics.title"/> to obtain more information.</para>
 
   <para>Modifying the segmentation rules may alter the number of segments/unique
-  segments. This, however, should generally be avoided once you have started
+  segments. This, however, should generally be avoided after you have started
   translating the project. See the <link linkend="app.segmentation"
   endterm="app.segmentation.title"/> appendix for details.</para>
 
-  <para>The buttons at the bottom can be used to add files to your project:</para>
+  <para>The buttons at the bottom of the window can be used to add files to your project:</para>
   
   <variablelist>
 	<varlistentry id="windows.source.files.list.copy.files">
@@ -89,7 +89,7 @@
 	  <term id="windows.source.files.list.download.page.title"><guibutton>Add
 	  Online MediaWiki Page...</guibutton></term>
 	  <listitem>
-		<para>Asks for the page URL and downloads it into the <link
+		<para>Asks for the URL of the page and downloads it into the <link
 		linkend="project.folder.source" endterm="project.folder.source.title"/>
 		folder.</para>
 	  </listitem>
@@ -105,10 +105,10 @@
   endterm="menus.project.download.mediawiki.page.title"/> menu items.</para>
   
   <note>
-	<para>To keep the Source Files list window to automatically open when a
-	project is loaded, you can manually change the <link
+	<para>You can manually edit the <link
 	linkend="configuration.folder.default.contents.omegat.prefs"
 	endterm="configuration.folder.default.contents.omegat.prefs.title"/>
-	configuration file.</para>
+	configuration file to prevent the Source Files list window from opening
+  automatically when a project is loaded.</para>
   </note>
 </section>

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -60,9 +60,9 @@
     <listitem>
         <para><guibutton>Replace:</guibutton> replaces each entry one at a time
         in the Editor pane.</para>
-		<para>Click <guibutton>Replace Next</guibutton> or
-		<guibutton>Skip</guibutton>, to move to the next entry, and click
-		<guibutton>Finish</guibutton> to end the replacement operation.</para>
+		<para>Clickthe <guibutton>Replace Next</guibutton> or
+		<guibutton>Skip</guibutton> button, to move to the next entry, and click the
+		<guibutton>Finish</guibutton> button to end the replacement operation.</para>
     </listitem>
   </itemizedlist>
 
@@ -131,7 +131,7 @@
       <varlistentry id="windows.text.replace.methods.exact">
         <term id="windows.text.replace.methods.exact.title">Exact search</term>
         <listitem>
-          <para>Search for the string exactly as it was entered in the search
+          <para>Search for the string exactly as entered in the search
           field.</para>
 
 		  <para>It is equivalent to a web search enclosed in quotation marks.</para>
@@ -173,8 +173,9 @@
 
 		  <note>
 			<para>The replacement string supports references to groups defined
-			in the search string. Use <code>$n</code> in the replacement field
-			to refer to the <code>nth</code> group in the search field.</para>
+			in the search string. Use <code>$n</code> (where <code>n</code> is a
+			digit from 1 to 9) in the replacement field to refer to the
+			<code>nth</code>group in the search field.</para>
 		  </note>
         </listitem>
       </varlistentry>
@@ -219,14 +220,14 @@
 			<varlistentry>
 			  <term>Full/Half-width char insensitive</term>
 			  <listitem>
-				<para>returns results that match both the full- and half-width
+				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
 				terms.</para>
 			  </listitem>
 			</varlistentry>
 		  </variablelist>
-		  <para>Hide the advanced options with <guibutton>Hide Advanced
-		  Options</guibutton></para>
+		  <para>Use the <guibutton>Hide Advanced Options</guibutton>
+			button to stop showing the advanced options.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -9,9 +9,9 @@
   endterm="menus.edit.search.project.title"/> to open a new search window and
   enter the word or phrase you wish to search for in the search field.</para>
   
-  <para>You can have several search windows opened at the same time. Use
+  <para>You can have several search windows opened at the same time. Hit
   <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>F</keycap></keycombo> to
-  call the last search window.</para>
+  reuse the most recent search window.</para>
 
   <para>Alternatively, select a word or phrase in the <link
   linkend="panes.editor" endterm="panes.editor.title"/>, <link
@@ -99,7 +99,7 @@
       <varlistentry id="windows.text.search.methods.exact">
         <term id="windows.text.search.methods.exact.title">Exact search</term>
         <listitem>
-          <para>Search for the string exactly as it was entered in the search
+          <para>Search for the string exactly as entered in the search
           field.</para>
 
 		  <para>It is equivalent to a web search enclosed in quotation marks.</para>
@@ -248,7 +248,7 @@
 	  <varlistentry>
 		<term>Display: file names</term>
 		<listitem>
-		  <para>The name of the file containing the segment is found is
+		  <para>The name of the file where the segment is found is
 		  displayed above each result.</para>
 		</listitem>
 	  </varlistentry>
@@ -264,27 +264,27 @@
 			<varlistentry>
 			  <term>Memory</term>
 			  <listitem>
-				<para>include the project memory (<link
+				<para>Include the project memory (<link
 				linkend="project.folder.project.save.tmx"
-				endterm="project.folder.project.save.tmx.title"/>)</para>
+				endterm="project.folder.project.save.tmx.title"/>).</para>
 			  </listitem>
 			</varlistentry>
 
 			<varlistentry>
 			  <term>TMs</term>
 			  <listitem>
-				<para>include the translation memories located in the <link
+				<para>Include the translation memories located in the <link
 				linkend="project.folder.tm" endterm="project.folder.tm.title"/>
-				folder</para>
+				folder.</para>
 			  </listitem>
 			</varlistentry>
 
 			<varlistentry>
 			  <term>Glossaries</term>
 			  <listitem>
-				<para>include the glossaries located in the <link
+				<para>Include the glossaries located in the <link
 				linkend="project.folder.glossary"
-				endterm="project.folder.glossary.title"/> folder</para>
+				endterm="project.folder.glossary.title"/> folder.</para>
 			  </listitem>
 			</varlistentry>
 		  </variablelist>
@@ -318,7 +318,7 @@
 			<varlistentry>
 			  <term>Full/Half-width char insensitive</term>
 			  <listitem>
-				<para>returns results that match both the full- and half-width
+				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
 				terms.</para>
 			  </listitem>
@@ -327,13 +327,14 @@
 			<varlistentry>
 			  <term>Number of matching segments</term>
 			  <listitem>
-				<para>sets the maximum number of matches displayed in the search
+				<para>Sets the maximum number of matches displayed in the search
 				result area.</para>
 			  </listitem>
 			</varlistentry>
 		  </variablelist>
 
-		  <para>Hide the advanced options with <guibutton>Hide Advanced Options</guibutton></para>
+		  <para>Use the <guibutton>Hide Advanced Options</guibutton> button to stop showing
+			the advanced options.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
@@ -409,11 +410,11 @@
   <section id="windows.text.search.filter">
     <title id="windows.text.search.filter.title">Filter</title>
 
-	<para>Click on <guibutton>Filter</guibutton> to show only the matching
-	search result segments in the <link linkend="panes.editor"
-	endterm="panes.editor.title"/> pane. To remove the filter, click on
-	<guibutton>Remove Filter</guibutton> at the top of the <link
-	linkend="panes.editor" endterm="panes.editor.title"/> pane or reload the
+	<para>Click on the <guibutton>Filter</guibutton> button to show only the 
+	matching search result segments in the <link linkend="panes.editor"
+	endterm="panes.editor.title"/> pane. To remove the filter, click on the
+	<guibutton>Remove Filter</guibutton> button at the top of the <link
+	linkend="panes.editor" endterm="panes.editor.title"/> pane, or reload the
 	project.</para>
   </section>
 </section>

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -392,8 +392,8 @@ TF_MENU_EDIT_GOTO=&Segment Number...
 TF_MENU_GOTO_NEXT_UNIQUE=Next Uni&que Segment
 TF_MENU_GOTO_SELECTED_MATCH_SOURCE=Source of Selected &Match
 
-TF_MENU_GOTO_FORWARD_IN_HISTORY=&Forward in History
 TF_MENU_GOTO_BACK_IN_HISTORY=&Back in History
+TF_MENU_GOTO_FORWARD_IN_HISTORY=&Forward in History
 
 TF_MENU_GOTO_X_SUBMENU=Auto-Popu&lated Segments
 TF_MENU_GOTO_NEXT_XAUTO=&Next Segment from tm/auto/

--- a/src/org/omegat/gui/main/MainWindowMenu.java
+++ b/src/org/omegat/gui/main/MainWindowMenu.java
@@ -376,8 +376,8 @@ public class MainWindowMenu implements ActionListener, MenuListener, IMainMenu {
         gotoXEntrySubmenu.add(gotoNextXEnforcedMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_XENFORCED"));
         gotoXEntrySubmenu.add(gotoPrevXEnforcedMenuItem = createMenuItem("TF_MENU_GOTO_PREV_XENFORCED"));
         gotoMenu.addSeparator();
-        gotoMenu.add(gotoHistoryForwardMenuItem = createMenuItem("TF_MENU_GOTO_FORWARD_IN_HISTORY"));
         gotoMenu.add(gotoHistoryBackMenuItem = createMenuItem("TF_MENU_GOTO_BACK_IN_HISTORY"));
+        gotoMenu.add(gotoHistoryForwardMenuItem = createMenuItem("TF_MENU_GOTO_FORWARD_IN_HISTORY"));
         gotoMenu.addSeparator();
         gotoMenu.add(gotoNotesPanelMenuItem = createMenuItem("TF_MENU_GOTO_NOTES_PANEL"));
         gotoMenu.add(gotoEditorPanelMenuItem = createMenuItem("TF_MENU_GOTO_EDITOR_PANEL"));


### PR DESCRIPTION
Revision of the pane chapter, consisting mainly of phrasing changes to tighten up wording, and fixing typos.

There is one major change:
In the note giving examples of modifications translators can make to the editor to adapt it to their workflow, I changed the text of  item (starting on Line #430) about inserting source text to match the new proposed default.

