### PR TITLE
Improve reuse of a backup project files

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2297,7 +2297,7 @@ PROJECT_TM_FOLDER=Translation memory folder {0} does not exist.
 PROJECT_EXPORT_TM_FOLDER=Export translation memory folder {0} does not exist.
 PROJECT_W_GLOSSARY=No writable glossary file in the glossary folder.
 PROJECT_LOCKED=Project locked. Perhaps it is already opened in another OmegaT instance
-PROJECT_INVALID=Specified folder is not a OmegaT poject, or project file is broken, or no valid backup.
+PROJECT_INVALID=The specified folder is not an OmegaT project, or the project file is broken, or there is no valid backup.
 
 #Team work
 SVN_START=SVN '{0}' execution start

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2297,6 +2297,7 @@ PROJECT_TM_FOLDER=Translation memory folder {0} does not exist.
 PROJECT_EXPORT_TM_FOLDER=Export translation memory folder {0} does not exist.
 PROJECT_W_GLOSSARY=No writable glossary file in the glossary folder.
 PROJECT_LOCKED=Project locked. Perhaps it is already opened in another OmegaT instance
+PROJECT_INVALID=Specified folder is not a OmegaT poject, or project file is broken, or no valid backup.
 
 #Team work
 SVN_START=SVN '{0}' execution start

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -345,11 +345,10 @@ public final class ProjectUICommands {
                 }
 
                 ProjectProperties props = ProjectFileStorage.loadProjectProperties(projectRoot);
