### PR TITLE
Clarify target file filter variable use

### DIFF
--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -313,10 +313,10 @@
 	  </variablelist>
 		
 	  <para>Additional variants are available for <literal>${nameOnly}</literal>
-	  and <literal>${Extension}</literal>.</para>
+	  and <literal>${extension}</literal>.</para>
 		
 	  <para>If the file name is ambiguous, variables of the form
-	  <literal>${nameonly-</literal><emphasis>extension number</emphasis>} and
+	  <literal>${nameOnly-</literal><emphasis>extension number</emphasis>} and
 	  <literal>${extension-</literal><emphasis>extension number} </emphasis> can
 	  be used.</para>
 

--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -315,10 +315,12 @@
 	  <para>Additional variants are available for <literal>${nameOnly}</literal>
 	  and <literal>${extension}</literal>.</para>
 		
-	  <para>If the file name is ambiguous, variables of the form
-	  <literal>${nameOnly-</literal><emphasis>extension number</emphasis>} and
-	  <literal>${extension-</literal><emphasis>extension number} </emphasis> can
-	  be used.</para>
+	  <para>If the use of multiple periods makes identifying the file name and
+	  extension ambiguous, you can use variables of the form
+	  <literal>${nameOnly-</literal><emphasis>number</emphasis>} or
+	  <literal>${extension-</literal><emphasis>number} </emphasis> to
+	  specify which portions are part of the name or extension, as shown in the
+	  example below.</para>
 
 	  <example id="target.name.example">
 		<title id="target.name.example.title">Target file names</title>


### PR DESCRIPTION
Address the issues found by Hiroshi regarding the description of the ${nameOnly-`number`} and ${extension-`number`} target file name variables.

@miurahr
Does this address your concerns?