### PR TITLE
XLiffFilters: disable old monolingual xlifffilter in default

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1494,6 +1494,29 @@ OpenXML_BREAK_ON_BR=Start a new paragraph &on Word soft return
 
 OpenXML_ERROR_IN_FILE=Error in file
 
+# org.omegat.filters4.xml.openxml.MsOfficeFileFilter.java
+MSOFFICE4_FILTER_NAME=Microsoft Office Open XML
+
+# org.omegat.filters4.xml.openxml.OpenXmlFilter.java
+OPENXML4_FILTER_NAME=Microsoft Office Open XML
+
+# org.omegat.filters4.xml.xliff.SdlProject.java
+SDLPROJECT_FILTER_NAME=SDL project
+
+# org.omegat.filters4.xml.xliff.SdlXliff.java
+SDLXLIFF_FILTER_NAME=SDL XLIFF
+
+# org.omegat.filters4.xml.xliff.Xliff1Filter.java
+XLIFF1FILTER_FILTER_NAME=XLIFF 1.x Bilingual
+
+# org.omegat.filters4.xml.xliff.Xliff2Filter.java
+XLIFF2FILTER_FILTER_NAME=XLIFF 2.x Bilingual
+
+# org.omegat.filters4.xml.xliff.*
+XLIFF_MANDATORY_ORIGINAL_MISSING=Missing attribute '{0}' in <{1}>
+
+
+
 # AboutDialog.java
 
 # 0: OmegaT Brand

--- a/src/org/omegat/filters2/IFilter.java
+++ b/src/org/omegat/filters2/IFilter.java
@@ -220,4 +220,16 @@ public interface IFilter {
     default boolean isBilingual() {
         return false;
     }
+
+    /**
+     * Is the filter enabled in default.
+     * <p>
+     * Deprecated filter may be disabled in default. So it can
+     * override the method to return false;
+     * @return false when the filter is disabled in default.
+     * @since 5.8.0
+     */
+    default boolean isEnabledInDefault() {
+        return true;
+    }
 }

--- a/src/org/omegat/filters2/IFilter.java
+++ b/src/org/omegat/filters2/IFilter.java
@@ -33,8 +33,9 @@ import java.util.Map;
 /**
  * Interface for filters declaration.
  *
- * TODO: each filter should be stateless, i.e. options shouldn't be stored in filter, but should be sent to
- * filter on each parse, align, or translate operation.
+ * TODO: each filter should be stateless, i.e. options shouldn't be stored in
+ * filter, but should be sent to filter on each parse, align, or translate
+ * operation.
  *
  * Filters shouldn't use Core, but use Context instead.
  *
@@ -49,16 +50,18 @@ public interface IFilter {
     String getFileFormatName();
 
     /**
-     * Returns the hint displayed while the user edits the filter, and when she adds/edits the instance of
-     * this filter. The hint may be any string, preferably in a non-geek language.
+     * Returns the hint displayed while the user edits the filter, and when she
+     * adds/edits the instance of this filter. The hint may be any string,
+     * preferably in a non-geek language.
      *
      * @return The hint for editing the filter in a non-geek language.
      */
     String getHint();
 
     /**
-     * The default list of filter instances that this filter class has. One filter class may have different
-     * filter instances, different by source file mask, encoding of the source file etc.
+     * The default list of filter instances that this filter class has. One
+     * filter class may have different filter instances, different by source
+     * file mask, encoding of the source file etc.
      * <p>
      * Note that the user may change the instances freely.
      *
@@ -71,9 +74,10 @@ public interface IFilter {
      * <p>
      * True means that OmegaT should handle all the encoding mess.
      * <p>
-     * Return false to state that your filter doesn't need encoding management provided by OmegaT, because it
-     * either autodetects the encoding based on file contents (like HTML filter does) or the encoding is fixed
-     * (like in OpenOffice files).
+     * Return false to state that your filter doesn't need encoding management
+     * provided by OmegaT, because it either autodetects the encoding based on
+     * file contents (like HTML filter does) or the encoding is fixed (like in
+     * OpenOffice files).
      *
      * @return whether source encoding can be changed by the user
      */
