### PR TITLE
Standardize use of "repeated/repetition" for segments

### DIFF
--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -976,7 +976,7 @@
             </row>
 
             <row>
-              <entry>Mark Non-Unique Segments</entry>
+              <entry>Mark Repeated Segments</entry>
               <entry>viewMarkNonUniqueSegmentsCheckBoxMenuItem</entry>
             </row>
 

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -182,7 +182,7 @@
         of translations</option></term>
 
 		<listitem>
-          <para>If there are duplicated (repeated) segments in the source
+          <para>If there are repeated segments in the source
           documents, checking this option will set the first translated segment
           as the default translation and automatically use the same target text
           in the remaining repeated segments.</para>

--- a/doc_src/en/OmegaT5_EditorsPanes.xml
+++ b/doc_src/en/OmegaT5_EditorsPanes.xml
@@ -903,9 +903,9 @@ Folder = <token>Dossier</token></programlisting>
 	
 	<variablelist>
 	  <varlistentry>
-		<term>Is duplicate</term>
+		<term>Is repetition</term>
 		<listitem>
-		  <para>Indicates that a segment is a duplicate and specifies whether
+		  <para>Indicates that a segment is a repetition and specifies whether
 		  it is the FIRST instance.</para>
 		</listitem>
 	  </varlistentry>

--- a/doc_src/en/Windows_SourceFilesList.xml
+++ b/doc_src/en/Windows_SourceFilesList.xml
@@ -58,7 +58,7 @@
   source file or the target file (if it exists).</para>
 
   <para>The number of <emphasis role="bold">Unique</emphasis> segments is
-  calculated by removing the number of duplicate segments from the total
+  calculated by removing the number of repeated segments from the total
   number of segments.</para>
 
   <para>The difference between &quot;Number of segments&quot; and &quot;Number

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -240,7 +240,7 @@
 		<term>Display: all matching segments</term>
 		<listitem>
 		  <para>Every segment is displayed individually, even if it is a
-		  duplicate found in either the same document or a different document in
+		  repetition found in either the same document or a different document in
 		  the project.</para>
 		</listitem>
 	  </varlistentry>

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -523,7 +523,7 @@ MW_PROMPT_SEG_NR_MSG=Enter the segment number:
 MW_PROMPT_SEG_NR_TITLE=Go to Segment
 
 # {0} = total number of duplicates for current segment
-MW_GO_TO_DUPLICATE_HEADER=Duplicate segments: {0}
+MW_GO_TO_DUPLICATE_HEADER=Repeated segments: {0}
 
 # {0,number,#} = segment number, with thousands separator suppressed
 MW_GO_TO_DUPLICATE_ITEM=Segment {0,number,#}
@@ -2635,7 +2635,7 @@ SEGPROP_KEY_CHANGED=Changed on
 SEGPROP_KEY_CREATOR=Created by
 SEGPROP_KEY_CREATED=Created on
 SEGPROP_KEY_RESNAME=Resource name
-SEGPROP_KEY_ISDUP=Duplicated
+SEGPROP_KEY_ISDUP=Repeated
 SEGPROP_VERB_ISDUP=Yes
 SEGPROP_NVERB_ISDUP=No
 SEGPROP_KEY_NOTE=Note


### PR DESCRIPTION
This is a follow-up to the change from "non-unique" to "repeated" that also changes "duplicate" makes consistent use of "repeated" or "repetition" when talking about segments.

I have not changed the names of the keys in the program, because it does not seem necessary to go that far. I also haven't changed any references to duplicates that do not refer to segments.