### PR TITLE
Filters: fix to catch exception when loading file and ignore when failure

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -499,6 +499,8 @@ MW_OPTIONMENU_APPEARANCE_THEME_LABEL=Theme:
 MW_REOPEN_QUESTION=OmegaT needs to reload the project to take the modifications into account.\n\
 Reload the project now?
 
+TF_SOURCE_LOAD_ERROR=Failed to load source file {0} in specified project!
+
 TF_TM_LOAD_ERROR=Failed to load translation memory {0} for project!
 
 TF_LOAD_ERROR=Failed to load specified project!

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -671,6 +671,7 @@ CT_AUTOCREATE_DIRECTORY=Folder {0} was automatically created for team mode proje
 CT_LOAD_FILE_MX=Loading: {0}
 
 CT_LOAD_SRC_COMPLETE=Source file loading complete
+CT_LOAD_SRC_SKIP_FILES=Source files loaded but skipping files(s) by filter error(s)
 
 CT_LOAD_TMX=Loading TMX files...
 CT_LOAD_TMX_CREATE_BACKUP=Completed and current translations saved as {0}

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -499,10 +499,9 @@ MW_OPTIONMENU_APPEARANCE_THEME_LABEL=Theme:
 MW_REOPEN_QUESTION=OmegaT needs to reload the project to take the modifications into account.\n\
 Reload the project now?
 
-TF_SOURCE_LOAD_ERROR=Failed to load source file {0} in specified project!
+TF_SOURCE_LOAD_ERROR=Skipped source file {0} because it could not be loaded.
 
 TF_TM_LOAD_ERROR=Failed to load translation memory {0} for project!
-
 TF_LOAD_ERROR=Failed to load specified project!
 
 TF_COMPILE_ERROR=Failed to create the translated files!

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -110,14 +110,15 @@ import org.omegat.util.gui.UIThreadsUtil;
 import gen.core.filters.Filters;
 
 /**
- * Loaded project implementation. Only translation could be changed after project will be loaded and set by
- * Core.setProject.
+ * Loaded project implementation. Only translation could be changed after
+ * project will be loaded and set by Core.setProject.
  *
- * All components can read all data directly without synchronization. All synchronization implemented inside
- * RealProject.
+ * All components can read all data directly without synchronization. All
+ * synchronization implemented inside RealProject.
  *
- * Since team sync is long operation, auto-saving was split into 3 phrases: get remote data in background, then rebase
- * during segment deactivation, then commit in background.
+ * Since team sync is long operation, auto-saving was split into 3 phrases: get
+ * remote data in background, then rebase during segment deactivation, then
+ * commit in background.
  *
  * @author Keith Godfrey
  * @author Henry Pijffers (henry.pijffers@saxnot.com)
@@ -168,18 +169,18 @@ public class RealProject implements IProject {
     private DirectoryMonitor tmOtherLanguagesMonitor;
 
     /**
-     * Indicates when there is an ongoing save event. Saving might take a while during
-     * team sync: if a merge is required the save might be postponed indefinitely while we
-     * wait for the user to confirm the current segment.
+     * Indicates when there is an ongoing save event. Saving might take a while
+     * during team sync: if a merge is required the save might be postponed
+     * indefinitely while we wait for the user to confirm the current segment.
      */
     private boolean isSaving = false;
 
     /**
-     * Storage for all translation memories, which shouldn't be changed and saved, i.e. for /tm/*.tmx files,
-     * aligned data from source files.
+     * Storage for all translation memories, which shouldn't be changed and
+     * saved, i.e. for /tm/*.tmx files, aligned data from source files.
      *
-     * This map recreated each time when files changed. So, you can free use it without thinking about
-     * synchronization.
+     * This map recreated each time when files changed. So, you can free use it
+     * without thinking about synchronization.
      */
     private Map<String, ExternalTMX> transMemories = new TreeMap<>();
 
@@ -210,11 +211,13 @@ public class RealProject implements IProject {
         EMPTY_TRANSLATION = new TMXEntry(empty, true, null);
     }
 
-    private final boolean allowTranslationEqualToSource = Preferences.isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
+    private final boolean allowTranslationEqualToSource = Preferences
+            .isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
 
     /**
-     * A list of external processes. Allows previously-started, hung or long-running processes to be
-     * forcibly terminated when compiling the project anew or when closing the project.
+     * A list of external processes. Allows previously-started, hung or
+     * long-running processes to be forcibly terminated when compiling the
+     * project anew or when closing the project.
      */
     private final Stack<Process> processCache = new Stack<>();
 