@@ -84,27 +88,28 @@ public interface IFilter {
      * <p>
      * True means that OmegaT should handle all the encoding mess.
      * <p>
-     * Return false to state that your filter doesn't need encoding management provided by OmegaT, because the
-     * encoding is fixed (like in OpenOffice files), or for some other reason.
+     * Return false to state that your filter doesn't need encoding management
+     * provided by OmegaT, because the encoding is fixed (like in OpenOffice
+     * files), or for some other reason.
      *
      * @return whether target encoding can be changed by the user
      */
     boolean isTargetEncodingVariable();
 
     /**
-     * Define fuzzy mark prefix for source which will be stored in TM. It's 'fuzzy' by default, but each
-     * filter can redefine it.
+     * Define fuzzy mark prefix for source which will be stored in TM. It's
+     * 'fuzzy' by default, but each filter can redefine it.
      *
      * @return fuzzy mark prefix
      */
     String getFuzzyMark();
 
     /**
-     * Returns whether the file is supported by the filter, given the file and possible file's encoding (
-     * <code>null</code> encoding means autodetect).
+     * Returns whether the file is supported by the filter, given the file and
+     * possible file's encoding ( <code>null</code> encoding means autodetect).
      * <p>
-     * For example, DocBook files have .xml extension, as possibly many other XML files, so the filter should
-     * check a DTD of the document.
+     * For example, DocBook files have .xml extension, as possibly many other
+     * XML files, so the filter should check a DTD of the document.
      *
      * @param inFile
      *            Source file.
@@ -151,8 +156,8 @@ public interface IFilter {
             ITranslateCallback callback) throws Exception;
 
     /**
-     * Align source and translated files.
-     * NB: this is not used for Tools->align files..., but for aligning in console mode
+     * Align source and translated files. NB: this is not used for Tools->align
+     * files..., but for aligning in console mode
      *
      * @param inFile
      *            source file
@@ -204,14 +209,16 @@ public interface IFilter {
 
     /**
      * Returns the encoding of the last parsed source file.
-     * @return the encoding of the last parsed source file, or null when no file has been parsed yet.
+     * 
+     * @return the encoding of the last parsed source file, or null when no file
+     *         has been parsed yet.
      */
     String getInEncodingLastParsedFile();
 
     /**
-     * Indicates whether the filter is bilingual, and thus can be used as external TM
-     * (i.e. files can be added to the /tm/ folder of an OmegaT project).
-     * Bilingual filters will supply both source strings and
+     * Indicates whether the filter is bilingual, and thus can be used as
+     * external TM (i.e. files can be added to the /tm/ folder of an OmegaT
+     * project). Bilingual filters will supply both source strings and
      * translation strings to {@link IParseCallback}.addEntry().
      *
      * @return <code>true</code> if the filter is bilingual
@@ -224,8 +231,9 @@ public interface IFilter {
     /**
      * Is the filter enabled in default.
      * <p>
-     * Deprecated filter may be disabled in default. So it can
-     * override the method to return false;
+     * Deprecated filter may be disabled in default. So it can override the
+     * method to return false;
+     * 
      * @return false when the filter is disabled in default.
      * @since 5.8.0
      */

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -71,8 +71,8 @@ import gen.core.filters.Filter.Option;
 import gen.core.filters.Filters;
 
 /**
- * A master class that registers and handles all the filters. Singleton - there can be only one instance of
- * this class.
+ * A master class that registers and handles all the filters. Singleton - there
+ * can be only one instance of this class.
  *
  * @author Maxym Mykhalchuk
  * @author Henry Pijffers
@@ -91,7 +91,8 @@ public class FilterMaster {
     private static final JAXBContext CONFIG_CTX;
 
     /**
-     * There was no version of file filters support (1.4.5 Beta 1 -- 1.6.0 RC12).
+     * There was no version of file filters support (1.4.5 Beta 1 -- 1.6.0
+     * RC12).
      */
     public static final String INITIAL_VERSION = "";
     /** File filters support of 1.6.0 RC12a: now upgrading the configuration. */
@@ -211,17 +212,20 @@ public class FilterMaster {
     /**
      * OmegaT core calls this method to translate a source file.
      * <ul>
-     * <li>OmegaT first looks through registered filter instances to find filter(s) that can handle this file.
+     * <li>OmegaT first looks through registered filter instances to find
+     * filter(s) that can handle this file.
      * <li>Tests if filter(s) want to handle it.
      * <li>If the filter accepts the file,
      * <li>Filter is asked to process the file.
      * </ul>
-     * If no filter is found, that processes this file, we simply copy it to target folder.
+     * If no filter is found, that processes this file, we simply copy it to
+     * target folder.
      *
      * @param sourcedir
      *            The folder of the source inFile.
      * @param filename
-     *            The name of the source inFile to process (only the part, relative to source folder).
+     *            The name of the source inFile to process (only the part,
+     *            relative to source folder).
      * @param targetdir
      *            The folder to place the translated inFile to.
      * @param fc
@@ -238,11 +242,12 @@ public class FilterMaster {
         }
 
         File inFile = new File(sourcedir, filename).getCanonicalFile();
-        File outFile = new File(targetdir, getTargetForSource(filename, lookup, fc.getTargetLang())).getCanonicalFile();
+        File outFile = new File(targetdir, getTargetForSource(filename, lookup, fc.getTargetLang()))
+                .getCanonicalFile();
 
         if (inFile.equals(outFile)) {
-            throw new TranslationException(
-                    StringUtil.format(OStrings.getString("FILTERMASTER_ERROR_SRC_TRG_SAME_FILE"), inFile.getPath()));
+            throw new TranslationException(StringUtil
+                    .format(OStrings.getString("FILTERMASTER_ERROR_SRC_TRG_SAME_FILE"), inFile.getPath()));
         }
 
         fc.setInEncoding(lookup.outFilesInfo.getSourceEncoding());
@@ -298,8 +303,8 @@ public class FilterMaster {
     }
 
     /**
-     * Gets the filter according to the source filename provided. In case of failing to find a filter to
-     * handle the file returns <code>null</code>.
+     * Gets the filter according to the source filename provided. In case of
+     * failing to find a filter to handle the file returns <code>null</code>.
      *
      * In case of finding an appropriate filter it
      * <ul>
@@ -308,11 +313,12 @@ public class FilterMaster {
      * <li>Checks whether the filter supports the file.
      * </ul>
      *
-     * @param inFile The full path to the source file
+     * @param inFile
+     *            The full path to the source file
      * @return The corresponding LookupInformation
      */
-    private LookupInformation lookupFilter(File inFile, FilterContext fc) throws TranslationException,
-            IOException {
+    private LookupInformation lookupFilter(File inFile, FilterContext fc)
+            throws TranslationException, IOException {
         for (Filter f : config.getFilters()) {
             if (!f.isEnabled()) {
                 continue;
@@ -391,7 +397,8 @@ public class FilterMaster {
     private static List<String> supportedEncodings = null;
 
     /**
-     * Queries JRE for the list of supported encodings. Also adds the human name for no/automatic inEncoding.
+     * Queries JRE for the list of supported encodings. Also adds the human name
+     * for no/automatic inEncoding.
      *
      *
      * @return names of all the encodings in an array
@@ -426,8 +433,8 @@ public class FilterMaster {
     }
 
     /**
-     * Loads information about the filters from an XML file. If there's an error loading a file, it calls
-     * <code>setupDefaultFilters</code>.
+     * Loads information about the filters from an XML file. If there's an error
+     * loading a file, it calls <code>setupDefaultFilters</code>.
      *
      * @throws IOException
      */
@@ -478,7 +485,8 @@ public class FilterMaster {
     // ////////////////////////////////////////////////////////////////////////
 
     /**
-     * Whether the mask matches the filename. Filename should be "name.ext", without path.
+     * Whether the mask matches the filename. Filename should be "name.ext",
+     * without path.
      *
      * @param filename
      *            The filename to check
@@ -507,10 +515,15 @@ public class FilterMaster {
 
     /**
      * Calculate the target path corresponding to the given source file.
-     * @param sourceDir Path to the project's <code>source</code> dir
-     * @param srcRelPath Relative path under <code>sourceDir</code> of the source file
-     * @param fc Filter context
-     * @return The relative path under <code>target</code> of the corresponding target file
+     * 
+     * @param sourceDir
+     *            Path to the project's <code>source</code> dir
+     * @param srcRelPath
+     *            Relative path under <code>sourceDir</code> of the source file
+     * @param fc
+     *            Filter context
+     * @return The relative path under <code>target</code> of the corresponding
+     *         target file
      * @throws IOException
      * @throws TranslationException
      */
@@ -525,7 +538,8 @@ public class FilterMaster {
         return getTargetForSource(srcRelPath, lookup, fc.getTargetLang());
     }
 
-    private static String getTargetForSource(String srcRelPath, LookupInformation lookup, Language targetLang) {
+    private static String getTargetForSource(String srcRelPath, LookupInformation lookup,
+            Language targetLang) {
         File srcRelFile = new File(srcRelPath);
         return new File(srcRelFile.getParent(),
                 constructTargetFilename(lookup.outFilesInfo.getSourceFilenameMask(), srcRelFile.getName(),
@@ -535,29 +549,36 @@ public class FilterMaster {
     }
 
     /**
-     * Construct a target filename according to pattern from a file's name. Filename should be "name.ext",
-     * without path.
+     * Construct a target filename according to pattern from a file's name.
+     * Filename should be "name.ext", without path.
      * <p>
      * Output filename pattern is pretty complex. <br>
-     * It may consist of normal characters and some substituted variables. They have the format
-     * <code>${variableName}</code> and are case insensitive. <br>
+     * It may consist of normal characters and some substituted variables. They
+     * have the format <code>${variableName}</code> and are case insensitive.
+     * <br>
      * There're such variables:
      * <ul>
-     * <li><code>${filename}</code> - full filename of the input file, both name and extension (default)
-     * <li><code>${nameOnly}</code> - only the name of the input file without extension part
+     * <li><code>${filename}</code> - full filename of the input file, both name
+     * and extension (default)
+     * <li><code>${nameOnly}</code> - only the name of the input file without
+     * extension part
      * <li><code>${extension}</code> - the extension of the input file
-     * <li><code>${nameOnly-1}</code> - only the name of the input file with first extension
+     * <li><code>${nameOnly-1}</code> - only the name of the input file with
+     * first extension
      * <li><code>${extension-1}</code> - the extensions, without the first one
      * <li><code>${targetLocale}</code> - target locale code (of a form "xx_YY")
-     * <li><code>${targetLanguage}</code> - the target language and country code together (of a form "XX-YY")
+     * <li><code>${targetLanguage}</code> - the target language and country code
+     * together (of a form "XX-YY")
      * <li><code>${targetLanguageCode}</code> - the target language only ("XX")
      * <li><code>${targetCountryCode}</code> - the target country only ("YY")
      * <li><code>${1}, ${2}, ...</code> - variables captured by jokers (* or ?)
      * </ul>
      * <p>
-     * Most file filters will use default "<code>${filename}</code>, that leads to the name of translated file
-     * being the same as the name of source file. But for example the Java(TM) Resource Bundles file filter
-     * will have the pattern equal to "<code>${nameonly}_${targetlanguage}.${extension}</code> ".
+     * Most file filters will use default "<code>${filename}</code>, that leads
+     * to the name of translated file being the same as the name of source file.
+     * But for example the Java(TM) Resource Bundles file filter will have the
+     * pattern equal to "<code>${nameonly}_${targetlanguage}.${extension}</code>
+     * ".
      * <p>
      * E.g. if you have
      * <ul>

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -763,7 +763,7 @@ public class FilterMaster {
         }
         Filter fc = new Filter();
         fc.setClassName(f.getClass().getName());
-        fc.setEnabled(true);
+        fc.setEnabled(f.isEnabledInDefault());
         for (Instance ins : f.getDefaultInstances()) {
             Files ff = new Files();
             ff.setSourceEncoding(ins.getSourceEncoding());

--- a/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -310,16 +310,25 @@ public class XLIFFFilter extends XMLFilter {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isInIgnored() {
         return ignored;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void text(String text) {
         this.text.append(text);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String translate(String entry, List<ProtectedPart> protectedParts) {
         if (entryParseCallback != null) {
@@ -335,5 +344,13 @@ public class XLIFFFilter extends XMLFilter {
         } else {
             return entry;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEnabledInDefault() {
+        return false;
     }
 }

--- a/src/org/omegat/filters4/AbstractZipFilter.java
+++ b/src/org/omegat/filters4/AbstractZipFilter.java
@@ -41,7 +41,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.TranslationException;
@@ -50,7 +49,7 @@ import org.omegat.filters4.xml.AbstractXmlFilter;
 import org.omegat.util.Log;
 
 /**
- * Filter for a file format which is an archive containing XML
+ * Filter for a file format which is an archive containing XML.
  *
  * @author Thomas Cordonnier
  */
@@ -58,15 +57,17 @@ public abstract class AbstractZipFilter extends AbstractFilter {
 
     @Override
     public boolean isSourceEncodingVariable() {
-         return true;
+        return true;
     }
 
     @Override
     public boolean isTargetEncodingVariable() {
-         return true;
+        return true;
     }
 
-    /** Indicate that this file contained in the archive should be considered **/
+    /**
+     * Indicate that this file contained in the archive should be considered
+     **/
     protected abstract boolean acceptInternalFile(ZipEntry entry, FilterContext context);
 
     @Override
@@ -87,24 +88,34 @@ public abstract class AbstractZipFilter extends AbstractFilter {
         return false;
     }
 
-    /** Indicate that this file contained in the archive should be translated **/
-    protected abstract boolean mustTranslateInternalFile(ZipEntry entry, boolean writeMode, FilterContext context);
+    /**
+     * Indicate that this file contained in the archive should be translated
+     **/
+    protected abstract boolean mustTranslateInternalFile(ZipEntry entry, boolean writeMode,
+            FilterContext context);
 
-    /** Indicate that this file contained in the archive should not appear in the target at all. Defaults to false **/
+    /**
+     * Indicate that this file contained in the archive should not appear in the
+     * target at all. Defaults to false.
+     **/
     protected boolean mustDeleteInternalFile(ZipEntry entry, boolean writeMode, FilterContext context) {
-         return false;
+        return false;
     }
 
     protected abstract AbstractXmlFilter getFilter(ZipEntry ze);
 
-    /** If not null, indicates that we want to see internal XML files in a certain order **/
+    /**
+     * If not null, indicates that we want to see internal XML files in a
+     * certain order.
+     **/
     protected Comparator<ZipEntry> getEntryComparator() {
-         return null;
+        return null;
     }
 
     /** Processes a ZIP file. */
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc) throws IOException, TranslationException {
+    public void processFile(File inFile, File outFile, FilterContext fc)
+            throws IOException, TranslationException {
         ZipFile zf = new ZipFile(inFile);
         ZipOutputStream zipout = null;
         if (outFile != null) {
@@ -113,7 +124,8 @@ public abstract class AbstractZipFilter extends AbstractFilter {
 
         try {
             Enumeration<? extends ZipEntry> zipcontents = zf.entries();
-            List<ZipEntry> toTranslate = new LinkedList<>(); Comparator<ZipEntry> cmp = getEntryComparator();
+            List<ZipEntry> toTranslate = new LinkedList<>();
+            Comparator<ZipEntry> cmp = getEntryComparator();
             while (zipcontents.hasMoreElements()) {
                 ZipEntry ze = zipcontents.nextElement();
                 if (mustTranslateInternalFile(ze, outFile != null, fc)) {
@@ -135,7 +147,7 @@ public abstract class AbstractZipFilter extends AbstractFilter {
             if (cmp != null) {
                 Collections.sort(toTranslate, cmp);
             }
-            for (ZipEntry ze: toTranslate) {
+            for (ZipEntry ze : toTranslate) {
                 translateEntry(zf, zipout, fc, ze);
             }
         } finally {
@@ -145,6 +157,7 @@ public abstract class AbstractZipFilter extends AbstractFilter {
             zf.close();
         }
     }
+
     private void translateEntry(ZipFile zf, ZipOutputStream zipout, FilterContext fc, ZipEntry ze) {
         try {
             AbstractXmlFilter xmlfilter = getFilter(ze);
@@ -153,19 +166,22 @@ public abstract class AbstractZipFilter extends AbstractFilter {
             if (zipout == null) {
                 xmlfilter.processFile(reader, null, fc);
             } else {
-                ZipEntry outEntry = new ZipEntry(ze.getName()); zipout.putNextEntry(outEntry);
-                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter (zipout, xReader.getEncoding()));
+                ZipEntry outEntry = new ZipEntry(ze.getName());
+                zipout.putNextEntry(outEntry);
+                BufferedWriter writer = new BufferedWriter(
+                        new OutputStreamWriter(zipout, xReader.getEncoding()));
                 xmlfilter.processFile(reader, writer, fc);
                 zipout.closeEntry();
             }
         } catch (Exception e) {
             Log.log(e);
-            // continue: an error in one file should not prevent generation of other files!
+            // continue: an error in one file should not prevent generation of
+            // other files!
         }
     }
 
     protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc)
-        throws IOException, TranslationException {
+            throws IOException, TranslationException {
         throw new IOException("Not implemented");
     }
 

--- a/src/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -66,14 +66,18 @@ import org.omegat.filters3.xml.XMLWriter;
 import org.omegat.util.StaticUtils;
 
 /**
- * Abstract for StaX-based filters <br/>
- * This class is more low-level than 'filters3' API, but this is necessary to implement
- * bilingual or very complex XML formats. <br/>
+ * Abstract for StaX-based filters.
+ * <p>
+ * This class is more low-level than 'filters3' API, but this is necessary to
+ * implement bilingual or very complex XML formats. <br/>
  * To implement your own filter based on this class you must implement
- * {@link processStartElement}, {@link processEndElement} and {@link processCharacters} <br/>
- * Boolean return value will be ignored during reading process (when event writer is null),
- * while during project compilation, it says whenever the event must be kept in the result
- * or not (generally, parts of the XML file which are translated must return false).
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processStartElement processStartElement},
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processEndElement processEndElement} and
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processCharacters processCharacters} <br/>
+ * Boolean return value will be ignored during reading process (when event
+ * writer is null), while during project compilation, it says whenever the event
+ * must be kept in the result or not (generally, parts of the XML file which are
+ * translated must return false).
  *
  * @author Thomas Cordonnier
  */
@@ -82,12 +86,14 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     /** Detected encoding and eol of the input XML file. */
     private String encoding, eol;
 
-    @Override public boolean isSourceEncodingVariable() {
-         return true;
+    @Override
+    public boolean isSourceEncodingVariable() {
+        return true;
     }
 
-    @Override public boolean isTargetEncodingVariable() {
-         return true;
+    @Override
+    public boolean isTargetEncodingVariable() {
+        return true;
     }
 
     /**
@@ -95,8 +101,6 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
      *
      * @param inFile
      *            The source file.
-     * @param outEncoding
-     *            Encoding of the source file, if the filter supports it. Otherwise null.
      * @return The reader of the source file.
      *
      * @throws UnsupportedEncodingException
@@ -105,8 +109,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
      *             If any I/O Error occurs upon reader creation.
      */
     @Override
-    public BufferedReader createReader(File inFile, String inEncoding) throws UnsupportedEncodingException,
-            IOException {
+    public BufferedReader createReader(File inFile, String inEncoding)
+            throws UnsupportedEncodingException, IOException {
         XMLReader xmlreader = new XMLReader(inFile, inEncoding);
         this.encoding = xmlreader.getEncoding();
         this.eol = xmlreader.getEol();
@@ -114,13 +118,14 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     }
 
     /**
-     * Creates a writer of the translated file. Accepts <code>null</code> output file -- returns a writer to
-     * <code>/dev/null</code> in this case ;-)
+     * Creates a writer of the translated file. Accepts <code>null</code> output
+     * file -- returns a writer to <code>/dev/null</code> in this case ;-)
      *
      * @param outFile
      *            The target file.
      * @param outEncoding
-     *            Encoding of the target file, if the filter supports it. Otherwise null.
+     *            Encoding of the target file, if the filter supports it.
+     *            Otherwise, null.
      * @return The writer for the target file.
      *
      * @throws UnsupportedEncodingException
@@ -129,8 +134,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
      *             If any I/O Error occurs upon writer creation
      */
     @Override
-    public BufferedWriter createWriter(File outFile, String outEncoding) throws UnsupportedEncodingException,
-        IOException {
+    public BufferedWriter createWriter(File outFile, String outEncoding)
+            throws UnsupportedEncodingException, IOException {
         if (outFile == null) {
             return new BufferedWriter(new StringWriter());
         } else {
@@ -143,8 +148,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
 
     /** Processes an XML file. Does encoding/EOL detection, if necessary **/
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc) throws IOException,
-        TranslationException {
+    public void processFile(File inFile, File outFile, FilterContext fc)
+            throws IOException, TranslationException {
         try (BufferedReader inReader = createReader(inFile, fc.getInEncoding())) {
             inEncodingLastParsedFile = this.encoding;
             if (outFile != null) {
@@ -162,23 +167,30 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
 
     /**
      * Processes a buffer.
-     * This method works only if buffered reader and writer are already configured with correct encoding and EOL.
+     * <p>
+     * This method works only if buffered reader and writer
+     * are already configured with correct encoding and EOL.
      **/
     @Override
-    public void processFile(BufferedReader inReader, BufferedWriter writer, FilterContext fc) throws IOException,
-        TranslationException {
+    public void processFile(BufferedReader inReader, BufferedWriter writer, FilterContext fc)
+            throws IOException, TranslationException {
         try {
-            XMLStreamReader strReader = null; XMLStreamWriter strWriter = null; XMLEventReader eventReader = null;
+            XMLStreamReader strReader = null;
+            XMLStreamWriter strWriter = null;
+            XMLEventReader eventReader = null;
             try {
                 strReader = iFactory.createXMLStreamReader(inReader);
                 eventReader = iFactory.createXMLEventReader(strReader);
-                isEventMode = false; // always start like this, even with new file
+                isEventMode = false; // always start like this, even with new
+                                     // file
                 if (writer == null) {
                     while (strReader.hasNext()) {
                         if (!isEventMode) {
                             checkCurrentCursorPosition(strReader, false);
                         }
-                        if (isEventMode) {    // calculated after checkCurrentCursorPosition, may have changed!
+                        if (isEventMode) { // calculated after
+                                           // checkCurrentCursorPosition, may
+                                           // have changed!
                             XMLEvent event = eventReader.nextEvent();
                             if (event.isStartElement()) {
                                 processStartElement(event.asStartElement(), null);
@@ -195,7 +207,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
                     strWriter = oFactory.createXMLStreamWriter(writer);
                     while (strReader.hasNext()) {
                         if (strReader.getEventType() == XMLEvent.START_DOCUMENT) {
-                            // special case: don't use strWriter because StaX has a bug!
+                            // special case: don't use strWriter because StaX
+                            // has a bug!
                             String toWrite = "<?xml ";
                             String version = strReader.getVersion();
                             if (version != null) {
@@ -206,19 +219,26 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
                                 toWrite += " encoding=\"" + escheme + "\"";
                             }
                             if (strReader.standaloneSet()) {
-                                toWrite += " standalone=\"" + (strReader.isStandalone() ? "yes" : "no") + "\"";
+                                toWrite += " standalone=\"" + (strReader.isStandalone() ? "yes" : "no")
+                                        + "\"";
                                 // not possible using strWriter!!!
                             }
-                            toWrite += " ?>"; writer.write(toWrite);
-                            strReader.next(); continue;
+                            toWrite += " ?>";
+                            writer.write(toWrite);
+                            strReader.next();
+                            continue;
                         }
                         if (!isEventMode) {
                             checkCurrentCursorPosition(strReader, true);
-                            // in non-event mode, we always write exactly what was in the source
+                            // in non-event mode, we always write exactly what
+                            // was in the source
                             fromReaderToWriter(strReader, strWriter);
                         }
-                        if (isEventMode) {    // calculated after checkCurrentCursorPosition, may have changed!
-                            XMLEvent event = eventReader.nextEvent(); boolean keep;
+                        if (isEventMode) { // calculated after
+                                           // checkCurrentCursorPosition, may
+                                           // have changed!
+                            XMLEvent event = eventReader.nextEvent();
+                            boolean keep;
                             if (event.isStartElement()) {
                                 keep = processStartElement(event.asStartElement(), strWriter);
                             } else if (event.isEndElement()) {
@@ -229,7 +249,10 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
                                 keep = true;
                             }
                             if (keep) {
-                                fromEventToWriter(event, strWriter); // convert current event to stream
+                                fromEventToWriter(event, strWriter); // convert
+                                                                     // current
+                                                                     // event to
+                                                                     // stream
                             }
                         } else {
                             strReader.next();
@@ -244,7 +267,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
                     strReader.close();
                 }
                 if (strWriter != null) {
-                     strWriter.flush(); strWriter.close();
+                    strWriter.flush();
+                    strWriter.close();
                 }
             }
         } catch (XMLStreamException e) {
@@ -254,7 +278,9 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
 
     /**
      * Indicates whenever we are in event mode or not.
-     * We always start with false, and checkCurrentCursorPosition may set it to true
+     * <p>
+     * We always start with
+     * false, and checkCurrentCursorPosition may set it to true
      **/
     protected boolean isEventMode = false;
 
@@ -262,109 +288,131 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     protected abstract void checkCurrentCursorPosition(XMLStreamReader reader, boolean doWrite);
 
     /**
-     * Called for each start element (including empty ones) when we are in event mode.
+     * Called for each start element (including empty ones) when we are in event
+     * mode.
+     * 
      * @return true if the element must be kept in translation, false otherwise
      **/
     protected abstract boolean processStartElement(StartElement el, XMLStreamWriter evWriter)
-        throws IOException, XMLStreamException;
+            throws IOException, XMLStreamException;
 
     /**
-     * Called for each end element (including empty ones) when we are in event mode.
+     * Called for each end element (including empty ones) when we are in event
+     * mode.
+     * 
      * @return true if the element must be kept in translation, false otherwise
      **/
     protected abstract boolean processEndElement(EndElement el, XMLStreamWriter evWriter)
-        throws IOException, XMLStreamException;
+            throws IOException, XMLStreamException;
 
     /**
      * Called for each sequence of characters when we are in event mode.
+     * 
      * @return true if the element must be kept in translation, false otherwise
      **/
     protected abstract boolean processCharacters(Characters el, XMLStreamWriter evWriter)
-        throws IOException, XMLStreamException;
+            throws IOException, XMLStreamException;
 
     // Inspired from http://www.java2s.com/Code/Java/XML/XmlReaderToWriter.htm
     private void fromReaderToWriter(XMLStreamReader xmlr, XMLStreamWriter writer) throws XMLStreamException {
         switch (xmlr.getEventType()) {
-            case XMLEvent.ENTITY_REFERENCE: writer.writeEntityRef(xmlr.getLocalName()); break;
-            case XMLEvent.DTD: writer.writeDTD(xmlr.getText()); break;
-            case XMLEvent.START_ELEMENT:
-                final String localName = xmlr.getLocalName(), namespaceURI = xmlr.getNamespaceURI();
-                if (namespaceURI != null && namespaceURI.length() > 0) {
-                    final String prefix = xmlr.getPrefix();
-                    if (prefix != null) {
-                        writer.writeStartElement(prefix, localName, namespaceURI);
-                    } else {
-                        writer.writeStartElement(namespaceURI, localName);
-                    }
+        case XMLEvent.ENTITY_REFERENCE:
+            writer.writeEntityRef(xmlr.getLocalName());
+            break;
+        case XMLEvent.DTD:
+            writer.writeDTD(xmlr.getText());
+            break;
+        case XMLEvent.START_ELEMENT:
+            final String localName = xmlr.getLocalName(), namespaceURI = xmlr.getNamespaceURI();
+            if (namespaceURI != null && namespaceURI.length() > 0) {
+                final String prefix = xmlr.getPrefix();
+                if (prefix != null) {
+                    writer.writeStartElement(prefix, localName, namespaceURI);
                 } else {
-                    writer.writeStartElement(localName);
+                    writer.writeStartElement(namespaceURI, localName);
                 }
-                for (int i = 0, len = xmlr.getNamespaceCount(); i < len; i++) {
-                    writer.writeNamespace(xmlr.getNamespacePrefix(i), xmlr.getNamespaceURI(i));
+            } else {
+                writer.writeStartElement(localName);
+            }
+            for (int i = 0, len = xmlr.getNamespaceCount(); i < len; i++) {
+                writer.writeNamespace(xmlr.getNamespacePrefix(i), xmlr.getNamespaceURI(i));
+            }
+            for (int i = 0, len = xmlr.getAttributeCount(); i < len; i++) {
+                String attUri = xmlr.getAttributeNamespace(i);
+                if (attUri != null) {
+                    writer.writeAttribute(attUri, xmlr.getAttributeLocalName(i), xmlr.getAttributeValue(i));
+                } else {
+                    writer.writeAttribute(xmlr.getAttributeLocalName(i), xmlr.getAttributeValue(i));
                 }
-                for (int i = 0, len = xmlr.getAttributeCount(); i < len; i++) {
-                    String attUri = xmlr.getAttributeNamespace(i);
-                    if (attUri != null) {
-                        writer.writeAttribute(attUri, xmlr.getAttributeLocalName(i), xmlr.getAttributeValue(i));
-                    } else {
-                        writer.writeAttribute(xmlr.getAttributeLocalName(i), xmlr.getAttributeValue(i));
-                    }
-                }
-                break;
-            case XMLEvent.END_ELEMENT:
-                writer.writeEndElement(); break;
-            case XMLEvent.SPACE: case XMLEvent.CHARACTERS:
-                writer.writeCharacters(xmlr.getTextCharacters(), xmlr.getTextStart(), xmlr.getTextLength()); break;
-            case XMLEvent.PROCESSING_INSTRUCTION:
-                writer.writeProcessingInstruction(xmlr.getPITarget(), xmlr.getPIData()); break;
-            case XMLEvent.CDATA:
-                writer.writeCData(xmlr.getText()); break;
-            case XMLEvent.COMMENT:
-                writer.writeComment(xmlr.getText()); break;
-            case XMLEvent.END_DOCUMENT:
-                writer.writeEndDocument(); break;
+            }
+            break;
+        case XMLEvent.END_ELEMENT:
+            writer.writeEndElement();
+            break;
+        case XMLEvent.SPACE:
+        case XMLEvent.CHARACTERS:
+            writer.writeCharacters(xmlr.getTextCharacters(), xmlr.getTextStart(), xmlr.getTextLength());
+            break;
+        case XMLEvent.PROCESSING_INSTRUCTION:
+            writer.writeProcessingInstruction(xmlr.getPITarget(), xmlr.getPIData());
+            break;
+        case XMLEvent.CDATA:
+            writer.writeCData(xmlr.getText());
+            break;
+        case XMLEvent.COMMENT:
+            writer.writeComment(xmlr.getText());
+            break;
+        case XMLEvent.END_DOCUMENT:
+            writer.writeEndDocument();
+            break;
         }
     }
 
     protected final void fromEventToWriter(XMLEvent ev, XMLStreamWriter writer) throws XMLStreamException {
         switch (ev.getEventType()) {
-            case XMLEvent.ENTITY_REFERENCE: writer.writeEntityRef(((EntityReference) ev).getName()); break;
-            // case XMLEvent.DTD: writer.writeDTD(((DTD) ev).getText()); break;
-            case XMLEvent.START_ELEMENT:
-                StartElement el = ev.asStartElement(); QName name = el.getName();
-                writer.writeStartElement(name.getPrefix(), name.getLocalPart(), name.getNamespaceURI());
-                for (Iterator<Namespace> iter = el.getNamespaces(); iter.hasNext();) {
-                    Namespace ns = iter.next();
-                    writer.writeNamespace(ns.getPrefix(), ns.getNamespaceURI());
-                }
-                for (Iterator<Attribute> iter = el.getAttributes(); iter.hasNext();) {
-                    Attribute attr = iter.next();
-                    writer.writeAttribute(
-                        attr.getName().getPrefix(), attr.getName().getNamespaceURI(),
-                        attr.getName().getLocalPart(), attr.getValue()
-                    );
-                }
-                break;
-            case XMLEvent.ATTRIBUTE:
-                writer.writeAttribute(
-                    ((Attribute) ev).getName().getPrefix(), ((Attribute) ev).getName().getNamespaceURI(),
-                    ((Attribute) ev).getName().getLocalPart(), ((Attribute) ev).getValue()
-                );
-                break;
-            case XMLEvent.END_ELEMENT:
-                writer.writeEndElement(); break;
-            case XMLEvent.SPACE: case XMLEvent.CHARACTERS:
-                writer.writeCharacters(((Characters) ev).getData()); break;
-            case XMLEvent.PROCESSING_INSTRUCTION:
-                writer.writeProcessingInstruction(((ProcessingInstruction) ev).getTarget(),
+        case XMLEvent.ENTITY_REFERENCE:
+            writer.writeEntityRef(((EntityReference) ev).getName());
+            break;
+        // case XMLEvent.DTD: writer.writeDTD(((DTD) ev).getText()); break;
+        case XMLEvent.START_ELEMENT:
+            StartElement el = ev.asStartElement();
+            QName name = el.getName();
+            writer.writeStartElement(name.getPrefix(), name.getLocalPart(), name.getNamespaceURI());
+            for (Iterator<Namespace> iter = el.getNamespaces(); iter.hasNext();) {
+                Namespace ns = iter.next();
+                writer.writeNamespace(ns.getPrefix(), ns.getNamespaceURI());
+            }
+            for (Iterator<Attribute> iter = el.getAttributes(); iter.hasNext();) {
+                Attribute attr = iter.next();
+                writer.writeAttribute(attr.getName().getPrefix(), attr.getName().getNamespaceURI(),
+                        attr.getName().getLocalPart(), attr.getValue());
+            }
+            break;
+        case XMLEvent.ATTRIBUTE:
+            writer.writeAttribute(((Attribute) ev).getName().getPrefix(),
+                    ((Attribute) ev).getName().getNamespaceURI(), ((Attribute) ev).getName().getLocalPart(),
+                    ((Attribute) ev).getValue());
+            break;
+        case XMLEvent.END_ELEMENT:
+            writer.writeEndElement();
+            break;
+        case XMLEvent.SPACE:
+        case XMLEvent.CHARACTERS:
+            writer.writeCharacters(((Characters) ev).getData());
+            break;
+        case XMLEvent.PROCESSING_INSTRUCTION:
+            writer.writeProcessingInstruction(((ProcessingInstruction) ev).getTarget(),
                     ((ProcessingInstruction) ev).getData());
-                break;
-            case XMLEvent.CDATA:
-                writer.writeCData(((Characters) ev).getData()); break;
-            case XMLEvent.COMMENT:
-                writer.writeComment(((Comment) ev).getText()); break;
-            case XMLEvent.END_DOCUMENT:
-                writer.writeEndDocument(); break;
+            break;
+        case XMLEvent.CDATA:
+            writer.writeCData(((Characters) ev).getData());
+            break;
+        case XMLEvent.COMMENT:
+            writer.writeComment(((Comment) ev).getText());
+            break;
+        case XMLEvent.END_DOCUMENT:
+            writer.writeEndDocument();
+            break;
         }
     }
 
@@ -400,15 +448,16 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
 
     // Memorize association between tags and list of events
     // This map is used by restoreTags
-    // but it is the responsability of child class to fill it during segment processing and to clean it after
+    // but it is the responsability of child class to fill it during segment
+    // processing and to clean it after
     protected Map<String, List<XMLEvent>> tagsMap = new TreeMap<>();
 
     protected static final Pattern OMEGAT_TAG = Pattern.compile("<(\\/?)([a-z]\\d+)\\/?>");
     protected static final XMLEventFactory eFactory = XMLEventFactory.newInstance();
 
     /**
-     * Produces xliff content for the translated text.
-     * Note: must be called after buildTags(src, true) to have the necessary variables filled!
+     * Produces xliff content for the translated text. Note: must be called
+     * after buildTags(src, true) to have the necessary variables filled!
      **/
     protected List<XMLEvent> restoreTags(String tra) {
         List<XMLEvent> res = new LinkedList<XMLEvent>();
@@ -433,14 +482,14 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
         StringWriter writer = new StringWriter();
         try {
             XMLEventWriter eventWriter = oFactory.createXMLEventWriter(writer);
-            for (XMLEvent ev: saved) {
+            for (XMLEvent ev : saved) {
                 eventWriter.add(ev);
             }
         } catch (Exception e) {
-            for (XMLEvent ev: saved) {
+            for (XMLEvent ev : saved) {
                 if (ev.isEndElement()) {
                     writer.write("</" + ev.asEndElement().getName().getPrefix() + ":"
-                        + ev.asEndElement().getName().getLocalPart() + ">");
+                            + ev.asEndElement().getName().getLocalPart() + ">");
                 } else {
                     writer.write(ev.toString());
                 }
@@ -462,8 +511,9 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
                 pp.setTextInSourceSegment(m.group());
                 pp.setDetailsFromSourceFile(buildProtectedPartDetails(saved));
                 if (org.omegat.core.statistics.StatisticsSettings.isCountingStandardTags()) {
-                    pp.setReplacementWordsCountCalculation(StaticUtils.TAG_REPLACEMENT_CHAR
-                        + m.group().replace('<', '_').replace('>', '_') + StaticUtils.TAG_REPLACEMENT_CHAR);
+                    pp.setReplacementWordsCountCalculation(
+                            StaticUtils.TAG_REPLACEMENT_CHAR + m.group().replace('<', '_').replace('>', '_')
+                                    + StaticUtils.TAG_REPLACEMENT_CHAR);
                 } else {
                     pp.setReplacementWordsCountCalculation(StaticUtils.TAG_REPLACEMENT);
                 }
@@ -479,12 +529,13 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     /** Convert <xxx/> to <xxx></xxx> **/
     protected static List<XMLEvent> toPair(StartElement ev) {
         List<XMLEvent> l = new LinkedList<XMLEvent>();
-        l.add(ev); l.add(eFactory.createEndElement(ev.getName(), null));
+        l.add(ev);
+        l.add(eFactory.createEndElement(ev.getName(), null));
         return l;
     }
 
     protected String findKey(StartElement findEl, boolean isEmpty) {
-        for (Map.Entry<String, List<XMLEvent>> me: tagsMap.entrySet()) {
+        for (Map.Entry<String, List<XMLEvent>> me : tagsMap.entrySet()) {
             try {
                 StartElement mapEl = me.getValue().get(0).asStartElement();
                 if (mapEl.getName().equals(findEl.getName())) {

--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -55,14 +55,15 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
      */
     private void defineDOCUMENTSOptions(Map<String, String> config) {
         /*
-         Complete string when all options are enabled
-         Word: "(document\\.xml)|(comments\\.xml)|(footnotes\\.xml)|(endnotes\\.xml)|(header\\d+\\.xml)|(footer\\d+\\.xml)"
-         Excel: "|(sharedStrings\\.xml)|(comments\\d+\\.xml)"
-         PowerPoint: "|(slide\\d+\\.xml)|(slideMaster\\d+\\.xml)| (slideLayout\\d+\\.xml)|(notesSlide\\d+\\.xml)"
-         Global: "|(data\\d+\\.xml)|(chart\\d+\\.xml)|(drawing\\d+\\.xml)"
-         Excel: "|(workbook\\.xml)"
-         Visio: "|(page\\d+\\.xml)
-        */
+         * Complete string when all options are enabled.
+         * Word: "(document\\.xml)|(comments\\.xml)|(footnotes\\.xml)|(endnotes\\.xml)
+         * |(header\\d+\\.xml)| (footer\\d+\\.xml)"
+         * Excel: "|(sharedStrings\\.xml)|(comments\\d+\\.xml)"
+         * PowerPoint: "|(slide\\d+\\.xml)|(slideMaster\\d+\\.xml)| (slideLayout\\d+\\.xml)|
+         * (notesSlide\\d+\\.xml)"
+         * Global: "|(data\\d+\\.xml)|(chart\\d+\\.xml)|(drawing\\d+\\.xml)"
+         * Excel: "|(workbook\\.xml)" Visio: "|(page\\d+\\.xml)
+         */
 
         DOCUMENTS = "(document\\d?\\.xml)";
 
@@ -109,18 +110,20 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
         if (options.getTranslateSheetNames()) {
             DOCUMENTS += "|(workbook\\.xml)";
         }
-        //if (options.getTranslateSlideLinks()) DOCUMENTS += "|(slide\\d+\\.xml\\.rels)";
+        // if (options.getTranslateSlideLinks()) DOCUMENTS +=
+        // "|(slide\\d+\\.xml\\.rels)";
 
         DOCUMENTS += "|(page\\d+\\.xml)";
 
         TRANSLATABLE = Pattern.compile(DOCUMENTS);
     }
-    
+
     public MsOfficeFileFilter() {
         super();
-        defineDOCUMENTSOptions(new HashMap<String,String>()); // Define the documents to read
+        defineDOCUMENTSOptions(new HashMap<String, String>()); // Define the
+                                                               // documents to
+                                                               // read
     }
-
 
     @Override
     public boolean isFileSupported(java.io.File inFile, Map<String, String> config, FilterContext context) {
@@ -140,11 +143,11 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     @Override
     protected boolean acceptInternalFile(ZipEntry entry, FilterContext fc) {
-        return entry.getName().endsWith("document.xml")    // Word
-            || entry.getName().endsWith("document2.xml")    // Word 365
-            || entry.getName().endsWith("sharedStrings.xml")    // Excel
-            || entry.getName().endsWith("slide1.xml")    // Powerpoint
-            || entry.getName().endsWith("page1.xml");    // Visio
+        return entry.getName().endsWith("document.xml") // Word
+                || entry.getName().endsWith("document2.xml") // Word 365
+                || entry.getName().endsWith("sharedStrings.xml") // Excel
+                || entry.getName().endsWith("slide1.xml") // Powerpoint
+                || entry.getName().endsWith("page1.xml"); // Visio
     }
 
     @Override
@@ -155,7 +158,10 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
         return TRANSLATABLE.matcher(removePath(entry.getName())).matches();
     }
 
-    /** If comments are not selected, their references are removed in document so better remove the file **/
+    /**
+     * If comments are not selected, their references are removed in document so
+     * better remove the file
+     **/
     protected boolean mustDeleteInternalFile(ZipEntry entry, boolean writeMode, FilterContext context) {
         if (entry.getName().endsWith("comments.xml")) {
             return !DOCUMENTS.contains("comments");
@@ -168,7 +174,8 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
             fileName = fileName.substring(fileName.lastIndexOf('/') + 1);
         }
         if (fileName.lastIndexOf('\\') >= 0) {
-            fileName = fileName.substring(fileName.lastIndexOf('\\') + 1); // Some weird files may use a backslash
+            // Some weird files may use a backslash
+            fileName = fileName.substring(fileName.lastIndexOf('\\') + 1);
         }
         return fileName;
     }
@@ -181,7 +188,7 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
             String[] words1 = s1.split("\\d+\\."), words2 = s2.split("\\d+\\.");
             // Digits at the end and same text
             if ((words1.length > 1 && words2.length > 1) && // Digits
-                    (words1[0].equals(words2[0]))) {        // Same text
+            (words1[0].equals(words2[0]))) { // Same text
                 int number1 = 0, number2 = 0;
                 Matcher getDigits = DIGITS.matcher(s1);
                 if (getDigits.find()) {
@@ -204,7 +211,8 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
                 // Specific case for Excel
                 // because "comments" is present twice in DOCUMENTS
                 if (shortname1.indexOf("sharedStrings") >= 0 || shortname2.indexOf("sharedStrings") >= 0) {
-                    if (shortname2.indexOf("sharedStrings") >= 0) return 1; // sharedStrings must be first
+                    if (shortname2.indexOf("sharedStrings") >= 0)
+                        return 1; // sharedStrings must be first
                     else {
                         return -1;
                     }
@@ -222,7 +230,8 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
                 } else if (index1 < index2) {
                     return -1;
                 } else {
-                    return s1.compareTo(s2); // Documents were not in DOCUMENTS, we keep the normal order
+                    return s1.compareTo(s2); // Documents were not in DOCUMENTS,
+                                             // we keep the normal order
                 }
             }
         };
@@ -230,13 +239,8 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[] {
-            new Instance("*.doc?"),
-            new Instance("*.dotx"),
-            new Instance("*.xls?"),
-            new Instance("*.ppt?"),
-            new Instance("*.vsdx")
-        };
+        return new Instance[] { new Instance("*.doc?"), new Instance("*.dotx"), new Instance("*.xls?"),
+                new Instance("*.ppt?"), new Instance("*.vsdx") };
     }
 
     public boolean hasOptions() {
@@ -248,7 +252,8 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
      *
      * @param currentOptions
      *            Current options to edit.
-     * @return Updated filter options if user confirmed the changes, and current options otherwise.
+     * @return Updated filter options if user confirmed the changes, and current
+     *         options otherwise.
      */
     @Override
     public Map<String, String> changeOptions(Window parent, Map<String, String> currentOptions) {

--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -26,20 +26,19 @@
 package org.omegat.filters4.xml.openxml;
 
 import java.awt.Window;
-
-import java.util.Comparator;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.regex.Pattern;
+import java.util.Map;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 
-import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.Instance;
 import org.omegat.filters3.xml.openxml.EditOpenXMLOptionsDialog;
 import org.omegat.filters3.xml.openxml.OpenXMLOptions;
 import org.omegat.filters4.AbstractZipFilter;
 import org.omegat.util.Log;
+import org.omegat.util.OStrings;
 
 /**
  * Filter for Microsoft Open XML
@@ -131,7 +130,7 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     @Override
     public String getFileFormatName() {
-        return "Microsoft Office Open XML (StaX)";
+        return OStrings.getString("MSOFFICE4_FILTER_NAME");
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -41,7 +41,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
 /**
- * Filter for Microsoft Open XML
+ * Filter for Microsoft Open XML.
  *
  * @author Thomas Cordonnier
  */

--- a/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
@@ -49,6 +49,7 @@ import org.omegat.filters3.xml.openxml.OpenXMLOptions;
 import org.omegat.filters4.xml.AbstractXmlFilter;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
+import org.omegat.util.OStrings;
 
 /**
  * Filter for Ms Office's XML files (those which are inside the DOCX, XLSX, PPTX...)
@@ -66,7 +67,7 @@ class OpenXmlFilter extends AbstractXmlFilter {
 
     @Override
     public String getFileFormatName() {
-        return "Microsoft Office Open XML";
+        return OStrings.getString("OPENXML4_FILTER_NAME");
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
@@ -53,7 +53,7 @@ import org.omegat.util.OStrings;
 
 /**
  * Filter for MS Office's XML files (those which are inside the DOCX, XLSX,
- * PPTX...)
+ * PPTX...).
  *
  * @author Thomas Cordonnier
  */

--- a/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -54,7 +54,7 @@ import org.omegat.filters2.FilterContext;
  */
 abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
-    // ---------------------------- IFilter API ----------------------------
+    // ---------------------------- IFilter API ---------------------------
 
     @Override
     public Instance[] getDefaultInstances() {
@@ -91,8 +91,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
     protected abstract String versionPrefix();
 
-    // ----------------------------- AbstractXmlFilter part
-    // ----------------------
+    // --------------------- AbstractXmlFilter part -----------------------
 
     /* -- Data about current unit */
     protected String path = "/", ignoreScope = null;

--- a/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -48,7 +48,7 @@ import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
 
 /**
- * Filter for support Xliff 1 files as bilingual (unlike filters3/xml/xliff)
+ * Filter for support Xliff files as bilingual.
  *
  * @author Thomas Cordonnier
  */
@@ -58,7 +58,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[]  { new Instance("*.xlf"), new Instance("*.xliff") };
+        return new Instance[] { new Instance("*.xlf"), new Instance("*.xliff") };
     }
 
     protected String namespace = null;
@@ -70,7 +70,8 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
             if (el == null) {
                 return false;
             }
-            if (el.getAttributeByName(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "version")) != null) {
+            if (el.getAttributeByName(
+                    new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "version")) != null) {
                 return false;
             }
             namespace = el.getName().getNamespaceURI();
@@ -90,7 +91,8 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
     protected abstract String versionPrefix();
 
-    // ----------------------------- AbstractXmlFilter part ----------------------
+    // ----------------------------- AbstractXmlFilter part
+    // ----------------------
 
     /* -- Data about current unit */
     protected String path = "/", ignoreScope = null;
@@ -99,27 +101,30 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     protected List<XMLEvent> source = new LinkedList<>(), target = null, note = new LinkedList<>();
 
     protected void cleanBuffers() {
-        source.clear(); target = null; note.clear();
+        source.clear();
+        target = null;
+        note.clear();
     }
 
-    @Override    // start events on body
+    @Override // start events on body
     protected void checkCurrentCursorPosition(XMLStreamReader reader, boolean doWrite) {
         if (reader.getEventType() == StartElement.START_ELEMENT) {
             if (reader.getLocalName().equals("body")) {
                 this.isEventMode = true;
             } else if (reader.getLocalName().equals("xliff")) {
-                 if (namespace == null) {
-                     namespace = reader.getName().getNamespaceURI();
-                 }
+                if (namespace == null) {
+                    namespace = reader.getName().getNamespaceURI();
+                }
             } else if (reader.getLocalName().equals("file") || reader.getLocalName().equals("group")
-            || reader.getLocalName().equals("unit")) {
+                    || reader.getLocalName().equals("unit")) {
                 final List<Attribute> attributes = new LinkedList<>();
                 for (int i = 0, len = reader.getAttributeCount(); i < len; i++) {
-                    attributes.add(eFactory.createAttribute(reader.getAttributeName(i), reader.getAttributeValue(i)));
+                    attributes.add(eFactory.createAttribute(reader.getAttributeName(i),
+                            reader.getAttributeValue(i)));
                 }
                 try {
-                     processStartElement(eFactory.createStartElement(reader.getName(), attributes.iterator(),
-                         null), null);
+                    processStartElement(
+                            eFactory.createStartElement(reader.getName(), attributes.iterator(), null), null);
                 } catch (Exception ex) {
                 }
             }
@@ -127,7 +132,8 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     }
 
     @Override
-    protected boolean processCharacters(Characters event, XMLStreamWriter evWriter) throws XMLStreamException {
+    protected boolean processCharacters(Characters event, XMLStreamWriter evWriter)
+            throws XMLStreamException {
         if (currentBuffer != null) {
             currentBuffer.add(event);
         }
@@ -139,7 +145,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
             if ("no".equals(startElement.getAttributeByName(new QName("translate")).getValue())) {
                 ignoreScope = startElement.getName().getLocalPart();
             } else if ("yes".equals(startElement.getAttributeByName(new QName("translate")).getValue())) {
-                if (ignoreScope != null)  {
+                if (ignoreScope != null) {
                     ignoreScope = "!" + startElement.getName().getLocalPart() + " " + ignoreScope;
                 }
             }
@@ -155,7 +161,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
     /** Add one unit to OmegaT, or more in case of <mrk mtype="seg"> **/
     protected void registerCurrentTransUnit(String entryId, List<XMLEvent> unitSource,
-        List<XMLEvent> unitTarget, String notePattern) {
+            List<XMLEvent> unitTarget, String notePattern) {
         String src = buildTags(unitSource, false);
         String tra = null;
         if (unitTarget != null && unitTarget.size() > 0) {
@@ -167,14 +173,16 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
         if (entryParseCallback != null) {
             StringBuffer noteStr = null;
             if (notePattern != null && note != null && note.size() > 0) {
-                 noteStr = new StringBuffer();
-                 for (XMLEvent ev: note) {
-                     noteStr.append(ev.toString());
-                 }
+                noteStr = new StringBuffer();
+                for (XMLEvent ev : note) {
+                    noteStr.append(ev.toString());
+                }
             }
             if (notePattern != null && !".*".equals(notePattern)) {
-                StringBuffer subNoteBuf = noteStr; if (subNoteBuf != null) {
-                    subNoteBuf = new StringBuffer(); String noteStrStr = noteStr.toString();
+                StringBuffer subNoteBuf = noteStr;
+                if (subNoteBuf != null) {
+                    subNoteBuf = new StringBuffer();
+                    String noteStrStr = noteStr.toString();
                     Matcher noteMatch = Pattern.compile(notePattern).matcher(noteStr.toString());
                     while (noteMatch.find()) {
                         if (noteMatch.group(1).equals(entryId.substring(entryId.lastIndexOf("/") + 1))) {
@@ -188,7 +196,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
                 noteStr = subNoteBuf;
             }
             entryParseCallback.addEntry(entryId, src.toString(), tra, false,
-                noteStr == null ? null : noteStr.toString(), path, this, buildProtectedParts(src));
+                    noteStr == null ? null : noteStr.toString(), path, this, buildProtectedParts(src));
         }
         if (entryAlignCallback != null) {
             entryAlignCallback.addTranslation(entryId, src.toString(), tra.toString(), false, path, this);
@@ -202,19 +210,19 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     protected abstract String[] getPairIdNames(boolean start);
 
     // Starts an OmegaT tag based on start element and native code
-    protected String startPair(boolean reuse, boolean isEmpty, StartElement stEl, char prefix,
-        int count, List<XMLEvent> nativeCode) {
+    protected String startPair(boolean reuse, boolean isEmpty, StartElement stEl, char prefix, int count,
+            List<XMLEvent> nativeCode) {
         if (reuse) {
             return findKey(stEl, isEmpty);
         } else {
             tagsMap.put("" + prefix + count, nativeCode);
             if (!isEmpty) {
                 Attribute pairId = null;
-                for (String attrName: getPairIdNames(true)) {
-                     pairId = stEl.getAttributeByName(new QName(attrName));
-                     if (pairId != null) {
-                         break;
-                     }
+                for (String attrName : getPairIdNames(true)) {
+                    pairId = stEl.getAttributeByName(new QName(attrName));
+                    if (pairId != null) {
+                        break;
+                    }
                 }
                 pairedHolders.put(pairId.getValue(), "" + prefix + count);
             }
@@ -223,14 +231,15 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     }
 
     // Ends an OmegaT tag based on start element and native code
-    protected String endPair(boolean reuse, StartElement stEl, char prefix, int count, List<XMLEvent> nativeCode) {
+    protected String endPair(boolean reuse, StartElement stEl, char prefix, int count,
+            List<XMLEvent> nativeCode) {
         tagsCount.put(prefix, count); // this is not a new tag!
         Attribute pairId = null;
-        for (String attrName: getPairIdNames(false)) {
-             pairId = stEl.getAttributeByName(new QName(attrName));
-             if (pairId != null) {
-                 break;
-             }
+        for (String attrName : getPairIdNames(false)) {
+            pairId = stEl.getAttributeByName(new QName(attrName));
+            if (pairId != null) {
+                break;
+            }
         }
         String key = pairedHolders.get(pairId.getValue());
         if (!reuse) {
@@ -239,13 +248,17 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
         return "</" + key + ">";
     }
 
-    protected void startStackElement(boolean reuse, StartElement stEl, char prefix, int count, StringBuffer res) {
+    protected void startStackElement(boolean reuse, StartElement stEl, char prefix, int count,
+            StringBuffer res) {
         if (reuse) {
-            String k = findKey(stEl, false); Matcher m = OMEGAT_TAG.matcher(k);
+            String k = findKey(stEl, false);
+            Matcher m = OMEGAT_TAG.matcher(k);
             if (m.matches()) {
-                 tagStack.push(m.group(2)); res.append(k);
+                tagStack.push(m.group(2));
+                res.append(k);
             } else {
-                 tagStack.push("z" + count); res.append("<z").append(count).append(">");
+                tagStack.push("z" + count);
+                res.append("<z").append(count).append(">");
             }
         } else {
             tagsMap.put("" + prefix + count, Collections.singletonList(stEl));
@@ -254,5 +267,6 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
         }
     }
 
-    protected static final javax.xml.stream.XMLEventFactory eFactory = javax.xml.stream.XMLEventFactory.newInstance();
+    protected static final javax.xml.stream.XMLEventFactory eFactory = javax.xml.stream.XMLEventFactory
+            .newInstance();
 }

--- a/src/org/omegat/filters4/xml/xliff/SdlProject.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlProject.java
@@ -33,7 +33,7 @@ import org.omegat.filters4.AbstractZipFilter;
 import org.omegat.util.OStrings;
 
 /**
- * Filter for SDL project
+ * Filter for SDL project.
  *
  * @author Thomas Cordonnier
  */
@@ -51,12 +51,12 @@ public class SdlProject extends AbstractZipFilter {
 
     protected boolean mustTranslateInternalFile(ZipEntry entry, boolean writeMode, FilterContext fc) {
         return entry.getName().startsWith(fc.getTargetLang().getLanguage())
-            && entry.getName().endsWith(".sdlxliff");
+                && entry.getName().endsWith(".sdlxliff");
     }
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[]  { new Instance("*.sdlppx") };
+        return new Instance[] { new Instance("*.sdlppx") };
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/xliff/SdlProject.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlProject.java
@@ -25,12 +25,12 @@
 
 package org.omegat.filters4.xml.xliff;
 
-import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 
-import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.Instance;
 import org.omegat.filters4.AbstractZipFilter;
+import org.omegat.util.OStrings;
 
 /**
  * Filter for SDL project
@@ -41,7 +41,7 @@ public class SdlProject extends AbstractZipFilter {
 
     @Override
     public String getFileFormatName() {
-        return "SDL project (StaX)";
+        return OStrings.getString("SDLPROJECT_FILTER_NAME");
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -48,6 +48,7 @@ import org.omegat.core.data.IProject;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
+import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 
 /**
@@ -63,7 +64,7 @@ public class SdlXliff extends Xliff1Filter {
 
     @Override
     public String getFileFormatName() {
-        return "SDL XLIFF (StaX)";
+        return OStrings.getString("SDLXLIFF_FILTER_NAME");
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -28,6 +28,7 @@ package org.omegat.filters4.xml.xliff;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -100,11 +101,16 @@ public class SdlXliff extends Xliff1Filter {
     private Map<EntryKey, UUID> altNoteLocations = new TreeMap<>();
     private Map<String, List<XMLEvent>> tagDefs = new TreeMap<>();
     private String currentProp = null;
-    private java.util.Set<String> midSet = new java.util.HashSet<String>();
-    private boolean has_seg_defs = false, mid_has_modifier = false, mid_has_modif_date = false;
+    private Set<String> midSet = new java.util.HashSet<>();
+    private boolean has_seg_defs = false;
+    private boolean mid_has_modifier = false;
+    private boolean mid_has_modif_date = false;
 
-    @Override // also starts on cmt-defs or tag-defs, else like in standard
-              // XLIFF
+
+    /**
+     * Also starts on cmt-defs or tag-defs, else like in standard XLIFF.
+     */
+    @Override
     protected void checkCurrentCursorPosition(javax.xml.stream.XMLStreamReader reader, boolean doWrite) {
         if (reader.getEventType() == StartElement.START_ELEMENT) {
             String name = reader.getLocalName();
@@ -320,7 +326,7 @@ public class SdlXliff extends Xliff1Filter {
                         }
                     }
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
         }
         // default
@@ -425,7 +431,7 @@ public class SdlXliff extends Xliff1Filter {
                             } else {
                                 writer.write(ev.toString());
                             }
-                    } catch (Exception ex2) {
+                    } catch (Exception ignored) {
                     }
                 }
                 return base + ": " + writer.toString();

--- a/src/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -52,7 +52,7 @@ import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 
 /**
- * Overrides XLiff-1 for features which only work with SDL-Xliff
+ * Overrides XLiff-1 for features which only work with SDL-Xliff.
  *
  * @author Thomas Cordonnier
  */
@@ -69,7 +69,7 @@ public class SdlXliff extends Xliff1Filter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[]  { new Instance("*.sdlxliff") };
+        return new Instance[] { new Instance("*.sdlxliff") };
     }
 
     @Override
@@ -80,7 +80,8 @@ public class SdlXliff extends Xliff1Filter {
                 return false;
             }
             namespace = el.getName().getNamespaceURI();
-            if (el.getAttributeByName(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "version")) != null) {
+            if (el.getAttributeByName(
+                    new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "version")) != null) {
                 return true;
             }
             return super.isFileSupported(inFile, config, context);
@@ -102,7 +103,8 @@ public class SdlXliff extends Xliff1Filter {
     private java.util.Set<String> midSet = new java.util.HashSet<String>();
     private boolean has_seg_defs = false, mid_has_modifier = false, mid_has_modif_date = false;
 
-    @Override    // also starts on cmt-defs or tag-defs, else like in standard XLIFF
+    @Override // also starts on cmt-defs or tag-defs, else like in standard
+              // XLIFF
     protected void checkCurrentCursorPosition(javax.xml.stream.XMLStreamReader reader, boolean doWrite) {
         if (reader.getEventType() == StartElement.START_ELEMENT) {
             String name = reader.getLocalName();
@@ -118,7 +120,7 @@ public class SdlXliff extends Xliff1Filter {
 
     @Override
     protected boolean processStartElement(StartElement startElement, XMLStreamWriter writer)
-        throws  XMLStreamException {
+            throws XMLStreamException {
         if (startElement.getName().getLocalPart().equals("cmt-def")) {
             commentBuf = new StringBuffer();
             sdlComments.put(startElement.getAttributeByName(new QName("id")).getValue(), commentBuf);
@@ -128,9 +130,11 @@ public class SdlXliff extends Xliff1Filter {
             if (startElement.getAttributeByName(new QName("mtype")).getValue().equals("seg")) {
                 currentMid = startElement.getAttributeByName(new QName("mid")).getValue();
                 midSet.add(currentMid);
-            } else if (startElement.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-comment")) {
-                String id = startElement.getAttributeByName(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "cid"))
-                    .getValue();
+            } else if (startElement.getAttributeByName(new QName("mtype")).getValue()
+                    .equals("x-sdl-comment")) {
+                String id = startElement
+                        .getAttributeByName(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "cid"))
+                        .getValue();
                 this.addNoteFromSource(currentMid, sdlComments.get(id).toString());
             }
         }
@@ -140,19 +144,21 @@ public class SdlXliff extends Xliff1Filter {
         }
         if (writer != null) {
             if (startElement.getName().equals(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "seg"))) {
-                mid_has_modifier = false; mid_has_modif_date = false;
-                currentProp = null; has_seg_defs = true; // start a new set of properties
+                mid_has_modifier = false;
+                mid_has_modif_date = false;
+                currentProp = null;
+                has_seg_defs = true; // start a new set of properties
                 fromEventToWriter(eFactory.createStartElement(startElement.getName(), null,
-                    startElement.getNamespaces()), writer);
+                        startElement.getNamespaces()), writer);
                 String id = null;
-                for (java.util.Iterator<Attribute> iter = startElement.getAttributes(); iter.hasNext(); ) {
+                for (java.util.Iterator<Attribute> iter = startElement.getAttributes(); iter.hasNext();) {
                     Attribute attr = iter.next();
                     if (attr.getName().getLocalPart().equals("id")) {
                         id = attr.getValue();
                     }
                     if (!attr.getName().getLocalPart().equals("conf")) {
                         writer.writeAttribute(attr.getName().getPrefix(), attr.getName().getNamespaceURI(),
-                            attr.getName().getLocalPart(), attr.getValue());
+                                attr.getName().getLocalPart(), attr.getValue());
                     }
                 }
                 if ((id != null) && this.isCurrentSegmentTranslated(id)) {
@@ -172,50 +178,52 @@ public class SdlXliff extends Xliff1Filter {
 
     @Override
     protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer)
-        throws  XMLStreamException {
+            throws XMLStreamException {
         if (endElement.getName().getLocalPart().equals("seg")) {
             if ((writer != null) && isCurrentSegmentTranslated(currentMid)) {
                 if (!mid_has_modifier) { // no such value in the file
                     writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "value");
                     writer.writeAttribute("key", "last_modified_by");
                     writer.writeCharacters(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,
-                        System.getProperty("user.name")));
-                    writer.writeEndElement(/*"sdl:value*/);
+                            System.getProperty("user.name")));
+                    writer.writeEndElement(/* "sdl:value */);
                 }
                 if (!mid_has_modif_date) { // no such value in the file
                     writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "value");
                     writer.writeAttribute("key", "modified_on");
                     writer.writeCharacters(TRADOS_DATE_FORMAT.format(new java.util.Date()));
-                    writer.writeEndElement(/*"sdl:value*/);
+                    writer.writeEndElement(/* "sdl:value */);
                 }
             }
-            midSet.remove(currentMid); currentMid = null;
+            midSet.remove(currentMid);
+            currentMid = null;
         }
         if (endElement.getName().getLocalPart().equals("trans-unit")) {
             if (writer != null) {
                 if ((midSet.size() > 0) && (!has_seg_defs)) {
                     writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "seg-defs");
                 }
-                for (String mid0: midSet) {    // those which were not generated by previous lines
+                for (String mid0 : midSet) { // those which were not generated
+                                             // by previous lines
                     writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "seg");
                     writer.writeAttribute("id", mid0);
                     writer.writeAttribute("conf", "Translated");
                     if (isCurrentSegmentTranslated(mid0)) {
                         writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "value");
                         writer.writeAttribute("key", "last_modified_by");
-                        writer.writeCharacters(Preferences.getPreferenceDefault(
-                            Preferences.TEAM_AUTHOR, System.getProperty("user.name")));
-                        writer.writeEndElement(/*"sdl:value*/);
+                        writer.writeCharacters(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,
+                                System.getProperty("user.name")));
+                        writer.writeEndElement(/* "sdl:value */);
 
                         writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "value");
                         writer.writeAttribute("key", "modified_on");
                         writer.writeCharacters(TRADOS_DATE_FORMAT.format(new java.util.Date()));
-                        writer.writeEndElement(/*"sdl:value*/);
+                        writer.writeEndElement(/* "sdl:value */);
                     }
-                    writer.writeEndElement(/*"sdl:seg*/);
+                    writer.writeEndElement(/* "sdl:seg */);
                 }
                 if ((midSet.size() > 0) && (!has_seg_defs)) {
-                    writer.writeEndElement(/*"sdl:seg-defs */);
+                    writer.writeEndElement(/* "sdl:seg-defs */);
                 }
             }
             midSet.clear();
@@ -235,7 +243,9 @@ public class SdlXliff extends Xliff1Filter {
                         return;
                     }
 
-                    UUID id = UUID.randomUUID(); omegatNotes.put(id, trans.note); defaultNoteLocations.put(source, id);
+                    UUID id = UUID.randomUUID();
+                    omegatNotes.put(id, trans.note);
+                    defaultNoteLocations.put(source, id);
                     createSdlNote(id, trans, writer);
                 });
                 proj.iterateByMultipleTranslations((EntryKey key, TMXEntry trans) -> {
@@ -243,11 +253,14 @@ public class SdlXliff extends Xliff1Filter {
                         return;
                     }
 
-                    UUID id = UUID.randomUUID(); omegatNotes.put(id, trans.note); altNoteLocations.put(key, id);
+                    UUID id = UUID.randomUUID();
+                    omegatNotes.put(id, trans.note);
+                    altNoteLocations.put(key, id);
                     createSdlNote(id, trans, writer);
                 });
             }
-            return false; // when isEventMode changes, next iteration will send the current event
+            return false; // when isEventMode changes, next iteration will send
+                          // the current event
         }
         return super.processEndElement(endElement, writer);
     }
@@ -255,16 +268,16 @@ public class SdlXliff extends Xliff1Filter {
     // Do not generate tag for comment inside source
     protected boolean isUntaggedTag(StartElement stEl) {
         return (stEl.getName().equals(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"))
-            && (stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-comment")
-            || stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-added")))
-            || super.isUntaggedTag(stEl);
+                && (stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-comment")
+                        || stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-added")))
+                || super.isUntaggedTag(stEl);
     }
 
     // Track change 'DELETED' should not appear at all in the
     protected boolean isDeletedTag(StartElement stEl) {
         return (stEl.getName().equals(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"))
-            && stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-deleted"))
-            || super.isUntaggedTag(stEl);
+                && stEl.getAttributeByName(new QName("mtype")).getValue().equals("x-sdl-deleted"))
+                || super.isUntaggedTag(stEl);
     }
 
     @Override
@@ -273,7 +286,7 @@ public class SdlXliff extends Xliff1Filter {
             try {
                 String tagId = stEl.getAttributeByName(new QName("id")).getValue();
                 List<XMLEvent> contents = tagDefs.get(tagId);
-                for (XMLEvent ev: contents) {
+                for (XMLEvent ev : contents) {
                     if (ev.isCharacters()) {
                         String txt = ev.asCharacters().getData();
                         if (txt.contains("italic") && !txt.contains("bold")) {
@@ -307,8 +320,7 @@ public class SdlXliff extends Xliff1Filter {
                         }
                     }
                 }
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
             }
         }
         // default
@@ -322,9 +334,9 @@ public class SdlXliff extends Xliff1Filter {
             writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "Comments");
             writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "Comment");
             writer.writeCharacters(trans.note);
-            writer.writeEndElement(/*Comment*/);
-            writer.writeEndElement(/*Comments*/);
-            writer.writeEndElement(/*cmt-def*/);
+            writer.writeEndElement(/* Comment */);
+            writer.writeEndElement(/* Comments */);
+            writer.writeEndElement(/* cmt-def */);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -336,24 +348,28 @@ public class SdlXliff extends Xliff1Filter {
             commentBuf.append(event.toString());
             if ((writer != null) && isCurrentSegmentTranslated(currentMid)) {
                 if ("last_modified_by".equals(currentProp)) {
-                    writer.writeCharacters(Preferences.getPreferenceDefault(
-                        Preferences.TEAM_AUTHOR, System.getProperty("user.name")));
-                    mid_has_modifier = true; return false;
+                    writer.writeCharacters(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,
+                            System.getProperty("user.name")));
+                    mid_has_modifier = true;
+                    return false;
                 }
                 if ("modified_on".equals(currentProp)) {
                     writer.writeCharacters(TRADOS_DATE_FORMAT.format(new java.util.Date()));
-                    mid_has_modif_date = true; return false;
+                    mid_has_modif_date = true;
+                    return false;
                 }
             }
         }
         return super.processCharacters(event, writer);
     }
 
-    // This method is called only during translation generation: so we can use it to add notes!
+    // This method is called only during translation generation: so we can use
+    // it to add notes!
     @Override
     protected List<XMLEvent> restoreTags(String unitId, String path, String src, String tra) {
         List<XMLEvent> res = super.restoreTags(unitId, path, src, tra);
-        EntryKey key = new EntryKey("", src, unitId, null, null, path); UUID addNote = null;
+        EntryKey key = new EntryKey("", src, unitId, null, null, path);
+        UUID addNote = null;
         if (altNoteLocations.get(key) != null) {
             addNote = altNoteLocations.get(key);
         } else if (defaultNoteLocations.get(src) != null) {
@@ -361,12 +377,13 @@ public class SdlXliff extends Xliff1Filter {
         }
         if ((addNote != null) && (omegatNotes.get(addNote) != null)) {
             List<Attribute> attr = new java.util.LinkedList<Attribute>();
-            attr.add(eFactory.createAttribute("sdl", "http://sdl.com/FileTypes/SdlXliff/1.0",
-                "cid", addNote.toString()));
+            attr.add(eFactory.createAttribute("sdl", "http://sdl.com/FileTypes/SdlXliff/1.0", "cid",
+                    addNote.toString()));
             attr.add(eFactory.createAttribute(new QName("mtype"), "x-sdl-comment"));
             res.add(0, eFactory.createStartElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"),
-                attr.iterator(), null));
-            res.add(eFactory.createEndElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"), null));
+                    attr.iterator(), null));
+            res.add(eFactory.createEndElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"),
+                    null));
         }
         return res;
     }
@@ -396,15 +413,15 @@ public class SdlXliff extends Xliff1Filter {
                 java.io.Writer writer = new java.io.StringWriter();
                 try {
                     javax.xml.stream.XMLEventWriter eventWriter = oFactory.createXMLEventWriter(writer);
-                    for (XMLEvent ev: tagDefList) {
+                    for (XMLEvent ev : tagDefList) {
                         eventWriter.add(ev);
                     }
                 } catch (XMLStreamException xe) {
                     try {
-                        for (XMLEvent ev: saved)
+                        for (XMLEvent ev : saved)
                             if (ev.isEndElement()) {
                                 writer.write("</" + ev.asEndElement().getName().getPrefix() + ":"
-                                    + ev.asEndElement().getName().getLocalPart() + ">");
+                                        + ev.asEndElement().getName().getLocalPart() + ">");
                             } else {
                                 writer.write(ev.toString());
                             }
@@ -417,9 +434,8 @@ public class SdlXliff extends Xliff1Filter {
         return base;
     }
 
-
     @Override
     protected boolean isStandardTranslationState() {
-        return false;  // because SDLXLIFF does not have attributes in target
+        return false; // because SDLXLIFF does not have attributes in target
     }
 }

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -42,7 +42,7 @@ import javax.xml.stream.events.XMLEvent;
 import org.omegat.util.OStrings;
 
 /**
- * Filter for support Xliff 1 files as bilingual (unlike filters3/xml/xliff)
+ * Filter for support Xliff 1 files as bilingual (unlike filters3/xml/xliff).
  *
  * @author Thomas Cordonnier
  */
@@ -56,155 +56,192 @@ public class Xliff1Filter extends AbstractXliffFilter {
     }
 
     protected final String versionPrefix() {
-        return "1.";  // can be 1.0, 1.1 or 1.2
+        return "1."; // can be 1.0, 1.1 or 1.2
     }
 
-    // ----------------------------- AbstractXmlFilter part----------------------
+    // ----------------------------- AbstractXmlFilter
+    // part----------------------
 
     /** Current translation unit **/
     private String unitId = null;
     private boolean flushedUnit = false;
-    private int lastGroupId = 0; // only used when group id is not present in the file
+    private int lastGroupId = 0; // only used when group id is not present in
+                                 // the file
     private List<XMLEvent> segSource = new LinkedList<>();
     private Map<String, List<XMLEvent>> subSegments = new TreeMap<>();
     private StartElement targetStartEvent = null;
     private int inSubSeg = 0;
 
     protected void cleanBuffers() {
-        source.clear(); target = null; note.clear(); segSource.clear(); subSegments.clear();
+        source.clear();
+        target = null;
+        note.clear();
+        segSource.clear();
+        subSegments.clear();
     }
 
     @Override
     @SuppressWarnings("fallthrough")
     protected boolean processStartElement(StartElement startElement, XMLStreamWriter writer)
-    throws  XMLStreamException {
+            throws XMLStreamException {
         switch (startElement.getName().getLocalPart()) {
-            case "xliff":
-                if (namespace == null) {
-                    namespace = startElement.getName().getNamespaceURI();
-                }
-                break;
-            case "file":
+        case "xliff":
+            if (namespace == null) {
+                namespace = startElement.getName().getNamespaceURI();
+            }
+            break;
+        case "file":
+            try {
+                path += "/" + startElement.getAttributeByName(new QName("original")).getValue();
+            } catch (NullPointerException noid) { // Note: in spec, original is
+                                                  // REQUIRED
+                throw new XMLStreamException(
+                        OStrings.getString("XLIFF_MANDATORY_ORIGINAL_MISSING", "original", "file"));
+            }
+            updateIgnoreScope(startElement);
+            break;
+        case "group":
+            try {
+                path += "/" + startElement.getAttributeByName(new QName("id")).getValue();
+            } catch (NullPointerException noid) { // in XLIFF 1, this attribute
+                                                  // is not REQUIRED
                 try {
-                    path += "/" + startElement.getAttributeByName(new QName("original")).getValue();
-                } catch (NullPointerException noid) { // Note: in spec, original is REQUIRED
-                    throw new XMLStreamException(OStrings.getString(
-                            "XLIFF_MANDATORY_ORIGINAL_MISSING",  "original",  "file"));
+                    path += "/" + startElement.getAttributeByName(new QName("resname")).getValue();
+                } catch (NullPointerException noresname) {
+                    // generate an unique id:
+                    // must be unique at document scope but must be identical
+                    // when you re-parse the document
+                    path += "/x-auto-" + lastGroupId;
+                    lastGroupId++;
                 }
-                updateIgnoreScope(startElement);
+            }
+            updateIgnoreScope(startElement);
+            break;
+        case "trans-unit":
+            try {
+                unitId = startElement.getAttributeByName(new QName("id")).getValue();
+            } catch (NullPointerException noid) { // Note: in spec, original is
+                                                  // REQUIRED
+                throw new XMLStreamException(
+                        OStrings.getString("XLIFF_MANDATORY_ORIGINAL_MISSING", "id", "trans-unit"));
+            }
+            flushedUnit = false;
+            targetStartEvent = null;
+            updateIgnoreScope(startElement);
+            break;
+        case "source":
+            currentBuffer = source;
+            source.clear();
+            break;
+        case "target":
+            target = new LinkedList<XMLEvent>();
+            currentBuffer = target;
+            inTarget = true;
+            targetStartEvent = startElement;
+            break;
+        case "note":
+            currentBuffer = note;
+            note.clear();
+            break;
+        case "seg-source":
+            currentBuffer = segSource;
+            segSource.clear();
+            break;
+        case "mrk":
+            if (startElement.getAttributeByName(new QName("mtype")).getValue().equals("seg")) {
+                String mid = startElement.getAttributeByName(new QName("mid")).getValue();
+                currentBuffer.add(startElement);
+                currentBuffer = new LinkedList<XMLEvent>();
+                if (!inTarget) {
+                    subSegments.put(mid, currentBuffer);
+                }
+                inSubSeg++;
                 break;
-            case "group":
-                try {
-                    path += "/" + startElement.getAttributeByName(new QName("id")).getValue();
-                } catch (NullPointerException noid) { // in XLIFF 1, this attribute is not REQUIRED
-                    try {
-                        path += "/" + startElement.getAttributeByName(new QName("resname")).getValue();
-                    } catch (NullPointerException noresname) {
-                        // generate an unique id:
-                        // must be unique at document scope but must be identical when you re-parse the document
-                        path += "/x-auto-" + lastGroupId; lastGroupId++;
-                    }
-                }
-                updateIgnoreScope(startElement);
-                break;
-            case "trans-unit":
-                try {
-                    unitId = startElement.getAttributeByName(new QName("id")).getValue();
-                } catch (NullPointerException noid) { // Note: in spec, original is REQUIRED
-                    throw new XMLStreamException(OStrings.getString(
-                            "XLIFF_MANDATORY_ORIGINAL_MISSING",  "id",  "trans-unit"));
-                }
-                flushedUnit = false; targetStartEvent = null;
-                updateIgnoreScope(startElement);
-                break;
-            case "source":
-                currentBuffer = source; source.clear(); break;
-            case "target":
-                target = new LinkedList<XMLEvent>(); currentBuffer = target;
-                inTarget = true; targetStartEvent = startElement;
-                break;
-            case "note":
-                currentBuffer = note; note.clear(); break;
-            case "seg-source":
-                currentBuffer = segSource; segSource.clear(); break;
-            case "mrk":
-                if (startElement.getAttributeByName(new QName("mtype")).getValue().equals("seg")) {
-                    String mid = startElement.getAttributeByName(new QName("mid")).getValue();
-                    currentBuffer.add(startElement);
-                    currentBuffer = new LinkedList<XMLEvent>();
-                    if (!inTarget) {
-                        subSegments.put(mid, currentBuffer);
-                    }
-                    inSubSeg++;
-                    break;
-                } else if (inSubSeg > 0) {
-                    inSubSeg++; // avoids to crash on <mrk> inside segment.
-                }
-                // Do not break because inside segment we want <m0>
-            default:
-                if (currentBuffer != null) {
-                    currentBuffer.add(startElement);
-                } else if (((ignoreScope == null || ignoreScope.startsWith("!")) && (unitId != null))
-                     && (!startElement.getName().getNamespaceURI().equals("urn:oasis:names:tc:xliff:document:1.2"))) {
-                    flushTranslations(writer);
-                    // <target> must be before any oter-namespace markup
-                }
+            } else if (inSubSeg > 0) {
+                inSubSeg++; // avoids to crash on <mrk> inside segment.
+            }
+            // Do not break because inside segment we want <m0>
+        default:
+            if (currentBuffer != null) {
+                currentBuffer.add(startElement);
+            } else if (((ignoreScope == null || ignoreScope.startsWith("!")) && (unitId != null))
+                    && (!startElement.getName().getNamespaceURI()
+                            .equals("urn:oasis:names:tc:xliff:document:1.2"))) {
+                flushTranslations(writer);
+                // <target> must be before any oter-namespace markup
+            }
         }
         return !inTarget;
     }
 
     @Override
     @SuppressWarnings("fallthrough")
-    protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer) throws  XMLStreamException {
+    protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer)
+            throws XMLStreamException {
         switch (endElement.getName().getLocalPart()) {
-            case "source": case "seg-source": case "note": currentBuffer = null; break;
-            case "target":
-                currentBuffer = null;
-                if (ignoreScope == null || ignoreScope.startsWith("!")) {
-                    flushTranslations(writer); // we are in the correct place
-                }
-                inTarget = false; return false;
-            case "trans-unit":
-                if (ignoreScope == null || ignoreScope.startsWith("!")) {
-                    flushTranslations(writer); // if there was no <target> at all
-                }
-                if (ignoreScope == null || ignoreScope.startsWith("!")) { // registerCurrentTransUnit(unitId);
-                    if (subSegments.isEmpty()) {
-                        registerCurrentTransUnit(unitId, source, target, ".*");
-                    } else {
-                        for (Map.Entry<String, List<XMLEvent>> me: subSegments.entrySet()) {
-                            registerCurrentTransUnit(unitId + "/" + me.getKey(), me.getValue(),
+        case "source":
+        case "seg-source":
+        case "note":
+            currentBuffer = null;
+            break;
+        case "target":
+            currentBuffer = null;
+            if (ignoreScope == null || ignoreScope.startsWith("!")) {
+                flushTranslations(writer); // we are in the correct place
+            }
+            inTarget = false;
+            return false;
+        case "trans-unit":
+            if (ignoreScope == null || ignoreScope.startsWith("!")) {
+                flushTranslations(writer); // if there was no <target> at all
+            }
+            if (ignoreScope == null || ignoreScope.startsWith("!")) { // registerCurrentTransUnit(unitId);
+                if (subSegments.isEmpty()) {
+                    registerCurrentTransUnit(unitId, source, target, ".*");
+                } else {
+                    for (Map.Entry<String, List<XMLEvent>> me : subSegments.entrySet()) {
+                        registerCurrentTransUnit(unitId + "/" + me.getKey(), me.getValue(),
                                 findSubsegment(target, me.getKey()), "\\[(\\d+)\\](.*)\\[\\1\\]");
-                        }
                     }
                 }
-                unitId = null; cleanBuffers();
-                if (endElement.getName().getLocalPart().equals(ignoreScope)) {
-                    ignoreScope = null;
-                } else if (ignoreScope != null && ignoreScope.startsWith("!" + endElement.getName().getLocalPart())) {
-                    ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
-                }
+            }
+            unitId = null;
+            cleanBuffers();
+            if (endElement.getName().getLocalPart().equals(ignoreScope)) {
+                ignoreScope = null;
+            } else if (ignoreScope != null
+                    && ignoreScope.startsWith("!" + endElement.getName().getLocalPart())) {
+                ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
+            }
+            break;
+        case "group":
+        case "file":
+            path = path.substring(0, path.lastIndexOf('/'));
+            cleanBuffers();
+            if (endElement.getName().getLocalPart().equals(ignoreScope)) {
+                ignoreScope = null;
+            } else if (ignoreScope != null
+                    && ignoreScope.startsWith("!" + endElement.getName().getLocalPart())) {
+                ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
+            }
+            break;
+        case "mrk":
+            if (inSubSeg == 1) {
+                List<XMLEvent> save = inTarget ? target : segSource;
+                save.addAll(currentBuffer);
+                currentBuffer = save;
+                currentBuffer.add(endElement);
+                inSubSeg = 0;
                 break;
-            case "group": case "file":
-                path = path.substring(0, path.lastIndexOf('/')); cleanBuffers();
-                if (endElement.getName().getLocalPart().equals(ignoreScope)) {
-                    ignoreScope = null;
-                } else if (ignoreScope != null && ignoreScope.startsWith("!" + endElement.getName().getLocalPart())) {
-                    ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
-                }
-                break;
-            case "mrk":
-                if (inSubSeg == 1) {
-                    List<XMLEvent> save = inTarget ? target : segSource; save.addAll(currentBuffer);
-                    currentBuffer = save; currentBuffer.add(endElement); inSubSeg = 0; break;
-                } else {
-                    if (inSubSeg > 0) inSubSeg--;
-                } // avoids to crash on <mrk> inside segment.
-                // Do not break because inside segment we want </m0>
-            default:
-                if (currentBuffer != null) {
-                    currentBuffer.add(endElement);
-                }
+            } else {
+                if (inSubSeg > 0)
+                    inSubSeg--;
+            } // avoids to crash on <mrk> inside segment.
+              // Do not break because inside segment we want </m0>
+        default:
+            if (currentBuffer != null) {
+                currentBuffer.add(endElement);
+            }
         }
         return !inTarget;
     }
@@ -220,114 +257,158 @@ public class Xliff1Filter extends AbstractXliffFilter {
     }
 
     protected boolean isCurrentSegmentTranslated(String mid) {
-        /*if (target == null) return false;
-        if (subSegments.isEmpty()) return true; // target not null*/
+        /*
+         * if (target == null) return false; if (subSegments.isEmpty()) return
+         * true; // target not null
+         */
         if ((entryTranslateCallback == null) || (mid == null)) {
             return false;
         }
         if (subSegments.get(mid) == null) {
-            return false; // do not crash if xliff target contains sub-segments not present in source
+            return false; // do not crash if xliff target contains sub-segments
+                          // not present in source
         }
-        return entryTranslateCallback.getTranslation(unitId + "/" + mid, buildTags(subSegments.get(mid),
-            false), path) != null;
+        return entryTranslateCallback.getTranslation(unitId + "/" + mid,
+                buildTags(subSegments.get(mid), false), path) != null;
     }
 
     /**
      * Converts List<XMLEvent> to OmegaT format, with <x0/>, <g0>...</g0>, etc.
-     Also build maps to be reused later
+     * Also build maps to be reused later
      **/
     protected String buildTags(List<XMLEvent> srcList, boolean reuse) {
         if (!reuse) {
-             tagsMap.clear();
-             for (Character c: tagsCount.keySet()) {
-                 tagsCount.put(c, 0);
-             }
+            tagsMap.clear();
+            for (Character c : tagsCount.keySet()) {
+                tagsCount.put(c, 0);
+            }
         }
-        StringBuffer res = new StringBuffer(); LinkedList<StringBuffer> saveBuf = new LinkedList<>();
+        StringBuffer res = new StringBuffer();
+        LinkedList<StringBuffer> saveBuf = new LinkedList<>();
         List<XMLEvent> nativeCode = null;
-        for (XMLEvent ev: srcList) {
+        for (XMLEvent ev : srcList) {
             if (nativeCode != null) {
                 nativeCode.add(ev);
             }
             if (ev.isCharacters()) {
-                 if (nativeCode == null) {
-                     res.append(ev.asCharacters().getData());
-                 }
+                if (nativeCode == null) {
+                    res.append(ev.asCharacters().getData());
+                }
             } else if (ev.isStartElement()) {
                 StartElement stEl = ev.asStartElement();
-                String name = stEl.getName().getLocalPart(); char prefix = findPrefix(stEl);
+                String name = stEl.getName().getLocalPart();
+                char prefix = findPrefix(stEl);
                 Integer count = tagsCount.get(prefix);
                 if (count == null) {
                     count = 0;
                 }
                 tagsCount.put(prefix, count + 1);
                 switch (name) {
-                    case "x":  // empty element
-                        res.append(startPair(reuse, true, stEl, 'x', count, toPair(stEl))); break;
-                    case "bx": // empty element, paired, start
-                        res.append(startPair(reuse, false, stEl, prefix, count, toPair(stEl))); break;
-                    case "ex":  // empty element, paired, end
-                        res.append(endPair(reuse, stEl, prefix, count, toPair(stEl))); break;
-                    case "bpt": // paired native code, start
+                case "x": // empty element
+                    res.append(startPair(reuse, true, stEl, 'x', count, toPair(stEl)));
+                    break;
+                case "bx": // empty element, paired, start
+                    res.append(startPair(reuse, false, stEl, prefix, count, toPair(stEl)));
+                    break;
+                case "ex": // empty element, paired, end
+                    res.append(endPair(reuse, stEl, prefix, count, toPair(stEl)));
+                    break;
+                case "bpt": // paired native code, start
+                    nativeCode = new LinkedList<XMLEvent>();
+                    res.append(startPair(reuse, false, stEl, prefix, count, nativeCode));
+                    saveBuf.push(res);
+                    res = new StringBuffer();
+                    nativeCode.add(ev);
+                    break;
+                case "ept": // paired native code, end
+                    nativeCode = new LinkedList<XMLEvent>();
+                    res.append(endPair(reuse, stEl, prefix, count, nativeCode));
+                    saveBuf.push(res);
+                    res = new StringBuffer();
+                    nativeCode.add(ev);
+                    break;
+                default: // g, mrk, ph, it and other-namespace
+                    if (isProtectedTag(stEl)) { // ph, it, mrk:mtype=protected,
+                                                // maybe other
                         nativeCode = new LinkedList<XMLEvent>();
-                        res.append(startPair(reuse, false, stEl, prefix, count, nativeCode));
-                        saveBuf.push(res); res = new StringBuffer(); nativeCode.add(ev);
-                        break;
-                    case "ept": // paired native code, end
-                        nativeCode = new LinkedList<XMLEvent>();
-                        res.append(endPair(reuse, stEl, prefix, count, nativeCode));
-                        saveBuf.push(res); res = new StringBuffer(); nativeCode.add(ev);
-                        break;
-                    default:    // g, mrk, ph, it and other-namespace
-                        if (isProtectedTag(stEl)) {  // ph, it, mrk:mtype=protected, maybe other
-                            nativeCode = new LinkedList<XMLEvent>();
-                            if (reuse) {
-                                res.append(findKey(stEl, true));
+                        if (reuse) {
+                            res.append(findKey(stEl, true));
+                        } else {
+                            Attribute posAttr = stEl.getAttributeByName(new QName("pos"));
+                            String posVal = posAttr == null ? "" : posAttr.getValue();
+                            if ("close".equals(posVal) || "end".equals(posVal)) { // in
+                                                                                  // OT,
+                                                                                  // appear
+                                                                                  // as
+                                                                                  // close
+                                                                                  // tag
+                                tagsMap.put("/" + prefix + count, nativeCode);
+                                res.append("</").append(prefix).append(count).append(">");
                             } else {
-                                Attribute posAttr = stEl.getAttributeByName(new QName("pos"));
-                                String posVal = posAttr == null ? "" : posAttr.getValue();
-                                if ("close".equals(posVal) || "end".equals(posVal)) { // in OT, appear as close tag
-                                    tagsMap.put("/" + prefix + count, nativeCode);
-                                    res.append("</").append(prefix).append(count).append(">");
-                                } else {
-                                    tagsMap.put("" + prefix + count, nativeCode);
-                                    if ("open".equals(posVal) || "begin".equals(posVal)) { // in OT, appear as open tag
-                                        res.append("<").append(prefix).append(count).append(">");
-                                    } else {  // in OT, appear as empty
-                                        res.append("<").append(prefix).append(count).append("/>");
-                                    }
+                                tagsMap.put("" + prefix + count, nativeCode);
+                                if ("open".equals(posVal) || "begin".equals(posVal)) { // in
+                                                                                       // OT,
+                                                                                       // appear
+                                                                                       // as
+                                                                                       // open
+                                                                                       // tag
+                                    res.append("<").append(prefix).append(count).append(">");
+                                } else { // in OT, appear as empty
+                                    res.append("<").append(prefix).append(count).append("/>");
                                 }
                             }
-                            saveBuf.push(res); res = new StringBuffer(); nativeCode.add(ev);
-                            tagStack.push("mark-protected"); break;
-                        } else if (isDeletedTag(stEl)) { // generate nothing, not either the contents
-                            tagStack.push("mark-deleted");
-                            saveBuf.add(res);
-                            res = new StringBuffer();
-                            break;
-                        } else if (isUntaggedTag(stEl)) {
-                             tagStack.push("mark-ignored"); break; // generate only contents, not the tag
                         }
-                        // else do not break, continue with default
-                        startStackElement(reuse, stEl, prefix, count, res);
+                        saveBuf.push(res);
+                        res = new StringBuffer();
+                        nativeCode.add(ev);
+                        tagStack.push("mark-protected");
                         break;
+                    } else if (isDeletedTag(stEl)) { // generate nothing, not
+                                                     // either the contents
+                        tagStack.push("mark-deleted");
+                        saveBuf.add(res);
+                        res = new StringBuffer();
+                        break;
+                    } else if (isUntaggedTag(stEl)) {
+                        tagStack.push("mark-ignored");
+                        break; // generate only contents, not the tag
+                    }
+                    // else do not break, continue with default
+                    startStackElement(reuse, stEl, prefix, count, res);
+                    break;
                 }
             } else if (ev.isEndElement()) {
                 EndElement endEl = ev.asEndElement();
                 switch (endEl.getName().getLocalPart()) {
-                    case "x": case "bx": case "ex": break; // Should be empty!!!
-                    case "bpt": case "ept": nativeCode = null; res.setLength(0); res = saveBuf.pop(); break;
-                    default: {
-                            String pop = tagStack.pop();
-                            if (pop.equals("mark-protected")) { // isProtectedTag(start element) was true
-                                nativeCode = null; res.setLength(0); res = saveBuf.pop(); break;
-                            } else if (pop.equals("mark-deleted")) { // isProtectedTag(start element) was true
-                                res.setLength(0); res = saveBuf.pop(); break; // dummy res buffer is not used at all
-                            } else if (!pop.equals("mark-ignored")) {
-                                tagsMap.put("/" + pop, Collections.singletonList(ev));
-                                res.append("</").append(pop).append(">");
-                            }
-                        }
+                case "x":
+                case "bx":
+                case "ex":
+                    break; // Should be empty!!!
+                case "bpt":
+                case "ept":
+                    nativeCode = null;
+                    res.setLength(0);
+                    res = saveBuf.pop();
+                    break;
+                default: {
+                    String pop = tagStack.pop();
+                    if (pop.equals("mark-protected")) { // isProtectedTag(start
+                                                        // element) was true
+                        nativeCode = null;
+                        res.setLength(0);
+                        res = saveBuf.pop();
+                        break;
+                    } else if (pop.equals("mark-deleted")) { // isProtectedTag(start
+                                                             // element) was
+                                                             // true
+                        res.setLength(0);
+                        res = saveBuf.pop();
+                        break; // dummy res buffer is not used at all
+                    } else if (!pop.equals("mark-ignored")) {
+                        tagsMap.put("/" + pop, Collections.singletonList(ev));
+                        res.append("</").append(pop).append(">");
+                    }
+                }
                 }
             }
         }
@@ -341,9 +422,10 @@ public class Xliff1Filter extends AbstractXliffFilter {
         }
         if (ctype != null && ctype.getValue().length() > 0) {
             if (ctype.getValue().startsWith("x-")) {
-                 // common prefix for non-standard type. And we want to leave x for <x/>
+                // common prefix for non-standard type. And we want to leave x
+                // for <x/>
                 return Character.toLowerCase(ctype.getValue().charAt(2));
-            } else {  // usually: bold, italics, etc.
+            } else { // usually: bold, italics, etc.
                 return Character.toLowerCase(ctype.getValue().charAt(0));
             }
         }
@@ -365,26 +447,33 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return name.charAt(0);
     }
 
-    // A tag whose content should be replaced by empty tag, for protection. Can be overridden
+    // A tag whose content should be replaced by empty tag, for protection. Can
+    // be overridden
     protected boolean isProtectedTag(StartElement stEl) {
-        return stEl.getName().equals(new QName(namespace, "ph")) || stEl.getName().equals(new QName(namespace, "it"))
-            || (stEl.getName().equals(new QName(namespace, "mrk"))
-            && stEl.getAttributeByName(new QName("mtype")).getValue().equals("protected"));
+        return stEl.getName().equals(new QName(namespace, "ph"))
+                || stEl.getName().equals(new QName(namespace, "it"))
+                || (stEl.getName().equals(new QName(namespace, "mrk"))
+                        && stEl.getAttributeByName(new QName("mtype")).getValue().equals("protected"));
     }
 
-    // A tag which should not appear in OmegaT, nor its contents. Can be overridden
+    // A tag which should not appear in OmegaT, nor its contents. Can be
+    // overridden
     protected boolean isDeletedTag(StartElement stEl) {
         return false;
     }
 
-    // A tag which should not appear in OmegaT, but its contents, yes. Can be overridden
+    // A tag which should not appear in OmegaT, but its contents, yes. Can be
+    // overridden
     protected boolean isUntaggedTag(StartElement stEl) {
         return false;
     }
 
-    /** Indicates that state is in standard <target> attribute. To be overriden by non-standard xliff variants **/
+    /**
+     * Indicates that state is in standard <target> attribute. To be overriden
+     * by non-standard xliff variants
+     **/
     protected boolean isStandardTranslationState() {
-         return true;
+        return true;
     }
 
     protected final void generateTargetStartElement(XMLStreamWriter writer) throws XMLStreamException {
@@ -399,22 +488,24 @@ public class Xliff1Filter extends AbstractXliffFilter {
 
         boolean isTranslated;
         if (subSegments.isEmpty()) {
-            isTranslated = entryTranslateCallback.getTranslation(unitId, buildTags(source, false), path) != null;
-        } else {    // set 'translated' only if all sub-segments are translated
+            isTranslated = entryTranslateCallback.getTranslation(unitId, buildTags(source, false),
+                    path) != null;
+        } else { // set 'translated' only if all sub-segments are translated
             isTranslated = true;
-            for (String mid: subSegments.keySet()) {
-                isTranslated = isTranslated && (null != entryTranslateCallback.getTranslation(unitId + "/" + mid,
-                    buildTags(subSegments.get(mid), false), path));
+            for (String mid : subSegments.keySet()) {
+                isTranslated = isTranslated && (null != entryTranslateCallback
+                        .getTranslation(unitId + "/" + mid, buildTags(subSegments.get(mid), false), path));
             }
         }
         if (isTranslated) {
-            writer.writeStartElement(namespace, "target"); writer.writeAttribute("state", "translated");
+            writer.writeStartElement(namespace, "target");
+            writer.writeAttribute("state", "translated");
             if (targetStartEvent != null) {
                 for (java.util.Iterator<Attribute> iter = targetStartEvent.getAttributes(); iter.hasNext();) {
                     Attribute next = iter.next();
                     if (!"state".equals(next.getName().getLocalPart())) {
                         writer.writeAttribute(next.getName().getPrefix(), next.getName().getNamespaceURI(),
-                            next.getName().getLocalPart(), next.getValue());
+                                next.getName().getLocalPart(), next.getValue());
                     }
                 }
             }
@@ -422,7 +513,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
             if (targetStartEvent == null) {
                 writer.writeStartElement(namespace, "target");
             } else {
-                 fromEventToWriter(targetStartEvent, writer);
+                fromEventToWriter(targetStartEvent, writer);
             }
         }
     }
@@ -440,23 +531,25 @@ public class Xliff1Filter extends AbstractXliffFilter {
             String src = buildTags(source, false);
             String tra = entryTranslateCallback.getTranslation(unitId, src, path);
             if (tra != null) {
-               generateTargetStartElement(writer);
-               for (XMLEvent ev: restoreTags(tra)) {
-                   fromEventToWriter(ev, writer);
-               }
+                generateTargetStartElement(writer);
+                for (XMLEvent ev : restoreTags(tra)) {
+                    fromEventToWriter(ev, writer);
+                }
             } else {
-               if (target == null) {
-                  return; // <target> not present at all in source file, should remain like this in output
-               }
-               generateTargetStartElement(writer); // only if there was a target in the source file
-               for (XMLEvent ev: target) {
-                   fromEventToWriter(ev, writer);
-               }
+                if (target == null) {
+                    return; // <target> not present at all in source file,
+                            // should remain like this in output
+                }
+                generateTargetStartElement(writer); // only if there was a
+                                                    // target in the source file
+                for (XMLEvent ev : target) {
+                    fromEventToWriter(ev, writer);
+                }
             }
         } else {
             inSubSeg = 0;
             generateTargetStartElement(writer);
-            for (XMLEvent ev: segSource) {
+            for (XMLEvent ev : segSource) {
                 if (ev.isStartElement()) {
                     StartElement el = ev.asStartElement();
                     if (el.getName().getLocalPart().equals("mrk")) {
@@ -464,30 +557,32 @@ public class Xliff1Filter extends AbstractXliffFilter {
                             fromEventToWriter(ev, writer);
                             String mid = el.getAttributeByName(new QName("mid")).getValue();
                             String src = buildTags(subSegments.get(mid), false);
-                             // First, translation from project memory
+                            // First, translation from project memory
                             String tra = entryTranslateCallback.getTranslation(unitId + "/" + mid, src, path);
                             if (tra != null) {
-                                for (XMLEvent tev: restoreTags(unitId, path, src, tra)) {
+                                for (XMLEvent tev : restoreTags(unitId, path, src, tra)) {
                                     fromEventToWriter(tev, writer);
                                 }
                             } else {
-                                 // Second, check in the target buffer (translation in source file)
+                                // Second, check in the target buffer
+                                // (translation in source file)
                                 List<XMLEvent> fromTarget = findSubsegment(target, mid);
                                 if (fromTarget != null && fromTarget.size() > 0) {
-                                    for (XMLEvent tev: fromTarget) {
+                                    for (XMLEvent tev : fromTarget) {
                                         fromEventToWriter(tev, writer);
                                     }
                                 } else { // if failed, use the source
-                                    for (XMLEvent tev: subSegments.get(mid)) {
+                                    for (XMLEvent tev : subSegments.get(mid)) {
                                         fromEventToWriter(tev, writer);
                                     }
                                 }
                             }
                             inSubSeg++;
-                            //writer.writeEndElement(/*mrk*/);
+                            // writer.writeEndElement(/*mrk*/);
                         } else {
                             if (inSubSeg > 0) {
-                                inSubSeg++; // avoids to crash on <mrk> inside segment
+                                inSubSeg++; // avoids to crash on <mrk> inside
+                                            // segment
                             }
                         }
                     }
@@ -505,15 +600,22 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 }
             }
         }
-        writer.writeEndElement(/*target*/); flushedUnit = true;
+        writer.writeEndElement(/* target */);
+        flushedUnit = true;
     }
 
-    /** Builds target from OmegaT to XLIFF format. May be overridden in subclasses **/
+    /**
+     * Builds target from OmegaT to XLIFF format. May be overridden in
+     * subclasses
+     **/
     protected List<XMLEvent> restoreTags(String unitId, String path, String src, String tra) {
         return restoreTags(tra);
     }
 
-    /** Extracts from <seg-source> or <target> the part between <mrk type=seg mid=xxx> and </mrk> **/
+    /**
+     * Extracts from <seg-source> or <target> the part between
+     * <mrk type=seg mid=xxx> and </mrk>
+     **/
     private List<XMLEvent> findSubsegment(List<XMLEvent> list, String mid) {
         if (list == null) {
             return null;
@@ -522,8 +624,9 @@ public class Xliff1Filter extends AbstractXliffFilter {
             return null;
         }
 
-        List<XMLEvent> buf = new LinkedList<XMLEvent>(); int depth = 0;
-        for (XMLEvent ev: target) {
+        List<XMLEvent> buf = new LinkedList<XMLEvent>();
+        int depth = 0;
+        for (XMLEvent ev : target) {
             if (ev.isEndElement()) {
                 EndElement el = ev.asEndElement();
                 if (el.getName().getLocalPart().equals("mrk")) {
@@ -541,7 +644,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 StartElement el = ev.asStartElement();
                 if (el.getName().getLocalPart().equals("mrk")) {
                     if (el.getAttributeByName(new QName("mtype")).getValue().equals("seg")
-                        && el.getAttributeByName(new QName("mid")).getValue().equals(mid)) {
+                            && el.getAttributeByName(new QName("mid")).getValue().equals(mid)) {
                         depth = 1;
                     } else if (depth > 0) {
                         depth++;

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -39,6 +39,8 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.omegat.util.OStrings;
+
 /**
  * Filter for support Xliff 1 files as bilingual (unlike filters3/xml/xliff)
  *
@@ -50,7 +52,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
 
     @Override
     public String getFileFormatName() {
-        return "Xliff 1.x(StaX)";
+        return OStrings.getString("XLIFF1X_FILTER_NAME");
     }
 
     protected final String versionPrefix() {
@@ -86,7 +88,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 try {
                     path += "/" + startElement.getAttributeByName(new QName("original")).getValue();
                 } catch (NullPointerException noid) { // Note: in spec, original is REQUIRED
-                    throw new XMLStreamException("Missing attribute 'original' in <file>");
+                    throw new XMLStreamException(OStrings.getString(
+                            "XLIFF_MANDATORY_ORIGINAL_MISSING",  "original",  "file"));
                 }
                 updateIgnoreScope(startElement);
                 break;
@@ -108,7 +111,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 try {
                     unitId = startElement.getAttributeByName(new QName("id")).getValue();
                 } catch (NullPointerException noid) { // Note: in spec, original is REQUIRED
-                    throw new XMLStreamException("Missing attribute 'id' in <trans-unit>");
+                    throw new XMLStreamException(OStrings.getString(
+                            "XLIFF_MANDATORY_ORIGINAL_MISSING",  "id",  "trans-unit"));
                 }
                 flushedUnit = false; targetStartEvent = null;
                 updateIgnoreScope(startElement);
@@ -240,7 +244,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
              }
         }
         StringBuffer res = new StringBuffer(); LinkedList<StringBuffer> saveBuf = new LinkedList<>();
-        List<XMLEvent> nativeCode = null; int errCount = 0;
+        List<XMLEvent> nativeCode = null;
         for (XMLEvent ev: srcList) {
             if (nativeCode != null) {
                 nativeCode.add(ev);

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -52,7 +52,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
 
     @Override
     public String getFileFormatName() {
-        return OStrings.getString("XLIFF1X_FILTER_NAME");
+        return OStrings.getString("XLIFF1FILTER_FILTER_NAME");
     }
 
     protected final String versionPrefix() {

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -48,7 +48,7 @@ import org.omegat.util.OStrings;
  */
 public class Xliff1Filter extends AbstractXliffFilter {
 
-    // ---------------------------- IFilter API----------------------------
+    // ---------------------------- IFilter API---------------------------
 
     @Override
     public String getFileFormatName() {
@@ -59,16 +59,15 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return "1."; // can be 1.0, 1.1 or 1.2
     }
 
-    // ----------------------------- AbstractXmlFilter
-    // part----------------------
+    // ----------------------- AbstractXmlFilter part----------------------
 
     /** Current translation unit **/
     private String unitId = null;
     private boolean flushedUnit = false;
     private int lastGroupId = 0; // only used when group id is not present in
                                  // the file
-    private List<XMLEvent> segSource = new LinkedList<>();
-    private Map<String, List<XMLEvent>> subSegments = new TreeMap<>();
+    private final List<XMLEvent> segSource = new LinkedList<>();
+    private final Map<String, List<XMLEvent>> subSegments = new TreeMap<>();
     private StartElement targetStartEvent = null;
     private int inSubSeg = 0;
 
@@ -93,8 +92,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
         case "file":
             try {
                 path += "/" + startElement.getAttributeByName(new QName("original")).getValue();
-            } catch (NullPointerException noid) { // Note: in spec, original is
-                                                  // REQUIRED
+            } catch (NullPointerException noid) {
+                // Note: in spec, original is REQUIRED
                 throw new XMLStreamException(
                         OStrings.getString("XLIFF_MANDATORY_ORIGINAL_MISSING", "original", "file"));
             }
@@ -103,8 +102,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
         case "group":
             try {
                 path += "/" + startElement.getAttributeByName(new QName("id")).getValue();
-            } catch (NullPointerException noid) { // in XLIFF 1, this attribute
-                                                  // is not REQUIRED
+            } catch (NullPointerException noid) {
+                // in XLIFF 1, this attribute is not REQUIRED
                 try {
                     path += "/" + startElement.getAttributeByName(new QName("resname")).getValue();
                 } catch (NullPointerException noresname) {
@@ -336,24 +335,17 @@ public class Xliff1Filter extends AbstractXliffFilter {
                         } else {
                             Attribute posAttr = stEl.getAttributeByName(new QName("pos"));
                             String posVal = posAttr == null ? "" : posAttr.getValue();
-                            if ("close".equals(posVal) || "end".equals(posVal)) { // in
-                                                                                  // OT,
-                                                                                  // appear
-                                                                                  // as
-                                                                                  // close
-                                                                                  // tag
+                            if ("close".equals(posVal) || "end".equals(posVal)) {
+                                // in OT, appear as close tag
                                 tagsMap.put("/" + prefix + count, nativeCode);
                                 res.append("</").append(prefix).append(count).append(">");
                             } else {
                                 tagsMap.put("" + prefix + count, nativeCode);
-                                if ("open".equals(posVal) || "begin".equals(posVal)) { // in
-                                                                                       // OT,
-                                                                                       // appear
-                                                                                       // as
-                                                                                       // open
-                                                                                       // tag
+                                if ("open".equals(posVal) || "begin".equals(posVal)) {
+                                    // in OT,appear as open tag
                                     res.append("<").append(prefix).append(count).append(">");
-                                } else { // in OT, appear as empty
+                                } else {
+                                    // in OT, appear as empty
                                     res.append("<").append(prefix).append(count).append("/>");
                                 }
                             }
@@ -363,8 +355,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
                         nativeCode.add(ev);
                         tagStack.push("mark-protected");
                         break;
-                    } else if (isDeletedTag(stEl)) { // generate nothing, not
-                                                     // either the contents
+                    } else if (isDeletedTag(stEl)) {
+                        // generate nothing, not either the contents
                         tagStack.push("mark-deleted");
                         saveBuf.add(res);
                         res = new StringBuffer();
@@ -447,8 +439,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return name.charAt(0);
     }
 
-    // A tag whose content should be replaced by empty tag, for protection. Can
-    // be overridden
+    // A tag whose content should be replaced by empty tag, for protection.
+    // Can be overridden
     protected boolean isProtectedTag(StartElement stEl) {
         return stEl.getName().equals(new QName(namespace, "ph"))
                 || stEl.getName().equals(new QName(namespace, "it"))

--- a/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -50,7 +50,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
 
     @Override
     public String getFileFormatName() {
-        return OStrings.getString("XLIFF2_FILTER_NAME");
+        return OStrings.getString("XLIFF2FILTER_FILTER_NAME");
     }
 
     protected final String versionPrefix() {

--- a/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -212,7 +212,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
                 tagsCount.put(c, 0);
             }
         }
-        StringBuffer res = new StringBuffer(), saveBuf = null;
+        StringBuffer res = new StringBuffer();
         for (XMLEvent ev : srcList) {
             if (ev.isCharacters()) {
                 res.append(ev.asCharacters().getData());

--- a/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -37,9 +37,11 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.omegat.util.OStrings;
+
 
 /**
- * Filter for support Xliff 1 files as bilingual (unlike filters3/xml/xliff)
+ * Filter for support Xliff 2.0 files as bilingual (unlike filters3/xml/xliff).
  *
  * @author Thomas Cordonnier
  */
@@ -49,7 +51,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
 
     @Override
     public String getFileFormatName() {
-        return "Xliff 2.x(StaX)";
+        return OStrings.getString("XLIFF2_FILTER_NAME");
     }
 
     protected final String versionPrefix() {
@@ -86,8 +88,8 @@ public class Xliff2Filter extends AbstractXliffFilter {
                 try {
                     path += "/" + startElement.getAttributeByName(new QName("id")).getValue();
                 } catch (NullPointerException noid) { // Note: in spec, id is REQUIRED
-                    throw new XMLStreamException("Missing attribute 'id' in <" 
-                        + startElement.getName().getLocalPart() + ">");
+                    throw new XMLStreamException(OStrings.getString(
+                            "XLIFF_MANDATORY_ORIGINAL_MISSING",  "id",  startElement.getName().getLocalPart()));
                 }
                 updateIgnoreScope(startElement);
                 break;


### PR DESCRIPTION
Improve XLIFF filters.

## Pull request type

- Other (describe below)


## Which ticket is resolved?
N.A.

## What does this PR change?

- Disable monolingual xliff 1 filter in default. User can enable it from local/global configuration.
- fix javadoc typo, periods, and code formatting of changes.
- I18N messages of  filters merged in #356


## Other information

Related #356
