### PR TITLE
docs_devel: fix header levels and anchor error

### DIFF
--- a/docs_devel/docs/19.PluginManifest.md
+++ b/docs_devel/docs/19.PluginManifest.md
@@ -22,9 +22,9 @@ left to right as described in the table below:
 | License     | Plugin-License                                         |
 | Category    | Plugin-Category                                        |
 
-### plugins for OmegaT 5.8.0 and up
+## plugins for OmegaT 5.8.0 and up
 
-#### Simple plugin that has a single plugin category
+### Simple plugin that has a single plugin category
 
 A plugin should be declared in main section of `META-INF/MANIFEST.MF`:
 
@@ -38,7 +38,7 @@ A plugin should be declared in main section of `META-INF/MANIFEST.MF`:
 
 where classname is the fully qualified classname of the plugin's initialization class.
 
-#### Complex plugin that has multiple drivers in plugin
+### Complex plugin that has multiple drivers in plugin
 
     Plugin-Name: …
     Plugin-Version: x.y.z
@@ -60,7 +60,7 @@ The package section can be used for specifying category and description for clas
 The classname section can be used for specifying category and description for the class.
 These are useful when you bundles multiple filters/drivers in the plugin, such as OKAPI filter plugin.
 
-#### Mandatory method in the plugin class 
+### Mandatory method in the plugin class 
 
 The plugin class should contain the following methods:
 

--- a/docs_devel/docs/91.appendix.md
+++ b/docs_devel/docs/91.appendix.md
@@ -1,11 +1,17 @@
 # Appendix
 
-### [Support matrix of alternate translations](assets/MultipleTranslationFieldsForFilters.ods)
+## Supplementary files
+
+### Alternate translation support
+
+ * [Support matrix of alternate translations](assets/MultipleTranslationFieldsForFilters.ods)
 
    This documents how different filters identify "alternate" translations. You can
    view it with LibreOffice or any ODF-compatible viewer.
 
-### [OmegaT.vpp](assets/OmegaT.vpp)
+### Source of a figure in contribution guide
+
+* [OmegaT.vpp](assets/OmegaT.vpp)
 
    This document is the source for the UML diagrams in the developer's guide; it
    contains no content not also viewable within the developer's guide.


### PR DESCRIPTION

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?
N.A.

## What does this PR change?

- Fix header level error
  -  don't jump from H1 to H3
- Fix anchor: don't put link on title

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