@@ -230,7 +233,8 @@ public class RealProject implements IProject {
         config = props;
         if (config.getRepositories() != null && !Core.getParams().containsKey(CLIParameters.NO_TEAM)) {
             try {
-                remoteRepositoryProvider = new RemoteRepositoryProvider(config.getProjectRootDir(), config.getRepositories(), config);
+                remoteRepositoryProvider = new RemoteRepositoryProvider(config.getProjectRootDir(),
+                        config.getRepositories(), config);
             } catch (Exception ex) {
                 // TODO
                 throw new RuntimeException(ex);
@@ -285,7 +289,8 @@ public class RealProject implements IProject {
             createDirectory(config.getTMOtherLangRoot(), OConsts.DEFAULT_OTHERLANG);
             createDirectory(config.getDictRoot(), OConsts.DEFAULT_DICT);
             createDirectory(config.getTargetRoot(), OConsts.DEFAULT_TARGET);
-            //createDirectory(m_config.getTMOtherLangRoot(), OConsts.DEFAULT_OTHERLANG);
+            // createDirectory(m_config.getTMOtherLangRoot(),
+            // OConsts.DEFAULT_OTHERLANG);
 
             saveProjectProperties();
 
@@ -322,7 +327,8 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Load exist project in a "big" sense -- loads project's properties, glossaries, tms, source files etc.
+     * Load exist project in a "big" sense -- loads project's properties,
+     * glossaries, tms, source files etc.
      */
     public synchronized void loadProject(boolean onlineMode) {
         Log.logInfoRB("LOG_DATAENGINE_LOAD_START");
@@ -354,14 +360,15 @@ public class RealProject implements IProject {
                 }
                 remoteRepositoryProvider.copyFilesFromReposToProject("");
 
-                // After adding filters.xml and segmentation.conf, we must reload them again
+                // After adding filters.xml and segmentation.conf, we must
+                // reload them again
                 config.loadProjectFilters();
                 config.loadProjectSRX();
             }
 
             loadFilterSettings();
             loadSegmentationSettings();
-            loadTranslations();  //load projectsave.tmx
+            loadTranslations(); // load projectsave.tmx
             loadSourceFiles();
 
             // This MUST happen after calling loadTranslations()
@@ -370,15 +377,17 @@ public class RealProject implements IProject {
                 rebaseAndCommitProject(true);
             }
 
-            //after loadSourcefiles, the entries are filled. The list can now (and only now) be readonly.
+            // after loadSourcefiles, the entries are filled. The list can now
+            // (and only now) be readonly.
             allProjectEntries = Collections.unmodifiableList(allProjectEntries);
-            //and now we can set the importHandler, used by loadTM
+            // and now we can set the importHandler, used by loadTM
             importHandler = new ImportFromAutoTMX(this, allProjectEntries);
 
-            //imports translation from source files into ProjectTMX
+            // imports translation from source files into ProjectTMX
             importTranslationsFromSources();
 
-            //loads external tmx, and auto/enfoce tmx'es (appending to projectTMX)
+            // loads external tmx, and auto/enfoce tmx'es (appending to
+            // projectTMX)
             loadTM();
 
             loadOtherLanguages();
@@ -430,19 +439,25 @@ public class RealProject implements IProject {
      * Load filter settings, either from the project or from global options
      */
     private void loadFilterSettings() {
-        // Set project specific file filters if they exist, or defaults otherwise.
-        // This MUST happen before calling loadTranslations() because the setting to ignore file context
-        // for alt translations is a filter setting, and it affects how alt translations are hashed.
+        // Set project specific file filters if they exist, or defaults
+        // otherwise.
+        // This MUST happen before calling loadTranslations() because the
+        // setting to ignore file context
+        // for alt translations is a filter setting, and it affects how alt
+        // translations are hashed.
         Filters filters = Optional.ofNullable(config.getProjectFilters()).orElse(Preferences.getFilters());
         Core.setFilterMaster(new FilterMaster(filters));
     }
 
     /**
-     * Load segmentation settings, either from the project or from global options
-    */
+     * Load segmentation settings, either from the project or from global
+     * options
+     */
     private void loadSegmentationSettings() {
-        // Set project specific segmentation rules if they exist, or defaults otherwise.
-        // This MUST happen before calling loadTranslations(), because projectTMX needs a segmenter.
+        // Set project specific segmentation rules if they exist, or defaults
+        // otherwise.
+        // This MUST happen before calling loadTranslations(), because
+        // projectTMX needs a segmenter.
         SRX srx = Optional.ofNullable(config.getProjectSRX()).orElse(Preferences.getSRX());
         Core.setSegmenter(new Segmenter(srx));
     }
@@ -484,8 +499,8 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Signals to the core thread that a project is being closed now, and if it's still being loaded, core
-     * thread shouldn't throw any error.
+     * Signals to the core thread that a project is being closed now, and if
+     * it's still being loaded, core thread shouldn't throw any error.
      */
     public void closeProject() {
         loaded = false;
@@ -560,8 +575,9 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Builds translated files corresponding to sourcePattern and creates fresh TM files. Convenience method. Assumes we
-     * want to run external post-processing commands.
+     * Builds translated files corresponding to sourcePattern and creates fresh
+     * TM files. Convenience method. Assumes we want to run external
+     * post-processing commands.
      *
      * @param sourcePattern
      *            The regexp of files to create
@@ -572,8 +588,9 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Builds translated files corresponding to sourcePattern and creates fresh TM files.
-     * Calls the actual compile project method, assumes we don't want to commit target files.
+     * Builds translated files corresponding to sourcePattern and creates fresh
+     * TM files. Calls the actual compile project method, assumes we don't want
+     * to commit target files.
      *
      * @param sourcePattern
      *            The regexp of files to create
@@ -586,7 +603,8 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Builds translated files corresponding to sourcePattern and creates fresh TM files.
+     * Builds translated files corresponding to sourcePattern and creates fresh
+     * TM files.
      *
      * @param sourcePattern
      *            The regexp of files to create
@@ -597,8 +615,8 @@ public class RealProject implements IProject {
      * @throws Exception
      */
     @Override
-    public void compileProjectAndCommit(String sourcePattern, boolean doPostProcessing, boolean commitTargetFiles)
-            throws Exception {
+    public void compileProjectAndCommit(String sourcePattern, boolean doPostProcessing,
+            boolean commitTargetFiles) throws Exception {
         Log.logInfoRB("LOG_DATAENGINE_COMPILE_START");
         UIThreadsUtil.mustNotBeSwingThread();
 
@@ -657,7 +675,8 @@ public class RealProject implements IProject {
                 if (!fn.getParentFile().exists()) {
                     // target directory doesn't exist - create it
                     if (!fn.getParentFile().mkdirs()) {
-                        throw new IOException(OStrings.getString("CT_ERROR_CREATING_TARGET_DIR") + fn.getParentFile());
+                        throw new IOException(
+                                OStrings.getString("CT_ERROR_CREATING_TARGET_DIR") + fn.getParentFile());
                     }
                 }
                 Core.getMainWindow().showStatusMessageRB("CT_COMPILE_FILE_MX", midName);
@@ -668,21 +687,23 @@ public class RealProject implements IProject {
                 numberOfCompiled++;
             }
         }
-        if (remoteRepositoryProvider != null && config.getTargetDir().isUnderRoot() && commitTargetFiles && isOnlineMode) {
+        if (remoteRepositoryProvider != null && config.getTargetDir().isUnderRoot() && commitTargetFiles
+                && isOnlineMode) {
             tmxPrepared = null;
             glossaryPrepared = null;
             // commit translations
             try {
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_TARGET_START");
                 remoteRepositoryProvider.switchAllToLatest();
-                remoteRepositoryProvider.copyFilesFromProjectToRepos(config.getTargetDir().getUnderRoot(), null);
-                remoteRepositoryProvider.commitFiles(config.getTargetDir().getUnderRoot(), "Project translation");
+                remoteRepositoryProvider.copyFilesFromProjectToRepos(config.getTargetDir().getUnderRoot(),
+                        null);
+                remoteRepositoryProvider.commitFiles(config.getTargetDir().getUnderRoot(),
+                        "Project translation");
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_TARGET_DONE");
             } catch (Exception e) {
                 Log.logErrorRB("TF_COMMIT_TARGET_ERROR");
                 Log.log(e);
-                throw new IOException(OStrings.getString("TF_COMMIT_TARGET_ERROR") + "\n"
-                        + e.getMessage());
+                throw new IOException(OStrings.getString("TF_COMMIT_TARGET_ERROR") + "\n" + e.getMessage());
             }
         }
 
@@ -710,7 +731,9 @@ public class RealProject implements IProject {
 
     /**
      * Set up and execute the user-specified external command.
-     * @param command Command to execute
+     * 
+     * @param command
+     *            Command to execute
      */
     private void doExternalCommand(String command) {
 
@@ -743,7 +766,8 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Clear cache of previously run external processes, terminating any that haven't finished.
+     * Clear cache of previously run external processes, terminating any that
+     * haven't finished.
      */
     private void flushProcessCache() {
         while (!processCache.isEmpty()) {
@@ -842,7 +866,8 @@ public class RealProject implements IProject {
 
         String tmxPath = config.getProjectInternalRelative() + OConsts.STATUS_EXTENSION;
         if (remoteRepositoryProvider.isUnderMapping(tmxPath)) {
-            tmxPrepared = RebaseAndCommit.prepare(remoteRepositoryProvider, config.getProjectRootDir(), tmxPath);
+            tmxPrepared = RebaseAndCommit.prepare(remoteRepositoryProvider, config.getProjectRootDir(),
+                    tmxPath);
         }
 
         final String glossaryPath = config.getWritableGlossaryFile().getUnderRoot();
@@ -886,10 +911,11 @@ public class RealProject implements IProject {
                         }
                         LOGGER.fine("Commit team sync");
                         try {
-                            String newVersion = RebaseAndCommit.commitPrepared(tmxPrepared, remoteRepositoryProvider,
-                                    null);
+                            String newVersion = RebaseAndCommit.commitPrepared(tmxPrepared,
+                                    remoteRepositoryProvider, null);
                             if (glossaryPrepared != null) {
-                                RebaseAndCommit.commitPrepared(glossaryPrepared, remoteRepositoryProvider, newVersion);
+                                RebaseAndCommit.commitPrepared(glossaryPrepared, remoteRepositoryProvider,
+                                        newVersion);
                             }
 
                             tmxPrepared = null;
@@ -912,29 +938,34 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Rebase changes in project to remote HEAD and upload changes to remote if possible.
+     * Rebase changes in project to remote HEAD and upload changes to remote if
+     * possible.
      * <p>
      * How it works.
      * <p>
-     * At each moment we have 3 versions of translation (project_save.tmx file) or writable glossary:
+     * At each moment we have 3 versions of translation (project_save.tmx file)
+     * or writable glossary:
      * <ol>
-     * <li>BASE - version which current translator downloaded from remote repository previously(on previous
-     * synchronization or startup).
+     * <li>BASE - version which current translator downloaded from remote
+     * repository previously(on previous synchronization or startup).
      *
-     * <li>WORKING - current version in translator's OmegaT. It doesn't exist it remote repository yet. It's
-     * inherited from BASE version, i.e. BASE + local changes.
+     * <li>WORKING - current version in translator's OmegaT. It doesn't exist it
+     * remote repository yet. It's inherited from BASE version, i.e. BASE +
+     * local changes.
      *
-     * <li>HEAD - latest version in repository, which other translators committed. It's also inherited from
-     * BASE version, i.e. BASE + remote changes.
+     * <li>HEAD - latest version in repository, which other translators
+     * committed. It's also inherited from BASE version, i.e. BASE + remote
+     * changes.
      * </ol>
-     * In an ideal world, we could just calculate diff between WORKING and BASE - it will be our local changes
-     * after latest synchronization, then rebase these changes on the HEAD revision, then commit into remote
-     * repository.
+     * In an ideal world, we could just calculate diff between WORKING and BASE
+     * - it will be our local changes after latest synchronization, then rebase
+     * these changes on the HEAD revision, then commit into remote repository.
      * <p>
      * But we have some real world limitations:
      * <ul>
-     * <li>Computers and networks work slowly, i.e. this synchronization will require some seconds, but
-     * translator should be able to edit translation in this time.
+     * <li>Computers and networks work slowly, i.e. this synchronization will
+     * require some seconds, but translator should be able to edit translation
+     * in this time.
      * <li>We have to handle network errors
      * <li>Other translators can commit own data in the same time.
      * </ul>
@@ -942,8 +973,9 @@ public class RealProject implements IProject {
      * <ol>
      * <li>Download HEAD revision from remote repository and load it in memory.
      * <li>Load BASE revision from local disk.
-     * <li>Calculate diff between WORKING and BASE, then rebase it on the top of HEAD revision. This step
-     * synchronized around memory TMX, so, all edits are stopped. Since it's enough fast step, it's okay.
+     * <li>Calculate diff between WORKING and BASE, then rebase it on the top of
+     * HEAD revision. This step synchronized around memory TMX, so, all edits
+     * are stopped. Since it's enough fast step, it's okay.
      * <li>Upload new revision into repository.
      * </ol>
      */
@@ -961,14 +993,14 @@ public class RealProject implements IProject {
 
                         @Override
                         public void parseBaseFile(File file) throws Exception {
-                            baseTMX = new ProjectTMX(config.getSourceLanguage(), config
-                                    .getTargetLanguage(), config.isSentenceSegmentingEnabled(), file, null);
+                            baseTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
+                                    config.isSentenceSegmentingEnabled(), file, null);
                         }
 
                         @Override
                         public void parseHeadFile(File file) throws Exception {
-                            headTMX = new ProjectTMX(config.getSourceLanguage(), config
-                                    .getTargetLanguage(), config.isSentenceSegmentingEnabled(), file, null);
+                            headTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
+                                    config.isSentenceSegmentingEnabled(), file, null);
                         }
 
                         @Override
@@ -989,9 +1021,9 @@ public class RealProject implements IProject {
                     });
             if (projectTMX != null) {
                 // it can be not loaded yet
-                ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(),
-                        config.getTargetLanguage(), config.isSentenceSegmentingEnabled(), new File(
-                                config.getProjectInternalDir(), OConsts.STATUS_EXTENSION), null);
+                ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
+                        config.isSentenceSegmentingEnabled(),
+                        new File(config.getProjectInternalDir(), OConsts.STATUS_EXTENSION), null);
                 projectTMX.replaceContent(newTMX);
             }
         }
@@ -1047,8 +1079,8 @@ public class RealProject implements IProject {
 
                             @Override
                             public String getCommentForCommit() {
-                                final String author = Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,
-                                        System.getProperty("user.name"));
+                                final String author = Preferences.getPreferenceDefault(
+                                        Preferences.TEAM_AUTHOR, System.getProperty("user.name"));
                                 return "Glossary changes by " + author;
                             }
 
@@ -1072,10 +1104,10 @@ public class RealProject implements IProject {
      * File 2: headTMX (theirs)
      */
     protected void mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
-        StmProperties props = new StmProperties()
-                .setLanguageResource(OStrings.getResourceBundle())
+        StmProperties props = new StmProperties().setLanguageResource(OStrings.getResourceBundle())
                 .setParentWindow(Core.getMainWindow().getApplicationFrame())
-                // More than this number of conflicts will trigger List View by default.
+                // More than this number of conflicts will trigger List View by
+                // default.
                 .setListViewThreshold(5);
         String srcLang = config.getSourceLanguage().getLanguage();
         String trgLang = config.getTargetLanguage().getLanguage();
@@ -1092,9 +1124,12 @@ public class RealProject implements IProject {
     /**
      * Create the given directory if it does not exist yet.
      *
-     * @param dir the directory path to create
-     * @param dirType the directory name to show in IOException
-     * @throws IOException when directory could not be created.
+     * @param dir
+     *            the directory path to create
+     * @param dirType
+     *            the directory name to show in IOException
+     * @throws IOException
+     *             when directory could not be created.
      */
     private void createDirectory(final String dir, final String dirType) throws IOException {
         File d = new File(dir);
@@ -1113,7 +1148,9 @@ public class RealProject implements IProject {
     // ///////////////////////////////////////////////////////////////
     // protected functions
 
-    /** Finds and loads project's TMX file with translations (project_save.tmx). */
+    /**
+     * Finds and loads project's TMX file with translations (project_save.tmx).
+     */
     private void loadTranslations() throws Exception {
         File file = new File(config.getProjectInternalDir(), OConsts.STATUS_EXTENSION);
         try {
@@ -1146,31 +1183,42 @@ public class RealProject implements IProject {
 
         File root = new File(config.getSourceRoot());
         List<String> srcPathList = FileUtil
-                .buildRelativeFilesList(root, Collections.emptyList(), config.getSourceRootExcludes()).stream()
-                .sorted(StreamUtil.comparatorByList(getSourceFilesOrder())).collect(Collectors.toList());
+                .buildRelativeFilesList(root, Collections.emptyList(), config.getSourceRootExcludes())
+                .stream().sorted(StreamUtil.comparatorByList(getSourceFilesOrder()))
+                .collect(Collectors.toList());
 
         for (String filepath : srcPathList) {
             Core.getMainWindow().showStatusMessageRB("CT_LOAD_FILE_MX", filepath);
 
-            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys, transMemories);
+            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys,
+                    transMemories);
 
             FileInfo fi = new FileInfo();
             fi.filePath = filepath;
 
             try {
                 loadFilesCallback.setCurrentFile(fi);
-                IFilter filter = fm.loadFile(config.getSourceRoot() + filepath,
-                        new FilterContext(config), loadFilesCallback);
+                IFilter filter = fm.loadFile(config.getSourceRoot() + filepath, new FilterContext(config),
+                        loadFilesCallback);
                 loadFilesCallback.fileFinished();
 
                 if (filter != null && !fi.entries.isEmpty()) {
-                    fi.filterClass = filter.getClass(); //Don't store the instance, because every file gets an instance and
-                                                        // then we consume a lot of memory for all instances.
-                                                        //See also IFilter "TODO: each filter should be stateless"
+                    fi.filterClass = filter.getClass(); // Don't store the
+                                                        // instance, because
+                                                        // every file gets an
+                                                        // instance and
+                                                        // then we consume a lot
+                                                        // of memory for all
+                                                        // instances.
+                                                        // See also IFilter
+                                                        // "TODO: each filter
+                                                        // should be stateless"
                     fi.filterFileFormatName = filter.getFileFormatName();
                     try {
                         fi.fileEncoding = filter.getInEncodingLastParsedFile();
-                    } catch (Error e) { // In case a filter doesn't have getInEncodingLastParsedFile() (e.g., Okapi plugin)
+                    } catch (Error e) { // In case a filter doesn't have
+                                        // getInEncodingLastParsedFile() (e.g.,
+                                        // Okapi plugin)
                         fi.fileEncoding = "";
                     }
                     projectFilesList.add(fi);
@@ -1232,9 +1280,12 @@ public class RealProject implements IProject {
             for (int i = 0; i < fi.entries.size(); i++) {
                 SourceTextEntry ste = fi.entries.get(i);
                 if (ste.getSourceTranslation() == null || ste.isSourceTranslationFuzzy()
-                        || ste.getSrcText().equals(ste.getSourceTranslation()) && !allowTranslationEqualToSource) {
-                    // There is no translation in source file, or translation is fuzzy
-                    // or translation = source and Allow translation to be equal to source is false
+                        || ste.getSrcText().equals(ste.getSourceTranslation())
+                                && !allowTranslationEqualToSource) {
+                    // There is no translation in source file, or translation is
+                    // fuzzy
+                    // or translation = source and Allow translation to be equal
+                    // to source is false
                     continue;
                 }
 
@@ -1243,7 +1294,8 @@ public class RealProject implements IProject {
                 // project with default translations
                 TMXEntry en = projectTMX.getMultipleTranslation(ste.getKey());
                 if (config.isSupportDefaultTranslations()) {
-                    // bug#969 - Alternative translations were not taken into account
+                    // bug#969 - Alternative translations were not taken into
+                    // account
                     // if no default translation is set.
                     if (en != null) {
                         prepare.translation = ste.getSourceTranslation();
@@ -1282,10 +1334,10 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Locates and loads external TMX files with legacy translations. Uses directory monitor for check file
-     * updates.
+     * Locates and loads external TMX files with legacy translations. Uses
+     * directory monitor for check file updates.
      */
-    private void loadTM()  {
+    private void loadTM() {
         File tmRoot = new File(config.getTMRoot());
         tmMonitor = new DirectoryMonitor(tmRoot, file -> {
             if (!ExternalTMFactory.isSupported(file)) {
@@ -1293,18 +1345,21 @@ public class RealProject implements IProject {
                 return;
             }
             if (file.getPath().replace('\\', '/').startsWith(config.getTMOtherLangRoot())) {
-                // tmx in other language, which is already shown in editor. Skip it.
+                // tmx in other language, which is already shown in editor. Skip
+                // it.
                 return;
             }
             // create new translation memories map
-            Map<String, ExternalTMX> newTransMemories = new TreeMap<>(new FileUtil.TmFileComparator(config.getTmDir().getAsFile()));
+            Map<String, ExternalTMX> newTransMemories = new TreeMap<>(
+                    new FileUtil.TmFileComparator(config.getTmDir().getAsFile()));
             newTransMemories.putAll(transMemories);
             if (file.exists()) {
                 try {
                     ExternalTMX newTMX = ExternalTMFactory.load(file);
                     newTransMemories.put(file.getPath(), newTMX);
 
-                    // Please note the use of "/". FileUtil.computeRelativePath rewrites all other
+                    // Please note the use of "/". FileUtil.computeRelativePath
+                    // rewrites all other
                     // directory separators into "/".
                     if (FileUtil.computeRelativePath(tmRoot, file).startsWith(OConsts.AUTO_TM + "/")) {
                         appendFromAutoTMX(newTMX, false);
@@ -1328,11 +1383,12 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Locates and loads external TMX files with translations from same source language into different target languages.
-     * (These are used to show to the translator as reference, either to see what other translators did in other languages,
-     * or to better understand the source language if he doesn't master the source language, but he does know the extra
-     * target language)
-     * Uses directory monitor for check file updates.
+     * Locates and loads external TMX files with translations from same source
+     * language into different target languages. (These are used to show to the
+     * translator as reference, either to see what other translators did in
+     * other languages, or to better understand the source language if he
+     * doesn't master the source language, but he does know the extra target
+     * language) Uses directory monitor for check file updates.
      */
     private void loadOtherLanguages() {
         File tmOtherLanguagesRoot = new File(config.getTMOtherLangRoot());
@@ -1424,7 +1480,8 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Returns whether the project was modified. I.e. translations were changed since last save.
+     * Returns whether the project was modified. I.e. translations were changed
+     * since last save.
      */
     public boolean isProjectModified() {
         return modified;
@@ -1474,8 +1531,8 @@ public class RealProject implements IProject {
     }
 
     @Override
-    public void setTranslation(final SourceTextEntry entry, final PrepareTMXEntry trans, boolean defaultTranslation,
-            TMXEntry.ExternalLinked externalLinked) {
+    public void setTranslation(final SourceTextEntry entry, final PrepareTMXEntry trans,
+            boolean defaultTranslation, TMXEntry.ExternalLinked externalLinked) {
         if (trans == null) {
             throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
         }
@@ -1536,14 +1593,14 @@ public class RealProject implements IProject {
             note = null;
         }
 
-        TMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX
-                .getDefaultTranslation(entry.getSrcText()) : projectTMX
-                .getMultipleTranslation(entry.getKey());
+        TMXEntry prevTrEntry = oldTE.defaultTranslation ? projectTMX.getDefaultTranslation(entry.getSrcText())
+                : projectTMX.getMultipleTranslation(entry.getKey());
         if (prevTrEntry != null) {
             PrepareTMXEntry en = new PrepareTMXEntry(prevTrEntry);
             en.note = note;
-            projectTMX.setTranslation(entry, new TMXEntry(en, prevTrEntry.defaultTranslation,
-                    prevTrEntry.linked), prevTrEntry.defaultTranslation);
+            projectTMX.setTranslation(entry,
+                    new TMXEntry(en, prevTrEntry.defaultTranslation, prevTrEntry.linked),
+                    prevTrEntry.defaultTranslation);
         } else {
             PrepareTMXEntry en = new PrepareTMXEntry();
             en.source = entry.getSrcText();
@@ -1620,20 +1677,22 @@ public class RealProject implements IProject {
 
     /**
      * Create tokenizer class. Classes are prioritized:
-     * <ol><li>Class specified on command line via <code>--ITokenizer</code>
-     * and <code>--ITokenizerTarget</code></li>
+     * <ol>
+     * <li>Class specified on command line via <code>--ITokenizer</code> and
+     * <code>--ITokenizerTarget</code></li>
      * <li>Class specified in project settings</li>
      * <li>{@link DefaultTokenizer}</li>
      * </ol>
      *
-     * @param cmdLine Tokenizer class specified on command line
+     * @param cmdLine
+     *            Tokenizer class specified on command line
      * @return Tokenizer implementation
      */
     protected ITokenizer createTokenizer(String cmdLine, Class<?> projectPref) {
         if (!StringUtil.isEmpty(cmdLine)) {
             try {
-                return (ITokenizer) this.getClass().getClassLoader().loadClass(cmdLine).getDeclaredConstructor()
-                        .newInstance();
+                return (ITokenizer) this.getClass().getClassLoader().loadClass(cmdLine)
+                        .getDeclaredConstructor().newInstance();
             } catch (ClassNotFoundException e) {
                 Log.log(e.toString());
             } catch (Throwable e) {
@@ -1662,8 +1721,8 @@ public class RealProject implements IProject {
             return null;
         }
         try {
-            return Core.getFilterMaster().getTargetForSource(config.getSourceRoot(),
-                    currentSource, new FilterContext(config));
+            return Core.getFilterMaster().getTargetForSource(config.getSourceRoot(), currentSource,
+                    new FilterContext(config));
         } catch (Exception e) {
             Log.log(e);
         }
@@ -1694,14 +1753,17 @@ public class RealProject implements IProject {
     }
 
     /**
-     * This method converts directory separators into Unix-style. It required to have the same filenames in
-     * the alternative translation in Windows and Unix boxes.
+     * This method converts directory separators into Unix-style. It required to
+     * have the same filenames in the alternative translation in Windows and
+     * Unix boxes.
      * <p>
-     * Also it can use {@code --alternate-filename-from} and {@code --alternate-filename-to} command line
-     * parameters for change filename in entry key. It allows to have many versions of one file in one
+     * Also it can use {@code --alternate-filename-from} and
+     * {@code --alternate-filename-to} command line parameters for change
+     * filename in entry key. It allows to have many versions of one file in one
      * project.
      * <p>
-     * Because the filename can be stored in the project TMX, it also removes any XML-unsafe chars.
+     * Because the filename can be stored in the project TMX, it also removes
+     * any XML-unsafe chars.
      *
      * @param filename
      *            filesystem's filename
@@ -1756,8 +1818,9 @@ public class RealProject implements IProject {
          * {@inheritDoc}
          */
         protected void addSegment(String id, short segmentIndex, String segmentSource,
-                List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
-                String[] props, String prevSegment, String nextSegment, String path) {
+                List<ProtectedPart> protectedParts, String segmentTranslation,
+                boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
+                String path) {
             // if the source string is empty, don't add it to TM
             if (segmentSource.trim().isEmpty()) {
                 throw new RuntimeException("Segment must not be empty");
@@ -1768,7 +1831,8 @@ public class RealProject implements IProject {
             protectedParts = TagUtil.applyCustomProtectedParts(segmentSource,
                     PatternConsts.getPlaceholderPattern(), protectedParts);
 
-            //If Allow translation equals to source is not set, we ignore such existing translations
+            // If Allow translation equals to source is not set, we ignore such
+            // existing translations
             if (ek.sourceText.equals(segmentTranslation) && !allowTranslationEqualToSource) {
                 segmentTranslation = null;
             }
@@ -1796,6 +1860,7 @@ public class RealProject implements IProject {
 
         /**
          * Getter for currentFile
+         * 
          * @return the current file being processed
          */
         @Override
@@ -1834,13 +1899,14 @@ public class RealProject implements IProject {
         List<String> sources = new ArrayList<>();
 
         @Override
-        public void addTranslation(String id, String source, String translation, boolean isFuzzy, String sourcePath,
-                IFilter filter) {
+        public void addTranslation(String id, String source, String translation, boolean isFuzzy,
+                String sourcePath, IFilter filter) {
             if (source != null && translation != null) {
                 ParseEntry.ParseEntryResult spr = new ParseEntry.ParseEntryResult();
                 boolean removeSpaces = Core.getFilterMaster().getConfig().isRemoveSpacesNonseg();
                 String sourceS = ParseEntry.stripSomeChars(source, spr, config.isRemoveTags(), removeSpaces);
-                String transS = ParseEntry.stripSomeChars(translation, spr, config.isRemoveTags(), removeSpaces);
+                String transS = ParseEntry.stripSomeChars(translation, spr, config.isRemoveTags(),
+                        removeSpaces);
                 if (config.isSupportDefaultTranslations()) {
                     if (sources.contains(sourceS)) {
                         return;
@@ -1850,10 +1916,10 @@ public class RealProject implements IProject {
 
                 PrepareTMXEntry tr = new PrepareTMXEntry();
                 if (config.isSentenceSegmentingEnabled()) {
-                    List<String> segmentsSource = Core.getSegmenter().segment(config.getSourceLanguage(), sourceS, null,
-                            null);
-                    List<String> segmentsTranslation = Core.getSegmenter()
-                            .segment(config.getTargetLanguage(), transS, null, null);
+                    List<String> segmentsSource = Core.getSegmenter().segment(config.getSourceLanguage(),
+                            sourceS, null, null);
+                    List<String> segmentsTranslation = Core.getSegmenter().segment(config.getTargetLanguage(),
+                            transS, null, null);
                     if (segmentsTranslation.size() != segmentsSource.size()) {
                         if (isFuzzy) {
                             transS = "[" + filter.getFuzzyMark() + "] " + transS;
@@ -1920,18 +1986,19 @@ public class RealProject implements IProject {
 
     @Override
     public void commitSourceFiles() throws Exception {
-        if (isRemoteProject() && config.getSourceDir().isUnderRoot())  {
+        if (isRemoteProject() && config.getSourceDir().isUnderRoot()) {
             try {
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_START");
                 remoteRepositoryProvider.switchAllToLatest();
-                remoteRepositoryProvider.copyFilesFromProjectToRepos(config.getSourceDir().getUnderRoot(), null);
-                remoteRepositoryProvider.commitFiles(config.getSourceDir().getUnderRoot(), "Commit source files");
+                remoteRepositoryProvider.copyFilesFromProjectToRepos(config.getSourceDir().getUnderRoot(),
+                        null);
+                remoteRepositoryProvider.commitFiles(config.getSourceDir().getUnderRoot(),
+                        "Commit source files");
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_DONE");
             } catch (Exception e) {
                 Log.logErrorRB("TF_COMMIT_ERROR");
                 Log.log(e);
-                throw new IOException(OStrings.getString("TF_COMMIT_ERROR") + "\n"
-                        + e.getMessage(), e);
+                throw new IOException(OStrings.getString("TF_COMMIT_ERROR") + "\n" + e.getMessage(), e);
             }
         }
     }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1187,6 +1187,8 @@ public class RealProject implements IProject {
                 .stream().sorted(StreamUtil.comparatorByList(getSourceFilesOrder()))
                 .collect(Collectors.toList());
 
+        List<String> errorSrcList = new ArrayList<>();
+
         for (String filepath : srcPathList) {
             Core.getMainWindow().showStatusMessageRB("CT_LOAD_FILE_MX", filepath);
 
@@ -1227,12 +1229,17 @@ public class RealProject implements IProject {
                 // ignore failed file and continue loading next.
                 Log.logErrorRB("TF_SOURCE_LOAD_ERROR", e.getLocalizedMessage());
                 Core.getMainWindow().displayErrorRB(e, "TF_SOURCE_LOAD_ERROR", filepath);
+                errorSrcList.add(filepath);
             }
         }
 
         findNonUniqueSegments();
 
-        Core.getMainWindow().showStatusMessageRB("CT_LOAD_SRC_COMPLETE");
+        if (errorSrcList.size() > 0) {
+            Core.getMainWindow().showStatusMessageRB("CT_LOAD_SRC_SKIP_FILES");
+        } else {
+            Core.getMainWindow().showStatusMessageRB("CT_LOAD_SRC_COMPLETE");
+        }
         long en = System.currentTimeMillis();
         Log.log("Load project source files: " + (en - st) + "ms");
     }

--- a/src/org/omegat/core/machinetranslators/BaseTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BaseTranslate.java
@@ -92,7 +92,9 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * Creat cache object.
      * <p>
      * MT connectors can override cache size and invalidate policy.
-     * @param name name of cache which should be unique among MT connectors.
+     * 
+     * @param name
+     *            name of cache which should be unique among MT connectors.
      * @return Cache object
      */
     protected Cache<String, String> getCacheLayer(String name) {
@@ -112,9 +114,13 @@ public abstract class BaseTranslate implements IMachineTranslation {
 
     /**
      * Common function to obtain CaffeineCache instance.
-     * @param name name of cache.
-     * @param sizeOfCache size of cache.
-     * @param duration duration before clear.
+     * 
+     * @param name
+     *            name of cache.
+     * @param sizeOfCache
+     *            size of cache.
+     * @param duration
+     *            duration before clear.
      * @return Cache object.
      */
     protected Cache<String, String> getCaffeineCache(String name, int sizeOfCache, Duration duration) {
@@ -186,8 +192,8 @@ public abstract class BaseTranslate implements IMachineTranslation {
         while (tag.find()) {
             String searchTag = tag.group();
             if (!sourceText.contains(searchTag)) { // The tag didn't appear
-                                                       // with a trailing space
-                                                       // in the source text
+                                                   // with a trailing space
+                                                   // in the source text
                 String replacement = searchTag.substring(0, searchTag.length() - 1);
                 machineText = machineText.replace(searchTag, replacement);
             }
@@ -198,8 +204,8 @@ public abstract class BaseTranslate implements IMachineTranslation {
         while (tag.find()) {
             String searchTag = tag.group();
             if (!sourceText.contains(searchTag)) { // The tag didn't appear
-                                                       // with a leading space
-                                                       // in the source text
+                                                   // with a leading space
+                                                   // in the source text
                 String replacement = searchTag.substring(1);
                 machineText = machineText.replace(searchTag, replacement);
             }

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -203,6 +203,8 @@ public class FilterMaster {
             filterObject = lookup.filterObject;
 
             filterObject.parseFile(inFile, lookup.config, fc, parseCallback);
+        } catch (TranslationException e) {
+            throw e;
         } catch (Exception ioe) {
             throw new IOException(filename + "\n" + ioe, ioe);
         }

--- a/src/org/omegat/filters3/xml/Handler.java
+++ b/src/org/omegat/filters3/xml/Handler.java
@@ -43,6 +43,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.ext.DeclHandler;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.DefaultHandler;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.filters2.FilterContext;
@@ -53,13 +61,6 @@ import org.omegat.filters3.Entry;
 import org.omegat.filters3.Tag;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.ext.DeclHandler;
-import org.xml.sax.ext.LexicalHandler;
-import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * The part of XML filter that actually does the job. This class is called back
@@ -148,7 +149,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
     }
 
     private boolean isSpacePreservingTag() {
-        if (Core.getFilterMaster().getConfig().isPreserveSpaces()) { // Preserve spaces for all tags
+        if (Core.getFilterMaster().getConfig().isPreserveSpaces()) {
+            // Preserve spaces for all tags
             return true;
         } else {
             return spacePreserve;
@@ -199,7 +201,9 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
      * next, but some nice things may happen before.
      */
     private DTD dtd = null;
-    /** SAX parser parses DTD -- we don't extract translatable text from there */
+    /**
+     * SAX parser parses DTD -- we don't extract translatable text from there
+     */
     private boolean inDTD = false;
 
     /**
@@ -216,10 +220,10 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         return processedFiles.isEmpty() ? null : processedFiles;
     }
 
-    /** Throws a nice error message when SAX parser encounders fastal error. */
-    private void reportFatalError(SAXParseException e) throws SAXException, MalformedURLException,
-            URISyntaxException {
-        int linenum = e.getLineNumber();
+    /** Throws a nice error message when SAX parser encounters fatal error. */
+    private void reportFatalError(SAXParseException e)
+            throws SAXException, MalformedURLException, URISyntaxException {
+        final int lineNumber = e.getLineNumber();
         String filename;
         if (e.getSystemId() != null) {
             File errorfile = new File(inFile.getParentFile(), localizeSystemId(e.getSystemId()));
@@ -231,9 +235,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         } else {
             filename = inFile.getAbsolutePath();
         }
-        throw new SAXException("\n"
-                + StringUtil.format(e.getMessage() + "\n" + OStrings.getString("XML_FATAL_ERROR"),
-                        filename, linenum));
+        throw new SAXException("\n" + StringUtil
+                .format(e.getMessage() + "\n" + OStrings.getString("XML_FATAL_ERROR"), filename, lineNumber));
     }
 
     /**
@@ -289,8 +292,7 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
             try {
                 String thisOutPath = sourceFolderFile.relativize(thisOutFile).toString();
                 return thisOutPath.replace("\\", "/");
-            }
-            catch (IllegalArgumentException ex) {
+            } catch (IllegalArgumentException ex) {
                 // Failed to relativize
             }
         }
@@ -371,12 +373,11 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
      * Resolves external entity and creates a new writer if it's an included
      * file.
      */
-    public InputSource doResolve(String publicId, String systemId) throws SAXException, TranslationException,
-            IOException, URISyntaxException {
-        if (dtd != null
-                && StringUtil.equal(publicId, dtd.getPublicId())
-                && (StringUtil.equal(systemId, dtd.getSystemId()) || StringUtil.equal(
-                        localizeSystemId(systemId), dtd.getSystemId()))) {
+    public InputSource doResolve(String publicId, String systemId)
+            throws SAXException, TranslationException, IOException, URISyntaxException {
+        if (dtd != null && StringUtil.equal(publicId, dtd.getPublicId())
+                && (StringUtil.equal(systemId, dtd.getSystemId())
+                        || StringUtil.equal(localizeSystemId(systemId), dtd.getSystemId()))) {
             inDTD = true;
         }
 
@@ -426,7 +427,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
             translator.text(s);
         }
 
-        // TODO: ideally, xml:space=preserved would be handled at this level, but that would suppose
+        // TODO: ideally, xml:space=preserved would be handled at this level,
+        // but that would suppose
         // knowing here whether we're inside a preformatted tag, etc.
         if (internalEntityStarted != null && s.equals(internalEntityStarted.getValue())) {
             currEntry().add(new XMLEntityText(internalEntityStarted));
@@ -456,8 +458,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         setSpacePreservingTag(XMLUtils.convertAttributes(attributes));
         if (!collectingIntactText()) {
             if (isContentBasedTag(tag, XMLUtils.convertAttributes(attributes))) {
-                intacttag = new XMLContentBasedTag(dialect, this, tag, getShortcut(tag), dialect
-                        .getContentBasedTags().get(tag), attributes);
+                intacttag = new XMLContentBasedTag(dialect, this, tag, getShortcut(tag),
+                        dialect.getContentBasedTags().get(tag), attributes);
                 xmltag = intacttag;
                 intacttagName = tag;
                 intacttagAttributes = XMLUtils.convertAttributes(attributes);
@@ -482,8 +484,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         if (!collectingIntactText()) {
             for (int i = 0; i < xmltag.getAttributes().size(); i++) {
                 Attribute attr = xmltag.getAttributes().get(i);
-                if ((dialect.getTranslatableAttributes().contains(attr.getName()) || dialect
-                        .getTranslatableTagAttributes().containsPair(tag, attr.getName()))
+                if ((dialect.getTranslatableAttributes().contains(attr.getName())
+                        || dialect.getTranslatableTagAttributes().containsPair(tag, attr.getName()))
                         && dialect.validateTranslatableTagAttribute(tag, attr.getName(),
                                 xmltag.getAttributes())) {
                     attr.setValue(StringUtil.makeValidXML(
@@ -494,14 +496,14 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
     }
 
     /**
-     * Queue tag that should be ignored by editor, including content and all subtags.
+     * Queue tag that should be ignored by editor, including content and all
+     * subtags.
      */
     private void queueIgnoredTag(String tag, Attributes attributes) {
         Tag xmltag = null;
         setSpacePreservingTag(XMLUtils.convertAttributes(attributes));
         if (xmltag == null) {
-            xmltag = new XMLTag(tag, getShortcut(tag), Tag.Type.BEGIN, attributes,
-                    this.translator);
+            xmltag = new XMLTag(tag, getShortcut(tag), Tag.Type.BEGIN, attributes, this.translator);
             xmlTagName.push(xmltag.getTag());
             xmlTagAttributes.push(xmltag.getAttributes());
         }
@@ -510,10 +512,10 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
 
     private void queueEndTag(String tag) {
         int len = currEntry().size();
-        if (len > 0
-                && (currEntry().get(len - 1) instanceof XMLTag)
-                && (((XMLTag) currEntry().get(len - 1)).getTag().equals(tag) && ((XMLTag) currEntry().get(
-                        len - 1)).getType() == Tag.Type.BEGIN) && !isClosingTagRequired()) {
+        if (len > 0 && (currEntry().get(len - 1) instanceof XMLTag)
+                && (((XMLTag) currEntry().get(len - 1)).getTag().equals(tag)
+                        && ((XMLTag) currEntry().get(len - 1)).getType() == Tag.Type.BEGIN)
+                && !isClosingTagRequired()) {
             if (((XMLTag) currEntry().get(len - 1)).getTag().equals(xmlTagName.lastElement())) {
                 xmlTagName.pop();
                 xmlTagAttributes.pop();
@@ -523,7 +525,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
             XMLTag xmltag = new XMLTag(tag, getShortcut(tag), Tag.Type.END, null, this.translator);
             if (xmltag.getTag().equals(xmlTagName.lastElement())) {
                 xmlTagName.pop();
-                xmltag.setStartAttributes(xmlTagAttributes.pop()); // Restore attributes
+                xmltag.setStartAttributes(xmlTagAttributes.pop()); // Restore
+                                                                   // attributes
             }
             currEntry().add(xmltag);
         }
@@ -551,7 +554,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
 
         if (!translator.isInIgnored()) {
             if (isOutOfTurnTag(tag)) {
-                XMLOutOfTurnTag ootTag = new XMLOutOfTurnTag(dialect, this, tag, getShortcut(tag), attributes);
+                XMLOutOfTurnTag ootTag = new XMLOutOfTurnTag(dialect, this, tag, getShortcut(tag),
+                        attributes);
                 currEntry().add(ootTag);
                 outofturnEntries.push(ootTag.getEntry());
             } else {
@@ -620,11 +624,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         String src = currEntry().sourceToShortcut(tagsAggregation, dialect, shortcutDetails);
         Element lead = currEntry().get(0);
         String translation = src;
-        if ((lead instanceof Tag)
-             && (isPreformattingTag(((Tag) lead).getTag(), ((Tag) lead).getAttributes())
-                 || isSpacePreservingTag())
-             && isTranslatableTag()
-             && !StringUtil.isEmpty(src)) {
+        if ((lead instanceof Tag) && (isPreformattingTag(((Tag) lead).getTag(), ((Tag) lead).getAttributes())
+                || isSpacePreservingTag()) && isTranslatableTag() && !StringUtil.isEmpty(src)) {
             resetSpacePreservingTag();
             translation = translator.translate(src, shortcutDetails);
         } else {
@@ -866,7 +867,8 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
     }
 
     /**
-     * If the space-preserving flag is not set, and the attributes say it is one, set it
+     * If the space-preserving flag is not set, and the attributes say it is
+     * one, set it
      *
      * @param atts
      *            The attributes of the current tag
@@ -891,7 +893,9 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         return dialect.getOutOfTurnTags() != null && dialect.getOutOfTurnTags().contains(tag);
     }
 
-    /** Returns a shortcut for a tag. Queries dialect first, else returns null. */
+    /**
+     * Returns a shortcut for a tag. Queries dialect first, else returns null.
+     */
     private String getShortcut(String tag) {
         if (dialect.getShortcuts() != null) {
             return dialect.getShortcuts().get(tag);
@@ -902,7 +906,9 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
 
     /**
      * Checks whether the xml:space="preserve" attribute is present
-     * @param currentAttributes The current Attributes
+     * 
+     * @param currentAttributes
+     *            The current Attributes
      * @return true or false
      */
     private boolean isSpacePreservingSet(org.omegat.filters3.Attributes currentAttributes) {
@@ -916,7 +922,7 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
         for (int i = 0; i < currentAttributes.size(); i++) {
             Attribute oneAttribute = currentAttributes.get(i);
             if ((oneAttribute.getName().equalsIgnoreCase("xml:space")
-                 && oneAttribute.getValue().equalsIgnoreCase("preserve"))) {
+                    && oneAttribute.getValue().equalsIgnoreCase("preserve"))) {
                 preserve = true;
             }
         }
@@ -1040,9 +1046,7 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
     public void fatalError(org.xml.sax.SAXParseException e) throws SAXException {
         try {
             reportFatalError(e);
-        } catch (MalformedURLException ex) {
-            throw new SAXException(ex);
-        } catch (URISyntaxException ex) {
+        } catch (MalformedURLException | URISyntaxException ex) {
             throw new SAXException(ex);
         }
     }

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -42,6 +42,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -49,13 +53,11 @@ import org.omegat.filters2.TranslationException;
 import org.omegat.util.Language;
 import org.omegat.util.OConsts;
 import org.omegat.util.PatternConsts;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 /**
- * Abstract basis filter for XML format filters: OpenDocument, DocBook etc. Ideally should allow creation of a
- * new XML dialect filter by simply specifying translatable tags and attributes.
+ * Abstract basis filter for XML format filters: OpenDocument, DocBook etc.
+ * Ideally should allow creation of a new XML dialect filter by simply
+ * specifying translatable tags and attributes.
  *
  * @author Maxym Mykhalchuk
  * @author Didier Briel
@@ -64,10 +66,10 @@ import org.xml.sax.SAXException;
  */
 public abstract class XMLFilter extends AbstractFilter implements Translator {
     /** Factory for SAX parsers. */
-    private SAXParserFactory parserFactory;
+    private final SAXParserFactory parserFactory;
 
     /** XML dialect this filter handles. */
-    private XMLDialect dialect;
+    private final XMLDialect dialect;
 
     /** Creates a new instance of XMLFilter */
     public XMLFilter(XMLDialect dialect) {
@@ -75,7 +77,7 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
         // parserFactory.setValidating(false);
         try {
             parserFactory.setFeature("http://xml.org/sax/features/validation", true);
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
         this.dialect = dialect;
     }
@@ -104,8 +106,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
      *             If any I/O Error occurs upon reader creation.
      */
     @Override
-    public BufferedReader createReader(File inFile, String inEncoding) throws UnsupportedEncodingException,
-            IOException {
+    public BufferedReader createReader(File inFile, String inEncoding)
+            throws UnsupportedEncodingException, IOException {
         XMLReader xmlreader = new XMLReader(inFile, inEncoding);
         this.encoding = xmlreader.getEncoding();
         this.eol = xmlreader.getEol();
@@ -113,13 +115,14 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
     }
 
     /**
-     * Creates a writer of the translated file. Accepts <code>null</code> output file -- returns a writer to
-     * <code>/dev/null</code> in this case ;-)
+     * Creates a writer of the translated file. Accepts <code>null</code> output
+     * file -- returns a writer to <code>/dev/null</code> in this case ;-)
      *
      * @param outFile
      *            The target file.
      * @param outEncoding
-     *            Encoding of the target file, if the filter supports it. Otherwise null.
+     *            Encoding of the target file, if the filter supports it.
+     *            Otherwise null.
      * @return The writer for the target file.
      *
      * @throws UnsupportedEncodingException
@@ -128,8 +131,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
      *             If any I/O Error occurs upon writer creation
      */
     @Override
-    public BufferedWriter createWriter(File outFile, String outEncoding) throws UnsupportedEncodingException,
-            IOException {
+    public BufferedWriter createWriter(File outFile, String outEncoding)
+            throws UnsupportedEncodingException, IOException {
         if (outEncoding == null) {
             outEncoding = this.encoding;
         }
@@ -168,8 +171,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
 
     /** Processes an XML file. */
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc) throws IOException,
-            TranslationException {
+    public void processFile(File inFile, File outFile, FilterContext fc)
+            throws IOException, TranslationException {
         try (BufferedReader inReader = createReader(inFile, fc.getInEncoding())) {
             inEncodingLastParsedFile = this.encoding;
             targetLanguage = fc.getTargetLang();
@@ -181,22 +184,22 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
             parser.setProperty("http://xml.org/sax/properties/declaration-handler", handler);
             parser.parse(source, handler);
-        } catch (ParserConfigurationException e) {
-            throw new TranslationException(e);
-        } catch (SAXException e) {
+        } catch (ParserConfigurationException | SAXException e) {
             throw new TranslationException(e);
         }
     }
+
     @Override
-    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc) throws IOException,
-            TranslationException {
+    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc)
+            throws IOException, TranslationException {
         throw new UnsupportedOperationException(
                 "XMLFilter.processFile(BufferedReader,BufferedWriter) should never be called!");
     }
 
     /**
-     * Whether source encoding can be varied by the user. If XML file has no encoding declaration, UTF-8 will
-     * be used, hence returns <code>false</code> by default.
+     * Whether source encoding can be varied by the user. If XML file has no
+     * encoding declaration, UTF-8 will be used, hence returns
+     * <code>false</code> by default.
      *
      * @return <code>false</code>
      */
@@ -216,7 +219,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
     }
 
     /**
-     * The method the Handler would call to pass translatable content to OmegaT core and receive translation.
+     * The method the Handler would call to pass translatable content to OmegaT
+     * core and receive translation.
      */
     @Override
     public String translate(String entry, List<ProtectedPart> protectedParts) {
@@ -226,7 +230,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
         } else if (entryTranslateCallback != null) {
             String translation = entryTranslateCallback.getTranslation(null, entry, null);
             return translation != null ? translation : entry;
-        } else { // We're not supposed to be there,  (parsing called from inside isFileSupported, for instance)
+        } else { // We're not supposed to be there, (parsing called from inside
+                 // isFileSupported, for instance)
             return entry; // so what we return is not important
         }
 
@@ -234,8 +239,9 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
 
     /**
      * Returns whether the XML file is supported by the filter. <br>
-     * Reads {@link org.omegat.util.OConsts#READ_AHEAD_LIMIT} and tries to detect constrained text and match
-     * constraints defined in {@link XMLDialect} against them.
+     * Reads {@link org.omegat.util.OConsts#READ_AHEAD_LIMIT} and tries to
+     * detect constrained text and match constraints defined in
+     * {@link XMLDialect} against them.
      */
     @Override
     public boolean isFileSupported(BufferedReader reader) {
@@ -283,14 +289,11 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             matcher = PatternConsts.XML_XMLNS.matcher(buf);
             if (matcher.find()) {
                 Pattern xmlns = dialect.getConstraints().get(XMLDialect.CONSTRAINT_XMLNS);
-                if (xmlns != null && (matcher.group(2) == null || !xmlns.matcher(matcher.group(2)).matches())) {
-                    return false;
-                }
-            } else if (dialect.getConstraints().containsKey(XMLDialect.CONSTRAINT_XMLNS)) {
-                return false;
+                return xmlns == null
+                        || (matcher.group(2) != null && xmlns.matcher(matcher.group(2)).matches());
+            } else {
+                return !dialect.getConstraints().containsKey(XMLDialect.CONSTRAINT_XMLNS);
             }
-
-            return true;
 
         } catch (Exception e) {
             return false;

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -184,8 +184,10 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
             parser.setProperty("http://xml.org/sax/properties/declaration-handler", handler);
             parser.parse(source, handler);
-        } catch (ParserConfigurationException | SAXException e) {
+        } catch (ParserConfigurationException e) {
             throw new TranslationException(e);
+        } catch (SAXException e) {
+            throw new TranslationException(e.getMessage());
         }
     }
 

--- a/test/data/filters/docBook/file-DocBookFilter-invalid2.xml
+++ b/test/data/filters/docBook/file-DocBookFilter-invalid2.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
+<section id="menus.view">
+  <title id="menus.view.title"><guimenu>View</guimenu></title>
+
+  <para>This menu allows you to select the information you want to OmegaT to
+  display.</para>
+
+  <para>All the colors indicated in the descriptions can be modified in the
+  <link linkend="dialogs.preferences.colours"
+  endterm="dialogs.preferences.colours.title"/> preference.</para>
+
+  <variablelist>
+    <varlistentry id="menus.view.mark.translated.segments">
+      <term
+      id="menus.view.mark.translated.segments.title"><guimenuitem>Highlight
+      Translated Segments</guimenuitem></term>
+      <listitem>
+        <para>If checked, translated segments are highlighted in yellow.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.mark.untranslated.segments">
+      <term
+      id="menus.view.mark.untranslated.segments.title"><guimenuitem>Highlight
+      Untranslated Segments</guimenuitem></term>
+      <listitem>
+        <para>If checked, untranslated segments are highlighted in violet.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.mark.paragraph.delimitations">
+      <term
+      id="menus.view.mark.paragraph.delimitations.title"><guimenuitem>Display
+      Paragraph Delimitations</guimenuitem></term>
+      <listitem>
+        <para>If checked, separations between paragraphs in the source document
+        are indicated visually. You can change the paragraph delimitation string
+        in the <link
+        linkend="dialogs.preferences.editor.paragraph.delimitation.format"
+        endterm="dialogs.preferences.editor.paragraph.delimitation.format.title"/>
+        preference.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.display.source.segments">
+      <term id="menus.view.display.source.segments.title"><guimenuitem>Display
+      Source Segments</guimenuitem></term>
+      <listitem>
+        <para>If checked, all the source segments are shown and highlighted
+        in green.  If not checked, only the current source segments is
+        shown.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.mark.non.unique.segments">
+      <term
+      id="menus.view.mark.non.unique.segments.title"><guimenuitem>Highlight
+      Repeated Segments</guimenuitem></term>
+      <listitem>
+        <para>If checked, repeated segments are highlighted in pale
+        gray.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.mark.segments.with.notes">
+      <term
+      id="menus.view.mark.segments.with.notes.title"><guimenuitem>Highlight
+      Segments with Notes</guimenuitem></term>
+      <listitem>
+        <para>If checked, segments with notes are highlighted in cyan. This
+        marking has priority over <guimenuitem>Highlight Translated
+        Segments</guimenuitem> and <guimenuitem>Highlight Untranslated
+        Segments</guimenuitem>.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry id="menus.view.mark.non.breakable.space">
+      <term id="menus.view.mark.non.breakable.space.title"><guimenuitem>Display
+      Non-Breakable Spaces</guimenuitem></term>
+      <listitem>
+        <para>If checked, non-breakable spaces are displayed with a gray
+        <para>If checked, non-breakable spaces are displayed with a gray
+        background.</para>
+      </listitem>
+    </varlistentry>
+
+  </variablelist>
+</section>

--- a/test/src/org/omegat/filters/DocBookFilterTest.java
+++ b/test/src/org/omegat/filters/DocBookFilterTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.omegat.core.data.IProject;
+import org.omegat.filters2.TranslationException;
 import org.omegat.filters3.xml.docbook.DocBookFilter;
 
 public class DocBookFilterTest extends TestFilterBase {
@@ -54,6 +55,12 @@ public class DocBookFilterTest extends TestFilterBase {
     @Test
     public void testTranslateExtWriter() throws Exception {
         translateText(new DocBookFilter(), "test/data/filters/docBook/file-DocBookFilter-extWriter.xml");
+    }
+
+    @Test(expected = TranslationException.class)
+    public void testLoadInvalidXml() throws Exception {
+        List<String> lines = parse(new DocBookFilter(),
+                "test/data/filters/docBook/file-DocBookFilter-invalid2.xml");
     }
 
     @Test

--- a/test/src/org/omegat/filters/DocBookFilterTest.java
+++ b/test/src/org/omegat/filters/DocBookFilterTest.java
@@ -27,6 +27,7 @@ package org.omegat.filters;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.nio.file.Files;
@@ -35,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters3.xml.docbook.DocBookFilter;
@@ -57,10 +59,21 @@ public class DocBookFilterTest extends TestFilterBase {
         translateText(new DocBookFilter(), "test/data/filters/docBook/file-DocBookFilter-extWriter.xml");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
     public void testLoadInvalidXml() throws Exception {
-        List<String> lines = parse(new DocBookFilter(),
-                "test/data/filters/docBook/file-DocBookFilter-invalid2.xml");
+        try {
+            List<String> lines = parse(new DocBookFilter(),
+                    "test/data/filters/docBook/file-DocBookFilter-invalid2.xml");
+        } catch (TranslationException e) {
+            // should contain invalid tag
+            assertTrue(e.getMessage().contains("para"));
+            // should contain invalid filename
+            assertTrue(e.getMessage().contains("file-DocBookFilter-invalid2.xml"));
+            // should contain invalid file's line number
+            assertTrue(e.getMessage().contains("85"));
+            return;
+        }
+        fail("Don't catch expected TranslationException when loading invalid docBook XML.");
     }
 
     @Test

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -27,13 +27,12 @@
 package org.omegat.filters;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
@@ -45,15 +44,12 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.xml.sax.SAXException;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.statistics.StatCount;
 import org.omegat.core.statistics.StatisticsSettings;
-import org.omegat.filters2.FilterContext;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.ITranslateCallback;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters3.Tag;
@@ -64,6 +60,8 @@ import org.omegat.filters3.xml.xliff.XLIFFOptions;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
+import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.IFilter;
 import org.omegat.util.xml.XMLBlock;
 import org.omegat.util.xml.XMLStreamReader;
 
@@ -230,7 +228,9 @@ public class XLIFFFilterTest extends TestFilterBase {
             loadSourceFiles(filter, f);
             fail("Should have died due to invalid XML character");
         } catch (TranslationException ex) {
-            assertTrue(wasCausedBy(ex, SAXException.class));
+            // Now OmegaT unwrap SAXException
+            assertNull(ex.getCause());
+            // assertTrue(wasCausedBy(ex, SAXException.class));
         }
     }
 
@@ -261,23 +261,21 @@ public class XLIFFFilterTest extends TestFilterBase {
             loadSourceFiles(filter, testFile.getAbsolutePath());
             fail("Should have died due to invalid XML character");
         } catch (TranslationException ex) {
-            assertTrue(wasCausedBy(ex, SAXException.class));
-            assertFalse(wasCausedBy(ex, URISyntaxException.class));
+            // Now OmegaT unwrap SAXException
+            // assertTrue(wasCausedBy(ex, SAXException.class));
+            assertNull(ex.getCause());
+            // assertFalse(wasCausedBy(ex, URISyntaxException.class));
         }
 
         FileUtils.deleteDirectory(tmpDir);
     }
 
-    private static boolean wasCausedBy(Throwable ex, Class<?> cls) {
-        Throwable cause = ex.getCause();
-        if (cause == null) {
-            return false;
-        } else if (cause.getClass().equals(cls)) {
-            return true;
-        } else {
-            return wasCausedBy(cause, cls);
-        }
-    }
+    /*
+     * Unused now. private static boolean wasCausedBy(Throwable ex, Class<?>
+     * cls) { Throwable cause = ex.getCause(); if (cause == null) { return
+     * false; } else if (cause.getClass().equals(cls)) { return true; } else {
+     * return wasCausedBy(cause, cls); } }
+     */
 
     @Test
     public void testProperties() throws Exception {


### PR DESCRIPTION
When XML filters try to load invalid XML files when loading project, it raises fatal error and abort loading project.
It is not useful for ordinal translators who just accept source file.

This changes to show error message and continue to load files when the failure occurred. 

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  XML/DocBook filter breaks project load when XML has error  
  * https://sourceforge.net/p/omegat/bugs/1138/


## What does this PR change?

- Catch `TranlationException` in `RealProject#loadSourceFiles` and show message and ignore a file.
- Add test case that raise `TranslationExeption` when  visits invalid docbook source file.
- Spotless code formatting

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
