### PR TITLE
Minor fix to make RealProjectTest test pass on Windows

### DIFF
--- a/test/src/org/omegat/core/data/RealProjectTest.java
+++ b/test/src/org/omegat/core/data/RealProjectTest.java
@@ -67,6 +67,9 @@ public class RealProjectTest {
 
     @After
     public final void tearDown() throws Exception {
+        if (project != null) {
+            project.unlockProject();
+        }
         FileUtils.deleteDirectory(tempDir.toFile());
     }
 


### PR DESCRIPTION
Because the project is not closed at the end of the test, the `omegat.project` file is locked and cause an Exception during cleanup.

