### PR TITLE
Use appropriate verbs in the View menu

### DIFF
--- a/doc_src/en/App_Bidi.xml
+++ b/doc_src/en/App_Bidi.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"../../../docbook-xml-4.5/docbookx.dtd">
+<section id="app.bidi">
+  <title id="app.bidi.title">Directional Formatting Characters</title>
+
+  <para>Bidi control characters can be found in the menu <link
+  linkend="menus.edit" endterm="menus.edit.title"/><link
+  linkend="menus.edit.insert.unicode.control.character"
+  endterm="menus.edit.insert.unicode.control.character.title"/> and may be used
+  to:</para>
+
+  <itemizedlist>
+	<listitem>
+	  <para>insert an invisible character with a certain strong directionality
+	  to force a specific position for a character with weak or neutral
+	  directionality</para>
+	</listitem>
+	<listitem>
+	  <para>create an embedding which works as a sort of protective environment
+	  within which text can flow in the opposite direction of the
+	  segment.</para>
+	</listitem>
+  </itemizedlist>
+  
+  <para>These control characters can change directionality but are
+  invisible. Use <link linkend="menus.view" endterm="menus.view.title"/><link
+  linkend="menus.view.mark.bidirectional.algorithm.control.character"
+  endterm="menus.view.mark.bidirectional.algorithm.control.character.title"/> to
+  see a visual hint of where these characters are inserted.</para>
+
+  <section id="app.bidi.marks">
+	<title id="app.bidi.marks.title">Marks</title>
+
+	<para>To change the position of a character with weak or neutral
+	directionality (like punctuation symbols), insert a LRM or a RLM character
+	after the character, depending on the directionality of the segment:</para>
+
+	<itemizedlist>
+	  <listitem>
+		<para>Insert a LRM after a weak-directionality character that must run
+		left-to-right in a right-to-left segment (e.g. an English excerpt inside
+		Arabic text)</para>
+	  </listitem>
+	  <listitem>
+		<para>Insert a RLM after a weak-directionality character that must run
+		right-to-left in a left-to-right segment (e.g. an Arabic excerpt inside
+		English text)</para>
+	  </listitem>
+	</itemizedlist>
+  </section>
+
+  <section id="app.bidi.embeddings">
+	<title id="app.bidi.embeddings.title">Embeddings</title>
+
+	<para>Embeddings can be used to create a longer portion of text (containing
+	several words and spaces) that must run in the opposite directionality of
+	that of the segment. You can create two kinds of embeddings depending on the
+	directionality of the segment:</para>
+
+	<itemizedlist>
+	  <listitem>
+		<para>To create a left-to-right embedding in a right-to-left segment,
+		insert a left-to-right embedding (LRE) character, then type or insert
+		the left-to-right text, then insert the pop directional formatting (PDF)
+		character.</para>
+	  </listitem>
+	  <listitem>
+		<para>To create a
+  right-to-left embedding in a left-to-right segment, you would insert a
+  right-to-left embedding (RLE) character, then type or insert the right-to-left
+		text, then insert the PDF character.</para>
+	  </listitem>
+	</itemizedlist>
+  </section>
+</section>

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -372,11 +372,12 @@
 
 	<varlistentry id="menus.edit.insert.unicode.control.character">
       <term id="menus.edit.insert.unicode.control.character.title"><guisubmenu>Insert
-      Unicode Control Character</guisubmenu></term>
+      Bidi Control Character</guisubmenu></term>
 	  <listitem>
-		<para>Inserts the selected Unicode control character. See <ulink
-		url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
-		Algorithm</ulink> for details.</para>
+		<para>Inserts the selected Unicode directional formatting character. See
+		<ulink
+		url="https://www.unicode.org/reports/tr9/#Directional_Formatting_Characters">Unicode
+		Bidirectional Algorithm</ulink> for details.</para>
 
 		<itemizedlist>
 		  <listitem>
@@ -399,6 +400,12 @@
 			<para><guimenuitem>Pop Directional Formatting (PDF U+202C)</guimenuitem></para>
 		  </listitem>
 		</itemizedlist>