-                if (props.getRepositories() == null) { // We assume it's a
-                                                       // project with no
-                                                       // repository mapping,
-                    props.setRepositories(repos); // so we add root repository
-                                                  // mapping
+                if (props.getRepositories() == null) {
+                    // We assume it's a project with no repository mapping,
+                    // so we add root repository mapping
+                    props.setRepositories(repos);
                 } else {
                     RepositoryDefinition remoteRepo = getRootGitRepositoryMapping(props.getRepositories());
                     if (isRepositoryEquals(remoteRepo, repo)) {
@@ -468,7 +467,7 @@ public final class ProjectUICommands {
             if (OmegaTFileChooser.APPROVE_OPTION != pfc
                     .showOpenDialog(Core.getMainWindow().getApplicationFrame())) {
                 return null;
-            }
+             }
             projectRootFolder = pfc.getSelectedFile();
         } else {
             projectRootFolder = projectDirectory;
@@ -478,7 +477,7 @@ public final class ProjectUICommands {
 
     private static boolean convertOldProjectIfNeed(File projectRootFolder) {
         try {
-            // convert old projects if need
+            // convert old projects if needed
             ConvertProject.convert(projectRootFolder);
         } catch (Exception ex) {
             Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_CONVERT_PROJECT");
@@ -525,41 +524,41 @@ public final class ProjectUICommands {
                  * Every time we reopen the project, we copy omegat.project from
                  * the remote project, We take following strategy and procedure
                  * to open the project.
-                 * 
-                 * ￼ 1. When opening a teamwork project as local only
+                 *
+                 *   1. When opening a teamwork project as local only
                  *      non-teamwork by passing 'no-team' to command line, skip
                  *      teamwork treatment.
-                 * 
-                 * ￼ 2. Save the currently effective repository mapping from
+                 *
+                 *   2. Save the currently effective repository mapping from
                  *      LOCAL to variable 'repos'.
-                 * 
-                 * ￼ 3. Update project.properties from REMOTE copy of
+                 *
+                 *   3. Update project.properties from REMOTE copy of
                  *      omegat.project that has postfix .NEW by calling
                  *      loadPropertiesFile(... ) with "omegat.project.NEW".
                  *      It respects a local root repository URL than remote
                  *      mapping configuration
-                 * 
-                 * ￼ 4. Handles mappings of four cases.
                  *
-                 *    ￼ a. no mapping
-                 * 
-                 * ￼    b. no remote mapping, there are local mapping(s)
-                 *  ￼      the locally defined mapping(s) are merged into
+                 *   4. Handles mappings of four cases.
+                 *
+                 *      a. no mapping
+                 *
+                 *      b. no remote mapping, there are local mapping(s)
+                 *         the locally defined mapping(s) are merged into
                  *         local omegat.project.
-                 * 
-                 * ￼    c. remote mapping, no local mapping(s)
-                 * 
-                 * ￼    d. remote and local mappings
-                 *       ￼ Local mapping changes are overwritten except
+                 *
+                 *      c. remote mapping, no local mapping(s)
+                 *
+                 *      d. remote and local mappings
+                 *         Local mapping changes are overwritten except
                  *         for root repository mapping.
-                 * 
-                 * ￼ 5. We save the original project file with as
+                 *
+                 *   5. We save the original project file with as
                  *      omegat.project.timestamp.bak
-                 * 
+                 *
                  * @note: We may want to make sure that the remote
-                 * props.GetRepositories match ￼ the previous current setup, but
-                 * this does not seem to be the intention of ￼ the current
-                 * mapping usage. ￼
+                 * props.GetRepositories match the previous current setup, but
+                 * this does not seem to be the intention of the current
+                 * mapping usage.
                  */
                 if (!Core.getParams().containsKey(CLIParameters.NO_TEAM)) {
                     ProjectProperties localProps = props;

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -132,8 +132,7 @@ public final class ProjectUICommands {
                 props.setSourceLanguage(Preferences.getPreferenceDefault(Preferences.SOURCE_LOCALE, "EN-US"));
                 props.setTargetLanguage(Preferences.getPreferenceDefault(Preferences.TARGET_LOCALE, "EN-GB"));
                 ProjectPropertiesDialog newProjDialog = new ProjectPropertiesDialog(
-                        Core.getMainWindow().getApplicationFrame(),
-                        props, dir.getAbsolutePath(),
+                        Core.getMainWindow().getApplicationFrame(), props, dir.getAbsolutePath(),
                         ProjectPropertiesDialog.Mode.NEW_PROJECT);
                 newProjDialog.setVisible(true);
                 newProjDialog.dispose();
@@ -260,7 +259,8 @@ public final class ProjectUICommands {
         }
         // add .zip extension if there is no
         final File med = ndm.getSelectedFile().getName().toLowerCase(Locale.ENGLISH).endsWith(".zip")
-                ? ndm.getSelectedFile() : new File(ndm.getSelectedFile().getAbsolutePath() + ".zip");
+                ? ndm.getSelectedFile()
+                : new File(ndm.getSelectedFile().getAbsolutePath() + ".zip");
 
         new SwingWorker<Void, Void>() {
             protected Void doInBackground() throws Exception {
@@ -310,6 +310,7 @@ public final class ProjectUICommands {
             File projectRoot;
             IMainWindow mainWindow;
             Cursor oldCursor;
+
             protected Void doInBackground() throws Exception {
                 mainWindow = Core.getMainWindow();
                 mainWindow.showStatusMessageRB(null);
@@ -344,21 +345,27 @@ public final class ProjectUICommands {
                 }
 
                 ProjectProperties props = ProjectFileStorage.loadProjectProperties(projectRoot);
-                if (props.getRepositories() == null) { // We assume it's a project with no repository mapping,
-                    props.setRepositories(repos);      // so we add root repository mapping
+                if (props.getRepositories() == null) { // We assume it's a
+                                                       // project with no
+                                                       // repository mapping,
+                    props.setRepositories(repos); // so we add root repository
+                                                  // mapping
                 } else {
                     RepositoryDefinition remoteRepo = getRootGitRepositoryMapping(props.getRepositories());
                     if (isRepositoryEquals(remoteRepo, repo)) {
-                        // when remote repository config is different with opening url, respect local one
+                        // when remote repository config is different with
+                        // opening url, respect local one
                         setRootGitRepositoryMapping(props.getRepositories(), repo);
                     }
                 }
-                // We write in all cases, because we might have added default excludes, for instance
+                // We write in all cases, because we might have added default
+                // excludes, for instance
                 ProjectFileStorage.writeProjectFile(props);
                 mainWindow.setCursor(oldCursor);
-                oldCursor=null;
+                oldCursor = null;
                 return null;
             }
+
             @Override
             protected void done() {
                 Core.getMainWindow().showProgressMessage(" ");
@@ -375,7 +382,8 @@ public final class ProjectUICommands {
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_DOWNLOAD_TEAM_PROJECT");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_DOWNLOAD_TEAM_PROJECT");
-                    if (oldCursor != null) mainWindow.setCursor(oldCursor);
+                    if (oldCursor != null)
+                        mainWindow.setCursor(oldCursor);
                 }
             }
         }.execute();
@@ -385,7 +393,8 @@ public final class ProjectUICommands {
      * Open project. Does nothing if there is already a project open.
      * Convenience method for {@link #projectOpen(File, boolean)}.
      *
-     * @param projectDirectory Open project stored in projectDirectory
+     * @param projectDirectory
+     *            Open project stored in projectDirectory
      */
     public static void projectOpen(File projectDirectory) {
         projectOpen(projectDirectory, false);
@@ -456,8 +465,8 @@ public final class ProjectUICommands {
         if (projectDirectory == null) {
             // select existing project file - open it
             OmegaTFileChooser pfc = new OpenProjectFileChooser();
-            if (OmegaTFileChooser.APPROVE_OPTION != pfc.showOpenDialog(Core.getMainWindow()
-                    .getApplicationFrame())) {
+            if (OmegaTFileChooser.APPROVE_OPTION != pfc
+                    .showOpenDialog(Core.getMainWindow().getApplicationFrame())) {
                 return null;
             }
             projectRootFolder = pfc.getSelectedFile();
@@ -484,7 +493,8 @@ public final class ProjectUICommands {
         ProjectProperties props;
         try {
             props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
-            // Here, 'props' is the current project setting read from local copy of omegat.project
+            // Here, 'props' is the current project setting read from local copy
+            // of omegat.project
         } catch (Exception ex) {
             Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK");
             Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK");
@@ -510,28 +520,47 @@ public final class ProjectUICommands {
                         newProjectFile);
             }
             boolean needToSaveProperties = false;
-            File newProjectFile = null;
-            if (props.hasRepositories()) {  /* This a remote project
-                 Every time we reopen the project, we copy omegat.project from the remote project,
-                 We take following strategy and procedure to open the project.
-                 1. When opening a teamwork project as local only non-teamwork by passing 'no-team' to
-                 command line, skip teamwork treatment.
-                 2. Save the currently effective repository mapping from LOCAL to variable 'repos'.
-                 3. Update project.properties from REMOTE copy of omegat.project that has postfix .NEW
-                    by calling loadPropertiesFile(... ) with "omegat.project.NEW".
-                    It respects a local root repository URL than remote mapping configuration
-                 4. Handles mappings of four cases.
-                     a. no mapping
-                     b. no remote mapping, there are local mapping(s)
-                        the locally defined mapping(s) are merged into local omegat.project.
-                     c. remote mapping, no local mapping(s)
-                     d. remote and local mappings
-                        Local mapping changes are overwritten except for root repository mapping.
-                 5.  We save the original project file with as omegat.project.timestamp.bak
-                 @note: We may want to make sure that the remote props.GetRepositories match
-                  the previous current setup, but this does not seem to be the intention of
-                  the current mapping usage.
-                */
+            if (props.hasRepositories()) {
+                /* <p>
+                 * Every time we reopen the project, we copy omegat.project from
+                 * the remote project, We take following strategy and procedure
+                 * to open the project.
+                 * 
+                 * ￼ 1. When opening a teamwork project as local only
+                 *      non-teamwork by passing 'no-team' to command line, skip
+                 *      teamwork treatment.
+                 * 
+                 * ￼ 2. Save the currently effective repository mapping from
+                 *      LOCAL to variable 'repos'.
+                 * 
+                 * ￼ 3. Update project.properties from REMOTE copy of
+                 *      omegat.project that has postfix .NEW by calling
+                 *      loadPropertiesFile(... ) with "omegat.project.NEW".
+                 *      It respects a local root repository URL than remote
+                 *      mapping configuration
+                 * 
+                 * ￼ 4. Handles mappings of four cases.
+                 *
+                 *    ￼ a. no mapping
+                 * 
+                 * ￼    b. no remote mapping, there are local mapping(s)
+                 *  ￼      the locally defined mapping(s) are merged into
+                 *         local omegat.project.
+                 * 
+                 * ￼    c. remote mapping, no local mapping(s)
+                 * 
+                 * ￼    d. remote and local mappings
+                 *       ￼ Local mapping changes are overwritten except
+                 *         for root repository mapping.
+                 * 
+                 * ￼ 5. We save the original project file with as
+                 *      omegat.project.timestamp.bak
+                 * 
+                 * @note: We may want to make sure that the remote
+                 * props.GetRepositories match ￼ the previous current setup, but
+                 * this does not seem to be the intention of ￼ the current
+                 * mapping usage. ￼
+                 */
                 if (!Core.getParams().containsKey(CLIParameters.NO_TEAM)) {
                     ProjectProperties localProps = props;
                     List<RepositoryDefinition> localRepos = props.getRepositories();
@@ -540,47 +569,52 @@ public final class ProjectUICommands {
                         RemoteRepositoryProvider remoteRepositoryProvider = new RemoteRepositoryProvider(
                                 props.getProjectRootDir(), props.getRepositories(), props);
                         remoteRepositoryProvider.switchToVersion(OConsts.FILE_PROJECT, null);
-                        remoteRepositoryProvider.copyFilesFromReposToProject(OConsts.FILE_PROJECT,
-                                 ".NEW", false);
+                        remoteRepositoryProvider.copyFilesFromReposToProject(OConsts.FILE_PROJECT, ".NEW",
+                                false);
                         newProjectFile = new File(projectRootFolder.getAbsoluteFile(),
                                 OConsts.FILE_PROJECT + ".NEW");
                         props = ProjectFileStorage.loadPropertiesFile(projectRootFolder.getAbsoluteFile(),
                                 new File(projectRootFolder.getAbsoluteFile(), OConsts.FILE_PROJECT + ".NEW"));
-                        // Here, 'props' is the REMOTE project setting read from the remote omegat.project
-                        if (props.getRepositories() == null) {  // We have a project without mapping
+                        // Here, 'props' is the REMOTE project setting read from
+                        // the remote omegat.project
+                        if (props.getRepositories() == null) {
+                            // We have a project without mapping
+                            // So we restore the mapping we just lost
                             Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
-                            props.setRepositories(localRepos); // So we restore the mapping we just lost
+                            props.setRepositories(localRepos);
                         } else {
                             // use mapping from remote configuration but
-                            // override repository URL when project URL is git type
-                            // when there is difference between local and remote config.
-                            RepositoryDefinition localRootRepository =
-                                    getRootGitRepositoryMapping(localRepos);
-                            RepositoryDefinition newRepository =
-                                    getRootGitRepositoryMapping(props.getRepositories());
+                            // override repository URL when project URL is git
+                            // type when there is difference between local and
+                            // remote config.
+                            RepositoryDefinition localRootRepository = getRootGitRepositoryMapping(
+                                    localRepos);
+                            RepositoryDefinition newRepository = getRootGitRepositoryMapping(
+                                    props.getRepositories());
                             if (!isRepositoryEquals(localRootRepository, newRepository)) {
-                                setRootGitRepositoryMapping(props.getRepositories(),
-                                        localRootRepository);
+                                setRootGitRepositoryMapping(props.getRepositories(), localRootRepository);
                             }
                         }
-                        needToSaveProperties = !isIdenticalOmegatProjectProperties(props,localProps);
+                        needToSaveProperties = !isIdenticalOmegatProjectProperties(props, localProps);
                     } catch (IRemoteRepository2.NetworkException ignore) {
-                        // Do nothing. Network errors are handled in RealProject.
+                        // Do nothing. Network errors are handled in
+                        // RealProject.
                     } catch (Exception e) {
                         Log.logErrorRB(e, "TF_PROJECT_PROPERTIES_ERROR");
                         throw e;
                     }
                 }
-                // team project - non-exist directories could be created from repo
+                // team project - non-exist directories could be created from
+                // repo
                 props.autocreateDirectories();
             } else {
                 // not a team project - ask for non-exist directories
                 File projectFile = new File(projectRootFolder, OConsts.FILE_PROJECT);
                 while (!props.isProjectValid()) {
-                    // something wrong with the project - display open dialog to fix it
+                    // something wrong with the project - display open dialog to
+                    // fix it
                     ProjectPropertiesDialog prj = new ProjectPropertiesDialog(
-                            Core.getMainWindow().getApplicationFrame(), props,
-                            projectFile.getAbsolutePath(),
+                            Core.getMainWindow().getApplicationFrame(), props, projectFile.getAbsolutePath(),
                             ProjectPropertiesDialog.Mode.RESOLVE_DIRS);
                     prj.setVisible(true);
                     props = prj.getResult();
@@ -622,8 +656,11 @@ public final class ProjectUICommands {
 
     /**
      * Detect whether local omegat.project is identical with remote one.
-     * @param that remote omegat.project.
-     * @param my local omegat.project.
+     * 
+     * @param that
+     *            remote omegat.project.
+     * @param my
+     *            local omegat.project.
      * @return true if identical, otherwise false.
      */
     private static boolean isIdenticalOmegatProjectProperties(ProjectProperties that, ProjectProperties my) {
@@ -645,22 +682,22 @@ public final class ProjectUICommands {
             if (!new EqualsBuilder()
                     .append(my.getRepositories().get(i).getType(), that.getRepositories().get(i).getType())
                     .append(my.getRepositories().get(i).getUrl(), that.getRepositories().get(i).getUrl())
-                    .append(my.getRepositories().get(i).getBranch(), that.getRepositories().get(i).getBranch())
+                    .append(my.getRepositories().get(i).getBranch(),
+                            that.getRepositories().get(i).getBranch())
                     .append(my.getRepositories().get(i).getMapping().size(),
                             that.getRepositories().get(i).getMapping().size())
                     .isEquals()) {
                 return false;
             }
-            if (my.getRepositories().get(i).getMapping().size() != that.getRepositories().get(i).getMapping().size()) {
+            if (my.getRepositories().get(i).getMapping().size() != that.getRepositories().get(i).getMapping()
+                    .size()) {
                 return false;
             }
-            for (int j = 0; j < my.getRepositories().get(i).getMapping().size(); j ++) {
+            for (int j = 0; j < my.getRepositories().get(i).getMapping().size(); j++) {
                 RepositoryMapping thisMap = my.getRepositories().get(i).getMapping().get(j);
                 RepositoryMapping thatMap = that.getRepositories().get(i).getMapping().get(j);
-                if (!new EqualsBuilder()
-                        .append(thisMap.getLocal(), thatMap.getLocal())
-                        .append(thisMap.getRepository(), thatMap.getRepository())
-                        .isEquals()) {
+                if (!new EqualsBuilder().append(thisMap.getLocal(), thatMap.getLocal())
+                        .append(thisMap.getRepository(), thatMap.getRepository()).isEquals()) {
                     return false;
                 }
             }
@@ -672,25 +709,29 @@ public final class ProjectUICommands {
                 .append(my.getProjectName(), that.getProjectName())
                 .append(my.getSourceLanguage().getLocaleCode(), that.getSourceLanguage().getLocaleCode())
                 .append(my.getTargetLanguage().getLocaleCode(), that.getTargetLanguage().getLocaleCode())
-                .append(my.getSourceTokenizer().getCanonicalName(), that.getSourceTokenizer().getCanonicalName())
-                .append(my.getTargetTokenizer().getCanonicalName(), that.getTargetTokenizer().getCanonicalName())
+                .append(my.getSourceTokenizer().getCanonicalName(),
+                        that.getSourceTokenizer().getCanonicalName())
+                .append(my.getTargetTokenizer().getCanonicalName(),
+                        that.getTargetTokenizer().getCanonicalName())
                 .append(my.getExportTmLevels(), that.getExportTmLevels())
                 .append(my.getExternalCommand(), that.getExternalCommand())
                 .append(my.getProjectRootDir(), that.getProjectRootDir())
                 .append(my.getSourceDir().getUnderRoot(), that.getSourceDir().getUnderRoot())
                 .append(my.getTargetDir().getUnderRoot(), that.getTargetDir().getUnderRoot())
                 .append(my.getGlossaryDir().getUnderRoot(), that.getGlossaryDir().getUnderRoot())
-                .append(my.getWritableGlossaryFile().getUnderRoot(), that.getWritableGlossaryFile().getUnderRoot())
+                .append(my.getWritableGlossaryFile().getUnderRoot(),
+                        that.getWritableGlossaryFile().getUnderRoot())
                 .append(my.getTmDir().getUnderRoot(), that.getTmDir().getUnderRoot())
                 .append(my.getExportTMRoot(), that.getExportTMRoot())
-                .append(my.getDictRoot(), that.getDictRoot())
-                .isEquals();
+                .append(my.getDictRoot(), that.getDictRoot()).isEquals();
     }
 
     private static RepositoryDefinition getRootGitRepositoryMapping(List<RepositoryDefinition> repos) {
         RepositoryDefinition repositoryDefinition = null;
         for (RepositoryDefinition definition : repos) {
-            if (definition.getMapping().get(0).getLocal().equals("/") && definition.getMapping().get(0).getRepository().equals("/") && definition.getType().equals("git")) {
+            if (definition.getMapping().get(0).getLocal().equals("/")
+                    && definition.getMapping().get(0).getRepository().equals("/")
+                    && definition.getType().equals("git")) {
                 repositoryDefinition = definition;
                 break;
             }
@@ -699,7 +740,7 @@ public final class ProjectUICommands {
     }
 
     private static void setRootGitRepositoryMapping(List<RepositoryDefinition> repos,
-                                                    RepositoryDefinition repositoryDefinition) {
+            RepositoryDefinition repositoryDefinition) {
         if (repositoryDefinition == null) {
             return;
         }
@@ -716,11 +757,8 @@ public final class ProjectUICommands {
         if (a == null || b == null) {
             return false;
         }
-        return new EqualsBuilder()
-                .append(a.getType(), b.getType())
-                .append(a.getUrl(), b.getUrl())
-                .append(a.getBranch(), b.getBranch())
-                .isEquals();
+        return new EqualsBuilder().append(a.getType(), b.getType()).append(a.getUrl(), b.getUrl())
+                .append(a.getBranch(), b.getBranch()).isEquals();
     }
 
     /**
@@ -739,11 +777,10 @@ public final class ProjectUICommands {
         }
     }
 
-
     /**
      * Project reload.
      * <p>
-     *     When select Project>Reload jump to here.
+     * When select Project>Reload jump to here.
      */
     public static void projectReload() {
         UIThreadsUtil.mustBeSwingThread();
@@ -765,11 +802,9 @@ public final class ProjectUICommands {
     /**
      * Reload project from remote repository.
      * <p>
-     *     When the project is a team project,
-     *     it reloads `omegat.project` from remote project
-     *     and open the project from start.
-     *     When the project is local project, it acts as
-     *     same as just reload.
+     * When the project is a team project, it reloads `omegat.project` from
+     * remote project and open the project from start. When the project is local
+     * project, it acts as same as just reload.
      */
     private static void projectReloadRemote() {
         ProjectProperties props = Core.getProject().getProjectProperties();
@@ -788,8 +823,8 @@ public final class ProjectUICommands {
     /**
      * Reload local project files.
      * <p>
-     *     This does not reload remote project when team mode.
-     *     It is useful when user added source files in local.
+     * This does not reload remote project when team mode. It is useful when
+     * user added source files in local.
      *
      */
     private static void projectReloadLocal() {
@@ -832,8 +867,8 @@ public final class ProjectUICommands {
     /**
      * Save project.
      * <p>
-     *     When the project is a team project, it also commit files and
-     *     push to remote.
+     * When the project is a team project, it also commit files and push to
+     * remote.
      */
     public static void projectSave() {
         UIThreadsUtil.mustBeSwingThread();
@@ -874,7 +909,7 @@ public final class ProjectUICommands {
     /**
      * Close project.
      * <p>
-     *     When the project is a team project, it commits and push first.
+     * When the project is a team project, it commits and push first.
      */
     public static void projectClose() {
         UIThreadsUtil.mustBeSwingThread();
@@ -910,7 +945,8 @@ public final class ProjectUICommands {
                 Core.getMainWindow().showProgressMessage(
                         Preferences.getPreferenceEnumDefault(Preferences.SB_PROGRESS_MODE,
                                 MainWindowUI.StatusBarMode.DEFAULT) == MainWindowUI.StatusBarMode.DEFAULT
-                        ? OStrings.getString("MW_PROGRESS_DEFAULT") : OStrings.getProgressBarDefaultPrecentageText());
+                                        ? OStrings.getString("MW_PROGRESS_DEFAULT")
+                                        : OStrings.getProgressBarDefaultPrecentageText());
 
                 return null;
             }
@@ -921,7 +957,8 @@ public final class ProjectUICommands {
                 } catch (Exception ex) {
                     processSwingWorkerException(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                 }
-                // Restore global prefs in case project had project-specific ones
+                // Restore global prefs in case project had project-specific
+                // ones
                 Core.setFilterMaster(new FilterMaster(Preferences.getFilters()));
                 Core.setSegmenter(new Segmenter(Preferences.getSRX()));
             }
@@ -1123,7 +1160,9 @@ public final class ProjectUICommands {
 
     /**
      * Open remote project specified by url.
-     * @param url remote project repository.
+     * 
+     * @param url
+     *            remote project repository.
      */
     public static void projectRemote(String url) {
         File projectDir;
@@ -1154,9 +1193,11 @@ public final class ProjectUICommands {
     }
 
     /**
-     * Copy the specified files to the specified destination. The project will be reloaded afterward.
+     * Copy the specified files to the specified destination. The project will
+     * be reloaded afterward.
      * <p>
-     * Convenience method for {@link #projectImportFiles(String, File[], boolean)}.
+     * Convenience method for
+     * {@link #projectImportFiles(String, File[], boolean)}.
      *
      * @param destination
      *            The path to copy the files to
@@ -1168,15 +1209,17 @@ public final class ProjectUICommands {
     }
 
     /**
-     * Copy the specified files to the specified destination, then reload if indicated. Note that a modal
-     * dialog will be shown if any of the specified files would be overwritten.
+     * Copy the specified files to the specified destination, then reload if
+     * indicated. Note that a modal dialog will be shown if any of the specified
+     * files would be overwritten.
      *
      * @param destination
      *            The path to copy the files to
      * @param toImport
      *            Files to copy to destination path
      * @param doReload
-     *            If true, the project will be reloaded after the files are successfully copied
+     *            If true, the project will be reloaded after the files are
+     *            successfully copied
      */
     public static void projectImportFiles(String destination, File[] toImport, boolean doReload) {
         UIThreadsUtil.mustBeSwingThread();
@@ -1250,11 +1293,12 @@ public final class ProjectUICommands {
      */
     public static void doWikiImport() {
         String remoteUrl = JOptionPane.showInputDialog(Core.getMainWindow().getApplicationFrame(),
-                OStrings.getString("TF_WIKI_IMPORT_PROMPT"),
-                OStrings.getString("TF_WIKI_IMPORT_TITLE"), JOptionPane.WARNING_MESSAGE);
+                OStrings.getString("TF_WIKI_IMPORT_PROMPT"), OStrings.getString("TF_WIKI_IMPORT_TITLE"),
+                JOptionPane.WARNING_MESSAGE);
         String projectsource = Core.getProject().getProjectProperties().getSourceRoot();
         if (remoteUrl == null || remoteUrl.trim().isEmpty()) {
-            // [1762625] Only try to get MediaWiki page if a string has been entered
+            // [1762625] Only try to get MediaWiki page if a string has been
+            // entered
             return;
         }
         try {
@@ -1273,7 +1317,8 @@ public final class ProjectUICommands {
             return false;
         }
         Path path = dir.toPath();
-        // Use NIO methods because File.canRead/canWrite give incorrect responses on Windows
+        // Use NIO methods because File.canRead/canWrite give incorrect
+        // responses on Windows
         if (!Files.isWritable(path) || !Files.isReadable(path)) {
             Log.logErrorRB("CT_ERROR_PROJECT_DIR_PERMISSIONS", path);
             Core.getMainWindow().displayWarningRB("CT_ERROR_CREATING_PROJECT");

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -78,6 +78,27 @@ public final class FileUtil {
     }
 
     /**
+     * Get most recent backup file path.
+     * 
+     * @param originalFile
+     *            target original file name.
+     */
+    public static File getRecentBackup(final File originalFile) {
+        File[] bakFiles = null;
+        try {
+            bakFiles = originalFile.getParentFile()
+                    .listFiles(f -> !f.isDirectory() && f.getName().startsWith(originalFile.getName())
+                            && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
+        } catch (Exception ignored) {
+        }
+        if (bakFiles == null) {
+            return null;
+        }
+        Arrays.sort(bakFiles, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
+        return bakFiles[0];
+    }
+
+    /**
      * Removes older backups to be under specified number of files.
      * @param originalFile target original file name.
      * @param maxBackups maximum number of back up files.

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -100,14 +100,17 @@ public final class FileUtil {
 
     /**
      * Removes older backups to be under specified number of files.
-     * @param originalFile target original file name.
-     * @param maxBackups maximum number of back up files.
+     * 
+     * @param originalFile
+     *            target original file name.
+     * @param maxBackups
+     *            maximum number of back up files.
      */
     public static void removeOldBackups(final File originalFile, int maxBackups) {
         try {
-            File[] bakFiles = originalFile.getParentFile().listFiles(
-                    f -> !f.isDirectory() && f.getName().startsWith(originalFile.getName())
-                    && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
+            File[] bakFiles = originalFile.getParentFile()
+                    .listFiles(f -> !f.isDirectory() && f.getName().startsWith(originalFile.getName())
+                            && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
 
             if (bakFiles != null && bakFiles.length > maxBackups) {
                 Arrays.sort(bakFiles, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
@@ -122,7 +125,9 @@ public final class FileUtil {
 
     /**
      * Create file backup with datetime suffix.
-     * @param original a file to copy as backup file.
+     * 
+     * @param original
+     *            a file to copy as backup file.
      * @return Backup file.
      */
     public static File backupFile(File original) throws IOException {
@@ -134,8 +139,8 @@ public final class FileUtil {
     }
 
     /**
-     * Renames file, with checking errors and 3 seconds retry against external programs (like antivirus or
-     * TortoiseSVN) locking.
+     * Renames file, with checking errors and 3 seconds retry against external
+     * programs (like antivirus or TortoiseSVN) locking.
      */
     public static void rename(File from, File to) throws IOException {
         if (!from.exists()) {
@@ -154,8 +159,8 @@ public final class FileUtil {
     }
 
     /**
-     * Copy file and create output directory if need. EOL will be converted into target-specific or into
-     * platform-specific if target doesn't exist.
+     * Copy file and create output directory if need. EOL will be converted into
+     * target-specific or into platform-specific if target doesn't exist.
      */
     public static void copyFileWithEolConversion(File inFile, File outFile, Charset charset)
             throws IOException {
@@ -169,7 +174,8 @@ public final class FileUtil {
             eol = getEOL(outFile, charset);
         }
         if (eol == null) {
-            // file does not exist or EOL not detected - use system-dependent value
+            // file does not exist or EOL not detected - use system-dependent
+            // value
             eol = System.lineSeparator();
         }
         try (BufferedReader in = Files.newBufferedReader(inFile.toPath(), charset)) {
@@ -187,7 +193,8 @@ public final class FileUtil {
     /**
      * Read a file to determine its end-of-line character(s).
      *
-     * If neither '\n' nor '\r' are present in the file then it will return null.
+     * If neither '\n' nor '\r' are present in the file then it will return
+     * null.
      *
      * @param file
      * @param charset
@@ -311,10 +318,12 @@ public final class FileUtil {
 
     /**
      * Expand tilde(~) in first character in path string.
-     * @param path path string
+     * 
+     * @param path
+     *            path string
      * @return expanded path string
      */
-    public static String expandTildeHomeDir(final String path){
+    public static String expandTildeHomeDir(final String path) {
         if (path.startsWith("~+/") || path.equals("~+")) {
             Path currentRelativePath = Paths.get("");
             String pwd = currentRelativePath.toAbsolutePath().toString();
@@ -339,16 +348,22 @@ public final class FileUtil {
     }
 
     /**
-     * Copy a collection of files to a destination. Recursively copies contents of directories
-     * while preserving relative paths. Provide an {@link ICollisionCallback} to determine
-     * what to do with files with conflicting names; they will be overwritten if the callback is null.
-     * @param destination Directory to copy to
-     * @param toCopy Files to copy
-     * @param onCollision Callback that determines what to do in case files with the same name
-     * already exist
+     * Copy a collection of files to a destination. Recursively copies contents
+     * of directories while preserving relative paths. Provide an
+     * {@link ICollisionCallback} to determine what to do with files with
+     * conflicting names; they will be overwritten if the callback is null.
+     * 
+     * @param destination
+     *            Directory to copy to
+     * @param toCopy
+     *            Files to copy
+     * @param onCollision
+     *            Callback that determines what to do in case files with the
+     *            same name already exist
      * @throws IOException
      */
-    public static void copyFilesTo(File destination, File[] toCopy, ICollisionCallback onCollision) throws IOException {
+    public static void copyFilesTo(File destination, File[] toCopy, ICollisionCallback onCollision)
+            throws IOException {
         if (destination.exists() && !destination.isDirectory()) {
             throw new IOException("Copy-to destination exists and is not a directory.");
         }
@@ -377,7 +392,8 @@ public final class FileUtil {
         }
     }
 
-    private static Map<File, File> copyFilesTo(File destination, File[] toCopy, File root) throws IOException {
+    private static Map<File, File> copyFilesTo(File destination, File[] toCopy, File root)
+            throws IOException {
         Map<File, File> collisions = new LinkedHashMap<File, File>();
         for (File file : toCopy) {
             if (destination.getPath().startsWith(file.getPath())) {
@@ -417,8 +433,9 @@ public final class FileUtil {
     }
 
     /**
-     * Converts Windows absolute path into current system's absolute path. It required for conversion like
-     * 'C:\zzz' into '/zzz' for be real absolute in Linux.
+     * Converts Windows absolute path into current system's absolute path. It
+     * required for conversion like 'C:\zzz' into '/zzz' for be real absolute in
+     * Linux.
      */
     public static String absoluteForSystem(String path, Platform.OsType currentOsType) {
         path = path.replace('\\', '/');
@@ -446,18 +463,18 @@ public final class FileUtil {
         }
     }
 
-    public static List<String> buildRelativeFilesList(File rootDir, List<String> includes, List<String> excludes)
-            throws IOException {
+    public static List<String> buildRelativeFilesList(File rootDir, List<String> includes,
+            List<String> excludes) throws IOException {
         Path root = rootDir.toPath();
         Pattern[] includeMasks = FileUtil.compileFileMasks(includes);
         Pattern[] excludeMasks = FileUtil.compileFileMasks(excludes);
         BiPredicate<Path, BasicFileAttributes> pred = (p, attr) -> {
-            return p.toFile().isFile() && FileUtil.checkFileInclude(root.relativize(p).toString(), includeMasks, excludeMasks);
+            return p.toFile().isFile()
+                    && FileUtil.checkFileInclude(root.relativize(p).toString(), includeMasks, excludeMasks);
         };
         try (Stream<Path> stream = Files.find(root, Integer.MAX_VALUE, pred, FileVisitOption.FOLLOW_LINKS)) {
             return stream.map(p -> root.relativize(p).toString().replace('\\', '/'))
-                .sorted(StreamUtil.localeComparator(Function.identity()))
-                .collect(Collectors.toList());
+                    .sorted(StreamUtil.localeComparator(Function.identity())).collect(Collectors.toList());
         }
     }
 
@@ -535,16 +552,18 @@ public final class FileUtil {
     }
 
     /**
-     * Given a list of paths, return a list of filenames (a la {@code File.getName()}) plus the minimum number of parent
-     * path segments required to make each filename unique within the result list. E.g.
+     * Given a list of paths, return a list of filenames (a la
+     * {@code File.getName()}) plus the minimum number of parent path segments
+     * required to make each filename unique within the result list. E.g.
      * <ul>
      * <li>{@code [foo/bar.txt, foo/baz.txt] -> [bar.txt, baz.txt]}
      * <li>{@code [foo/bar/baz.txt, foo/fop/baz.txt] -> [bar/baz.txt, fop/baz.txt]}
      * <li>{@code [foo/bar/baz/fop.txt, foo/buz/baz/fop.txt] -> [bar/baz/fop.txt, buz/baz/fop.txt]}
-     * <li>{@code [foo.txt, foo.txt] -> [foo.txt, foo.txt]} (actual duplicates are unmodified)
+     * <li>{@code [foo.txt, foo.txt] -> [foo.txt, foo.txt]} (actual duplicates
+     * are unmodified)
      * </ul>
-     * Note that paths will be normalized (indirections removed, trailing and duplicate separators removed, separators
-     * become {@code /}).
+     * Note that paths will be normalized (indirections removed, trailing and
+     * duplicate separators removed, separators become {@code /}).
      *
      * @param paths
      *            A list of paths
@@ -553,7 +572,8 @@ public final class FileUtil {
     public static List<String> getUniqueNames(List<String> paths) {
         // Normalize
         List<String> fullPaths = new ArrayList<>(paths);
-        fullPaths.replaceAll(p -> Optional.ofNullable(FilenameUtils.normalizeNoEndSeparator(p, true)).orElse(""));
+        fullPaths.replaceAll(
+                p -> Optional.ofNullable(FilenameUtils.normalizeNoEndSeparator(p, true)).orElse(""));
         // Create working array with first attempt (one segment)
         List<String> working = new ArrayList<>(fullPaths);
         working.replaceAll(p -> StringUtil.getTailSegments(p, '/', 1));
@@ -574,7 +594,8 @@ public final class FileUtil {
                     // Re-trim the duplicate with one extra segment
                     String curr = working.get(i);
                     String trimmed = StringUtil.getTailSegments(fullPaths.get(i), '/', ++segments[i]);
-                    // Re-trimmed value only valid if distinct from previous value
+                    // Re-trimmed value only valid if distinct from previous
+                    // value
                     if (!curr.equals(trimmed)) {
                         working.set(i, trimmed);
                         didTrim = true;
@@ -596,8 +617,8 @@ public final class FileUtil {
     }
 
     /**
-     * Comparator to sort the tm/ folder alphabetically, but always put tm/enforce
-     * and tm/auto results before other similar % matches.
+     * Comparator to sort the tm/ folder alphabetically, but always put
+     * tm/enforce and tm/auto results before other similar % matches.
      */
     public static class TmFileComparator implements Comparator<String> {
         private static final String AUTO_PREFIX = OConsts.AUTO_TM + "/";


### PR DESCRIPTION
This change intend to improve an error handler and retry backup file when loading `omegat.project`

A root cause of the problem is a change #280 and #255 is not well integrated.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Error displayed when opening a project on Windows 10
  * https://sourceforge.net/p/omegat/bugs/1136/

## What does this PR change?

- Reuse backup files.
- Pick a latest backup file
- When project file are broken, reuse backup file
- Don't copy backup file to project file
- Don't produce `omegat.project.bak` file.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
