### PR TITLE
docs_build: Don't override index.html if manual exists by instant-start task

### DIFF
--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -159,7 +159,17 @@
 	  <available property="FirstSteps.exists" file="../doc_src/${language}/First_Steps.xml"/>
 	</target>
 
-	<target name="old-css" depends="check-first-steps" unless="${FirstSteps.exists}">
+    <target name="check-manual-exist">
+      <condition property="ManualContents.exists">
+        <or>
+          <available file="../doc_src/${language}/Introduction.xml"/>
+          <available file="../doc_src/${language}/InstallingAndRunning.xml"/>
+          <available file="../doc_src/${language}/AboutOmegaT.xml"/>
+        </or>
+      </condition>
+    </target>
+
+    <target name="old-css" depends="check-first-steps" unless="${FirstSteps.exists}">
       <copy file="OmegaT_old.css"
             tofile="../docs/${language}/OmegaT.css" />
     </target>
@@ -170,8 +180,14 @@
     </target>
 
 	<target name="css" depends="old-css,new-css"/>
-	
-	<target name="instant-start" depends="check-first-steps, css, pictures" unless="${FirstSteps.exists}">
+
+    <target name="copy-index-from-first-step" depends="check-manual-exist,generate-instant-start"
+            unless="${ManualContents.exists}">
+        <copy file="../docs/${language}/first_steps.html"
+              tofile="../docs/${language}/index.html" />
+    </target>
+
+	<target name="generate-instant-start" depends="check-first-steps, css, pictures" unless="${FirstSteps.exists}">
         <java dir="."
               fork="true"
               failonerror="true"
@@ -199,9 +215,9 @@
         </java>
         <copy file="${language}/${version.properties.filename}"
               tofile="../docs/${language}/${version.properties.filename}" />
-        <copy file="../docs/${language}/first_steps.html"
-              tofile="../docs/${language}/index.html" />
     </target>
+
+    <target name="instant-start" depends="generate-instant-start, copy-index-from-first-step"/>
 
     <target name="first-steps" depends="check-first-steps, css" if="${FirstSteps.exists}">
         <java dir="."

--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -187,7 +187,7 @@
               tofile="../docs/${language}/index.html" />
     </target>
 
-	<target name="generate-instant-start" depends="check-first-steps, css, pictures" unless="${FirstSteps.exists}">
+    <target name="generate-instant-start" depends="check-first-steps, css, pictures" unless="${FirstSteps.exists}">
         <java dir="."
               fork="true"
               failonerror="true"

--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -156,30 +156,30 @@
     </target>
 
     <target name="check-first-steps">
-	  <available property="FirstSteps.exists" file="../doc_src/${language}/First_Steps.xml"/>
-	</target>
+        <available property="FirstSteps.exists" file="../doc_src/${language}/First_Steps.xml"/>
+    </target>
 
     <target name="check-manual-exist">
-      <condition property="ManualContents.exists">
-        <or>
-          <available file="../doc_src/${language}/Introduction.xml"/>
-          <available file="../doc_src/${language}/InstallingAndRunning.xml"/>
-          <available file="../doc_src/${language}/AboutOmegaT.xml"/>
-        </or>
-      </condition>
+        <condition property="ManualContents.exists">
+            <or>
+                <available file="../doc_src/${language}/Introduction.xml"/>
+                <available file="../doc_src/${language}/InstallingAndRunning.xml"/>
+                <available file="../doc_src/${language}/AboutOmegaT.xml"/>
+            </or>
+        </condition>
     </target>
 
     <target name="old-css" depends="check-first-steps" unless="${FirstSteps.exists}">
-      <copy file="OmegaT_old.css"
-            tofile="../docs/${language}/OmegaT.css" />
+        <copy file="OmegaT_old.css"
+              tofile="../docs/${language}/OmegaT.css"/>
     </target>
 
-	<target name="new-css" depends="check-first-steps" if="${FirstSteps.exists}">
-      <copy file="OmegaT_new.css"
-            tofile="../docs/${language}/OmegaT.css" />
+    <target name="new-css" depends="check-first-steps" if="${FirstSteps.exists}">
+        <copy file="OmegaT_new.css"
+              tofile="../docs/${language}/OmegaT.css"/>
     </target>
 
-	<target name="css" depends="old-css,new-css"/>
+    <target name="css" depends="old-css,new-css"/>
 
     <target name="copy-index-from-first-step" depends="check-manual-exist,generate-instant-start"
             unless="${ManualContents.exists}">


### PR DESCRIPTION
PR #376 force override manual's `index.html` by `first_step.html` by `instant-start` task

This fix the bug.

## Pull request type

- Bug fix -> [bug]
- Documentation -> [documentation]


## What does this PR change?

- Check manual source is exist or not
- when manual does not exist, copy first_step.html as index.html

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