+		<para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
+		linkend="menus.view.mark.bidirectional.algorithm.control.character"
+		endterm="menus.view.mark.bidirectional.algorithm.control.character.title"
+		/> to display the characters for easier manipulation. See <link
+		linkend="app.bidi" endterm="app.bidi.title"/> for details.</para>
+
       </listitem>
 	</varlistentry>
 

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -6,29 +6,33 @@
   <para>This menu allows you to select the information you want to OmegaT to
   display.</para>
 
+  <para>All the colors indicated in the descriptions can be modified in the
+  <link linkend="dialogs.preferences.colours"
+  endterm="dialogs.preferences.colours.title"/> preference.</para>
+
   <variablelist>
     <varlistentry id="menus.view.mark.translated.segments">
       <term
-		  id="menus.view.mark.translated.segments.title"><guimenuitem>Translated
-      Segments</guimenuitem></term>
+      id="menus.view.mark.translated.segments.title"><guimenuitem>Highlight
+      Translated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, translated segments will be marked in yellow.</para>
+        <para>If checked, translated segments will be highlighted in yellow.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.untranslated.segments">
       <term
-      id="menus.view.mark.untranslated.segments.title"><guimenuitem>Untranslated
-      Segments</guimenuitem></term>
+      id="menus.view.mark.untranslated.segments.title"><guimenuitem>Highlight
+      Untranslated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, untranslated segments will be marked in violet.</para>
+        <para>If checked, untranslated segments will be highlighted in violet.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.paragraph.delimitations">
       <term
-      id="menus.view.mark.paragraph.delimitations.title"><guimenuitem>Paragraph
-      Delimitations</guimenuitem></term>
+      id="menus.view.mark.paragraph.delimitations.title"><guimenuitem>Display
+      Paragraph Delimitations</guimenuitem></term>
       <listitem>
         <para>If checked, separations between paragraphs in the source document
         are indicated visually. You can change the paragraph delimitation string
@@ -40,40 +44,40 @@
     </varlistentry>
 
     <varlistentry id="menus.view.display.source.segments">
-      <term id="menus.view.display.source.segments.title"><guimenuitem>Source
-      Segments</guimenuitem></term>
+      <term id="menus.view.display.source.segments.title"><guimenuitem>Display
+      Source Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, all the source segments will be shown and marked in
-        green.  If not checked, only the current source segments will be
+        <para>If checked, all the source segments will be shown and highlighted
+        in green.  If not checked, only the current source segments will be
         shown.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.unique.segments">
       <term
-      id="menus.view.mark.non.unique.segments.title"><guimenuitem>Non-Unique
-      Segments</guimenuitem></term>
+      id="menus.view.mark.non.unique.segments.title"><guimenuitem>Highlight
+      Non-Unique Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, non-unique segments will be marked in pale
+        <para>If checked, non-unique segments will be highlighted in pale
         gray.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.segments.with.notes">
-      <term id="menus.view.mark.segments.with.notes.title"><guimenuitem>Segments
-      with Notes</guimenuitem></term>
+      <term
+      id="menus.view.mark.segments.with.notes.title"><guimenuitem>Highlight
+      Segments with Notes</guimenuitem></term>
       <listitem>
-        <para>If checked, segments with notes will be marked in cyan. This
-        marking has priority over <guimenuitem>Mark Translated
-        Segments</guimenuitem> and <guimenuitem>Mark Untranslated
+        <para>If checked, segments with notes will be highlighted in cyan. This
+        marking has priority over <guimenuitem>Highlight Translated
+        Segments</guimenuitem> and <guimenuitem>Highlight Untranslated
         Segments</guimenuitem>.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.breakable.space">
-      <term
-      id="menus.view.mark.non.breakable.space.title"><guimenuitem>Non-Breakable
-      Spaces</guimenuitem></term>
+      <term id="menus.view.mark.non.breakable.space.title"><guimenuitem>Display
+      Non-Breakable Spaces</guimenuitem></term>
       <listitem>
         <para>If checked, non-breakable spaces will be displayed with a gray
         background.</para>
