### PR TITLE
Feature: add shortcuts to navigate notes

### DIFF
--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -853,15 +853,15 @@
             <row>
               <entry>Next Note</entry>
               <entry>gotoNextNoteMenuItem</entry>
-              <entry>ctrl alt DOWN</entry>
-              <entry>meta alt DOWN</entry>
+              <entry>ctrl alt N</entry>
+              <entry>meta alt N</entry>
             </row>
 
             <row>
               <entry>Previous Note</entry>
               <entry>gotoPreviousNoteMenuItem</entry>
-              <entry>ctrl alt UP</entry>
-              <entry>meta alt UP</entry>
+              <entry>ctrl alt P</entry>
+              <entry>meta alt P</entry>
             </row>
 
             <row>
@@ -923,15 +923,15 @@
             <row>
               <entry>Notes Pane</entry>
               <entry>gotoNotesPanelMenuItem</entry>
-              <entry>ctrl alt N</entry>
-              <entry>meta alt N</entry>
+              <entry>ctrl alt 9</entry>
+              <entry>meta alt 9</entry>
             </row>
 
             <row>
               <entry>Editor Pane</entry>
               <entry>gotoEditorPanelMenuItem</entry>
-              <entry>ctrl alt E</entry>
-              <entry>meta alt E</entry>
+              <entry>ctrl alt 0</entry>
+              <entry>meta alt 0</entry>
             </row>
 
           </tbody>

--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -853,11 +853,15 @@
             <row>
               <entry>Next Note</entry>
               <entry>gotoNextNoteMenuItem</entry>
+              <entry>ctrl alt DOWN</entry>
+              <entry>meta alt DOWN</entry>
             </row>
 
             <row>
               <entry>Previous Note</entry>
               <entry>gotoPreviousNoteMenuItem</entry>
+              <entry>ctrl alt UP</entry>
+              <entry>meta alt UP</entry>
             </row>
 
             <row>

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -101,7 +101,8 @@
 
     <varlistentry id="menus.goto.next.note">
       <term id="menus.goto.next.note.title"><guimenuitem>Next
-      Note</guimenuitem></term>
+      Note</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>↓</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the next segment with a note.</para>
       </listitem>
@@ -109,7 +110,8 @@
 
     <varlistentry id="menus.goto.previous.note">
       <term id="menus.goto.previous.note.title"><guimenuitem>Previous
-      Note</guimenuitem></term>
+      Note</guimenuitem>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>↑</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the previous segment with a note.</para>
       </listitem>

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -102,7 +102,7 @@
     <varlistentry id="menus.goto.next.note">
       <term id="menus.goto.next.note.title"><guimenuitem>Next
       Note</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>↓</keycap></keycombo></term>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the next segment with a note.</para>
       </listitem>
@@ -111,7 +111,7 @@
     <varlistentry id="menus.goto.previous.note">
       <term id="menus.goto.previous.note.title"><guimenuitem>Previous
       Note</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>↑</keycap></keycombo></term>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the previous segment with a note.</para>
       </listitem>
@@ -223,7 +223,7 @@
 
     <varlistentry id="menus.goto.notes.pane">
       <term id="menus.goto.notes.pane.title"><guimenuitem>Notes Pane</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
+	  <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>9</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.notes"
         endterm="panes.notes.title"/> pane to write or modify a note associated
@@ -234,7 +234,7 @@
     <varlistentry id="menus.goto.editor.pane">
       <term id="menus.goto.editor.pane.title"><guimenuitem>Editor
       Pane</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>E</keycap></keycombo></term>
+      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>0</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.editor"
         endterm="panes.editor.title"/> pane to proceed with your

--- a/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -108,8 +108,8 @@ gotoNextTranslatedMenuItem=meta shift U
 gotoNextSegmentMenuItem=meta N
 gotoPreviousSegmentMenuItem=meta P
 gotoSegmentMenuItem=meta J
-#	gotoNextNoteMenuItem=
-#	gotoPreviousNoteMenuItem=
+gotoNextNoteMenuItem=meta alt DOWN
+gotoPreviousNoteMenuItem=meta alt UP
 gotoNextUniqueMenuItem=meta shift K
 gotoMatchSourceSegment=meta shift M
 #-separator-#

--- a/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -108,8 +108,8 @@ gotoNextTranslatedMenuItem=meta shift U
 gotoNextSegmentMenuItem=meta N
 gotoPreviousSegmentMenuItem=meta P
 gotoSegmentMenuItem=meta J
-gotoNextNoteMenuItem=meta alt DOWN
-gotoPreviousNoteMenuItem=meta alt UP
+gotoNextNoteMenuItem=meta alt N
+gotoPreviousNoteMenuItem=meta alt P
 gotoNextUniqueMenuItem=meta shift K
 gotoMatchSourceSegment=meta shift M
 #-separator-#
@@ -123,8 +123,8 @@ gotoPrevXEnforcedMenuItem=meta alt shift PERIOD
 gotoHistoryForwardMenuItem=meta shift N
 gotoHistoryBackMenuItem=meta shift P
 #-separator-#
-gotoNotesPanelMenuItem=meta alt N
-gotoEditorPanelMenuItem=meta alt E
+gotoNotesPanelMenuItem=meta alt 9
+gotoEditorPanelMenuItem=meta alt 0
 
 #############
 # View menu #

--- a/src/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -108,8 +108,8 @@ gotoNextTranslatedMenuItem=ctrl shift U
 gotoNextSegmentMenuItem=ctrl N
 gotoPreviousSegmentMenuItem=ctrl P
 gotoSegmentMenuItem=ctrl J
-gotoNextNoteMenuItem=ctrl alt DOWN
-gotoPreviousNoteMenuItem=ctrl alt UP
+gotoNextNoteMenuItem=ctrl alt N
+gotoPreviousNoteMenuItem=ctrl alt P
 gotoNextUniqueMenuItem=ctrl shift K
 gotoMatchSourceSegment=ctrl shift M
 #-separator-#
@@ -123,8 +123,8 @@ gotoPrevXEnforcedMenuItem=ctrl alt shift PERIOD
 gotoHistoryForwardMenuItem=ctrl shift N
 gotoHistoryBackMenuItem=ctrl shift P
 #-separator-#
-gotoNotesPanelMenuItem=ctrl alt N
-gotoEditorPanelMenuItem=ctrl alt E
+gotoNotesPanelMenuItem=ctrl alt 9
+gotoEditorPanelMenuItem=ctrl alt 0
 
 #############
 # View menu #

--- a/src/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -108,8 +108,8 @@ gotoNextTranslatedMenuItem=ctrl shift U
 gotoNextSegmentMenuItem=ctrl N
 gotoPreviousSegmentMenuItem=ctrl P
 gotoSegmentMenuItem=ctrl J
-#	gotoNextNoteMenuItem=
-#	gotoPreviousNoteMenuItem=
+gotoNextNoteMenuItem=ctrl alt DOWN
+gotoPreviousNoteMenuItem=ctrl alt UP
 gotoNextUniqueMenuItem=ctrl shift K
 gotoMatchSourceSegment=ctrl shift M
 #-separator-#


### PR DESCRIPTION
Now that we have the Notes pane displayed by default, shortcuts to enter the Notes pane and go back to the Editor pane, I think it would be very useful to add shortcuts to navigate the annotated segments.

I'm proposing C-A-UP/DOWN