### PR TITLE
Add regression test for RFE#1506: handling XLIFF state attributes

### DIFF
--- a/src/org/omegat/filters3/xml/xliff/XLIFFDialect.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFDialect.java
@@ -63,8 +63,9 @@ public class XLIFFDialect extends DefaultXMLDialect {
     private boolean ignoreTypeForBptTags;
     private boolean changeStateToNeedsReviewTranslation;
     /**
-     * Sets whether alternative translations are identified by previous and next paragraphs or by &lt;trans-unit&gt; ID
-    */
+     * Sets whether alternative translations are identified by previous and next
+     * paragraphs or by &lt;trans-unit&gt; ID
+     */
     protected ID_TYPE altTransIDType;
 
     public XLIFFDialect() {
@@ -80,21 +81,21 @@ public class XLIFFDialect extends DefaultXMLDialect {
 
         defineOutOfTurnTags(new String[] { "sub", });
 
-        if (options.get26Compatibility()) { // Old tag handling compatible with 2.6
+        if (options.get26Compatibility()) { // Old tag handling compatible with
+                                            // 2.6
             defineIntactTags(new String[] { "source", "header", "bin-unit", "prop-group", "count-group",
-                    "alt-trans", "note",
-                    "ph", "bpt", "ept", "it", "context", "seg-source", "sdl:seg-defs"});
+                    "alt-trans", "note", "ph", "bpt", "ept", "it", "context", "seg-source", "sdl:seg-defs" });
 
         } else { // New tag handling
             defineIntactTags(new String[] { "source", "header", "bin-unit", "prop-group", "count-group",
-                    "alt-trans", "note",
-                    "context", "seg-source", "sdl:seg-defs"});
+                    "alt-trans", "note", "context", "seg-source", "sdl:seg-defs" });
 
             defineContentBasedTag("bpt", Tag.Type.BEGIN);
             defineContentBasedTag("ept", Tag.Type.END);
             defineContentBasedTag("it", Tag.Type.ALONE);
             defineContentBasedTag("ph", Tag.Type.ALONE);
-            // "mrk", only <mrk mtype="protected"> is content-based tag. see validateContentBasedTag
+            // "mrk", only <mrk mtype="protected"> is content-based tag. see
+            // validateContentBasedTag
 
             forceShortCutToF = options.getForceShortcutToF();
             ignoreTypeForPhTags = options.getIgnoreTypeForPhTags();
@@ -132,6 +133,7 @@ public class XLIFFDialect extends DefaultXMLDialect {
     /**
      * In the XLKIFF filter, content shouldn't be translated if translate="no"
      * http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#translate
+     * 
      * @param tag
      *            An XML tag
      * @param atts
@@ -145,9 +147,9 @@ public class XLIFFDialect extends DefaultXMLDialect {
             return true;
         }
 
-        if (!tag.equalsIgnoreCase("group") &&     // Translate can only appear in these tags
-            !tag.equalsIgnoreCase("trans-unit") &&
-            !tag.equalsIgnoreCase("bin-unit")) {
+        if (!tag.equalsIgnoreCase("group") && // Translate can only appear in
+                                              // these tags
+                !tag.equalsIgnoreCase("trans-unit") && !tag.equalsIgnoreCase("bin-unit")) {
             return false;
         }
 
@@ -166,9 +168,14 @@ public class XLIFFDialect extends DefaultXMLDialect {
 
     /**
      * Handle &lt;target state="..."&gt; attribute according to filter settings.
-     * @see <a href="https://sourceforge.net/p/omegat/feature-requests/1506/">RFE #1506</a>
-     * @param tag XML tag to be processed.
-     * @param translated is the value considered translated?
+     * 
+     * @see <a href=
+     *      "https://sourceforge.net/p/omegat/feature-requests/1506/">RFE
+     *      #1506</a>
+     * @param tag
+     *            XML tag to be processed.
+     * @param translated
+     *            is the value considered translated?
      */
     @Override
     public void handleXMLTag(XMLTag tag, boolean translated) {
@@ -180,7 +187,8 @@ public class XLIFFDialect extends DefaultXMLDialect {
             return;
         }
         String state = attr.getValue();
-        String nextTranslatedState = changeStateToNeedsReviewTranslation ? "needs-review-translation" : "translated";
+        String nextTranslatedState = changeStateToNeedsReviewTranslation ? "needs-review-translation"
+                : "translated";
         if (translated && ("needs-translation".equals(state) || "needs-review-translation".equals(state))) {
             attr.setValue(nextTranslatedState);
         } else if ("new".equals(state)) {
@@ -206,18 +214,22 @@ public class XLIFFDialect extends DefaultXMLDialect {
                 if ("bpt".equals(tag.getTag())) {
                     // XLIFF specification requires 'rid' and 'id' attributes,
                     // but some tools uses 'i' attribute like for TMX
-                    tagHandler.startBPT(tag.getAttribute("rid"), tag.getAttribute("id"), tag.getAttribute("i"));
+                    tagHandler.startBPT(tag.getAttribute("rid"), tag.getAttribute("id"),
+                            tag.getAttribute("i"));
                     shortcutLetter = calcTagShortcutLetter(tag, ignoreTypeForBptTags);
                     tagHandler.setTagShortcutLetter(shortcutLetter);
                     tagIndex = tagHandler.endBPT();
-                    shortcut = "<" + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
+                    shortcut = "<"
+                            + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
                             + tagIndex + '>';
                     tagProtected = false;
                 } else if ("ept".equals(tag.getTag())) {
-                    tagHandler.startEPT(tag.getAttribute("rid"), tag.getAttribute("id"), tag.getAttribute("i"));
+                    tagHandler.startEPT(tag.getAttribute("rid"), tag.getAttribute("id"),
+                            tag.getAttribute("i"));
                     tagIndex = tagHandler.endEPT();
                     shortcutLetter = tagHandler.getTagShortcutLetter();
-                    shortcut = "</" + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
+                    shortcut = "</"
+                            + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
                             + tagIndex + '>';
                     tagProtected = false;
                 } else if ("it".equals(tag.getTag())) {
@@ -227,17 +239,22 @@ public class XLIFFDialect extends DefaultXMLDialect {
                     // XLIFF specification requires 'open/close' values,
                     // but some tools may use 'begin/end' values like for TMX
                     shortcutLetter = calcTagShortcutLetter(tag);
-                    if ("close".equals(tagHandler.getCurrentPos()) || "end".equals(tagHandler.getCurrentPos())) {
-                        // In some cases, even if we're able to compute a shortcut, it's better to force to "f"
+                    if ("close".equals(tagHandler.getCurrentPos())
+                            || "end".equals(tagHandler.getCurrentPos())) {
+                        // In some cases, even if we're able to compute a
+                        // shortcut, it's better to force to "f"
                         // for better compatibility with corresponding TMX files
                         if (forceShortCutToF) {
                             shortcutLetter = 'f';
                         }
                         shortcut = "</"
-                                + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
+                                + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter))
+                                        : 'f')
                                 + tagIndex + '>';
                     } else {
-                        shortcut = "<" + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
+                        shortcut = "<"
+                                + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter))
+                                        : 'f')
                                 + tagIndex + '>';
                     }
                     tagProtected = false;
@@ -245,15 +262,16 @@ public class XLIFFDialect extends DefaultXMLDialect {
                     tagHandler.startOTHER();
                     tagIndex = tagHandler.endOTHER();
                     shortcutLetter = calcTagShortcutLetter(tag, ignoreTypeForPhTags);
-                    shortcut = "<" + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
+                    shortcut = "<"
+                            + (shortcutLetter != 0 ? String.valueOf(Character.toChars(shortcutLetter)) : 'f')
                             + tagIndex + "/>";
                     tagProtected = false;
                 } else if ("mrk".equals(tag.getTag())) {
                     tagHandler.startOTHER();
                     tagIndex = tagHandler.endOTHER();
                     shortcutLetter = 'm';
-                    shortcut = "<m" + tagIndex + ">" + tag.getIntactContents().sourceToOriginal() + "</m" + tagIndex
-                            + ">";
+                    shortcut = "<m" + tagIndex + ">" + tag.getIntactContents().sourceToOriginal() + "</m"
+                            + tagIndex + ">";
                     tagProtected = true;
                 } else {
                     shortcutLetter = 'f';
@@ -270,11 +288,13 @@ public class XLIFFDialect extends DefaultXMLDialect {
                 if (tagProtected) {
                     // protected text with related tags, like <m0>Acme</m0>
                     if (StatisticsSettings.isCountingProtectedText()) {
-                        // Protected texts are counted, but related tags are not counted in the word count
+                        // Protected texts are counted, but related tags are not
+                        // counted in the word count
                         pp.setReplacementWordsCountCalculation(StaticUtils.TAG_REPLACEMENT
                                 + tag.getIntactContents().sourceToOriginal() + StaticUtils.TAG_REPLACEMENT);
                     } else {
-                        // All protected parts are not counted in the word count(default)
+                        // All protected parts are not counted in the word
+                        // count(default)
                         pp.setReplacementWordsCountCalculation(StaticUtils.TAG_REPLACEMENT);
                     }
                     pp.setReplacementUniquenessCalculation(StaticUtils.TAG_REPLACEMENT);

--- a/src/org/omegat/filters3/xml/xliff/XLIFFDialect.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFDialect.java
@@ -181,7 +181,7 @@ public class XLIFFDialect extends DefaultXMLDialect {
         }
         String state = attr.getValue();
         String nextTranslatedState = changeStateToNeedsReviewTranslation ? "needs-review-translation" : "translated";
-        if (translated && "needs-translation".equals(state)) {
+        if (translated && ("needs-translation".equals(state) || "needs-review-translation".equals(state))) {
             attr.setValue(nextTranslatedState);
         } else if ("new".equals(state)) {
             String next = translated ? nextTranslatedState : "needs-translation";

--- a/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -70,9 +70,10 @@ public class XLIFFFilter extends XMLFilter {
     private String id;
 
     /**
-     * Sets whether alternative translations are identified by previous and next paragraphs or by &lt;trans-unit&gt; ID
-    */
-     private ID_TYPE altTransIDType = ID_TYPE.CONTEXT;
+     * Sets whether alternative translations are identified by previous and next
+     * paragraphs or by &lt;trans-unit&gt; ID
+     */
+    private ID_TYPE altTransIDType = ID_TYPE.CONTEXT;
 
     /**
      * Register plugin into OmegaT.
@@ -112,9 +113,8 @@ public class XLIFFFilter extends XMLFilter {
      */
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[] { new Instance("*.xlf", null, null),
-                                new Instance("*.xliff", null, null),
-                                new Instance("*.sdlxliff", null, null), };
+        return new Instance[] { new Instance("*.xlf", null, null), new Instance("*.xliff", null, null),
+                new Instance("*.sdlxliff", null, null), };
     }
 
     /**
@@ -157,7 +157,8 @@ public class XLIFFFilter extends XMLFilter {
      *
      * @param currentOptions
      *            Current options to edit.
-     * @return Updated filter options if user confirmed the changes, and current options otherwise.
+     * @return Updated filter options if user confirmed the changes, and current
+     *         options otherwise.
      */
     @Override
     public Map<String, String> changeOptions(Window parent, Map<String, String> currentOptions) {
@@ -177,28 +178,30 @@ public class XLIFFFilter extends XMLFilter {
     }
 
     /**
-     * We're not actually checking whether it is a valid XLIFF file; we just need a place to call defineDialect.
+     * We're not actually checking whether it is a valid XLIFF file; we just
+     * need a place to call defineDialect.
      */
     @Override
     public boolean isFileSupported(File inFile, Map<String, String> config, FilterContext context) {
         boolean result = super.isFileSupported(inFile, config, context);
         if (result) {
-                // Defining the actual dialect, because at this step
-                // we have the options
-                XLIFFDialect dialect = (XLIFFDialect) this.getDialect();
-                dialect.defineDialect(new XLIFFOptions(config));
-                try {
-                    super.processFile(inFile, null, context);
-                } catch (Exception e) {
-                    Log.log(e);
-                }
-                this.altTransIDType = dialect.altTransIDType;
+            // Defining the actual dialect, because at this step
+            // we have the options
+            XLIFFDialect dialect = (XLIFFDialect) this.getDialect();
+            dialect.defineDialect(new XLIFFOptions(config));
+            try {
+                super.processFile(inFile, null, context);
+            } catch (Exception e) {
+                Log.log(e);
+            }
+            this.altTransIDType = dialect.altTransIDType;
         }
         return result;
     }
 
     /**
-     * Support of group and trans-unit resname attribute and trans-unit <note> as comment, based on ResXFilter code
+     * Support of group and trans-unit resname attribute and trans-unit <note>
+     * as comment, based on ResXFilter code
      */
     @Override
     public void tagStart(String path, Attributes atts) {

--- a/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.xml.sax.Attributes;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.filters2.FilterContext;
@@ -44,7 +46,6 @@ import org.omegat.filters3.xml.xliff.XLIFFOptions.ID_TYPE;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
-import org.xml.sax.Attributes;
 
 /**
  * Filter for XLIFF files.
@@ -67,7 +68,8 @@ public class XLIFFFilter extends XMLFilter {
     private HashSet<String> altIDCache = new HashSet<String>();
 
     private String id;
-   /**
+
+    /**
      * Sets whether alternative translations are identified by previous and next paragraphs or by &lt;trans-unit&gt; ID
     */
      private ID_TYPE altTransIDType = ID_TYPE.CONTEXT;

--- a/test/data/filters/xliff/file-xliff-RFE1506-translated-expectation.xliff
+++ b/test/data/filters/xliff/file-xliff-RFE1506-translated-expectation.xliff
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file id="92" original="/22.txt" source-language="en" target-language="ja" datatype="plaintext" project-id="375123" tool-id="foo">
+    <header>
+      <tool tool-id="foo" tool-name="Boo" tool-version="1.0"/>
+    </header>
+    <body>
+      <trans-unit id="5078">
+        <source>1.0.1</source>
+        <target state="needs-translation">1.0.1</target>
+      </trans-unit>
+      <trans-unit id="5086" approved="yes">
+        <source>foo</source>
+        <target state="final">bar</target>
+      </trans-unit>
+      <trans-unit id="5088" approved="yes">
+        <source>Organizations list</source>
+        <target state="needs-review-translation">組織</target>
+      </trans-unit>
+      <trans-unit id="5090">
+        <source>Create</source>
+        <target state="translated">作成</target>
+      </trans-unit>
+     <trans-unit id="5128" approved="yes">
+        <source>- Emoji</source>
+        <target state="final">絵文字</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/data/filters/xliff/file-xliff-RFE1506.xliff
+++ b/test/data/filters/xliff/file-xliff-RFE1506.xliff
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file id="92" original="/22.txt" source-language="en" target-language="ja" datatype="plaintext" project-id="375123" tool-id="foo">
+    <header>
+      <tool tool-id="foo" tool-name="Boo" tool-version="1.0"/>
+    </header>
+    <body>
+      <trans-unit id="5078">
+        <source>1.0.1</source>
+        <target state="needs-translation">1.0.1</target>
+      </trans-unit>
+      <trans-unit id="5086" approved="yes">
+        <source>foo</source>
+        <target state="final">bar</target>
+      </trans-unit>
+      <trans-unit id="5088" approved="yes">
+        <source>Organization</source>
+        <target state="needs-review-translation">組織</target>
+      </trans-unit>
+      <trans-unit id="5090">
+        <source>Create</source>
+        <target state="needs-translation">Create</target>
+      </trans-unit>
+     <trans-unit id="5128" approved="yes">
+        <source>Emoji</source>
+        <target state="needs-review-translation">Emoji</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -118,10 +118,12 @@ public class XLIFFFilterTest extends TestFilterBase {
         assertEquals("Gandalf", ste.getProtectedParts()[0].getReplacementMatchCalculation());
         assertEquals("<m1>", ste.getProtectedParts()[1].getTextInSourceSegment());
         assertEquals("<mrk mtype=\"other\">", ste.getProtectedParts()[1].getDetailsFromSourceFile());
-        assertEquals(StaticUtils.TAG_REPLACEMENT, ste.getProtectedParts()[1].getReplacementMatchCalculation());
+        assertEquals(StaticUtils.TAG_REPLACEMENT,
+                ste.getProtectedParts()[1].getReplacementMatchCalculation());
         assertEquals("</m1>", ste.getProtectedParts()[2].getTextInSourceSegment());
         assertEquals("</mrk>", ste.getProtectedParts()[2].getDetailsFromSourceFile());
-        assertEquals(StaticUtils.TAG_REPLACEMENT, ste.getProtectedParts()[2].getReplacementMatchCalculation());
+        assertEquals(StaticUtils.TAG_REPLACEMENT,
+                ste.getProtectedParts()[2].getReplacementMatchCalculation());
         checkMultiNoPrevNext("one <o0>two</o0> three", null, null, null);
         checkMultiNoPrevNext("one <t0/> three", null, null, null);
         checkMultiNoPrevNext("one <w0/> three", null, null, null);
@@ -147,8 +149,8 @@ public class XLIFFFilterTest extends TestFilterBase {
                     }
                 });
         File trFile = new File(outFile.getPath() + "-translated");
-        List<String> lines = Files.lines(inFile.toPath()).map(line -> line.replace("NONTRANSLATED", "TRANSLATED"))
-                .collect(Collectors.toList());
+        List<String> lines = Files.lines(inFile.toPath())
+                .map(line -> line.replace("NONTRANSLATED", "TRANSLATED")).collect(Collectors.toList());
         Files.write(trFile.toPath(), lines);
         compareXML(trFile, outFile);
     }
@@ -282,16 +284,20 @@ public class XLIFFFilterTest extends TestFilterBase {
         String f = "test/data/filters/xliff/file-XLIFFFilter-properties.xlf";
         IProject.FileInfo fi = loadSourceFiles(filter, f);
 
-        // Check reading as properties. We don't really care about the order of the content in the parsed
-        // properties array (as long as the key=value pairs are consistent), so we do lose checking.
+        // Check reading as properties. We don't really care about the order of
+        // the content in the parsed
+        // properties array (as long as the key=value pairs are consistent), so
+        // we do lose checking.
         checkMultiStart(fi, f);
         checkMultiProps("tr1=This is test", null, null, "", "tr2=test2", "note", "foo", "group", "bazinga");
         checkMultiProps("tr2=test2", null, null, "tr1=This is test", "", "note", "bar", "resname", "baz",
                 "group", "bazinga");
         checkMultiEnd();
 
-        // Check reading as old comment string blobs. We don't really care about the order of the content in
-        // the parsed properties array, but the way the test currently works, it will break if the order
+        // Check reading as old comment string blobs. We don't really care about
+        // the order of the content in
+        // the parsed properties array, but the way the test currently works, it
+        // will break if the order
         // changes.
         checkMultiStart(fi, f);
         checkMulti("tr1=This is test", null, null, "", "tr2=test2", "foo\nbazinga");
@@ -306,46 +312,57 @@ public class XLIFFFilterTest extends TestFilterBase {
             public int getLength() {
                 return 1;
             }
+
             @Override
             public String getURI(int i) {
                 return null;
             }
+
             @Override
             public String getLocalName(int i) {
                 return "state";
             }
+
             @Override
             public String getQName(int i) {
                 return "state";
             }
+
             @Override
             public String getType(int i) {
                 return null;
             }
+
             @Override
             public String getValue(int i) {
                 return "needs-translation";
             }
+
             @Override
             public int getIndex(String s, String s1) {
                 return 1;
             }
+
             @Override
             public int getIndex(String s) {
                 return 1;
             }
+
             @Override
             public String getType(String s, String s1) {
                 return getType(0);
             }
+
             @Override
             public String getType(String s) {
                 return getType(0);
             }
+
             @Override
             public String getValue(String s, String s1) {
                 return getValue(0);
             }
+
             @Override
             public String getValue(String s) {
                 return "needs-translation";
@@ -370,16 +387,16 @@ public class XLIFFFilterTest extends TestFilterBase {
         tag = new XMLTag("target", null, Tag.Type.BEGIN, attributes, filter);
         dialect.handleXMLTag(tag, true);
         assertEquals("needs-review-translation", tag.getAttribute("state"));
-   }
+    }
 
     /**
-     * Test with live example of XLIFF version 1.2,
-     * as similar with exported file from Crowdin service.
+     * Test with live example of XLIFF version 1.2, as similar with exported
+     * file from Crowdin service.
      */
     @Test
     public void testTranslationRFE1506() throws Exception {
         checkXLiffTranslationRFE1506(filter, context, outFile, false);
-        checkXLiffTranslationRFE1506(filter, context, outFile,true);
+        checkXLiffTranslationRFE1506(filter, context, outFile, true);
     }
 
     /**
@@ -387,59 +404,58 @@ public class XLIFFFilterTest extends TestFilterBase {
      * <p>
      * Just return when pass the cases. Otherwise, raises assertion error.
      *
-     * @param filter filter object
-     * @param context filter context
-     * @param outFile translated output from the filter.
-     * @throws IOException when failed to read target file.
+     * @param filter
+     *            filter object
+     * @param context
+     *            filter context
+     * @param outFile
+     *            translated output from the filter.
+     * @throws IOException
+     *             when failed to read target file.
      */
-    public static void checkXLiffTranslationRFE1506(IFilter filter, FilterContext context,
-                                                    File outFile, boolean optionNeedsTranslate) throws Exception {
+    public static void checkXLiffTranslationRFE1506(IFilter filter, FilterContext context, File outFile,
+            boolean optionNeedsTranslate) throws Exception {
         File target = new File("test/data/filters/xliff/file-xliff-RFE1506.xliff");
         Map<String, String> config = new HashMap<>();
         if (optionNeedsTranslate) {
             config.put("changetargetstateneedsreviewtranslation", "true");
         }
         assertTrue(filter.isFileSupported(target, config, context));
-        filter.translateFile(target, outFile, config, context,
-                new ITranslateCallback() {
-                    public String getTranslation(String id, String source, String path) {
-                        if ("Create".equals(source)) {
-                            return "\u4F5C\u6210";
-                        }
-                        if ("Emoji".equals(source)) {
-                            return "\u7D75\u6587\u5B57";
-                        }
-                        return null; // not translated or already translated
-                    }
+        filter.translateFile(target, outFile, config, context, new ITranslateCallback() {
+            public String getTranslation(String id, String source, String path) {
+                if ("Create".equals(source)) {
+                    return "\u4F5C\u6210";
+                }
+                if ("Emoji".equals(source)) {
+                    return "\u7D75\u6587\u5B57";
+                }
+                return null; // not translated or already translated
+            }
 
-                    public String getTranslation(String id, String source) {
-                        return getTranslation(id,source,"");
-                    }
+            public String getTranslation(String id, String source) {
+                return getTranslation(id, source, "");
+            }
 
-                    public void linkPrevNextSegments() {
-                    }
+            public void linkPrevNextSegments() {
+            }
 
-                    public void setPass(int pass) {
-                    }
-                });
+            public void setPass(int pass) {
+            }
+        });
         try (XMLStreamReader xml = new XMLStreamReader()) {
             xml.setStream(outFile);
             /*
-             expect:
-             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-            */
+             * expect: <xliff version="1.2"
+             * xmlns="urn:oasis:names:tc:xliff:document:1.2">
+             */
             XMLBlock xliffBlock = xml.advanceToTag("xliff");
             assertEquals("1.2", xliffBlock.getAttribute("version"));
-            assertEquals("urn:oasis:names:tc:xliff:document:1.2",
-                    xliffBlock.getAttribute("xmlns"));
+            assertEquals("urn:oasis:names:tc:xliff:document:1.2", xliffBlock.getAttribute("xmlns"));
             xml.advanceToTag("body");
             /*
-             expect:
-               <trans-unit id="5078">
-                <source>1.0.1</source>
-                <target state="needs-translation">1.0.1</target>
-              </trans-unit>
-            */
+             * expect: <trans-unit id="5078"> <source>1.0.1</source> <target
+             * state="needs-translation">1.0.1</target> </trans-unit>
+             */
             XMLBlock block = xml.advanceToTag("trans-unit");
             assertEquals("5078", block.getAttribute("id"));
             xml.advanceToTag("source");
@@ -450,12 +466,10 @@ public class XLIFFFilterTest extends TestFilterBase {
             block = xml.advanceToTag("trans-unit");
             assertTrue(block.isClose());
             /*
-             expect:
-               <trans-unit id="5086" approved="yes">
-                <source>foo</source>
-                <target state="final">bar</target>
-              </trans-unit>
-            */
+             * expect: <trans-unit id="5086" approved="yes">
+             * <source>foo</source> <target state="final">bar</target>
+             * </trans-unit>
+             */
             block = xml.advanceToTag("trans-unit");
             assertEquals("5086", block.getAttribute("id"));
             xml.advanceToTag("source");
@@ -466,12 +480,11 @@ public class XLIFFFilterTest extends TestFilterBase {
             block = xml.advanceToTag("trans-unit");
             assertTrue(block.isClose());
             /*
-             expect:
-               <trans-unit id="5088" approved="yes">
-                <source>Organization</source>
-                <target state="needs-review-translation">&#x7D44;&#x7E54;</target>
-              </trans-unit>
-            */
+             * expect: <trans-unit id="5088" approved="yes">
+             * <source>Organization</source> <target
+             * state="needs-review-translation">&#x7D44;&#x7E54;</target>
+             * </trans-unit>
+             */
             block = xml.advanceToTag("trans-unit");
             assertEquals("5088", block.getAttribute("id"));
             xml.advanceToTag("source");
@@ -482,18 +495,15 @@ public class XLIFFFilterTest extends TestFilterBase {
             block = xml.advanceToTag("trans-unit");
             assertTrue(block.isClose());
             /*
-             expect in default:
-               <trans-unit id="5090">
-                <source>Create</source>
-                <target state="translated">&#x4F5C;&#x6210;</target>
-              </trans-unit>
-
-             expect with option:
-               <trans-unit id="5090">
-                <source>Create</source>
-                <target state="needs-review-translation">&#x4F5C;&#x6210;</target>
-              </trans-unit>
-            */
+             * expect in default: <trans-unit id="5090"> <source>Create</source>
+             * <target state="translated">&#x4F5C;&#x6210;</target>
+             * </trans-unit>
+             * 
+             * expect with option: <trans-unit id="5090">
+             * <source>Create</source> <target
+             * state="needs-review-translation">&#x4F5C;&#x6210;</target>
+             * </trans-unit>
+             */
             block = xml.advanceToTag("trans-unit");
             assertEquals("5090", block.getAttribute("id"));
             xml.advanceToTag("source");
@@ -508,12 +518,10 @@ public class XLIFFFilterTest extends TestFilterBase {
             block = xml.advanceToTag("trans-unit");
             assertTrue(block.isClose());
             /*
-             expected:
-                  <trans-unit id="5128" approved="yes">
-                    <source>- Emoji</source>
-                    <target state="final">&#x7D75;&#x6587;&#x5B57;</target>
-                  </trans-unit>
-            */
+             * expected: <trans-unit id="5128" approved="yes"> <source>-
+             * Emoji</source> <target
+             * state="final">&#x7D75;&#x6587;&#x5B57;</target> </trans-unit>
+             */
             block = xml.advanceToTag("trans-unit");
             assertEquals("5128", block.getAttribute("id"));
             xml.advanceToTag("source");


### PR DESCRIPTION
[RFE#1506 XLIFF: update target tag's state attribute according to translation status](https://sourceforge.net/p/omegat/feature-requests/1506/)  requests OmegaT XLIFF filter to handle state attribute of target tag.

A proposal here add a regression test and fix a bug that detected by a regression test.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- XLIFF: update target tag's state attribute according to translation status
  * https://sourceforge.net/p/omegat/feature-requests/1506/

## What does this PR change?

- Add a case file: file-xliff-RFE1506.xliff
- There also is expectation file-xliff-RFE1506-translated-expectation.xliff
- Check output expectation with XMLStreamReader
- Fix a bug detected by the test
  - when source has "needs-review-translation" state, then it should become "translated" in the translation.

## Other information

Related PR  #356 