@@ -81,8 +85,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.white.space">
-      <term
-      id="menus.view.mark.white.space.title"><guimenuitem>Whitespace</guimenuitem></term>
+      <term id="menus.view.mark.white.space.title"><guimenuitem>Display
+      Whitespace</guimenuitem></term>
       <listitem>
         <para>If checked, white spaces will be displayed with a small
         dot.</para>
@@ -91,8 +95,8 @@
 
     <varlistentry id="menus.view.mark.bidirectional.algorithm.control.character">
       <term
-      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>Bidi
-      Control Characters</guimenuitem></term>
+      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>Display
+      Bidi Control Characters</guimenuitem></term>
       <listitem>
         <para>This option displays Unicode directional formatting characters. See <ulink
         url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
@@ -107,11 +111,11 @@
 
     <varlistentry id="menus.view.mark.auto.populated.segments">
       <term
-      id="menus.view.mark.auto.populated.segments.title"><guimenuitem>Auto-Populated
-      Segments</guimenuitem></term>
+      id="menus.view.mark.auto.populated.segments.title"><guimenuitem>Highlight
+      Auto-Populated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, segments that have been auto-populated are marked in
-        various colors.</para>
+        <para>If checked, segments that have been auto-populated will be
+        displayed in various colors.</para>
 
 		<para>See the <link
 		linkend="dialogs.preferences.editor.save.auto-populated.status"
@@ -121,8 +125,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.glossary.matches">
-      <term id="menus.view.mark.glossary.matches.title"><guimenuitem>Glossary
-      Matches</guimenuitem></term>
+      <term id="menus.view.mark.glossary.matches.title"><guimenuitem>Mark
+      Glossary Matches</guimenuitem></term>
       <listitem>
         <para>Underlines source terms that have a match in the
         glossaries. Hovering on an underlined term displays the matching target
@@ -133,8 +137,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.language.checker">
-      <term id="menus.view.mark.language.checker.title"><guimenuitem>Language
-      Checker</guimenuitem></term>
+      <term id="menus.view.mark.language.checker.title"><guimenuitem>Mark
+      Language Checker Issues</guimenuitem></term>
       <listitem>
         <para>Underlines parts of the target where LanguageTool has found
         errors. See the <link linkend="dialog.preferences.languagetool.plugin"
@@ -144,9 +148,8 @@
     </varlistentry>
 	
     <varlistentry id="menus.view.aggressive.font.fallback">
