### PR TITLE
Security: filters3: protect XXE parser attack in default parser config

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1299,6 +1299,9 @@ ILIASFILTER_FILTER_NAME=ILIAS Language File
 # org.omegat.filters3.xml.Handler
 XML_FATAL_ERROR=Error in file {0}, line {1}
 
+# org.omegat.filters3.xml.XMLFilter
+XML_FILTER_ERROR=Unable to parse source XML file
+
 # org.omegat.filters3.xml.opendoc.OpenDocFilter
 OpenDoc_FILTER_NAME=OpenDocument
 OpenDoc_FILTER_OPTIONS=OpenDocument Filter Options

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -99,6 +99,11 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
         return dialect;
     }
 
+    protected void setSAXFeature(String feature, boolean b) throws SAXNotSupportedException,
+            SAXNotRecognizedException, ParserConfigurationException {
+        parserFactory.setFeature(feature, b);
+    }
+
     /** Detected encoding of the input XML file. */
     private String encoding;
 
@@ -134,7 +139,7 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
      *            The target file.
      * @param outEncoding
      *            Encoding of the target file, if the filter supports it.
-     *            Otherwise null.
+     *            Otherwise, null.
      * @return The writer for the target file.
      *
      * @throws UnsupportedEncodingException

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -81,13 +81,16 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
         try {
             // We validate XML in default
             parserFactory.setFeature("http://xml.org/sax/features/validation", true);
-            // When driver writer want not to validate please override and set features false.
-            // ex. setSAXFeature("http://xml.org/sax/features/validation", false);
+            // When a driver writer wants not to validate, please override and
+            // set features false.
+            // ex. setSAXFeature("http://xml.org/sax/features/validation",
+            // false);
 
             // Protecting from a XXE attack.
 
             // "Feature for Secure Processing (FSP)" is the central mechanism to
-            // help safeguard XML processing. It instructs XML processors, such as parsers,
+            // help safeguard XML processing. It instructs XML processors, such
+            // as parsers,
             // validators, and transformers, to try and process XML securely.
             parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             // Avoid internet connection to validate with external DTD.
@@ -96,7 +99,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             // Disable external parameter entities
             parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            // as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+            // as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and
+            // Entity Attacks"
             parserFactory.setXIncludeAware(false);
         } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException ex) {
             Log.logErrorRB(ex, "XML_FILTER_ERROR", ex.getMessage());
@@ -109,8 +113,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
         return dialect;
     }
 
-    protected void setSAXFeature(String feature, boolean b) throws SAXNotSupportedException,
-            SAXNotRecognizedException, ParserConfigurationException {
+    protected void setSAXFeature(String feature, boolean b)
+            throws SAXNotSupportedException, SAXNotRecognizedException, ParserConfigurationException {
         parserFactory.setFeature(feature, b);
     }
 

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -98,8 +98,8 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             // as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
             parserFactory.setXIncludeAware(false);
-        } catch (Exception ex) {
-            Log.log(ex.getMessage());
+        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException ex) {
+            Log.logErrorRB(ex, "XML_FILTER_ERROR", ex.getMessage());
         }
         this.dialect = dialect;
     }

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -74,9 +74,21 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
     /** Creates a new instance of XMLFilter */
     public XMLFilter(XMLDialect dialect) {
         parserFactory = SAXParserFactory.newInstance();
-        // parserFactory.setValidating(false);
         try {
+            // We validate XML in default
             parserFactory.setFeature("http://xml.org/sax/features/validation", true);
+            // When driver writer want not to validate please override and set features false.
+            // ex. parserFactory.setValidating(false);
+
+            // Protecting from a XXE attack.
+            // We try to avoid internet connection to validate with external DTD.
+            parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            // Disable external general entities
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            // Disable external parameter entities
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            // Disable XInclude
+            parserFactory.setXIncludeAware(false);
         } catch (Exception ignored) {
         }
         this.dialect = dialect;

--- a/src/org/omegat/filters3/xml/docbook/DocBookFilter.java
+++ b/src/org/omegat/filters3/xml/docbook/DocBookFilter.java
@@ -28,6 +28,11 @@ package org.omegat.filters3.xml.docbook;
 
 import java.io.BufferedReader;
 
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
 import org.omegat.filters2.Instance;
 import org.omegat.filters3.xml.XMLDialect;
 import org.omegat.filters3.xml.XMLFilter;
@@ -48,6 +53,17 @@ public class DocBookFilter extends XMLFilter {
      */
     public DocBookFilter() {
         super(new DocBookDialect());
+        try {
+            // DocBook filter requires to validate docbook external DTD.
+            // The filter requires internet access.
+            // XXX: this is vulnerable for XXE attack.
+            setSAXFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
+            // XXX: we should take care of external entities
+            setSAXFeature("http://xml.org/sax/features/external-general-entities", true);
+            // XXX: we should take care of external entities
+            setSAXFeature("http://xml.org/sax/features/external-parameter-entities", true);
+        } catch (SAXNotSupportedException | SAXNotRecognizedException | ParserConfigurationException ignored) {
+        }
     }
 
     /**

--- a/src/org/omegat/filters3/xml/docbook/DocBookFilter.java
+++ b/src/org/omegat/filters3/xml/docbook/DocBookFilter.java
@@ -62,7 +62,8 @@ public class DocBookFilter extends XMLFilter {
             setSAXFeature("http://xml.org/sax/features/external-general-entities", true);
             // XXX: we should take care of external entities
             setSAXFeature("http://xml.org/sax/features/external-parameter-entities", true);
-        } catch (SAXNotSupportedException | SAXNotRecognizedException | ParserConfigurationException ignored) {
+        } catch (SAXNotSupportedException | SAXNotRecognizedException
+                | ParserConfigurationException ignored) {
         }
     }
 


### PR DESCRIPTION
JAXB SAX parser is known as XXE vulnerable default configuration.
This change make it strengthen for XXE attack.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Title ex. fix...
  * URL ex. https://...
 
- Title
  * URL

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

-  Disable external entities and xinclude feature
-  Add setSAXFeature method for docbook filter
-  docbook filter relax a protection

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

Reference: 
https://securityboulevard.com/2020/09/xml-external-entity-xxe-pitfalls-with-jaxb/