-      <term
-      id="menus.view.aggressive.font.fallback.title"><guimenuitem>Aggressive
-      Font Fallback</guimenuitem></term>
+      <term id="menus.view.aggressive.font.fallback.title"><guimenuitem>Use
+      Aggressive Font Fallback</guimenuitem></term>
       <listitem>
         <para>Check this option in case OmegaT does not display certain glyphs
         properly (even if the fonts containing the relevant glyphs are installed
@@ -161,8 +164,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.modification.info">
-      <term id="menus.view.modification.info.title"><guisubmenu>Modification
-      Info</guisubmenu></term>
+      <term id="menus.view.modification.info.title"><guisubmenu>Display
+      Modification Info</guisubmenu></term>
       <listitem>
         <para>Displays the time and the author of the last change made to a
         segment.</para>

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -16,7 +16,7 @@
       id="menus.view.mark.translated.segments.title"><guimenuitem>Highlight
       Translated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, translated segments will be highlighted in yellow.</para>
+        <para>If checked, translated segments are highlighted in yellow.</para>
       </listitem>
     </varlistentry>
 
@@ -25,7 +25,7 @@
       id="menus.view.mark.untranslated.segments.title"><guimenuitem>Highlight
       Untranslated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, untranslated segments will be highlighted in violet.</para>
+        <para>If checked, untranslated segments are highlighted in violet.</para>
       </listitem>
     </varlistentry>
 
@@ -47,8 +47,8 @@
       <term id="menus.view.display.source.segments.title"><guimenuitem>Display
       Source Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, all the source segments will be shown and highlighted
-        in green.  If not checked, only the current source segments will be
+        <para>If checked, all the source segments are shown and highlighted
+        in green.  If not checked, only the current source segments is
         shown.</para>
       </listitem>
     </varlistentry>
@@ -58,7 +58,7 @@
       id="menus.view.mark.non.unique.segments.title"><guimenuitem>Highlight
       Non-Unique Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, non-unique segments will be highlighted in pale
+        <para>If checked, non-unique segments are highlighted in pale
         gray.</para>
       </listitem>
     </varlistentry>
@@ -68,7 +68,7 @@
       id="menus.view.mark.segments.with.notes.title"><guimenuitem>Highlight
       Segments with Notes</guimenuitem></term>
       <listitem>
-        <para>If checked, segments with notes will be highlighted in cyan. This
+        <para>If checked, segments with notes are highlighted in cyan. This
         marking has priority over <guimenuitem>Highlight Translated
         Segments</guimenuitem> and <guimenuitem>Highlight Untranslated
         Segments</guimenuitem>.</para>
@@ -79,7 +79,7 @@
       <term id="menus.view.mark.non.breakable.space.title"><guimenuitem>Display
       Non-Breakable Spaces</guimenuitem></term>
       <listitem>
-        <para>If checked, non-breakable spaces will be displayed with a gray
+        <para>If checked, non-breakable spaces are displayed with a gray
         background.</para>
       </listitem>
     </varlistentry>
@@ -88,7 +88,7 @@
       <term id="menus.view.mark.white.space.title"><guimenuitem>Display
       Whitespace</guimenuitem></term>
       <listitem>
-        <para>If checked, white spaces will be displayed with a small
+        <para>If checked, white spaces are displayed with a small
         dot.</para>
       </listitem>
     </varlistentry>
@@ -114,8 +114,8 @@
       id="menus.view.mark.auto.populated.segments.title"><guimenuitem>Highlight
       Auto-Populated Segments</guimenuitem></term>
       <listitem>
-        <para>If checked, segments that have been auto-populated will be
-        displayed in various colors.</para>
+        <para>If checked, segments that have been auto-populated are
+        highlighted in various colors.</para>
 
 		<para>See the <link
 		linkend="dialogs.preferences.editor.save.auto-populated.status"

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -91,12 +91,17 @@
 
     <varlistentry id="menus.view.mark.bidirectional.algorithm.control.character">
       <term
-      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>BiDi
+      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>Bidi
       Control Characters</guimenuitem></term>
       <listitem>
-        <para>This option displays <ulink
+        <para>This option displays Unicode directional formatting characters. See <ulink
         url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
-        Algorithm</ulink></para>
+        Algorithm</ulink> for details.</para>
+		<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
+		linkend="menus.edit.insert.unicode.control.character"
+		endterm="menus.edit.insert.unicode.control.character.title"/> to insert
+		a selection of characters directly from the OmegaT interface. See <link
+		linkend="app.bidi" endterm="app.bidi.title"/> for details.</para>
 	  </listitem>
     </varlistentry>
 

--- a/doc_src/en/OmegaT5_Appendices.xml
+++ b/doc_src/en/OmegaT5_Appendices.xml
@@ -16,6 +16,9 @@
   <xi:include href="App_Glossaries.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
+  <xi:include href="App_Bidi.xml"
+              xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
   <xi:include href="App_PostProcessingCommands.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -362,7 +362,7 @@ TF_MENU_EDIT_COMPARE_4=Select Match #&4
 TF_MENU_EDIT_COMPARE_5=Select Match #&5
 
 ## The right-click menu in Windows Notepad contains similar terms and can be used as a reference
-TF_MENU_EDIT_INSERT_CHARS=Insert Unicode Control C&haracter
+TF_MENU_EDIT_INSERT_CHARS=Insert Bidi Control C&haracter
 TF_MENU_EDIT_INSERT_CHARS_LRM=Left-to-Right Mark (LRM U+200&E)
 TF_MENU_EDIT_INSERT_CHARS_RLM=Right-to-Left Mark (RLM U+200&F)
 TF_MENU_EDIT_INSERT_CHARS_LRE=Left-to-Right Embedding (LRE U+202&A)
@@ -419,7 +419,7 @@ MW_VIEW_MENU_MARK_NOTED_SEGMENTS=Mark Segments &with Notes
 
 MW_VIEW_MENU_MARK_NBSP=Mark &Non-Breakable Spaces
 MW_VIEW_MENU_MARK_WHITESPACE=Mar&k Whitespace
-MW_VIEW_MENU_MARK_BIDI=Mark &Bidirectional Algorithm Control Characters
+MW_VIEW_MENU_MARK_BIDI=Mark &Bidi Control Characters
 
 MW_VIEW_MENU_MARK_AUTOPOPULATED=Mark &Auto-Populated Segments
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -408,30 +408,30 @@ TF_MENU_GOTO_EDITOR_PANEL=Editor Pane
 
 MW_VIEW_MENU=&View
 
-TF_MENU_DISPLAY_MARK_TRANSLATED=Mark &Translated Segments
-TF_MENU_DISPLAY_MARK_UNTRANSLATED=Mark &Untranslated Segments
-TF_MENU_DISPLAY_MARK_PARAGRAPH=Mark &Paragraph Delimitations
+TF_MENU_DISPLAY_MARK_TRANSLATED=Highlight &Translated Segments
+TF_MENU_DISPLAY_MARK_UNTRANSLATED=Highlight &Untranslated Segments
+TF_MENU_DISPLAY_MARK_PARAGRAPH=Display &Paragraph Delimitations
 
 MW_VIEW_MENU_DISPLAY_SEGMENT_SOURCES=Display &Source Segments
-MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS=Mark Non-Unique Se&gments
+MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS=Highlight Non-Unique Se&gments
 
-MW_VIEW_MENU_MARK_NOTED_SEGMENTS=Mark Segments &with Notes
+MW_VIEW_MENU_MARK_NOTED_SEGMENTS=Highlight Segments &with Notes
 
-MW_VIEW_MENU_MARK_NBSP=Mark &Non-Breakable Spaces
-MW_VIEW_MENU_MARK_WHITESPACE=Mar&k Whitespace
-MW_VIEW_MENU_MARK_BIDI=Mark &Bidi Control Characters
+MW_VIEW_MENU_MARK_NBSP=Display &Non-Breakable Spaces
+MW_VIEW_MENU_MARK_WHITESPACE=Displa&y Whitespace
+MW_VIEW_MENU_MARK_BIDI=Display &Bidi Control Characters
 
-MW_VIEW_MENU_MARK_AUTOPOPULATED=Mark &Auto-Populated Segments
+MW_VIEW_MENU_MARK_AUTOPOPULATED=Highlight &Auto-Populated Segments
 
 MW_VIEW_GLOSSARY_MARK=Mark Gl&ossary Matches
-LT_OPTIONS_MENU_ENABLED=&Language Checker
+LT_OPTIONS_MENU_ENABLED=Mark &Language Checker Issues
 
-MW_VIEW_MENU_MARK_FONT_FALLBACK=Aggressive &Font Fallback
+MW_VIEW_MENU_MARK_FONT_FALLBACK=Use Aggressive &Font Fallback
 
-MW_VIEW_MENU_MODIFICATION_INFO=&Modification Info
-MW_VIEW_MENU_MODIFICATION_INFO_NONE=Display &None
-MW_VIEW_MENU_MODIFICATION_INFO_SELECTED=Display for Current &Segment
-MW_VIEW_MENU_MODIFICATION_INFO_ALL=Display for &All Segments
+MW_VIEW_MENU_MODIFICATION_INFO=Display &Modification Info
+MW_VIEW_MENU_MODIFICATION_INFO_NONE=&None
+MW_VIEW_MENU_MODIFICATION_INFO_SELECTED=for Current &Segment
+MW_VIEW_MENU_MODIFICATION_INFO_ALL=for &All Segments
 
 MW_OPTIONSMENU_RESTORE_GUI=&Restore Main Window
 


### PR DESCRIPTION
A review of the View menu reached the conclusion that more appropriate verbs should be used.

## Which ticket is resolved?

https://sourceforge.net/p/omegat/documentation/401/

## What does this PR change?

- This PR modifies the items in the View menu with verbs that better describes the action
- It modifies the descriptions in the manual to reflect the changes
- It adds a reference to the Color preference so that the user knows where to change the colors used.
