### PR TITLE
Unify to "-our" spelling in user facing material

### DIFF
--- a/doc_src/en/HowTo_Run.xml
+++ b/doc_src/en/HowTo_Run.xml
@@ -69,7 +69,7 @@
 	endterm="launch.with.command.line.title"
 	linkend="launch.with.command.line"/> section for details.</para>
 
-	<para>You can modify the behavior of OmegaT.app by editing the
+	<para>You can modify the behaviour of OmegaT.app by editing the
 	<filename>Configuration.properties</filename> (OmegaT configuration) as well
 	as the <filename>Info.plist</filename> (Java configuration) files located
 	inside the OmegaT.app package.</para>
@@ -150,7 +150,7 @@
 	<title id="launch.with.command.line.title">Command line launch</title>
 
 	<para>Using the command line allows you to set various options that control
-	or modify the behavior of the application. You can also define and save sets
+	or modify the behaviour of the application. You can also define and save sets
 	of options in scripts that you can then use to launch OmegaT for a
 	particular purpose.</para>
 

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.team.project">
-  <title id="how.to.use.team.project.title">Use a Team Project</title>
+  <title id="how.to.use.team.project.title">Use a team project</title>
 
   <para>Team projects use synchronization mechanisms between project members.</para>
 

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -800,7 +800,7 @@
 	  and, in the search window, use
 	  <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo> and
 	  <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo> to navigate the
-	  results. OmegaT synchronises the Editor contents with the selected result,
+	  results. OmegaT synchronizes the Editor contents with the selected result,
 	  so you can edit the segments right away.</para>
         
       <para>Time for a break. As you savour your coffee, you reflect

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -161,7 +161,7 @@
       <listitem>
         <para>Exports the current selection to a text file for processing. If no
         text has been selected, the current source segment is written to this
-        file. To remain consistent with usual clipboard behavior this file is
+        file. To remain consistent with usual clipboard behaviour this file is
         not emptied when the user exits OmegaT. The exported contents are copied
         to the <link
         linkend="configuration.folder.default.contents.script.selection.title"

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -6,7 +6,7 @@
   <para>This menu allows you to select the information you want to OmegaT to
   display.</para>
 
-  <para>All the colors indicated in the descriptions can be modified in the
+  <para>All the colours indicated in the descriptions can be modified in the
   <link linkend="dialogs.preferences.colours"
   endterm="dialogs.preferences.colours.title"/> preference.</para>
 
@@ -115,7 +115,7 @@
       Auto-Populated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, segments that have been auto-populated are
-        highlighted in various colors.</para>
+        highlighted in various colours.</para>
 
 		<para>See the <link
 		linkend="dialogs.preferences.editor.save.auto-populated.status"

--- a/doc_src/en/OmegaT5_Preferences.xml
+++ b/doc_src/en/OmegaT5_Preferences.xml
@@ -357,7 +357,7 @@
           <para>Select a theme for the OmegaT user interface.</para>
 
           <para>Additional themes can be added as plugins. The themes also
-          provide predefined set of default colors.</para>
+          provide predefined set of default colours.</para>
 
 		  <para>Not all natively provided Java themes are compatible with OmegaT
 		  operation.</para>
@@ -417,9 +417,9 @@
 	</section>
 
 	<section id="dialogs.preferences.colours">
-      <title id="dialogs.preferences.colours.title"><guilabel>Colors</guilabel></title>
+      <title id="dialogs.preferences.colours.title"><guilabel>Colours</guilabel></title>
 
-      <para>You can assign different colors for the various parts of the user
+      <para>You can assign different colours for the various parts of the user
       interface.</para>
 
       <para>Scripts can be used to set predefined themes. OmegaT is bundled with

--- a/doc_src/en/OmegaT5_ProjectFolder.xml
+++ b/doc_src/en/OmegaT5_ProjectFolder.xml
@@ -377,9 +377,9 @@
 		<term id="project.folder.tm.mt.title">tm/mt</term>
 		<listitem>
 		  <para>When a match is inserted from a TMX contained in this folder, the
-		  background color of the active segment changes to red.</para>
+		  background colour of the active segment changes to red.</para>
 
-		  <para>The background color is restored to normal when you leave the
+		  <para>The background colour is restored to normal when you leave the
 		  segment or when you modify the segment.</para>
 		</listitem>
 	  </varlistentry>

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -3,7 +3,7 @@
 ----------------------------------------------------------------------
   23 Enhancements
   26 Bug fixes
-  9 Localisation updates
+  9 Localization updates
 ----------------------------------------------------------------------
 5.8.0 vs 5.7.1
 
@@ -105,7 +105,7 @@ which are in the same server
   - When converting git local-managed project, OmegaT raise NPE
   https://sourceforge.net/p/omegat/bugs/1118/
 
-  - URL likifier raise exception when opening resource property file
+  - URL linkifier raise exception when opening resource property file
   https://sourceforge.net/p/omegat/bugs/1117/
 
   - BundleProperties filter should accept UTF-8 properties file
@@ -154,24 +154,24 @@ which are in the same server
   - Highlight found text even if normalized text (for feature "full/half width insensitive") 
     differs from original
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 5.8 (UI, readme)
-  - Brazilian Portuguese localisation updated to 5.8 (UI)
-  - Catalan localisation updated to 5.8 (UI, readme)
-  - Corsican localisation updated to 5.8 (UI, readme)
-  - Dutch localisation updated to 5.8 (UI)
-  - German localisation updated to 5.8 (UI, readme)
-  - Japanese localisation updated to 5.8.0 (UI, documentation)
-  - Simplified Chinese localisation updated to 5.8 (UI, readme)
-  - Ukrainian localisation updated to 5.8 (UI, readme)
+  - Belarusian localization updated to 5.8 (UI, readme)
+  - Brazilian Portuguese localization updated to 5.8 (UI)
+  - Catalan localization updated to 5.8 (UI, readme)
+  - Corsican localization updated to 5.8 (UI, readme)
+  - Dutch localization updated to 5.8 (UI)
+  - German localization updated to 5.8 (UI, readme)
+  - Japanese localization updated to 5.8.0 (UI, documentation)
+  - Simplified Chinese localization updated to 5.8 (UI, readme)
+  - Ukrainian localization updated to 5.8 (UI, readme)
 
 ----------------------------------------------------------------------
 OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   0 Enhancements
   1 Bug fix
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 5.7.1 vs 5.7.0
 
@@ -185,7 +185,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   4 Enhancements
   2 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 5.7.0 vs 5.6.0
 
@@ -211,16 +211,16 @@ OmegaT 5.7.1 (2022-03-19)
   - Menus don't get keyboard focus after opening
   https://sourceforge.net/p/omegat/bugs/1073/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 5.6 (UI)
+  - Italian localization updated to 5.6 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 5.6.0 (2021-10-05)
 ----------------------------------------------------------------------
   5 Enhancements
   8 Bug fixes
-  9 Localisation updates
+  9 Localization updates
 ----------------------------------------------------------------------
 5.6.0 vs 5.5.0
 
@@ -258,33 +258,33 @@ OmegaT 5.7.1 (2022-03-19)
   - Effect of "Untranslated segments only" unclear
   https://sourceforge.net/p/omegat/bugs/995/
 
-  - Glossary translation color not applied to term separator
+  - Glossary translation colour not applied to term separator
   https://sourceforge.net/p/omegat/bugs/1071/
 
   - Short freeze when displaying dictionary entries
   https://sourceforge.net/p/omegat/bugs/1056/
 
-  - Properties notification color is too bright in dark mode
+  - Properties notification colour is too bright in dark mode
   https://sourceforge.net/p/omegat/bugs/1055/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Corsican localisation updated to 5.6 (UI, readme, scripts)
-  - Dutch localisation updated to 5.6 (UI)
-  - French localisation updated to 5.6 (UI, documentation)
-  - German localisation updated to 5.6 (UI, readme)
-  - Japanese localisation updated to 5.6 (UI)
-  - Portuguese localisation updated to 5.6 (UI, Instant Start)
-  - Russian localisation updated to 5.6 (UI)
-  - Simplified Chinese localisation updated to 5.6 (UI)
-  - Ukrainian localisation updated to 5.6 (UI)
+  - Corsican localization updated to 5.6 (UI, readme, scripts)
+  - Dutch localization updated to 5.6 (UI)
+  - French localization updated to 5.6 (UI, documentation)
+  - German localization updated to 5.6 (UI, readme)
+  - Japanese localization updated to 5.6 (UI)
+  - Portuguese localization updated to 5.6 (UI, Instant Start)
+  - Russian localization updated to 5.6 (UI)
+  - Simplified Chinese localization updated to 5.6 (UI)
+  - Ukrainian localization updated to 5.6 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 5.5.0 (2021-05-18)
 ----------------------------------------------------------------------
   11 Enhancements
   3 Bug fixes
-  15 Localisation updates
+  15 Localization updates
 ----------------------------------------------------------------------
 5.5.0 vs 5.4.4
 
@@ -299,7 +299,7 @@ OmegaT 5.7.1 (2022-03-19)
   - Improve access speed for uncompressed StarDict dictionaries
   https://sourceforge.net/p/omegat/feature-requests/1532/
 
-  - Make glossary colors customizable
+  - Make glossary colours customizable
   https://sourceforge.net/p/omegat/feature-requests/1537/
 
   - Glossary layout plugin system
@@ -335,30 +335,30 @@ OmegaT 5.7.1 (2022-03-19)
   for SVN repos.
   https://sourceforge.net/p/omegat/bugs/1036/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 5.5.0 (UI, readme)
-  - Brazilian Portuguese localisation updated to 5.5.0 (UI, readme)
-  - Catalan localisation updated to 5.5.0 (UI, readme)
-  - Corsican localisation updated to 5.5.0 (UI, scripts, readme)
-  - Dutch localisation updated to 5.5.0 (UI, readme, documentation)
-  - Finnish localisation updated to 5.5.0 (UI, readme, documentation)
-  - French localisation updated to 5.5.0 (UI, scripts, readme, documentation)
-  - German localisation updated to 5.5.0 (UI, scripts, readme, documentation)
-  - Italian localisation updated to 5.5.0 (UI, readme, documentation)
-  - Japanese localisation updated to 5.5.0 (UI, documentation)
-  - Morisien localisation added at 5.5.0 (UI, scripts, readme, Instant Start)
-  - Portuguese localisation updated to 5.5.0 (UI, scripts, readme, documentation)
-  - Russian localisation updated to 5.5.0 (UI, readme)
-  - Simplified Chinese localisation updated to 5.5.0 (UI, documentation)
-  - Ukrainian localisation updated to 5.5.0 (UI, readme, documentation)
+  - Belarusian localization updated to 5.5.0 (UI, readme)
+  - Brazilian Portuguese localization updated to 5.5.0 (UI, readme)
+  - Catalan localization updated to 5.5.0 (UI, readme)
+  - Corsican localization updated to 5.5.0 (UI, scripts, readme)
+  - Dutch localization updated to 5.5.0 (UI, readme, documentation)
+  - Finnish localization updated to 5.5.0 (UI, readme, documentation)
+  - French localization updated to 5.5.0 (UI, scripts, readme, documentation)
+  - German localization updated to 5.5.0 (UI, scripts, readme, documentation)
+  - Italian localization updated to 5.5.0 (UI, readme, documentation)
+  - Japanese localization updated to 5.5.0 (UI, documentation)
+  - Morisien localization added at 5.5.0 (UI, scripts, readme, Instant Start)
+  - Portuguese localization updated to 5.5.0 (UI, scripts, readme, documentation)
+  - Russian localization updated to 5.5.0 (UI, readme)
+  - Simplified Chinese localization updated to 5.5.0 (UI, documentation)
+  - Ukrainian localization updated to 5.5.0 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 5.4.4 (2021-04-21)
 ----------------------------------------------------------------------
   1 Enhancement
   0 Bug fixes
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 5.4.4 vs 5.4.3
 
@@ -372,7 +372,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   0 Enhancements
   1 Bug fix
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 5.4.3 vs 5.4.2
 
@@ -386,7 +386,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   1 Enhancement
   1 Bug fix
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 5.4.2 vs 5.4.1
 
@@ -407,13 +407,13 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   0 Enhancements
   1 Bug fix
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 5.4.1 vs 5.4.0
 
   Bug fixes:
 
-  - Default color for untranslated segments is wrong
+  - Default colour for untranslated segments is wrong
   https://sourceforge.net/p/omegat/bugs/1031/
 
 ----------------------------------------------------------------------
@@ -421,7 +421,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   7 Enhancements
   8 Bug fixes
-  10 Localisation updates
+  10 Localization updates
 ----------------------------------------------------------------------
 5.4.0 vs 5.3.0
 
@@ -437,7 +437,7 @@ OmegaT 5.7.1 (2022-03-19)
     translation status
   https://sourceforge.net/p/omegat/feature-requests/1506/
 
-  - Externalize default color definitions
+  - Externalize default colour definitions
   https://sourceforge.net/p/omegat/feature-requests/1514/
 
   - Remove discontinued Yandex.Translate MT connector
@@ -466,10 +466,10 @@ OmegaT 5.7.1 (2022-03-19)
   - Too many glossary hits on right click lead to them displayed off screen
   https://sourceforge.net/p/omegat/bugs/1009/
 
-  - Wrong background color in dark mode on Linux Mint
+  - Wrong background colour in dark mode on Linux Mint
   https://sourceforge.net/p/omegat/bugs/1013/
 
-  - Project Files table does not respect LAF colors
+  - Project Files table does not respect LAF colours
   https://sourceforge.net/p/omegat/bugs/1016/
 
   - Team project that uses a mapping to a remote sub directory silently fails to commit local changes
@@ -478,25 +478,25 @@ OmegaT 5.7.1 (2022-03-19)
   - Status label too small on HiDPI screens
   https://sourceforge.net/p/omegat/bugs/1026/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 5.4.0 (UI, scripts, readme, documentation)
-  - Catalan localisation updated to 5.4.0 (UI, Instant Start, readme, scripts)
-  - Corsican localisation updated to 5.4.0 (UI)
-  - Dutch localisation updated to 5.4.0 (UI, scripts, documentation)
-  - Finnish localisation updated to 5.4.0 (UI, documentation)
-  - Japanese localisation updated to 5.4.0 (UI, scripts, readme, documentation)
-  - Russian localisation updated to 5.4.0 (UI, scripts, readme)
-  - Simplified Chinese localisation updated to 5.4.0 (UI, documentation)
-  - Turkish localisation updated to 5.4.0 (UI, Instant Start, readme, scripts)
-  - Ukrainian localisation updated to 5.4.0 (UI)
+  - Belarusian localization updated to 5.4.0 (UI, scripts, readme, documentation)
+  - Catalan localization updated to 5.4.0 (UI, Instant Start, readme, scripts)
+  - Corsican localization updated to 5.4.0 (UI)
+  - Dutch localization updated to 5.4.0 (UI, scripts, documentation)
+  - Finnish localization updated to 5.4.0 (UI, documentation)
+  - Japanese localization updated to 5.4.0 (UI, scripts, readme, documentation)
+  - Russian localization updated to 5.4.0 (UI, scripts, readme)
+  - Simplified Chinese localization updated to 5.4.0 (UI, documentation)
+  - Turkish localization updated to 5.4.0 (UI, Instant Start, readme, scripts)
+  - Ukrainian localization updated to 5.4.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 5.3.0 (2020-08-03)
 ----------------------------------------------------------------------
   6 Enhancements
   10 Bug fixes
-  10 Localisation updates
+  10 Localization updates
 ----------------------------------------------------------------------
 5.3.0 vs 5.2.0
 
@@ -554,25 +554,25 @@ OmegaT 5.7.1 (2022-03-19)
   - Tag validation false positives for some tags from html2 filter
   https://sourceforge.net/p/omegat/bugs/1001/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Corsican localisation added at 5.3.0 (UI, scripts, readme)
-  - Dutch localisation updated to 5.3.0 (UI, documentation)
-  - Finnish localisation updated 5.3.0 (UI, documentation)
-  - French localisation updated to 5.3.0 (UI, readme)
-  - Italian localisation updated to 5.3.0 (UI, documentation)
-  - Russian localisation updated to 5.3.0 (UI, documentation)
-  - Simplified Chinese localisation updated to 5.3.0 (UI, documentation)
-  - Spanish localisation updated to 5.3.0 (UI, readme)
-  - Turkmen localisation updated to 5.3.0 (UI)
-  - Ukrainian localisation updated to 5.3.0 (UI, readme, documentation)
+  - Corsican localization added at 5.3.0 (UI, scripts, readme)
+  - Dutch localization updated to 5.3.0 (UI, documentation)
+  - Finnish localization updated 5.3.0 (UI, documentation)
+  - French localization updated to 5.3.0 (UI, readme)
+  - Italian localization updated to 5.3.0 (UI, documentation)
+  - Russian localization updated to 5.3.0 (UI, documentation)
+  - Simplified Chinese localization updated to 5.3.0 (UI, documentation)
+  - Spanish localization updated to 5.3.0 (UI, readme)
+  - Turkmen localization updated to 5.3.0 (UI)
+  - Ukrainian localization updated to 5.3.0 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 5.2.0 (2020-01-26)
 ----------------------------------------------------------------------
   3 Enhancements
   5 Bug fixes
-  7 Localisation updates
+  7 Localization updates
 ----------------------------------------------------------------------
 5.2.0 vs 5.1.0
 
@@ -604,22 +604,22 @@ OmegaT 5.7.1 (2022-03-19)
   - Zero-indexed tags in level 2 TMX are not handled correctly
   https://sourceforge.net/p/omegat/bugs/974/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portuguese localisation updated to 5.2.0 (UI)
-  - Dutch localisation updated to 5.2.0 (readme, documentation)
-  - Finnish localisation added at 5.2.0 (UI, Instant Start, scripts, readme, documentation)
-  - French localisation updated to 5.2.0 (UI)
-  - Italian localisation updated to 5.2.0 (readme, documentation)
-  - Simplified Chinese localisation updated to 5.0.0 (UI, readme, documentation)
-  - Turkmen localisation updated to 5.2.0 (UI)
+  - Brazilian Portuguese localization updated to 5.2.0 (UI)
+  - Dutch localization updated to 5.2.0 (readme, documentation)
+  - Finnish localization added at 5.2.0 (UI, Instant Start, scripts, readme, documentation)
+  - French localization updated to 5.2.0 (UI)
+  - Italian localization updated to 5.2.0 (readme, documentation)
+  - Simplified Chinese localization updated to 5.0.0 (UI, readme, documentation)
+  - Turkmen localization updated to 5.2.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 5.1.0 (2019-11-04)
 ----------------------------------------------------------------------
   2 Enhancements
   0 Bug fixes
-  7 Localisation updates
+  7 Localization updates
 ----------------------------------------------------------------------
 5.1.0 vs 5.0.0
 
@@ -631,22 +631,22 @@ OmegaT 5.7.1 (2022-03-19)
   - Show glossary file name as tooltip in the glossary pane
   https://sourceforge.net/p/omegat/feature-requests/1183/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 5.1.0 (UI)
-  - Czech localisation updated to 5.1.0 (UI, documentation)
-  - Dutch localisation updated to 5.1.0 (UI)
-  - Italian localisation updated to 5.1.0 (UI, documentation)
-  - Russian localisation updated to 5.1.0 (UI)
-  - Turkish localisation updated to 5.1.0 (UI)
-  - Ukrainian localisation updated to 5.1.0 (UI)
+  - Belarusian localization updated to 5.1.0 (UI)
+  - Czech localization updated to 5.1.0 (UI, documentation)
+  - Dutch localization updated to 5.1.0 (UI)
+  - Italian localization updated to 5.1.0 (UI, documentation)
+  - Russian localization updated to 5.1.0 (UI)
+  - Turkish localization updated to 5.1.0 (UI)
+  - Ukrainian localization updated to 5.1.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 5.0.0 (2019-10-01)
 ----------------------------------------------------------------------
   3 Enhancements
   2 Bug fixes
-  9 Localisation updates
+  9 Localization updates
 ----------------------------------------------------------------------
 5.0.0 vs 4.3.2
 
@@ -670,24 +670,24 @@ OmegaT 5.7.1 (2022-03-19)
   - Regex search-and-replace results are incorrect for some replacements
   https://sourceforge.net/p/omegat/bugs/955/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Basque localisation updated to 5.0.0 (UI, Instant Start, scripts, readme)
-  - Brazilian Portuguese localisation updated to 5.0.0 (UI, scripts)
-  - Czech localisation updated to 5.0.0 (UI, scripts)
-  - Dutch localisation updated to 5.0.0 (UI)
-  - French localisation updated to 5.0.0 (UI)
-  - Italian localisation updated to 5.0.0 (UI, scripts, documentation)
-  - Russian localisation updated to 5.0.0 (UI)
-  - Simplified Chinese localisation updated to 5.0.0 (UI, scripts)
-  - Ukrainian localisation updated to 5.0.0 (UI, Instant Start, scripts, readme)
+  - Basque localization updated to 5.0.0 (UI, Instant Start, scripts, readme)
+  - Brazilian Portuguese localization updated to 5.0.0 (UI, scripts)
+  - Czech localization updated to 5.0.0 (UI, scripts)
+  - Dutch localization updated to 5.0.0 (UI)
+  - French localization updated to 5.0.0 (UI)
+  - Italian localization updated to 5.0.0 (UI, scripts, documentation)
+  - Russian localization updated to 5.0.0 (UI)
+  - Simplified Chinese localization updated to 5.0.0 (UI, scripts)
+  - Ukrainian localization updated to 5.0.0 (UI, Instant Start, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.3.3 (2022-03-18)
 ----------------------------------------------------------------------
   0 Enhancements
   1 Bug fix
-  0 Localisation updates
+  0 Localization updates
 ----------------------------------------------------------------------
 4.3.3 vs 4.3.1
 
@@ -701,7 +701,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   0 Enhancements
   1 Bug fix
-  2 Localisation updates
+  2 Localization updates
 ----------------------------------------------------------------------
 4.3.2 vs 4.3.1
 
@@ -710,11 +710,11 @@ OmegaT 5.7.1 (2022-03-19)
   - Context menu not popping up in repeated segments
   https://sourceforge.net/p/omegat/bugs/917/
 
-  Localisation updates
+  Localization updates
 
-  - Finnish localisation added at 4.3.2 (UI, Instant Start, scripts, readme,
+  - Finnish localization added at 4.3.2 (UI, Instant Start, scripts, readme,
     documentation)
-  - Simplified Chinese localisation updated to 4.3.2 (UI, Instant Start,
+  - Simplified Chinese localization updated to 4.3.2 (UI, Instant Start,
     scripts, readme, documentation)
 
 ----------------------------------------------------------------------
@@ -722,7 +722,7 @@ OmegaT 5.7.1 (2022-03-19)
 ----------------------------------------------------------------------
   1 Enhancement
   2 Bug fixes
-  10 Localisation updates
+  10 Localization updates
 ----------------------------------------------------------------------
 4.3.1 vs 4.3.0
 
@@ -739,31 +739,31 @@ OmegaT 5.7.1 (2022-03-19)
   - OmegaT can't access projects in macOS 10.15 Catalina
   https://sourceforge.net/p/omegat/bugs/959/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Basque localisation updated to 4.3.1 (UI, Instant Start, scripts, readme)
-  - Belarusian localisation updated to 4.3.1 (UI)
-  - Brazilian Portuguese localisation updated to 4.3.1 (UI, scripts)
-  - Czech localisation updated to 4.3.1 (UI, scripts, documentation)
-  - French localisation updated to 4.3.1 (UI)
-  - Italian localisation updated to 4.3.1 (UI, scripts, documentation)
-  - Russian localisation updated to 4.3.1 (UI)
-  - Simplified Chinese localisation updated to 4.3.1 (UI, scripts)
-  - Turkish localisation updated to 4.3.1 (UI)
-  - Ukrainian localisation updated to 4.3.1 (UI, Instant Start, scripts, readme)
+  - Basque localization updated to 4.3.1 (UI, Instant Start, scripts, readme)
+  - Belarusian localization updated to 4.3.1 (UI)
+  - Brazilian Portuguese localization updated to 4.3.1 (UI, scripts)
+  - Czech localization updated to 4.3.1 (UI, scripts, documentation)
+  - French localization updated to 4.3.1 (UI)
+  - Italian localization updated to 4.3.1 (UI, scripts, documentation)
+  - Russian localization updated to 4.3.1 (UI)
+  - Simplified Chinese localization updated to 4.3.1 (UI, scripts)
+  - Turkish localization updated to 4.3.1 (UI)
+  - Ukrainian localization updated to 4.3.1 (UI, Instant Start, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.3.0 (2019-07-09)
 ----------------------------------------------------------------------
   6 Enhancements
   8 Bug fixes
-  5 Localisation updates
+  5 Localization updates
 ----------------------------------------------------------------------
 4.3.0 vs 4.2.0
 
   Implemented requests:
 
-  - Add custom color setting for search results
+  - Add custom colour setting for search results
   https://sourceforge.net/p/omegat/feature-requests/1065/
 
   - Enable Context Menu key in all panes
@@ -807,20 +807,20 @@ OmegaT 5.7.1 (2022-03-19)
 
   - Revised user manual
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portuguese localisation updated to 4.3.0 (UI)
-  - Dutch localisation updated to 4.3.0 (UI, readme, documentation)
-  - French localisation updated to 4.3.0 (UI, scripts, readme)
-  - Russian localisation updated to 4.3.0 (UI)
-  - Simplified Chinese localisation updated to 4.3.0 (UI)
+  - Brazilian Portuguese localization updated to 4.3.0 (UI)
+  - Dutch localization updated to 4.3.0 (UI, readme, documentation)
+  - French localization updated to 4.3.0 (UI, scripts, readme)
+  - Russian localization updated to 4.3.0 (UI)
+  - Simplified Chinese localization updated to 4.3.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.2.0 (2019-04-23)
 ----------------------------------------------------------------------
   5 Enhancements
   1 Bug fix
-  8 Localisation updates
+  8 Localization updates
 ----------------------------------------------------------------------
 4.2.0 vs 4.1.5 update 4
 
@@ -848,23 +848,23 @@ OmegaT 5.7.1 (2022-03-19)
   - Added basic autocompletion to the scripting window (Ctrl+Enter to cycle
   through suggestions)
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portuguese localisation updated to 4.2.0 (UI, readme)
-  - Croatian localisation updated to 4.2.0 (UI, readme)
-  - Dutch localisation updated to 4.2.0 (UI, readme)
-  - French localisation updated to 4.2.0 (UI, readme)
-  - Italian localisation updated to 4.2.0 (UI, readme)
-  - Russian localisation updated to 4.2.0 (UI, scripts, readme)
-  - Simplified Chinese localisation updated to 4.2.0 (UI, scripts, readme)
-  - Turkish localisation updated to 4.2.0 (UI, scripts, readme)
+  - Brazilian Portuguese localization updated to 4.2.0 (UI, readme)
+  - Croatian localization updated to 4.2.0 (UI, readme)
+  - Dutch localization updated to 4.2.0 (UI, readme)
+  - French localization updated to 4.2.0 (UI, readme)
+  - Italian localization updated to 4.2.0 (UI, readme)
+  - Russian localization updated to 4.2.0 (UI, scripts, readme)
+  - Simplified Chinese localization updated to 4.2.0 (UI, scripts, readme)
+  - Turkish localization updated to 4.2.0 (UI, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.5 update 4 (2019-03-04)
 ----------------------------------------------------------------------
   6 Enhancements
   4 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.1.5 update 4 vs 4.1.5 update 3
 
@@ -903,16 +903,16 @@ not defined correctly
   - OmegaT ignores Word document with different file structure
   https://sourceforge.net/p/omegat/bugs/935/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 4.1.5 update 3 (documentation)
+  - Italian localization updated to 4.1.5 update 3 (documentation)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.5 update 3 (2018-11-14)
 ----------------------------------------------------------------------
   2 Enhancements
   2 Bug fixes
-  5 Localisation updates
+  5 Localization updates
 ----------------------------------------------------------------------
 4.1.5 update 3 vs 4.1.5 update 2
 
@@ -932,20 +932,20 @@ as an offline condition
   - Console mode crashes with a valid project
   https://sourceforge.net/p/omegat/bugs/926/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Dutch localisation updated to 4.1.5 update 3 (UI, readme)
-  - Interlingua localisation updated to 4.1.5 update 3 (UI, readme)
-  - Italian localisation updated to 4.1.5 update 3 (UI, scripts, readme, documentation)
-  - Russian localisation updated to 4.1.5 update 3 (UI, scripts, readme)
-  - Sardinian localisation updated to 4.1.5 update 3 (Instant Start)
+  - Dutch localization updated to 4.1.5 update 3 (UI, readme)
+  - Interlingua localization updated to 4.1.5 update 3 (UI, readme)
+  - Italian localization updated to 4.1.5 update 3 (UI, scripts, readme, documentation)
+  - Russian localization updated to 4.1.5 update 3 (UI, scripts, readme)
+  - Sardinian localization updated to 4.1.5 update 3 (Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.5 update 2 (2018-09-19)
 ----------------------------------------------------------------------
   2 Enhancements
   2 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.1.5 update 2 vs 4.1.5 update 1
 
@@ -964,16 +964,16 @@ apiKey) for IBM Watson MT
   - Incomplete mirroring in team projects
   https://sourceforge.net/p/omegat/bugs/920/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Sardinian localisation updated to 4.1.5 (UI)
+  - Sardinian localization updated to 4.1.5 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.5 update 1 (2018-08-06)
 ----------------------------------------------------------------------
   3 Enhancements
   4 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 4.1.5 update 1 vs 4.1.5
 
@@ -1010,7 +1010,7 @@ works with Ctrl+I in addition to Ctrl+R
 ----------------------------------------------------------------------
   8 Enhancements
   3 Bug fixes
-  8 Localisation updates
+  8 Localization updates
 ----------------------------------------------------------------------
 4.1.5 vs 4.1.4
 
@@ -1052,23 +1052,23 @@ item in the omegat.prefs file to take advantage of this change.
   - Edits may be lost without warning when closing OmegaT
   https://sourceforge.net/p/omegat/bugs/902/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 4.1.5 (UI, scripts, readme, documentation)
-  - Croatian localisation updated to 4.1.5 (UI, readme, documentation)
-  - Czech localisation updated to 4.1.5 (UI, scripts, readme, documentation)
-  - Dutch localisation updated to 4.1.5 (UI, scripts, readme, documentation)
-  - Interlingua localisation updated to 4.1.5 (UI, scripts, readme, documentation)
-  - Italian localisation updated to 4.1.5 (UI, scripts, readme, documentation)
-  - Russian localisation updated to 4.1.5 (UI)
-  - Swedish localisation updated to 4.1.5 (UI, Instant Start)
+  - Belarusian localization updated to 4.1.5 (UI, scripts, readme, documentation)
+  - Croatian localization updated to 4.1.5 (UI, readme, documentation)
+  - Czech localization updated to 4.1.5 (UI, scripts, readme, documentation)
+  - Dutch localization updated to 4.1.5 (UI, scripts, readme, documentation)
+  - Interlingua localization updated to 4.1.5 (UI, scripts, readme, documentation)
+  - Italian localization updated to 4.1.5 (UI, scripts, readme, documentation)
+  - Russian localization updated to 4.1.5 (UI)
+  - Swedish localization updated to 4.1.5 (UI, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.4 (2018-04-02)
 ----------------------------------------------------------------------
   5 Enhancements
   2 Bug fixes
-  6 Localisation updates
+  6 Localization updates
 ----------------------------------------------------------------------
 4.1.4 vs 4.1.3 update 2
 
@@ -1096,22 +1096,22 @@ item in the omegat.prefs file to take advantage of this change.
   - Search result marking never ends, consuming CPU
   https://sourceforge.net/p/omegat/bugs/897/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portugese localisation updated to 4.1.3 update 2 (UI)
-  - Czech localisation updated to 4.1.4 (UI, scripts, readme, documentation)
-  - Croatian localisation updated to 4.1.4 (UI, scripts, readme, documentation)
-  - Dutch localisation updated to 4.1.3 update 2 (UI)
-  - Interlingua localisation updated to 4.1.3 update 2 (UI)
-  - Italian localisation updated to 4.1.3 update 2 (UI)
-  - Russian localisation updated to 4.1.3 update 2 (UI)
+  - Brazilian Portugese localization updated to 4.1.3 update 2 (UI)
+  - Czech localization updated to 4.1.4 (UI, scripts, readme, documentation)
+  - Croatian localization updated to 4.1.4 (UI, scripts, readme, documentation)
+  - Dutch localization updated to 4.1.3 update 2 (UI)
+  - Interlingua localization updated to 4.1.3 update 2 (UI)
+  - Italian localization updated to 4.1.3 update 2 (UI)
+  - Russian localization updated to 4.1.3 update 2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.3 update 2 (2018-01-16)
 ----------------------------------------------------------------------
   2 Enhancements
   2 Bug fixes
-  6 Localisation updates
+  6 Localization updates
 ----------------------------------------------------------------------
 4.1.3 update 2 vs 4.1.3 update 1
 
@@ -1132,21 +1132,21 @@ separately"
   - Team tool `init` command does not set correct tokenizers
   https://sourceforge.net/p/omegat/bugs/895/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portuguese localisation updated to 4.1.3 update 2 (UI)
-  - Dutch localisation updated to 4.1.3 update 2 (UI)
-  - Interlingua localisation updated to 4.1.3 update 2 (UI)
-  - Italian localisation updated to 4.1.3 update 2 (UI, scripts, readme)
-  - Russian localisation updated to 4.1.3 update 2 (UI)
-  - Swedish localisation updated to 4.1.3 update 2 (UI, scripts, readme)
+  - Brazilian Portuguese localization updated to 4.1.3 update 2 (UI)
+  - Dutch localization updated to 4.1.3 update 2 (UI)
+  - Interlingua localization updated to 4.1.3 update 2 (UI)
+  - Italian localization updated to 4.1.3 update 2 (UI, scripts, readme)
+  - Russian localization updated to 4.1.3 update 2 (UI)
+  - Swedish localization updated to 4.1.3 update 2 (UI, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.3 update 1 (2017-12-14)
 ----------------------------------------------------------------------
   1 Enhancement
   2 Bug fixes
-  3 Localisation updates
+  3 Localization updates
 ----------------------------------------------------------------------
 4.1.3 update 1 vs 4.1.3
 
@@ -1164,18 +1164,18 @@ arrow keys
   - Download Team Projects failed to download content for 3.6-style
 projects (i.e., with no mapping information)
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Brazilian Portuguese localisation updated to 4.1.3 update 1 (UI)
-  - Dutch localisation updated to 4.1.3 update 1 (UI, readme)
-  - Russian localisation updated to 4.1.3 update 1 (UI, readme)
+  - Brazilian Portuguese localization updated to 4.1.3 update 1 (UI)
+  - Dutch localization updated to 4.1.3 update 1 (UI, readme)
+  - Russian localization updated to 4.1.3 update 1 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.3 (2017-12-03)
 ----------------------------------------------------------------------
   9 Enhancements
   4 Bug fixes
-  3 Localisation updates
+  3 Localization updates
 ----------------------------------------------------------------------
 4.1.3 vs 4.1.2 update 2
 
@@ -1205,7 +1205,7 @@ projects (i.e., with no mapping information)
   - Unify glossary matching and marking logic
   https://sourceforge.net/p/omegat/feature-requests/1354/
 
-  - Improve capitalization behavior in glossary auto-replacement
+  - Improve capitalization behaviour in glossary auto-replacement
   https://sourceforge.net/p/omegat/feature-requests/1355/
 
   Bug fixes:
@@ -1222,18 +1222,18 @@ High Sierra
 
   - Tags were lost when saving TMX from Aligner
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Russian localisation updated to 4.1.2 update 3 (UI, readme)
-  - Brazilian Portuguese localisation updated to 4.1.2 update 3 (UI)
-  - Interlingua localisation updated to 4.1.2 update 3 (UI, readme)
+  - Russian localization updated to 4.1.2 update 3 (UI, readme)
+  - Brazilian Portuguese localization updated to 4.1.2 update 3 (UI)
+  - Interlingua localization updated to 4.1.2 update 3 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.2 update 2 (2017-09-22)
 ----------------------------------------------------------------------
   2 Enhancements
   2 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.1.2 update 2 vs 4.1.2 update 1
 
@@ -1255,16 +1255,16 @@ team projects in 4.x format or work on any selected folder (recursively)
   - When retrieving files from mapped HTTP locations, OmegaT crashed
 if the server didn't send an Etag
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Dutch localisation updated to 4.1.2 update 2 (UI, readme, documentation)
+  - Dutch localization updated to 4.1.2 update 2 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.2 update 1 (2017-08-09)
 ----------------------------------------------------------------------
   4 Enhancements
   2 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.1.2 update 1 vs 4.1.2
 
@@ -1291,16 +1291,16 @@ in the table
   - Repository mapping lost when downloading team project
   https://sourceforge.net/p/omegat/bugs/859/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 4.1.2 (UI)
+  - Italian localization updated to 4.1.2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.2 (2017-06-22)
 ----------------------------------------------------------------------
  12 Enhancements
   6 Bug fixes
-  2 Localisation updates
+  2 Localization updates
 ----------------------------------------------------------------------
 4.1.2 vs 4.1.1
 
@@ -1367,17 +1367,17 @@ project-specific
   - Tokenizer language discovery at runtime not working
   https://sourceforge.net/p/omegat/bugs/869/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 4.1.1 (UI, readme)
-  - Norwegian localisation updated to 4.1 (UI, readme)
+  - Italian localization updated to 4.1.1 (UI, readme)
+  - Norwegian localization updated to 4.1 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.1 (2017-03-15)
 ----------------------------------------------------------------------
  11 Enhancements
   4 Bug fixes
-  8 Localisation updates
+  8 Localization updates
 ----------------------------------------------------------------------
 4.1.1 vs 4.1.0
 
@@ -1429,23 +1429,23 @@ cover most cases, which are described in the script comments
   - Scripting: console.print() and println() add an extra line break
   https://sourceforge.net/p/omegat/bugs/855/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 4.0 (UI, documentation, scripts, readme)
-  - Dutch localisation updated to 4.0 (UI, documentation, scripts, readme)
-  - Italian localisation updated to 4.1.0 (UI, documentation)
-  - Polish localisation updated to 4.0.0 (UI, readme, scripts)
+  - Belarusian localization updated to 4.0 (UI, documentation, scripts, readme)
+  - Dutch localization updated to 4.0 (UI, documentation, scripts, readme)
+  - Italian localization updated to 4.1.0 (UI, documentation)
+  - Polish localization updated to 4.0.0 (UI, readme, scripts)
   - Brazilian Portuguese updated to 3.6 (UI, documentation, scripts, readme)
-  - Spanish localisation updated to 4.0.0 (UI, tutorial)
-  - Traditional Chinese (TW) localisation updated to 4.0 (UI)
-  - Japanese localisation updated to 4.1.1 (UI)
+  - Spanish localization updated to 4.0.0 (UI, tutorial)
+  - Traditional Chinese (TW) localization updated to 4.0 (UI)
+  - Japanese localization updated to 4.1.1 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.1.0 (2017-01-09)
 ----------------------------------------------------------------------
   9 Enhancements
   4 Bug fixes
-  2 Localisation updates
+  2 Localization updates
 ----------------------------------------------------------------------
 4.1.0 vs 4.0.1
 
@@ -1496,17 +1496,17 @@ encountering certain malformed header lines
   - Changes to segments get lost in team projects randomly and silently
   https://sourceforge.net/p/omegat/bugs/836/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 4.0.1 (UI, readme, documentation)
-  - Russian localisation updated to 4.1.0 (UI)
+  - Italian localization updated to 4.0.1 (UI, readme, documentation)
+  - Russian localization updated to 4.1.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 4.0.1 (2016-10-03)
 ----------------------------------------------------------------------
   7 Enhancements
   2 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.0.1 vs 4.0.0 update 1
 
@@ -1542,16 +1542,16 @@ encountering certain malformed header lines
   - Tokenizers did not automatically match languages when creating a
 new project
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 4.0 (UI, documentation, scripts)
+  - Italian localization updated to 4.0 (UI, documentation, scripts)
 
 ----------------------------------------------------------------------
  OmegaT 4.0.0 update 1 (2016-09-12)
 ----------------------------------------------------------------------
   0 Enhancement
   3 Bug fix
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 4.0.0 update 1 vs 4.0.0
 
@@ -1570,7 +1570,7 @@ below the root of the project
 ----------------------------------------------------------------------
  35 Enhancements
   8 Bug fixes
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 4.0.0 vs 3.6.0 update 3
 
@@ -1709,16 +1709,16 @@ could fail with duplicate numbers
   - Some CLI modes don't accept "." as project path
   https://sourceforge.net/p/omegat/bugs/830/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Interlingua localisation updated to 4.0 (UI, documentation, readme, scripts)
+  - Interlingua localization updated to 4.0 (UI, documentation, readme, scripts)
 
 ----------------------------------------------------------------------
  OmegaT 3.6.0 update 11
 ----------------------------------------------------------------------
   0 Enhancement
   1 Bug fix
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 11 vs 3.6.0 update 10
 
@@ -1733,7 +1733,7 @@ codes are the same
 ----------------------------------------------------------------------
   0 Enhancement
   3 Bug fixes
-  2 Localisation updates
+  2 Localization updates
 ----------------------------------------------------------------------
 3.6.0 update 10 vs 3.6.0 update 9
 
@@ -1748,17 +1748,17 @@ codes are the same
   - Adjacent next match skipped by Replace Next
   https://sourceforge.net/p/omegat/bugs/899/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Czech localisation updated to 3.6 (documentation)
-  - Croatian localisation updated to 3.6 (documentation)
+  - Czech localization updated to 3.6 (documentation)
+  - Croatian localization updated to 3.6 (documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.6.0 update 9 (2018-03-31)
 ----------------------------------------------------------------------
   0 Enhancement
   3 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 9 vs 3.6.0 update 8
 
@@ -1777,7 +1777,7 @@ fuzzy match searching from working correctly
 ----------------------------------------------------------------------
   0 Enhancement
   2 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 8 vs 3.6.0 update 7
 
@@ -1793,7 +1793,7 @@ fuzzy match searching from working correctly
 ----------------------------------------------------------------------
   0 Enhancement
   2 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 7 vs 3.6.0 update 6
 
@@ -1810,7 +1810,7 @@ fuzzy match searching from working correctly
 ----------------------------------------------------------------------
   0 Enhancement
   3 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 6 vs 3.6.0 update 5
 
@@ -1830,7 +1830,7 @@ instead of FR-FR)
 ----------------------------------------------------------------------
   1 Enhancement
   4 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 5 vs 3.6.0 update 4
 
@@ -1858,7 +1858,7 @@ be able to work with the new one.
 ----------------------------------------------------------------------
   0 Enhancement
   1 Bug fix
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 4 vs 3.6.0 update 3
 
@@ -1872,7 +1872,7 @@ be able to work with the new one.
 ----------------------------------------------------------------------
   0 Enhancement
   4 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 3 vs 3.6.0 update 2
 
@@ -1883,7 +1883,7 @@ be able to work with the new one.
   - Windows: wrong setup language when selecting "English"
   https://sourceforge.net/p/omegat/bugs/834/
 
-  - Incorrect search result highlighting with custom colors
+  - Incorrect search result highlighting with custom colours
   https://sourceforge.net/p/omegat/bugs/835/
 
   - Tag fix failure when tag has same offset in source and target
@@ -1893,7 +1893,7 @@ be able to work with the new one.
 ----------------------------------------------------------------------
   5 Enhancements
   4 Bug fixes
-  0 Localisation update
+  0 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 2 vs 3.6.0 update 1
 
@@ -1917,7 +1917,7 @@ supported languages, regardless of the languages installed in Windows
 
   Bug fixes:
 
-  - When the text color is customized, the caret color does not match
+  - When the text colour is customized, the caret colour does not match
   https://sourceforge.net/p/omegat/bugs/811/
 
   - Some markers throw NPE when source text is not shown in editor
@@ -1933,7 +1933,7 @@ were not taken into account, only the predefined values were used
 ----------------------------------------------------------------------
   2 Enhancements
   1 Bug fix
-  1 Localisation update
+  1 Localization update
 ----------------------------------------------------------------------
 3.6.0 update 1 vs 3.6.0
 
@@ -1949,16 +1949,16 @@ were not taken into account, only the predefined values were used
 
   - The Okapi Filters Plugin for OmegaT could crash
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 3.6 (UI, documentation)
+  - Italian localization updated to 3.6 (UI, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.6.0 (2016-03-09)
 ----------------------------------------------------------------------
  16 Enhancements
   7 Bug fixes
-  5 Localisation updates
+  5 Localization updates
 ----------------------------------------------------------------------
 3.6.0 vs 3.5.4
 
@@ -2014,7 +2014,7 @@ were not taken into account, only the predefined values were used
 
   Bug fixes:
 
-  - Custom text color used for text in dialogs
+  - Custom text colour used for text in dialogs
   https://sourceforge.net/p/omegat/bugs/725/
 
   - Jumping to a large entry makes it appear at the bottom of the editor
@@ -2039,20 +2039,20 @@ digits
 certificates; in case of an javax.net.ssl.SSLHandshakeException, see the
 bug comments for instructions on adding the certificate to the trust store.
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 3.6 (UI, readme)
-  - Czech localisation updated to 3.6 (UI, documentation, scripts, readme)
-  - Dutch localisation updated to 3.6 (UI, documentation, scripts, readme)
-  - Hungarian localisation updated to 3.6 (UI)
-  - Norvegian localisation updated to 3.6 (UI, scripts, readme)
+  - Belarusian localization updated to 3.6 (UI, readme)
+  - Czech localization updated to 3.6 (UI, documentation, scripts, readme)
+  - Dutch localization updated to 3.6 (UI, documentation, scripts, readme)
+  - Hungarian localization updated to 3.6 (UI)
+  - Norvegian localization updated to 3.6 (UI, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.5.4 (2016-03-23)
 ----------------------------------------------------------------------
    5 Enhancements
    9 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.5.4 vs 3.5.3
 
@@ -2100,9 +2100,9 @@ remained at the end of lines when the line was cut on a space.
   - Cannot open projects residing in path with symbolic link
   https://sourceforge.net/p/omegat/bugs/804/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Italian localisation updated to 3.5.3 (UI, documentation, scripts, readme)
+  - Italian localization updated to 3.5.3 (UI, documentation, scripts, readme)
   - Brazilian Portuguese updated to 3.5 (UI)
 
 ----------------------------------------------------------------------
@@ -2110,7 +2110,7 @@ remained at the end of lines when the line was cut on a space.
 ----------------------------------------------------------------------
   23 Enhancements
    7 Bug fixes
-   8 Localisation updates
+   8 Localization updates
 ----------------------------------------------------------------------
 3.5.3 vs 3.5.2 update 1
 
@@ -2207,29 +2207,29 @@ Tag nesting is now only tested for OmegaT tags.
   - MyMemory machine and human translation not working
   https://sourceforge.net/p/omegat/bugs/773/
 
-  - Fragments to be removed not colored correctly
+  - Fragments to be removed not coloured correctly
   https://sourceforge.net/p/omegat/bugs/549/
 
   - Editor freezes when navigating segments by double-click (OS X only)
   https://sourceforge.net/p/omegat/bugs/529/
 
-  Localisation Updates:
+  Localization Updates:
 
-  - Belarusian localisation updated to 3.5.3 (UI, tutorial, scripts, readme)
-  - Czech localisation updated to 3.5.3 (UI, documentation, scripts, readme)
-  - Dutch localisation updated to 3.5.3 (UI, documentation, scripts, readme)
-  - German localisation updated to 3.5.2 (UI)
-  - Interlingua localisation updated to 3.5.3 (UI, documentation, scripts, readme)
-  - Japanese localisation updated to 3.5.3 (UI, documentation, scripts, readme)
-  - Norwegian localisation updated to 3.5.3 (UI, tutorial, scripts, readme)
-  - Spanish localisation updated to 3.5.3 (UI, tutorial)
+  - Belarusian localization updated to 3.5.3 (UI, tutorial, scripts, readme)
+  - Czech localization updated to 3.5.3 (UI, documentation, scripts, readme)
+  - Dutch localization updated to 3.5.3 (UI, documentation, scripts, readme)
+  - German localization updated to 3.5.2 (UI)
+  - Interlingua localization updated to 3.5.3 (UI, documentation, scripts, readme)
+  - Japanese localization updated to 3.5.3 (UI, documentation, scripts, readme)
+  - Norwegian localization updated to 3.5.3 (UI, tutorial, scripts, readme)
+  - Spanish localization updated to 3.5.3 (UI, tutorial)
 
 ----------------------------------------------------------------------
  OmegaT 3.5.2 update 1 (2015-09-25)
 ----------------------------------------------------------------------
    0 Enhancement
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.5.2 update 1 vs 3.5.2
 
@@ -2248,7 +2248,7 @@ Tag nesting is now only tested for OmegaT tags.
 ----------------------------------------------------------------------
    9 Enhancements
    8 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 3.5.2 vs 3.5.1
 
@@ -2308,20 +2308,20 @@ the arrow keys
 correctly from configuration files
 
 
-  Localisation Updates:
+  Localization Updates:
 
- - Belarusian localisation updated to 3.5 (UI)
- - Brazilian Portuguese localisation updated to 3.5 (UI, documentation, scripts, readme)
- - Dutch localisation updated to 3.5.2 (UI, readme)
- - Hungarian localisation updated to 3.5.2 (UI)
- - Italian localisation updated to 3.5.2 (UI, readme)
+ - Belarusian localization updated to 3.5 (UI)
+ - Brazilian Portuguese localization updated to 3.5 (UI, documentation, scripts, readme)
+ - Dutch localization updated to 3.5.2 (UI, readme)
+ - Hungarian localization updated to 3.5.2 (UI)
+ - Italian localization updated to 3.5.2 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.5.1 (2015-07-26)
 ----------------------------------------------------------------------
    8 Enhancements
    4 Bug fixes
-   7 Localisation update
+   7 Localization update
 ----------------------------------------------------------------------
 3.5.1 vs 3.5 update 1
 
@@ -2367,22 +2367,22 @@ from lower-case to upper-case, it was turning the phrase to title-case
 case. Depending on the zip application, it was difficult to unpack it
 correctly.
 
-  Localisation updates:
+  Localization updates:
 
-  - Belarusian localisation updated to 3.5 (UI)
-  - Dutch localisation updated to 3.5 (UI)
-  - Hungarian localisation updated to 3.5 (UI)
-  - Italian localisation updated to 3.5 (UI)
-  - Japanese localisation updated to 3.5 (UI)
-  - Norwegian localisation created (UI, Instant Start, scripts, readme)
-  - Portuguese localisation updated to 3.5 (UI)
+  - Belarusian localization updated to 3.5 (UI)
+  - Dutch localization updated to 3.5 (UI)
+  - Hungarian localization updated to 3.5 (UI)
+  - Italian localization updated to 3.5 (UI)
+  - Japanese localization updated to 3.5 (UI)
+  - Norwegian localization created (UI, Instant Start, scripts, readme)
+  - Portuguese localization updated to 3.5 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.5 update 1 (2015-06-11)
 ----------------------------------------------------------------------
    3 Enhancements
    2 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 3.5 update 1 vs 3.5
 
@@ -2405,17 +2405,17 @@ at the root of the glossary folder
   - It was not possible to have two glossaries with the same name
 in different sub-folders
 
-  Localisation updates:
-  - Dutch localisation updated to 3.5 (UI, documentation, scripts, readme)
-  - Interlingua localisation updated to 3.5 (UI, scripts, readme)
-  - Italian localisation updated to 3.5 (UI, scripts)
+  Localization updates:
+  - Dutch localization updated to 3.5 (UI, documentation, scripts, readme)
+  - Interlingua localization updated to 3.5 (UI, scripts, readme)
+  - Italian localization updated to 3.5 (UI, scripts)
 
 ----------------------------------------------------------------------
  OmegaT 3.5 (2015-06-05)
 ----------------------------------------------------------------------
   18 Enhancements
    4 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 3.5 vs 3.4
 
@@ -2488,20 +2488,20 @@ to the segment being current before the Search window was opened.
 
   - Auto-completer popup size was often too small for its contents
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 3.4 update 1 (UI, documentation, readme)
-  - Russian localisation updated to 3.4 update 1 (UI, readme, scripts)
-  - Belarusian localisation updated to 3.5 (UI, readme, scripts)
-  - Japanese localisation updated to 3.5 (UI, documentation, scripts)
-  - Italian localisation updated to 3.4 update 1 (UI)
+  - Dutch localization updated to 3.4 update 1 (UI, documentation, readme)
+  - Russian localization updated to 3.4 update 1 (UI, readme, scripts)
+  - Belarusian localization updated to 3.5 (UI, readme, scripts)
+  - Japanese localization updated to 3.5 (UI, documentation, scripts)
+  - Italian localization updated to 3.4 update 1 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.4 (2015-04-20)
 ----------------------------------------------------------------------
   12 Enhancements
    4 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 3.4 vs 3.1.9 update 1
 
@@ -2560,18 +2560,18 @@ of "foo\.\scripts"
   - OmegaT does not look nice on Mac retina display
   https://sourceforge.net/p/omegat/bugs/712/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 3.4 (UI, documentation, scripts, readme)
-  - Italian localisation updated to 3.4 (UI, documentation, scripts)
-  - Japanese localisation updated to 3.4 (UI, readme)
+  - Dutch localization updated to 3.4 (UI, documentation, scripts, readme)
+  - Italian localization updated to 3.4 (UI, documentation, scripts)
+  - Japanese localization updated to 3.4 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.9 update 4 (2015-09-12)
 ----------------------------------------------------------------------
    1 Enhancement
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.1.9 update 4 vs. 3.1.9 update 3
 
@@ -2593,7 +2593,7 @@ opening files or folders
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.1.9 update 3 vs. 3.1.9 update 2
 
@@ -2604,16 +2604,16 @@ translation contained text, an error occurred when trying to create
 the translated document, resulting in the translated document being
 empty
 
-  Localisation updates:
+  Localization updates:
 
-  - New Norwegian localisation (UI, Instant start, scripts, readme)
+  - New Norwegian localization (UI, Instant start, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.9 update 2 (2015-06-03)
 ----------------------------------------------------------------------
    2 Enhancements
    3 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.1.9 update 2 vs. 3.1.9 update 1
 
@@ -2621,7 +2621,7 @@ empty
 
   - Updated LanguageTool to 2.2
 
-  - *.strings (Mac OS X localisation format) was added to the Key=value
+  - *.strings (Mac OS X localization format) was added to the Key=value
 filter. That's only a partial solution, as " and ; characters remain
 in the translatable text, and have to be preserved by the translator.
 
@@ -2636,17 +2636,17 @@ entered as "CSV"
   - Exclusion masks not working correctly under Windows
   https://sourceforge.net/p/omegat/bugs/746/
 
-  Localisation updates:
+  Localization updates:
 
-  - Brazilian Portuguese localisation updated to 3.0.7 (UI, documentation, readme)
-  - Japanese localisation updated to 3.1.9 update 1 (UI)
+  - Brazilian Portuguese localization updated to 3.0.7 (UI, documentation, readme)
+  - Japanese localization updated to 3.1.9 update 1 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.9 update 1 (2015-04-15)
 ----------------------------------------------------------------------
    1 Enhancement
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.1.9 update 1 vs. 3.1.9
 
@@ -2671,7 +2671,7 @@ quitting OmegaT
 ----------------------------------------------------------------------
   21 Enhancements
   13 Bug fixes
-   6 Localisation updates
+   6 Localization updates
 ----------------------------------------------------------------------
 3.1.9 vs. 3.1.8
 
@@ -2704,7 +2704,7 @@ quitting OmegaT
   - Make it easy to find specific files by name or path
   https://sourceforge.net/p/omegat/feature-requests/1070/
 
-  - Improve resizing behavior of Project Files dialog
+  - Improve resizing behaviour of Project Files dialog
   https://sourceforge.net/p/omegat/feature-requests/1071/
 
   - Make segment numbers visible for all segments
@@ -2733,7 +2733,7 @@ There's also a new tab for colour selection.
   - It is possible to define the text and background colour of modification
 information and the active segment's source and target
 
-  - Dialogs are now centered against the main window instead of the screen
+  - Dialogs are now centred against the main window instead of the screen
 
   - The Visio filter was updated to remove unneeded tags in Visio 2010 documents
 
@@ -2782,27 +2782,27 @@ for the bug description.
   - The font set in Options > Font was only used after the change when
 Apply this font to the Project Files dialog was used
 
-  Localisation updates:
+  Localization updates:
 
-  - Belarusian localisation updated to 3.1.9 (UI, tutorial, scripts, readme)
-  - Basque localisation updated to 3.1.9 (UI, tutorial, scripts, readme)
-  - Dutch localisation updated to 3.1.9 (UI, documentation, scripts, readme)
-  - Italian localisation updated to 3.1.9 (UI, documentation, scripts, readme)
-  - Japanese localisation updated to 3.1.9 (UI, documentation, readme)
-  - Russian localisation updated to 3.1.9 (UI, tutorial, scripts, readme)
+  - Belarusian localization updated to 3.1.9 (UI, tutorial, scripts, readme)
+  - Basque localization updated to 3.1.9 (UI, tutorial, scripts, readme)
+  - Dutch localization updated to 3.1.9 (UI, documentation, scripts, readme)
+  - Italian localization updated to 3.1.9 (UI, documentation, scripts, readme)
+  - Japanese localization updated to 3.1.9 (UI, documentation, readme)
+  - Russian localization updated to 3.1.9 (UI, tutorial, scripts, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.8 (2014-12-04)
 ----------------------------------------------------------------------
    6 Enhancements
   10 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 3.1.8 vs. 3.1.7
 
   Implemented requests:
 
-  - Allow custom background/foreground colors for different elements in the editor
+  - Allow custom background/foreground colours for different elements in the editor
   https://sourceforge.net/p/omegat/feature-requests/1035/
 
   - Show dialog for unsupported SVN errors
@@ -2833,7 +2833,7 @@ instead of the standard Java ones
 Search window before the first searching execution, the cursor (i.e.,
 mouse pointer) changed to the Wait icon and could not be restored
 
-  - Strange glossary behavior - removing of newly added terms
+  - Strange glossary behaviour - removing of newly added terms
   https://sourceforge.net/p/omegat/bugs/696/
 
   - OmegaT keeps temporary files project_save.tmx-based_on_revision_number.new
@@ -2851,20 +2851,20 @@ mouse pointer) changed to the Wait icon and could not be restored
   - In team projects, OmegaT was sometimes failing to rename files (perhaps
 blocked by antivirus or cache software). There's now a 3-second retry.
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 3.1.7 (UI)
-  - Interlingua localisation updated to 3.1.7 (UI, documentation)
-  - Italian localisation updated to 3.1.7 (UI)
-  - Japanese localisation updated to 3.1.8 (UI, documentation)
-  - French localisation updated to 3.1.8 (UI, readme, documentation)
+  - Dutch localization updated to 3.1.7 (UI)
+  - Interlingua localization updated to 3.1.7 (UI, documentation)
+  - Italian localization updated to 3.1.7 (UI)
+  - Japanese localization updated to 3.1.8 (UI, documentation)
+  - French localization updated to 3.1.8 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.7 (2014-10-20)
 ----------------------------------------------------------------------
    9 Enhancements
    7 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 3.1.7 vs. 3.1.6
 
@@ -2926,18 +2926,18 @@ different plural when the source sentences of the plural were the same.
 As the identifier for alternative translations of PO were changed, it is not
 recommanded to change version during a project.
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 3.1.7 (UI, readme, documentation)
-  - Italian localisation updated to 3.1.6 (UI, readme)
-  - Dutch localisation updated to 3.1.6 (UI, readme, documentation)
+  - Japanese localization updated to 3.1.7 (UI, readme, documentation)
+  - Italian localization updated to 3.1.6 (UI, readme)
+  - Dutch localization updated to 3.1.6 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.6 (2014-09-10)
 ----------------------------------------------------------------------
    5 Enhancements
    8 Bug fixes
-   3 Localisation update
+   3 Localization update
 ----------------------------------------------------------------------
 3.1.6 vs. 3.1.5
 
@@ -2984,18 +2984,18 @@ tags and could not be translated.
 
   - Recent projects were not always updated
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 3.1.5 (UI, readme, documentation, scripts)
-  - Italian localisation updated to 3.1.5 (UI, readme)
-  - Japanese localisation updated to 3.1.6 (UI, readme, documentation)
+  - Dutch localization updated to 3.1.5 (UI, readme, documentation, scripts)
+  - Italian localization updated to 3.1.5 (UI, readme)
+  - Japanese localization updated to 3.1.6 (UI, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.5 (2014-08-13)
 ----------------------------------------------------------------------
    2 Enhancements
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.1.5 vs. 3.1.4
 
@@ -3025,7 +3025,7 @@ tags and could not be translated.
 ----------------------------------------------------------------------
   12 Enhancements
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.1.4 vs. 3.1.3
 
@@ -3079,17 +3079,17 @@ to the comment pane
   - Editing behaviour "leave the segment empty" setting not working when filter is active
   https://sourceforge.net/p/omegat/bugs/686/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.1.3 (UI, readme, documentation)
-  - Japanese localisation updated to 3.1.4 (UI, readme)
+  - Italian localization updated to 3.1.3 (UI, readme, documentation)
+  - Japanese localization updated to 3.1.4 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.3 (2014-07-11)
 ----------------------------------------------------------------------
   12 Enhancements
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.1.3 vs. 3.1.2
 
@@ -3147,17 +3147,17 @@ ant-contrib. See details in /release/WebStart-specific/build.xml
 
   - Text filter: some of the last lines of the target document could be lost
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.1.2 (UI, scripts, readme)
-  - Interlingua localisation updated to 3.1.2 ((UI, scripts, readme, documentation)
+  - Italian localization updated to 3.1.2 (UI, scripts, readme)
+  - Interlingua localization updated to 3.1.2 ((UI, scripts, readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.2 (2014-06-26)
 ----------------------------------------------------------------------
   17 Enhancements
    2 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 3.1.2 vs. 3.1.1 update 1
 
@@ -3191,7 +3191,7 @@ ant-contrib. See details in /release/WebStart-specific/build.xml
 
   - When --no-team is used, Project > Dowload team project is disabled
 
-  - Make "auto" colors more distinctive
+  - Make "auto" colours more distinctive
 
   - Auto-completer choices can be confirmed by a double click
 
@@ -3202,12 +3202,12 @@ be forced by prefixing the URL with "git!" or "svn!".
 E.g., svn!https://omegat.xxxx.xx/omegat-fr
 
   - Scripts with a separate .properties file for user messages are now
-included in localisation bundles
+included in localization bundles
 
   - Specific preferences can be built into a Java Web Start package at
 compilation time, by putting an omegat.prefs file in /release/WebStart-specific
 
-  - .properties files for script localisation can now be put into a
+  - .properties files for script localization can now be put into a
 /properties folder inside the /scripts folder. For compatibility, .properties from
 the root of the /script folder are loaded if they exist.
 
@@ -3224,22 +3224,22 @@ for online services, and the option --no-team was added
   - Word: anything placed before the leading tag is omitted in translated document
   https://sourceforge.net/p/omegat/bugs/634/
 
-  - The color used in the View menu to identify "auto" colors was
+  - The colour used in the View menu to identify "auto" colours was
 COLOR_MARK_COMES_FROM_TM_XICE instead of COLOR_MARK_COMES_FROM_TM_XAUTO
 used by most users
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.1.0 (UI, Documentation)
-  - Japanese localisation updated to 3.1.1 update 2 (UI, Documentation, Scripts)
-  - Russian localisation updated to 3.1.2 (UI, Scripts, Readme)
+  - Italian localization updated to 3.1.0 (UI, Documentation)
+  - Japanese localization updated to 3.1.1 update 2 (UI, Documentation, Scripts)
+  - Russian localization updated to 3.1.2 (UI, Scripts, Readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.1 update 1 (2014-05-21)
 ----------------------------------------------------------------------
    1 Enhancement
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.1.1 update 1 vs. 3.1.1
 
@@ -3267,7 +3267,7 @@ not converted back to real tags in the target document
 ----------------------------------------------------------------------
   13 Enhancements
    5 Bug fixes
-   4 Localisation updates
+   4 Localization updates
 ----------------------------------------------------------------------
 3.1.1 vs. 3.1.0
 
@@ -3331,19 +3331,19 @@ removing the filter or pressing Cancel could be lost
   - Unable to save note for untranslated segment
   https://sourceforge.net/p/omegat/bugs/677/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 3.1.0 (UI, Documentation, Readme)
-  - Galician localisation updated to 3.1.0 (UI, Documentation, Readme)
-  - Italian localisation updated to 3.1.0 (UI, Documentation)
-  - Japanese localisation updated to 3.1.1 (UI, Readme)
+  - Dutch localization updated to 3.1.0 (UI, Documentation, Readme)
+  - Galician localization updated to 3.1.0 (UI, Documentation, Readme)
+  - Italian localization updated to 3.1.0 (UI, Documentation)
+  - Japanese localization updated to 3.1.1 (UI, Readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.1.0 (2014-04-14)
 ----------------------------------------------------------------------
   35 Enhancements
    7 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.1.0 vs. 3.0.8 update 5
 
@@ -3376,7 +3376,7 @@ removing the filter or pressing Cancel could be lost
   - Priority TM to override project_save.tmx
   https://sourceforge.net/p/omegat/feature-requests/957/
 
-  - Localisation support for scripts
+  - Localization support for scripts
   https://sourceforge.net/p/omegat/feature-requests/975/
 
   - Event for scripts
@@ -3485,17 +3485,17 @@ in source and target
   - Scripting window layout leaves "RUN" button out
   https://sourceforge.net/p/omegat/bugs/646/
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 3.1.0 (UI, Documentation, Readme)
-  - Italian localisation updated to 3.1.0 (UI, Documentation)
+  - Japanese localization updated to 3.1.0 (UI, Documentation, Readme)
+  - Italian localization updated to 3.1.0 (UI, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.8 update 5 (2014-03-24)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.0.8 update 5 vs. 3.0.8 update 4
 
@@ -3508,7 +3508,7 @@ in source and target
 ----------------------------------------------------------------------
    1 Enhancement
    0 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.8 update 4 vs. 3.0.8 update 3
 
@@ -3517,16 +3517,16 @@ in source and target
   - Mac: a pre-defined line in OmegaT.sh makes it easier to use
 system Java 1.6 on OS X
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.0.8 update 2 (UI)
+  - Italian localization updated to 3.0.8 update 2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.8 update 3 (2014-01-27)
 ----------------------------------------------------------------------
    2 Enhancements
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.0.8 update 3 vs. 3.0.8 update 2
 
@@ -3549,7 +3549,7 @@ New Project or Open Project
 ----------------------------------------------------------------------
    7 Enhancements
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.0.8 update 2 vs. 3.0.8 update 1
 
@@ -3592,17 +3592,17 @@ Download MediaWiki Page were greyed out
 
   - Swedish segmentation rules were not properly displayed in the Segmentation Rules dialog
 
-  Localisation updates:
+  Localization updates:
 
-  - Simplified Chinese localisation updated to 3.0.8 (UI, Documentation)
-  - Japanese localisation updated to 3.0.8 update 2 (UI, Documentation, Readme)
+  - Simplified Chinese localization updated to 3.0.8 (UI, Documentation)
+  - Japanese localization updated to 3.0.8 update 2 (UI, Documentation, Readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.8 update 1 (2013-12-26)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   11 Localisation updates
+   11 Localization updates
 ----------------------------------------------------------------------
 3.0.8 update 1 vs. 3.0.8
 
@@ -3611,26 +3611,26 @@ Download MediaWiki Page were greyed out
   - Enabling Remove Tags results in almost empty translated Word files
   https://sourceforge.net/p/omegat/bugs/635/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.0.8 (UI, Documentation)
-  - Hungarian localisation updated to 3.0.8 (Instant Start)
-  - Czech localisation updated to 3.0.2 (UI, Documentation)
-  - German localisation updated to 3.0 (UI)
-  - Russian localisation updated to 3.0.3 (UI, Documentation)
-  - Greek localisation updated to 3.0 (Documentation)
-  - Belarus localisation updated to 3.0 (UI, Instant Start, Readme)
-  - Korean localisation added at 3.0.7 (UI, Instant Start, Readme)
-  - Dutch localisation updated to 3.0.8 (UI, Documentation)
-  - Simplified Chinese localisation updated to 3.0.8 (UI)
-  - Japanese localisation updated to 3.0.8 (UI, Documentation)
+  - Italian localization updated to 3.0.8 (UI, Documentation)
+  - Hungarian localization updated to 3.0.8 (Instant Start)
+  - Czech localization updated to 3.0.2 (UI, Documentation)
+  - German localization updated to 3.0 (UI)
+  - Russian localization updated to 3.0.3 (UI, Documentation)
+  - Greek localization updated to 3.0 (Documentation)
+  - Belarus localization updated to 3.0 (UI, Instant Start, Readme)
+  - Korean localization added at 3.0.7 (UI, Instant Start, Readme)
+  - Dutch localization updated to 3.0.8 (UI, Documentation)
+  - Simplified Chinese localization updated to 3.0.8 (UI)
+  - Japanese localization updated to 3.0.8 (UI, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.8 (2013-12-17)
 ----------------------------------------------------------------------
   10 Enhancements
    4 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.8 vs. 3.0.7
 
@@ -3691,16 +3691,16 @@ folder was hard to read. It was changed to "salmon red".
   - Error: java.lang.IndexOutOfBoundsException on tag validation with custom tags
   https://sourceforge.net/p/omegat/bugs/638/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.0.7 (UI, documentation)
+  - Italian localization updated to 3.0.7 (UI, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.7 (2013-11-21)
 ----------------------------------------------------------------------
    7 Enhancements
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.7 vs. 3.0.6
 
@@ -3742,16 +3742,16 @@ remained displayed at the bottom of the window
 if the option "Use XML for standalone tags" was set. This was wrong
 as beginning <it> tags are not standalone tags, but opening tags.
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 3.0.7 (UI, documentation)
+  - Japanese localization updated to 3.0.7 (UI, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.6 (2013-11-05)
 ----------------------------------------------------------------------
    9 Enhancements
    3 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 3.0.6 vs. 3.0.5
 
@@ -3794,17 +3794,17 @@ when Remove Tags is used
   - Filelist not sorted during creating translated files
   https://sourceforge.net/p/omegat/bugs/619/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.0.5 (UI, Documentation)
-  - Japanese localisation updated to 3.0.6 (UI, Documentation)
+  - Italian localization updated to 3.0.5 (UI, Documentation)
+  - Japanese localization updated to 3.0.6 (UI, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.5 (2013-10-03)
 ----------------------------------------------------------------------
   10 Enhancements
    4 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.5 vs. 3.0.4 update 2
 
@@ -3864,16 +3864,16 @@ result with the match pane. The percentage kept is, however, still the
 rightmost one. As the computation method is different, all statistics
 will give different results compared with the previous version.
 
-  Localisation updates:
+  Localization updates:
 
-  - Interlingua localisation updated to 3.0.4 (UI, Documentation, Readme)
+  - Interlingua localization updated to 3.0.4 (UI, Documentation, Readme)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.4 update 2 (2013-08-06)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.4 update 2 vs. 3.0.4 update 1
 
@@ -3882,16 +3882,16 @@ will give different results compared with the previous version.
   - java.lang.IndexOutOfBoundsException during strict tag validation
   http://sourceforge.net/p/omegat/bugs/608/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 3.0.4 (UI)
+  - Italian localization updated to 3.0.4 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.4 update 1 (2013-07-25)
 ----------------------------------------------------------------------
    3 Enhancements
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.0.4 update 1 vs. 3.0.4
 
@@ -3925,7 +3925,7 @@ missing tags
 ----------------------------------------------------------------------
   10 Enhancements
    6 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 3.0.4 vs. 3.0.3
 
@@ -3981,16 +3981,16 @@ fixed.
   - There was an exception when LanguageTool was enabled with no project
 loaded
 
-  Localisation updates:
+  Localization updates:
 
-  - French localisation updated to 3.0.2 (Documentation)
+  - French localization updated to 3.0.2 (Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.3 (2013-06-06)
 ----------------------------------------------------------------------
    4 Enhancements
    4 Bug fixes
-   8 Localisation updates
+   8 Localization updates
 ----------------------------------------------------------------------
 3.0.3 vs. 3.0.2 update 1
 
@@ -4026,23 +4026,23 @@ Options, some trailing conditional paragraph end tags could remain at
 the end of the segment. It mainly affected segmented XLIFF generated by
 Rainbow.
 
-  Localisation updates:
+  Localization updates:
 
-  - Catalan localisation updated to 3.0.1 (UI, Instant Start, Readme)
-  - Czech localisation updated to 3.0 (UI, Instant Start, Readme)
-  - Dutch localisation updated to 3.0.2 (UI, Documentation, Readme)
-  - Greek localisation updated to 3.0 (UI, Partial documentation, Instant Start)
-  - Japanese localisation updated to 3.0.2 (UI)
-  - Slovenian localisation updated to 3.0 (UI)
-  - Ukrainian localisation updated to 3.0 (UI, Instant Start, Readme)
-  - Welsh localisation updated to 3.0 (UI)
+  - Catalan localization updated to 3.0.1 (UI, Instant Start, Readme)
+  - Czech localization updated to 3.0 (UI, Instant Start, Readme)
+  - Dutch localization updated to 3.0.2 (UI, Documentation, Readme)
+  - Greek localization updated to 3.0 (UI, Partial documentation, Instant Start)
+  - Japanese localization updated to 3.0.2 (UI)
+  - Slovenian localization updated to 3.0 (UI)
+  - Ukrainian localization updated to 3.0 (UI, Instant Start, Readme)
+  - Welsh localization updated to 3.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.2 update 1 (2013-05-21)
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.0.2 update 1 vs. 3.0.2
 
@@ -4059,7 +4059,7 @@ Rainbow.
 ----------------------------------------------------------------------
    2 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 3.0.2 vs. 3.0.1
 
@@ -4068,7 +4068,7 @@ Rainbow.
   - View log from within OmegaT
   https://sourceforge.net/p/omegat/feature-requests/243/
 
-  - Allow user to adjust tokenizer behavior
+  - Allow user to adjust tokenizer behaviour
   https://sourceforge.net/p/omegat/feature-requests/866/
 
 ----------------------------------------------------------------------
@@ -4076,7 +4076,7 @@ Rainbow.
 ----------------------------------------------------------------------
    5 Enhancements
    6 Bug fixes
-   8 Localisation updates
+   8 Localization updates
 ----------------------------------------------------------------------
 3.0.1 vs. 3.0.0
 
@@ -4118,23 +4118,23 @@ of OmegaT, the second instance would freeze
 
   - In some cases, MyMemory wasn't returning any results
 
-  Localisation updates:
+  Localization updates:
 
   - Belarusian localization updated to 3.0.0 (UI, Readme)
-  - Galician localisation updated to 3.0.0 (UI, Readme, Documentation)
-  - German localisation updated to 3.0.0 (UI, Readme, Instant Start)
-  - Greek localisation updated to 3.0.0 (UI, Instant Start)
-  - Hungarian localisation updated to 3.0.0 (UI)
-  - Japanese localisation updated to 3.0.1 (UI, Readme, Documentation)
-  - Simplified Chinese localisation updated to 3.0.0 (UI)
-  - Welsh localisation updated to 3.0.0 (UI, Readme, Instant Start)
+  - Galician localization updated to 3.0.0 (UI, Readme, Documentation)
+  - German localization updated to 3.0.0 (UI, Readme, Instant Start)
+  - Greek localization updated to 3.0.0 (UI, Instant Start)
+  - Hungarian localization updated to 3.0.0 (UI)
+  - Japanese localization updated to 3.0.1 (UI, Readme, Documentation)
+  - Simplified Chinese localization updated to 3.0.0 (UI)
+  - Welsh localization updated to 3.0.0 (UI, Readme, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 3.0.0 (2013-04-25)
 ----------------------------------------------------------------------
   27 Enhancements
    5 Bug fixes
-   7 Localisation updates
+   7 Localization updates
 ----------------------------------------------------------------------
 3.0.0 vs. 2.6.3
 
@@ -4242,22 +4242,22 @@ OmegaT failed to load the valid ones
 
   - OmegaT team projects were not working behind some firewalls
 
-  Localisation updates:
+  Localization updates:
 
-  - Basque localisation updated to 3.0.0 (UI, readme, Instant Start)
-  - Brazilian Portuguese localisation updated to 3.0.0 (UI, Instant Start)
-  - Dutch localisation updated to 3.0.0 (UI, readme, Instant Start)
-  - Italian localisation updated to 3.0.0 (UI, readme, Instant Start)
-  - Japanese localisation updated to 3.0.0 (UI)
-  - Russian localisation updated to 3.0.0 (UI, readme, Instant Start)
-  - Turkish localisation updated to 3.0.0 (UI)
+  - Basque localization updated to 3.0.0 (UI, readme, Instant Start)
+  - Brazilian Portuguese localization updated to 3.0.0 (UI, Instant Start)
+  - Dutch localization updated to 3.0.0 (UI, readme, Instant Start)
+  - Italian localization updated to 3.0.0 (UI, readme, Instant Start)
+  - Japanese localization updated to 3.0.0 (UI)
+  - Russian localization updated to 3.0.0 (UI, readme, Instant Start)
+  - Turkish localization updated to 3.0.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 11 (2014-08-06)
 ----------------------------------------------------------------------
    3 Enhancements
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 11 vs. 2.6.3 update 10
 
@@ -4283,16 +4283,16 @@ ant-contrib. See details in /release/WebStart-specific/build.xml
   - Excel files: when using the option to translate sheet names, some not-
 translatable text could appear (the content of <definedNames> tags)
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.6.3 update 10 (UI, readme)
+  - Japanese localization updated to 2.6.3 update 10 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 10 (2014-06-18)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 10 vs. 2.6.3 update 9
 
@@ -4303,16 +4303,16 @@ translatable text could appear (the content of <definedNames> tags)
   - In team projects, a "server authentication" could happen, which
 prevented from properly entering credentials
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.6.3 update 7 (Documentation)
+  - Japanese localization updated to 2.6.3 update 7 (Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 9 (2014-03-24)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 9 vs. 2.6.3 update 8
 
@@ -4321,16 +4321,16 @@ prevented from properly entering credentials
   - There was still an issue with team projects, where newer translations
 could sometimes be overwritten by older ones. It should now be fixed.
 
-  Localisation updates:
+  Localization updates:
 
-  - Interlingua localisation updated to 2.6.3 update 7 (UI, readme, Documentation)
+  - Interlingua localization updated to 2.6.3 update 7 (UI, readme, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 8 (2014-02-25)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 8 vs. 2.6.3 update 7
 
@@ -4349,7 +4349,7 @@ sometimes be overwritten by older ones.
 ----------------------------------------------------------------------
    1 Enhancement
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 7 vs. 2.6.3 update 6
 
@@ -4375,7 +4375,7 @@ blocked or not. This was fixed, and no question is asked anymore.
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 6 vs. 2.6.3 update 5
 
@@ -4388,7 +4388,7 @@ blocked or not. This was fixed, and no question is asked anymore.
 ----------------------------------------------------------------------
    1 Enhancement
    5 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 5 vs. 2.6.3 update 4
 
@@ -4419,7 +4419,7 @@ trailing spaces were not removed
 ----------------------------------------------------------------------
    0 Enhancement
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 4 vs. 2.6.3 update 3
 
@@ -4441,7 +4441,7 @@ resource for bundle java.util.PropertyResourceBundle, key INITIALIZING
 ----------------------------------------------------------------------
    0 Enhancement
    4 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.6.3 update 3 vs. 2.6.3 update 2
 
@@ -4459,16 +4459,16 @@ under Git
   - HTML filter: submit and button input values were translated even
  when not configured to do so
 
-  Localisation updates:
+  Localization updates:
 
-  - French localisation updated to 2.6.3 (Documentation)
+  - French localization updated to 2.6.3 (Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 2 (2013-05-29)
 ----------------------------------------------------------------------
    1 Enhancement
    0 Bug fix
-   10 Localisation updates
+   10 Localization updates
 ----------------------------------------------------------------------
 2.6.3 update 2 vs. 2.6.3 update 1
 
@@ -4476,26 +4476,26 @@ under Git
 
   - Add \bn\.\s as an exception to Finnish rules
 
-  Localisation updates:
+  Localization updates:
 
-  - Belarusian localisation updated to 2.6.3 (backported from 3.0) (UI, Readme)
-  - Catalan localisation updated to 2.6.3 (UI, Readme, Instant Start)
-  - Czech localisation updated to 2.6.3 (UI, Readme, Documentation)
-  - Galician localisation backported from 3.0.0 (Documentation)
-  - German localisation updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
-  - Greek localisation updated to 2.6.3 (backported from 3.0) (UI, Instant Start)
-  - Hungarian localisation updated to 2.6.3 (backported from 3.0) (UI)
-  - Japanese localisation updated to 2.6.3-2 (Documentation)
-  - Turkish localisation updated to 2.6.3 (backported from 3.0) (UI)
-  - Simplified Chinese localisation updated to 2.6.3 (backported from 3.0) (UI)
-  - Welsh localisation updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
+  - Belarusian localization updated to 2.6.3 (backported from 3.0) (UI, Readme)
+  - Catalan localization updated to 2.6.3 (UI, Readme, Instant Start)
+  - Czech localization updated to 2.6.3 (UI, Readme, Documentation)
+  - Galician localization backported from 3.0.0 (Documentation)
+  - German localization updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
+  - Greek localization updated to 2.6.3 (backported from 3.0) (UI, Instant Start)
+  - Hungarian localization updated to 2.6.3 (backported from 3.0) (UI)
+  - Japanese localization updated to 2.6.3-2 (Documentation)
+  - Turkish localization updated to 2.6.3 (backported from 3.0) (UI)
+  - Simplified Chinese localization updated to 2.6.3 (backported from 3.0) (UI)
+  - Welsh localization updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 update 1 (2013-04-25)
 ----------------------------------------------------------------------
    3 Enhancements
    2 Bug fixes
-   7 Localisation updates
+   7 Localization updates
 ----------------------------------------------------------------------
 2.6.3 update 1 vs. 2.6.3
 
@@ -4516,22 +4516,22 @@ external entities, the target files could be empty
 
   - Word selection with a double-click could sometimes be off
 
-  Localisation updates:
+  Localization updates:
 
   - Dutch localization updated to 2.6.3 (UI, Documentation, Readme)
-  - Interlingua localisation updated to 2.6.3 (UI, Readme, Instant Start)
-  - Italian localisation updated to 2.6.3 (UI, Readme, Documentation)
-  - Japanese localisation updated to 2.6.3 (UI, Documentation)
-  - Russian localisation updated to 2.6.3 (UI, , Readme, Documentation)
-  - Basque localisation updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
-  - Brasilian Portuguese localisation updated to 2.6.3 (backported from 3.0) (UI, Instant Start)
+  - Interlingua localization updated to 2.6.3 (UI, Readme, Instant Start)
+  - Italian localization updated to 2.6.3 (UI, Readme, Documentation)
+  - Japanese localization updated to 2.6.3 (UI, Documentation)
+  - Russian localization updated to 2.6.3 (UI, , Readme, Documentation)
+  - Basque localization updated to 2.6.3 (backported from 3.0) (UI, Readme, Instant Start)
+  - Brasilian Portuguese localization updated to 2.6.3 (backported from 3.0) (UI, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.3 (2013-03-08)
 ----------------------------------------------------------------------
    3 Enhancements
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.3 vs. 2.6.2
 
@@ -4556,7 +4556,7 @@ machines
 ----------------------------------------------------------------------
   10 Enhancements
    4 Bug fixes
-   4 Localisation updates
+   4 Localization updates
 ----------------------------------------------------------------------
 2.6.2 vs. 2.6.1 update 2
 
@@ -4610,19 +4610,19 @@ to synchronise it.
   - In the Fuzzy Matches pane, depending on the order of the options,
 the display could be corrupted when ${diff} was used
 
-  Localisation updates:
+  Localization updates:
 
-  - Slovenian localisation updated to 2.6.1 update 2 (UI)
+  - Slovenian localization updated to 2.6.1 update 2 (UI)
   - Dutch localization updated to 2.6.1 update 2 (UI, documentation, readme)
   - Russian localization updated to 2.6.1 update 2 (UI, documentation, readme)
-  - Italian localisation updated to 2.6.1 update 2 (UI)
+  - Italian localization updated to 2.6.1 update 2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.6.1 update 2 (2012-12-06)
 ----------------------------------------------------------------------
   11 Enhancements
    7 Bug fixes
-   7 Localisation updates
+   7 Localization updates
 ----------------------------------------------------------------------
 2.6.1 update 2 vs. 2.6.1 update 1
 
@@ -4681,10 +4681,10 @@ and doesn't show files any more.
 
   - Multiple save commands could interfere, causing you to lose all translations in team project.
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.6.1 update 2 (UI)
-  - Italian localisation updated to 2.6.1 (UI)
+  - Japanese localization updated to 2.6.1 update 2 (UI)
+  - Italian localization updated to 2.6.1 (UI)
   - Czech localization updated to 2.6.0 update 2 (UI, documentation, readme)
   - Russian localization updated to 2.6.1 (UI, documentation, readme)
   - Dutch localization updated to 2.6.0 (UI, documentation, readme)
@@ -4696,7 +4696,7 @@ and doesn't show files any more.
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.1 update 1 vs. 2.6.1
 
@@ -4710,7 +4710,7 @@ to load a file
 ----------------------------------------------------------------------
    8 Enhancements
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.1 vs. 2.6.0 update 4
 
@@ -4764,7 +4764,7 @@ was not showing the saved setting
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.6.0 update 2 vs. 2.6.0 update 1
 
@@ -4773,7 +4773,7 @@ was not showing the saved setting
   - Automatic loading of translations from the /tm/auto folder had
 stopped working except under Windows
 
-  Localisation updates:
+  Localization updates:
 
   - Japanese localization updated to 2.6.0 update 1 (UI)
   - Italian localization updated to 2.6.0 update 1 (UI)
@@ -4783,7 +4783,7 @@ stopped working except under Windows
 ----------------------------------------------------------------------
    2 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.0 update 1 vs. 2.6.0
 
@@ -4801,7 +4801,7 @@ to write in the repository anymore
 ----------------------------------------------------------------------
    3 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.6.0 vs. 2.5.3
 
@@ -4822,7 +4822,7 @@ to write in the repository anymore
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.5 update 5 vs. 2.5.5 update 4
 
@@ -4840,7 +4840,7 @@ to write in the repository anymore
 ----------------------------------------------------------------------
    4 Enhancements
    0 Bug fix
-   4 Localisation updates
+   4 Localization updates
 ----------------------------------------------------------------------
 2.5.5 update 4 vs. 2.5.5 update 3
 
@@ -4851,7 +4851,7 @@ to write in the repository anymore
   - Finnish segmentation rules
   - Japanese segmentation rules modifications
 
-  Localisation updates:
+  Localization updates:
 
   - Dutch localization updated to 2.5.5 (UI, documentation, readme)
   - Russian localization updated to 2.5.5 (UI, documentation, readme)
@@ -4863,7 +4863,7 @@ to write in the repository anymore
 ----------------------------------------------------------------------
    2 Enhancements
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.5 update 3 vs. 2.5.5 update 2
 
@@ -4878,7 +4878,7 @@ to write in the repository anymore
   - <revision> tags were shown to the translator in the TXML (Wordfast)
 filter
 
-  Localisation updates:
+  Localization updates:
 
   - German localization updated to 2.5.5 (UI)
 
@@ -4887,7 +4887,7 @@ filter
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.5 update 2 vs. 2.5.5 update 1
 
@@ -4901,7 +4901,7 @@ filter
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.5 update 1 vs. 2.5.5
 
@@ -4912,7 +4912,7 @@ filter
 
   - PowerPoint documents (.pptx and .pptm) could not be opened with Java 1.7
 
-  Localisation updates:
+  Localization updates:
 
   - Japanese localization updated to 2.5.5 (UI)
 
@@ -4921,7 +4921,7 @@ filter
 ----------------------------------------------------------------------
    3 Enhancements
    5 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.5.5 vs. 2.5.4 update 1
 
@@ -4957,16 +4957,16 @@ in RTL mode with Shift+Ctrl+O, spaces could be wrongly located. As a workaround,
 tags are not displayed in grey when translating an RTL language is involved or when
 the Editor is in RTL mode.
 
-  Localisation updates:
+  Localization updates:
 
-  - Russian localisation updated to 2.5.4 update 1 (UI, Instant Start)
+  - Russian localization updated to 2.5.4 update 1 (UI, Instant Start)
   - Japanese localization updated to 2.5.5 (UI)
 ----------------------------------------------------------------------
  OmegaT 2.5.4 update 1 (2012-05-22)
 ----------------------------------------------------------------------
    3 Enhancements
    4 Bug fixes
-   4 Localisation updates
+   4 Localization updates
 ----------------------------------------------------------------------
 2.5.4 update 1 vs. 2.5.4
 
@@ -4998,19 +4998,19 @@ labelled jCheckBox1 instead of "Enable project specific filters"
   - When changing project-specific segmentation rules to default and back,
 the results were not immediately visible
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.5.4 (UI, readme)
-  - Dutch localisation updated to 2.5.4 (UI, readme, documentation)
-  - Russian localisation updated to 2.5.4 (UI, readme, Instant Start)
-  - Basque localisation updated to 2.5.2 (UI, readme, Instant Start)
+  - Italian localization updated to 2.5.4 (UI, readme)
+  - Dutch localization updated to 2.5.4 (UI, readme, documentation)
+  - Russian localization updated to 2.5.4 (UI, readme, Instant Start)
+  - Basque localization updated to 2.5.2 (UI, readme, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.4 (2012-05-09)
 ----------------------------------------------------------------------
    6 Enhancements
    0 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.4 vs. 2.5.3
 
@@ -5038,16 +5038,16 @@ has been extended with new variables for a given number of extensions
 See https://sourceforge.net/p/omegat/feature-requests/733/
 
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.5.3 (UI)
+  - Italian localization updated to 2.5.3 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.3 (2012-04-20)
 ----------------------------------------------------------------------
    3 Enhancements
    3 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.3 vs. 2.5.2 update 2
 
@@ -5080,16 +5080,16 @@ in the target document.
 segment was not an attribute, and therefore had no comments to
 display
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.5.2 update 2 (UI)
+  - Italian localization updated to 2.5.2 update 2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.2 update 2 (2012-03-30)
 ----------------------------------------------------------------------
    1 Enhancement
    5 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.2 update 2 vs. 2.5.2
 
@@ -5116,16 +5116,16 @@ system line separator (e.g., CR+LF under Windows, LF under Linux)
 
   - In the Android filter, the "do not translate" mark has been corrected
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.5.2 (UI)
+  - Dutch localization updated to 2.5.2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.2 update 1 (2012-03-19)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.2 update 1 vs. 2.5.2
 
@@ -5141,7 +5141,7 @@ was done in project properties.
 ----------------------------------------------------------------------
    8 Enhancements
    2 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 2.5.2 vs. 2.5.1 update 1
 
@@ -5180,20 +5180,20 @@ even if it was empty
 
   - When using Insert Source Tags, a space was added before the first one
 
-  Localisation updates:
+  Localization updates:
 
-  - Simplified Chinese localisation updated to 2.5.0 (UI, readme, documentation)
-  - Italian localisation updated to 2.5.1 (UI)
-  - Dutch localisation updated to 2.5.1 (UI)
-  - Japanese localisation updated to 2.5.1 (UI)
-  - Slovenian localisation updated to 2.5.2 (UI)
+  - Simplified Chinese localization updated to 2.5.0 (UI, readme, documentation)
+  - Italian localization updated to 2.5.1 (UI)
+  - Dutch localization updated to 2.5.1 (UI)
+  - Japanese localization updated to 2.5.1 (UI)
+  - Slovenian localization updated to 2.5.2 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.1 update 1 (2012-02-18)
 ----------------------------------------------------------------------
    2 Enhancements
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.1 update 1 vs. 2.5.1
 
@@ -5218,7 +5218,7 @@ even if it was empty
 ----------------------------------------------------------------------
   10 Enhancements
    1 Bug fix
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.5.1 vs. 2.5.0 update 5
 
@@ -5236,7 +5236,7 @@ even if it was empty
   - Validate Java MessageFormat pattern tags ({0} etc.)
   https://sourceforge.net/p/omegat/feature-requests/752/
 
-  - Render tags in different color in editor
+  - Render tags in different colour in editor
   https://sourceforge.net/p/omegat/feature-requests/471/
 
   - Add "date" & "time" to translated file name pattern
@@ -5261,17 +5261,17 @@ not only OmegaT-tags
   - Camtasia filter: <Line> is incorrectly added as src segment
   https://sourceforge.net/p/omegat/bugs/530/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.5.0 update 5 (UI, readme, documentation)
-  - Italian localisation updated to 2.5.0 update 5 (UI, Instant Start, readme)
+  - Dutch localization updated to 2.5.0 update 5 (UI, readme, documentation)
+  - Italian localization updated to 2.5.0 update 5 (UI, Instant Start, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.0 update 5 (2012-01-16)
 ----------------------------------------------------------------------
    9 Enhancements
    5 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.5.0 update 5 vs. 2.5.0 update 4
 
@@ -5326,17 +5326,17 @@ for all segments
   - For external TMXs, the parameter "Use XML for standalone tags" was not
 working for all tags
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.5.0 update 3 (UI, readme, documentation)
-  - Italian localisation updated to 2.5.0 update 3 (UI)
+  - Dutch localization updated to 2.5.0 update 3 (UI, readme, documentation)
+  - Italian localization updated to 2.5.0 update 3 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.0 update 4 (2011-11-17)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.0 update 4 vs. 2.5.0 update 3
 
@@ -5349,7 +5349,7 @@ working for all tags
 ----------------------------------------------------------------------
    8 Enhancements
    3 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.0 update 3 vs. 2.5.0 update 2
 
@@ -5392,16 +5392,16 @@ launched directly under the Scripting menu entry. Requires version
   - Entering an empty target segment was creating an empty translation
 instead of removing the translation
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.5.0 update 2 (UI, readme)
+  - Italian localization updated to 2.5.0 update 2 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.0 update 2 (2011-11-02)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.5.0 update 2 vs. 2.5.0 update 1
 
@@ -5418,7 +5418,7 @@ no tags at all
 ----------------------------------------------------------------------
    1 Enhancement
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.5.0 update 1 vs. 2.5.0
 
@@ -5441,17 +5441,17 @@ translations in TMX
   - Search function doesn't work when searching files
   https://sourceforge.net/p/omegat/bugs/512/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.5.0 (UI)
-  - Italian localisation updated to 2.5.0 (UI, Instant Start, readme)
+  - Dutch localization updated to 2.5.0 (UI)
+  - Italian localization updated to 2.5.0 (UI, Instant Start, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.5.0 (2011-09-27)
 ----------------------------------------------------------------------
    8 Enhancements
    0 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.5.0 vs. 2.3.0 update 2
 
@@ -5493,16 +5493,16 @@ save of project_save.tmx, instead of the time when the backup occurs.
 A new backup (project_save.tmx.bak) is also done each time the project
 is saved.
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.5 (UI)
+  - Dutch localization updated to 2.5 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.3.0 update 8 (2012-04-28)
 ----------------------------------------------------------------------
    1 Enhancement
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 8 vs. 2.3.0 update 7
 
@@ -5516,7 +5516,7 @@ is saved.
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.3.0 update 7 vs. 2.3.0 update 6
 
@@ -5530,15 +5530,15 @@ is saved.
   - Yiddish (language code "YI" or "JI") was not declared as a right
 to left language
 
-  - Simplified Chinese localisation updated to 2.3 (backported from 2.5.0) (documentation)
-  - Japanese localisation updated to 2.3 (UI)
+  - Simplified Chinese localization updated to 2.3 (backported from 2.5.0) (documentation)
+  - Japanese localization updated to 2.3 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.3.0 update 6 (2012-01-27)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 6 vs. 2.3.0 update 5
 
@@ -5552,7 +5552,7 @@ to left language
 ----------------------------------------------------------------------
    1 Enhancement
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 5 vs. 2.3.0 update 4
 
@@ -5566,7 +5566,7 @@ sending 5000 instead of 2000 characters requests
 ----------------------------------------------------------------------
    1 Enhancement
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 4 vs. 2.3.0 update 3
 
@@ -5590,16 +5590,16 @@ the dictionaries could fail to be recognised
   - Some Open XML files could not be loaded, because they used
 backslashes instead of slashes in the zip container
 
-  Localisation updates:
-  - Slovenian localisation updated to 2.3 (UI)
-  - Dutch localisation updated to 2.3 (backported from 2.5.0 update 3) (documentation)
+  Localization updates:
+  - Slovenian localization updated to 2.3 (UI)
+  - Dutch localization updated to 2.3 (backported from 2.5.0 update 3) (documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.3.0 update 3 (2011-10-21)
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 3 vs. 2.3.0 update 2
 
@@ -5618,7 +5618,7 @@ hidden in OmegaT
 ----------------------------------------------------------------------
    1 Enhancement
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.3.0 update 2 vs. 2.3.0 update 1
 
@@ -5634,15 +5634,15 @@ tags
 
   - Parse exception in the LaTeX filter
 
-  Localisation updates:
-  - Spanish localisation updated to 2.3 (UI, documentation, readme)
+  Localization updates:
+  - Spanish localization updated to 2.3 (UI, documentation, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.3.0 update 1 (2011-07-29)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.3.0 update 1 vs. 2.3.0
 
@@ -5651,18 +5651,18 @@ tags
   - Mozilla DTD handler is skipping segments
   https://sourceforge.net/p/omegat/bugs/502/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.3, backported from 2.5 (UI)
-  - Hungarian localisation updated to 2.3 (UI, Instant Start)
-  - Italian localisation updated to 2.3 (UI, Instant Start, readme)
+  - Dutch localization updated to 2.3, backported from 2.5 (UI)
+  - Hungarian localization updated to 2.3 (UI, Instant Start)
+  - Italian localization updated to 2.3 (UI, Instant Start, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.3.0 (2011-07-09)
 ----------------------------------------------------------------------
   10 Enhancements
    6 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.3.0 vs. 2.2.3 update 4
 
@@ -5718,17 +5718,17 @@ translation in OmegaT
 
   - XLIFF filter: in some cases, some extra tags could appear
 
-  Localisation updates:
+  Localization updates:
 
-  - Brazilian Portuguese localisation updated to 2.2.3 update 2 (UI, documentation)
-  - Dutch localisation updated to 2.2.4 (UI)
+  - Brazilian Portuguese localization updated to 2.2.3 update 2 (UI, documentation)
+  - Dutch localization updated to 2.2.4 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.3 update 4 (2011-03-19)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.2.3 update 4 vs. 2.2.3 update 3
 
@@ -5747,7 +5747,7 @@ dictionary. The affected locales were "id", which was changed to "in",
 ----------------------------------------------------------------------
    0 Enhancement
    4 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.2.3 update 3 vs. 2.2.3 update 2
 
@@ -5763,18 +5763,18 @@ with a preceding \
   - XML: preserve spaces
   https://sourceforge.net/p/omegat/bugs/287/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.2.3 update 2 (UI, documentation)
-  - Czech localisation updated to 2.2.3 update 2 (UI, documentation, readme)
-  - Brazilian Portuguese localisation updated to 2.2.3 update 2 (UI, Instant Start, readme)
+  - Italian localization updated to 2.2.3 update 2 (UI, documentation)
+  - Czech localization updated to 2.2.3 update 2 (UI, documentation, readme)
+  - Brazilian Portuguese localization updated to 2.2.3 update 2 (UI, Instant Start, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.3 update 2 (2011-01-22)
 ----------------------------------------------------------------------
    2 Enhancements
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.2.3 update 2 vs. 2.2.3 update 1
 
@@ -5798,16 +5798,16 @@ variable was wrongly spelt: ${targetCoutryCode} instead of
 ${targetCountryCode}. Configurations with the old variable name will
 still work.
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.2.3 (UI)
+  - Dutch localization updated to 2.2.3 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.3 update 1 (2011-01-12)
 ----------------------------------------------------------------------
    3 Enhancements
    5 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.2.3 update 1 vs. 2.2.3
 
@@ -5842,16 +5842,16 @@ empty
 Translate href, Translate comments) only took effect after quitting
 and restarting OmegaT
 
-  Localisation updates:
+  Localization updates:
 
-  - Hungarian localisation updated to 2.2.3 (UI, documentation, readme)
+  - Hungarian localization updated to 2.2.3 (UI, documentation, readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.3 (2010-12-22)
 ----------------------------------------------------------------------
    4 Enhancements
    1 Bug fix
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 2.2.3 vs. 2.2.2 update 1
 
@@ -5876,20 +5876,20 @@ and restarting OmegaT
   - When a paragraph-based TMX was resegmented to sequence mode, the
 source language rules were used to segment the target paragraph
 
-  Localisation updates:
+  Localization updates:
 
-  - Belarusian localisation updated to 2.2.1 update 1 (UI)
-  - Italian localisation updated to 2.2.2 update 1 (UI)
-  - Catalan localisation updated to 2.2.2 update 1 (UI, Readme, documentation)
-  - Dutch localisation updated to 2.2.2 (UI, documentation)
-  - Japanese localisation updated to 2.2.3 (UI)
+  - Belarusian localization updated to 2.2.1 update 1 (UI)
+  - Italian localization updated to 2.2.2 update 1 (UI)
+  - Catalan localization updated to 2.2.2 update 1 (UI, Readme, documentation)
+  - Dutch localization updated to 2.2.2 (UI, documentation)
+  - Japanese localization updated to 2.2.3 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.2 update 1 (2010-12-10)
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.2.2 update 1 vs. 2.2.2
 
@@ -5903,7 +5903,7 @@ to XML entities in the target document
 ----------------------------------------------------------------------
    2 Enhancements
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.2.2 vs. 2.2.1
 
@@ -5914,11 +5914,11 @@ to XML entities in the target document
 
   - Partial support for StarDict dictionaries with sametypesequence=x
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.2.2 (UI)
-  - Italian localisation updated to 2.2.1 (UI, documentation)
-  - Dutch localisation updated to 2.2.1 (UI)
+  - Japanese localization updated to 2.2.2 (UI)
+  - Italian localization updated to 2.2.1 (UI, documentation)
+  - Dutch localization updated to 2.2.1 (UI)
 
   Bug fixes:
 
@@ -5930,13 +5930,13 @@ to XML entities in the target document
 ----------------------------------------------------------------------
    0 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.2.1 update 1 vs. 2.2.1
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.2.1 (UI)
+  - Japanese localization updated to 2.2.1 (UI)
 
   Bug fixes:
 
@@ -5951,7 +5951,7 @@ didn't appear in bold.
 ----------------------------------------------------------------------
    4 Enhancements
    3 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 2.2.1 vs. 2.2.0 update 4
 
@@ -5973,13 +5973,13 @@ or "Hidden attribute" in Word.
 allows to set whether all source segments are bold (as previously), or
 only the current one.
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.2.0 (UI, Readme, documentation)
-  - Basque localisation updated to 2.2.0 (UI, Readme, documentation)
-  - Dutch localisation updated to 2.2.0 (UI, Readme, documentation)
-  - Japanese localisation updated to 2.2.0 (UI)
-  - Belarusian localisation updated to 2.1.0 (UI)
+  - Italian localization updated to 2.2.0 (UI, Readme, documentation)
+  - Basque localization updated to 2.2.0 (UI, Readme, documentation)
+  - Dutch localization updated to 2.2.0 (UI, Readme, documentation)
+  - Japanese localization updated to 2.2.0 (UI)
+  - Belarusian localization updated to 2.1.0 (UI)
 
   Bug fixes:
 
@@ -5997,7 +5997,7 @@ characters.
 ----------------------------------------------------------------------
    1 Enhancement
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.2.0 update 4 vs. 2.2.0 update 3
 
@@ -6006,10 +6006,10 @@ characters.
   - The options of the Open XML filter have been reorganised because
 some options (e.g., Diagrams) apply to all the documents.
 
-  Localisation updates:
+  Localization updates:
 
-  - Russian localisation updated to 2.2.0 (UI, Instant Start, Readme)
-  - Swedish localisation updated to 2.2.0 (UI, Instant Start, Readme)
+  - Russian localization updated to 2.2.0 (UI, Instant Start, Readme)
+  - Swedish localization updated to 2.2.0 (UI, Instant Start, Readme)
 
   Bug fixes:
 
@@ -6024,7 +6024,7 @@ translation
 ----------------------------------------------------------------------
    3 Enhancements
    0 Bug fix
-   2 Localisation update
+   2 Localization update
 ----------------------------------------------------------------------
 2.2.0 update 3 vs. 2.2.0 update 2
 
@@ -6040,17 +6040,17 @@ translation
   - The "HTML and XHTML files segmentation" segmentation rule has been renamed
 to "HTML, XHTML and ODF segmentation"
 
-  Localisation updates:
+  Localization updates:
 
-  - Polish localisation updated to 2.1.3 (UI, Instant Start, Readme, documentation)
-  - Brazilian Portuguese localisation updated to 2.2.0 (UI, Instant Start, Readme)
+  - Polish localization updated to 2.1.3 (UI, Instant Start, Readme, documentation)
+  - Brazilian Portuguese localization updated to 2.2.0 (UI, Instant Start, Readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.0 update 2 (2010-10-21)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.2.0 update 2 vs. 2.2.0 update 1
 
@@ -6062,16 +6062,16 @@ characters. This applied also to the HTML Help Compiler Filter.
   - MT using Google fails to give results in Traditional Chinese
   https://sourceforge.net/p/omegat/bugs/481/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.2.0 update 1 (UI, Instant Start, Readme, documentation)
+  - Italian localization updated to 2.2.0 update 1 (UI, Instant Start, Readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.0 update 1 (2010-10-13)
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.2.0 update 1 vs. 2.2.0
 
@@ -6085,18 +6085,18 @@ characters. This applied also to the HTML Help Compiler Filter.
   - XML, wrong handling of comments and PI in translatable text
   https://sourceforge.net/p/omegat/bugs/297/
 
-  Localisation updates:
+  Localization updates:
 
-  - Galician localisation updated to 2.1.9 (UI, Instant Start, Readme)
-  - Italian localisation updated to 2.2.0 (UI, Instant Start, Readme)
-  - Japanese localisation updated to 2.2.0 (UI, Instant Start, Readme, 2.0.5 documentation)
+  - Galician localization updated to 2.1.9 (UI, Instant Start, Readme)
+  - Italian localization updated to 2.2.0 (UI, Instant Start, Readme)
+  - Japanese localization updated to 2.2.0 (UI, Instant Start, Readme, 2.0.5 documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.2.0 (2010-10-03)
 ----------------------------------------------------------------------
    1 Enhancement
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.2.0 vs. 2.1.9
 
@@ -6122,7 +6122,7 @@ of unfiltered results
 ----------------------------------------------------------------------
    0 Enhancement
    4 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.1.9 vs. 2.1.8 update 1
 
@@ -6138,18 +6138,18 @@ of unfiltered results
   - Very slow editor with Java 1.6 on a Mac
   https://sourceforge.net/p/omegat/bugs/479/
 
-  Localisation updates:
+  Localization updates:
 
-  - Swedish localisation updated to 2.1.8 (UI, Readme)
-  - Italian localisation updated to 2.1.8 (UI, Readme, Instant Start)
-  - Dutch localisation updated to 2.1.8 (UI, Readme, Instant Start, documentation)
+  - Swedish localization updated to 2.1.8 (UI, Readme)
+  - Italian localization updated to 2.1.8 (UI, Readme, Instant Start)
+  - Dutch localization updated to 2.1.8 (UI, Readme, Instant Start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.8 update 1 (2010-08-25)
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.8 update 1 vs. 2.1.8
 
@@ -6166,7 +6166,7 @@ of unfiltered results
 ----------------------------------------------------------------------
    1 Enhancement
    0 Bug fix
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.1.8 vs. 2.1.7 update 3
 
@@ -6175,17 +6175,17 @@ of unfiltered results
   - Aggregate OpenXML tags
   https://sourceforge.net/p/omegat/feature-requests/629/
 
-  Localisation updates:
+  Localization updates:
 
-  - Italian localisation updated to 2.1.7 (UI, Readme, Instant Start)
-  - Spanish localisation updated to 2.1.7 (UI, Readme, Instant Start, documentation)
+  - Italian localization updated to 2.1.7 (UI, Readme, Instant Start)
+  - Spanish localization updated to 2.1.7 (UI, Readme, Instant Start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.7 update 3 (2010-07-22)
 ----------------------------------------------------------------------
    2 Enhancements
    5 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.7 update 3 vs. 2.1.7 update 2
 
@@ -6223,7 +6223,7 @@ translator.
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.1.7 update 2 vs. 2.1.7 update 1
 
@@ -6236,16 +6236,16 @@ on supported file formats
 
   - In some circumstances, the search results could be all highlighted
 
-  Localisation updates
+  Localization updates
 
-  - Japanese localisation updated to 2.1.x (UI, Readme, Instant Start)
+  - Japanese localization updated to 2.1.x (UI, Readme, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.7 update 1 (2010-06-27)
 ----------------------------------------------------------------------
    1 Enhancement
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.1.7 update 1 vs. 2.1.7
 
@@ -6262,17 +6262,17 @@ on supported file formats
   - Search window - search items containing $ behave strangely
   https://sourceforge.net/p/omegat/bugs/472/
 
-  Localisation updates:
+  Localization updates:
 
-  - Danish localisation updated to 2.1.x (UI, Readme, Instant Start)
-  - Czech localisation updated to 2.1.x (UI, Readme, Instant Start, documentation)
+  - Danish localization updated to 2.1.x (UI, Readme, Instant Start)
+  - Czech localization updated to 2.1.x (UI, Readme, Instant Start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.7 (2010-06-08)
 ----------------------------------------------------------------------
    6 Enhancements
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.1.7 vs. 2.1.6
 
@@ -6303,17 +6303,17 @@ on supported file formats
   - Cursor jumps to end of selection during Shift+left
   https://sourceforge.net/p/omegat/bugs/469/
 
-  Localisation updates:
+  Localization updates:
 
-  - Catalan localisation updated to 2.1.4 (UI, Readme, Instant Start, documentation)
-  - Hungarian localisation updated to 2.1.x (UI, Readme, Instant Start, documentation)
+  - Catalan localization updated to 2.1.4 (UI, Readme, Instant Start, documentation)
+  - Hungarian localization updated to 2.1.x (UI, Readme, Instant Start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.6 (2010-05-11)
 ----------------------------------------------------------------------
    2 Enhancements
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.6 vs. 2.1.5 update 1
 
@@ -6338,7 +6338,7 @@ in some circumstances
 ----------------------------------------------------------------------
    1 Enhancement
    2 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.5 update 1 vs. 2.1.5
 
@@ -6359,7 +6359,7 @@ in some circumstances
 ----------------------------------------------------------------------
    3 Enhancements
    1 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.5 vs. 2.1.4 update 1
 
@@ -6386,7 +6386,7 @@ For explanations, see Searches in the English documentation
 ----------------------------------------------------------------------
    6 Enhancements
    6 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.4 update 1 vs. 2.1.4
 
@@ -6435,7 +6435,7 @@ codes were entered in lowercase
 ----------------------------------------------------------------------
    7 Enhancements
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.4 vs. 2.1.3
 
@@ -6457,7 +6457,7 @@ http://sourceforge.net/projects/omegat-plugins)
 
    Other enhancements:
 
-   - File filter for WiX localisation files (.wxl)
+   - File filter for WiX localization files (.wxl)
 
    - sdlxliff added to the default list of XLIFF extensions
 
@@ -6482,7 +6482,7 @@ recognised
 ----------------------------------------------------------------------
    6 Enhancements
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.3 vs. 2.1.2
 
@@ -6522,7 +6522,7 @@ recognised
 ----------------------------------------------------------------------
   13 Enhancements
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.1.2 vs. 2.1.1
 
@@ -6580,17 +6580,17 @@ set in Editing Behaviour, the previous segment was entered as translation.
   - In search: '?' would find 0 or 1 character, while search instructions
 clearly state that it should find 1 character, which is now the case
 
-  Localisation updates:
+  Localization updates:
 
-  - Catalan localisation updated to 2.1.1 (UI, Readme, Instant Start, documentation)
-  - New Swedish localisation (2.1.0) (UI, Readme, Instant Start)
+  - Catalan localization updated to 2.1.1 (UI, Readme, Instant Start, documentation)
+  - New Swedish localization (2.1.0) (UI, Readme, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.1.1 (2009-12-14)
 ----------------------------------------------------------------------
    8 Enhancements
    6 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.1 vs. 2.1.0
 
@@ -6617,7 +6617,7 @@ clearly state that it should find 1 character, which is now the case
 
   - Text selected in the Glossary pane can be inserted with a right click
 
-  - New options to enable checking localisation variables
+  - New options to enable checking localization variables
   (see https://sourceforge.net/p/omegat/bugs/434/)
 
   Bug Fixes:
@@ -6644,7 +6644,7 @@ as a repetition in Match Statistics
 ----------------------------------------------------------------------
    2 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.1.0 vs. 2.0.5
 
@@ -6661,12 +6661,12 @@ as a repetition in Match Statistics
 ----------------------------------------------------------------------
    0 Enhancement
    0 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.0.5 update 4 vs. 2.0.5 update 3
 
-  Localisation updates:
-  - New Galician localisation (UI, Readme, Instant Start)
+  Localization updates:
+  - New Galician localization (UI, Readme, Instant Start)
   (backported from 2.1.4)
 
 ----------------------------------------------------------------------
@@ -6674,7 +6674,7 @@ as a repetition in Match Statistics
 ----------------------------------------------------------------------
    2 Enhancements
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.0.5 update 3 vs. 2.0.5 update 2
 
@@ -6698,10 +6698,10 @@ as a repetition in Match Statistics
 
   - Various corrections in the manual
 
-  Localisation updates:
+  Localization updates:
 
-  - Russian localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
-  - Simplified Chinese localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  - Russian localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  - Simplified Chinese localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
     (backported from 2.1.x)
 
 ----------------------------------------------------------------------
@@ -6709,25 +6709,25 @@ as a repetition in Match Statistics
 ----------------------------------------------------------------------
    0 Enhancement
    0 Bug fix
-   7 Localisation updates
+   7 Localization updates
 ----------------------------------------------------------------------
 2.0.5 update 2 vs. 2.0.5 update 1
 
-  Localisation updates:
-  - Basque localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
-  - Welsh localisation updated to 2.0.5 (UI, Readme, Instant Start)
-  - Catalan localisation updated to 2.0.5, backported from 2.1.1 (UI, Readme, Instant Start, documentation)
-  - New Swedish localisation (2.0.5), backported from 2.1.0 (UI, Readme, Instant Start)
-  - Czech localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
-  - Hungarian localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
-  - Dutch localisation updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  Localization updates:
+  - Basque localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  - Welsh localization updated to 2.0.5 (UI, Readme, Instant Start)
+  - Catalan localization updated to 2.0.5, backported from 2.1.1 (UI, Readme, Instant Start, documentation)
+  - New Swedish localization (2.0.5), backported from 2.1.0 (UI, Readme, Instant Start)
+  - Czech localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  - Hungarian localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
+  - Dutch localization updated to 2.0.5 (UI, Readme, Instant Start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.5 update 1 (2010-01-27)
 ----------------------------------------------------------------------
    5 Enhancements
    6 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.0.5 update 1 vs. 2.0.5
 
@@ -6742,7 +6742,7 @@ as a repetition in Match Statistics
 
   - Hunspell for Linux 64-bit updated to 1.2.8
 
-  - Images are included in the minimal localisation pack
+  - Images are included in the minimal localization pack
 
   - <wp:align> and <w:drawing> tags are hidden in the OpenXML filter
 
@@ -6763,17 +6763,17 @@ a space
   - Spanish exception rule error
   https://sourceforge.net/p/omegat/bugs/445/
 
-  Localisation updates:
+  Localization updates:
 
-  - Turkish localisation updated to 2.0.5 (UI, Readme, Instant Start)
-  - Slovenian localisation updated to 2.0.5 (documentation)
+  - Turkish localization updated to 2.0.5 (UI, Readme, Instant Start)
+  - Slovenian localization updated to 2.0.5 (documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.5 (2009-10-10)
 ----------------------------------------------------------------------
    2 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.0.5 vs. 2.0.4 update 1
 
@@ -6789,7 +6789,7 @@ a space
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.0.4 update 1 vs. 2.0.4
 
@@ -6803,17 +6803,17 @@ a space
   - PO: bad handling of already translated strings
   https://sourceforge.net/p/omegat/bugs/368/
 
-  Localisation updates:
+  Localization updates:
 
-  - German localisation updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
-  - Japanese localisation updated to 2.0.4 (UI, Instant Start)
+  - German localization updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
+  - Japanese localization updated to 2.0.4 (UI, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.4 (2009-09-09)
 ----------------------------------------------------------------------
    3 Enhancements
    0 Bug fix
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 2.0.4 vs. 2.0.3 update 2
 
@@ -6834,7 +6834,7 @@ a space
 ----------------------------------------------------------------------
    1 Enhancements
    2 Bug fixes
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.0.3 update 2 vs. 2.0.3 update 1
 
@@ -6848,33 +6848,33 @@ a space
   - A double click on the last segment was sending to the first one
   - OmegaT was only getting the first meaning in StarDict format
 
-  Localisation updates:
+  Localization updates:
 
-  - Belarusian localisation updated to 2.0.3 (UI)
-  - Dutch localisation updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
-  - Catalan localisation updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
+  - Belarusian localization updated to 2.0.3 (UI)
+  - Dutch localization updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
+  - Catalan localization updated to 2.0.3 (UI, Readme, Instant Start, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.3 update 1 (2009-07-09)
 ----------------------------------------------------------------------
    0 Enhancement
    0 Bug fix
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.0.3 update 1 vs. 2.0.3
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.0.3 (UI, Instant Start)
-  - German localisation updated to 2.0.3 (UI, Instant Start, Readme)
-  - Slovenian localisation updated to 2.0.3 (UI, Instant Start, Readme, documentation)
+  - Japanese localization updated to 2.0.3 (UI, Instant Start)
+  - German localization updated to 2.0.3 (UI, Instant Start, Readme)
+  - Slovenian localization updated to 2.0.3 (UI, Instant Start, Readme, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.3 (2009-06-13)
 ----------------------------------------------------------------------
    4 Enhancements
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.0.3 vs. 2.0.2 update 1
 
@@ -6901,16 +6901,16 @@ to the one obtained in OmegaT.
   - "Unable to read project file!" after creating a new project
   https://sourceforge.net/p/omegat/bugs/423/
 
-  Localisation updates:
+  Localization updates:
 
-  - Dutch localisation updated to 2.0.2 (UI, Instant Start, Readme, Documentation)
+  - Dutch localization updated to 2.0.2 (UI, Instant Start, Readme, Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.2 update 1 (2009-05-20)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 2.0.2 update 1 vs. 2.0.2
 
@@ -6921,17 +6921,17 @@ to the one obtained in OmegaT.
   - The Enter/Return key was creating a new line when Use TAB to Advance
 was checked
 
-  Localisation updates:
+  Localization updates:
 
-  - Slovenian localisation updated to 2.0.1 (UI, readme)
-  - Japanese localisation updated to 2.0.2 (UI, Instant Start)
+  - Slovenian localization updated to 2.0.1 (UI, readme)
+  - Japanese localization updated to 2.0.2 (UI, Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.2 (2009-05-14)
 ----------------------------------------------------------------------
    9 Enhancements
    9 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.0.2 vs. 2.0.1
 
@@ -7002,16 +7002,16 @@ of " +"
   - The SkipMeta option in the HTML and XHTML filters was not initialised to
 the default value
 
-  Localisation update:
+  Localization update:
 
-  - Spanish localisation updated to 2.0.1 (UI, readme, instant start)
+  - Spanish localization updated to 2.0.1 (UI, readme, instant start)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.1 (2009-02-16)
 ----------------------------------------------------------------------
    8 Enhancements
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 2.0.1 vs. 2.0.0 update 1
 
@@ -7048,16 +7048,16 @@ and copied to the clipboard.
   - Fix for detection of printf-variables with index specifier
   (for feature https://sourceforge.net/p/omegat/feature-requests/494/)
 
-  Localisation updates :
+  Localization updates :
 
-  - Slovenian localisation updated to 2.0 (readme)
+  - Slovenian localization updated to 2.0 (readme)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.0 update 1 (2009-01-09)
 ----------------------------------------------------------------------
    5 Enhancements
    1 Bug fix
-   3 Localisation updates
+   3 Localization updates
 ----------------------------------------------------------------------
 2.0.0 update 1 vs. 2.0.0
 
@@ -7097,18 +7097,18 @@ steps of matching:
   https://sourceforge.net/p/omegat/bugs/336/
   (Requires tokenizers from http://sourceforge.net/projects/omegat-plugins)
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 2.0 (UI)
-  - Basque localisation updated to 2.0 (UI)
-  - Slovenian localisation updated to 2.0 (UI)
+  - Japanese localization updated to 2.0 (UI)
+  - Basque localization updated to 2.0 (UI)
+  - Slovenian localization updated to 2.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 2.0.0 (2008-11-13)
 ----------------------------------------------------------------------
   13 Enhancements
    0  Bug fix
-   1 Localisation
+   1 Localization
 ----------------------------------------------------------------------
 2.0.0 vs. 1.8.1
 
@@ -7156,29 +7156,29 @@ can be applied or not with a new option in Options/Font.
 
   - OpenXML filter: New option to translate slide masters in PowerPoint documents
 
-  Localisation updates:
+  Localization updates:
 
-  - French localisation updated to 2.0 (UI)
+  - French localization updated to 2.0 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 7 (2009-10-01)
 ----------------------------------------------------------------------
    0 Enhancement
    0 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 1.8.1 update 7 vs. 1.8.1 update 6
 
-  Localisation updates:
+  Localization updates:
 
-  - Spanish localisation updated to 1.8 (Instant Start)
+  - Spanish localization updated to 1.8 (Instant Start)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 6 ( 2009-07-26)
 ----------------------------------------------------------------------
    1 Enhancement
    1 Bug fix
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 1.8.1 update 6 vs. 1.8.1 update 5
 
@@ -7191,16 +7191,16 @@ can be applied or not with a new option in Options/Font.
   - Windows: project's absolute paths are displayed with /
   https://sourceforge.net/p/omegat/bugs/428/
 
-  Localisation updates:
+  Localization updates:
 
-  - German localisation updated to 1.8 (UI, Instant Start, Readme, backported from 2.0.3)
+  - German localization updated to 1.8 (UI, Instant Start, Readme, backported from 2.0.3)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 5 (2009-06-08)
 ----------------------------------------------------------------------
    0 Enhancement
    2 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 1.8.1 update 5 vs. 1.8.1 update 4
 
@@ -7211,17 +7211,17 @@ can be applied or not with a new option in Options/Font.
 
   - XLIFF filter: the content of <seg-source> was visible
 
-  Localisation updates:
+  Localization updates:
 
   - Russian documentation updated to 1.8 (UI, Instant Start, readme, documentation)
-  - Dutch localisation updated to 1.8 (Documentation)
+  - Dutch localization updated to 1.8 (Documentation)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 4 (2009-04-23)
 ----------------------------------------------------------------------
    0 Enhancement
    4 Bug fixes
-   0 Localisation
+   0 Localization
 ----------------------------------------------------------------------
 1.8.1 update 4 vs. 1.8.1 update 3
 
@@ -7244,7 +7244,7 @@ translatable content
 ----------------------------------------------------------------------
    3 Enhancements
    3 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 1.8.1 update 3 vs. 1.8.1 update 2
 
@@ -7271,17 +7271,17 @@ translatable content
   - Linux: Exception on reading omegat/learned_words.txt
   https://sourceforge.net/p/omegat/bugs/414/
 
-  Localisation updates:
+  Localization updates:
 
-  - New Welsh localisation (UI, readme, instant start)
-  - czech localisation updated to 1.8 (UI, readme, instant start, documentation)
+  - New Welsh localization (UI, readme, instant start)
+  - czech localization updated to 1.8 (UI, readme, instant start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 2 (2009-02-05)
 ----------------------------------------------------------------------
    2 Enhancements
    3 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 1.8.1 update 2 vs. 1.8.1 update 1
 
@@ -7301,16 +7301,16 @@ launcher), based on version 3.0.1 of Launch4J.
   - Spellcheck: words added to dictionary lost after restart
   https://sourceforge.net/p/omegat/bugs/339/
 
-  Localisation updates:
+  Localization updates:
 
-  - Slovenian localisation updated to 1.8 (readme, instant start, documentation)
+  - Slovenian localization updated to 1.8 (readme, instant start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 update 1 (2009-01-09)
 ----------------------------------------------------------------------
    1 Enhancement
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 1.8.1 update 1 vs. 1.8.1
 
@@ -7332,17 +7332,17 @@ launcher), based on version 3.0.1 of Launch4J.
   The change might require to revalidate the translation for some existing
 segments
 
-  Localisation updates:
+  Localization updates:
 
-  - Japanese localisation updated to 1.8 (UI)
-  - Slovenian localisation updated to 1.8 (UI)
+  - Japanese localization updated to 1.8 (UI)
+  - Slovenian localization updated to 1.8 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.1 (2008-11-04)
 ----------------------------------------------------------------------
    4 Enhancements
    1 Bug fixe
-   4 Localisation updates
+   4 Localization updates
 ----------------------------------------------------------------------
 1.8.1 vs. 1.8.0 update 2
 
@@ -7368,19 +7368,19 @@ segments
   - Vista: wrong location of configuration files
   https://sourceforge.net/p/omegat/bugs/407/
 
-  Localisation updates:
+  Localization updates:
 
-  - Slovak localisation updated to 1.8 (UI)
-  - Dutch localisation updated to 1.8 (UI, readme)
-  - Czech localisation updated to 1.8 (UI, readme)
-  - Serbo-Croatian localisation updated to 1.8 (UI, readme)
+  - Slovak localization updated to 1.8 (UI)
+  - Dutch localization updated to 1.8 (UI, readme)
+  - Czech localization updated to 1.8 (UI, readme)
+  - Serbo-Croatian localization updated to 1.8 (UI, readme)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.0 update 2 (2008-05-12)
 ----------------------------------------------------------------------
    2 Enhancements
    4 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 1.8.0 update 2 vs. 1.8.0 update 1
 
@@ -7402,31 +7402,31 @@ segments
   - Non-ascii char badly handled in hunspell lib loading on OS-X
   https://sourceforge.net/p/omegat/bugs/350/
 
-  Localisation updates:
+  Localization updates:
 
-  - Catalan localisation updated to 1.8 (UI)
+  - Catalan localization updated to 1.8 (UI)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.0 update 1 (2008-03-30)
 ----------------------------------------------------------------------
    0 Enhancement
    0 Bug fix
-   0 Localisation updates
+   0 Localization updates
 ----------------------------------------------------------------------
 1.8.0 update 1 vs. 1.8.0
 
-  Localisation updates:
+  Localization updates:
 
-  - Albanian localisation updated to 1.8 (UI, readme)
-  - Belarusian localisation updated to 1.8 (UI)
-  - New Portuguese (Portugal) localisation (UI)
+  - Albanian localization updated to 1.8 (UI, readme)
+  - Belarusian localization updated to 1.8 (UI)
+  - New Portuguese (Portugal) localization (UI)
 
 ----------------------------------------------------------------------
  OmegaT 1.8.0 (2008-03-02)
 ----------------------------------------------------------------------
   13 Enhancements
    3 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 1.8.0 vs. 1.7.3 update 4
 
@@ -7482,7 +7482,7 @@ segments
   - Mistake of segmentation after <PRE>
   https://sourceforge.net/p/omegat/bugs/345/
 
-  Localisation updates:
+  Localization updates:
 
   - Belarusian UI updated to 1.7.+
   - French UI updated to 1.8
@@ -7492,7 +7492,7 @@ segments
 ----------------------------------------------------------------------
    0 Enhancement
    4 Bug fixes
-   2 Localisation updates
+   2 Localization updates
 ----------------------------------------------------------------------
 1.7.3 update 4 vs. 1.7.3 update 3
 
@@ -7512,15 +7512,15 @@ localization
 
   Other enhancements:
 
-  - Slovak localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Czech localisation updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Slovak localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Czech localization updated to 1.7.3 (UI, readme, instant start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 1.7.3 update 3 (2008-05-12)
 ----------------------------------------------------------------------
    2 Enhancements
    4 Bug fixes
-   0 Localisation update
+   0 Localization update
 ----------------------------------------------------------------------
 1.7.3 update 3 vs. 1.7.3 update 2
 
@@ -7551,7 +7551,7 @@ when uninstalling the JRE version
 ----------------------------------------------------------------------
    3 Enhancements
    3 Bug fixes
-   1 Localisation update
+   1 Localization update
 ----------------------------------------------------------------------
 1.7.3 update 2 vs. 1.7.3 update 1
 
@@ -7582,14 +7582,14 @@ when uninstalling the JRE version
 
   Other enhancements:
 
-  - New Arabic localisation (UI, readme, instant start)
+  - New Arabic localization (UI, readme, instant start)
 
 ----------------------------------------------------------------------
  OmegaT 1.7.3 update 1 (2008-02-17)
 ----------------------------------------------------------------------
    1 Enhancement
    7 Bug fixes
-   7 Localisation updates
+   7 Localization updates
 ----------------------------------------------------------------------
 1.7.3 update 1 vs. 1.7.3
 
@@ -7621,26 +7621,26 @@ when uninstalling the JRE version
   - Non-translatable strings displayed in OOo documents
   https://sourceforge.net/p/omegat/bugs/359/
 
-  Localisation updates:
+  Localization updates:
 
-  - Serbo-Croatian localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Slovenian localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Russian localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Basque localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Hungarian localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Catalan localisation updated to 1.7.3 (UI, readme, instant start, documentation)
-  - Dutch localisation updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Serbo-Croatian localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Slovenian localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Russian localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Basque localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Hungarian localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Catalan localization updated to 1.7.3 (UI, readme, instant start, documentation)
+  - Dutch localization updated to 1.7.3 (UI, readme, instant start, documentation)
 
 ----------------------------------------------------------------------
  OmegaT 1.7.3 (2007-11-28)
 ----------------------------------------------------------------------
    1 Enhancement
    3 Bug fixes
-   5 Localisation updates
+   5 Localization updates
 ----------------------------------------------------------------------
 1.7.3 vs. 1.7.2
 
-Contains a revised manual, two new localisations (Danish, polish) and bug fixes
+Contains a revised manual, two new localizations (Danish, polish) and bug fixes
 
   Other enhancements:
 
@@ -7657,24 +7657,24 @@ Contains a revised manual, two new localisations (Danish, polish) and bug fixes
   - Footnotes break segments in OOo 1.x documents
   https://sourceforge.net/p/omegat/bugs/333/
 
-  Localisation updates:
+  Localization updates:
 
-  - Danish 1.6.2 localisation + instant start
-  - Polish 1.6.2 localisation + partial manual
-  - Catalan localisation updated to 1.7.2
+  - Danish 1.6.2 localization + instant start
+  - Polish 1.6.2 localization + partial manual
+  - Catalan localization updated to 1.7.2
   - Belarusian UI updated to 1.7.2
-  - French localisation updated to 1.7.3
+  - French localization updated to 1.7.3
 
 ----------------------------------------------------------------------
  OmegaT 1.7.2 (2007-09-24)
 ----------------------------------------------------------------------
    3 Enhancements
    7 Bug fixes
-   8 Localisation updates
+   8 Localization updates
 ----------------------------------------------------------------------
 1.7.2 vs. 1.7.1
 
-Contains three new localisations (Simplified Chinese, Traditional Chinese and Czech) and bug fixes
+Contains three new localizations (Simplified Chinese, Traditional Chinese and Czech) and bug fixes
 
   Implemented requests:
 
@@ -7712,21 +7712,21 @@ Contains three new localisations (Simplified Chinese, Traditional Chinese and Cz
 
   Other enhancements:
 
-  - Simplified Chinese UI localisation + manual translation
-  - French localisation updated to 1.7.1
-  - Basque localisation updated to 1.7.1
-  - Slovak localisation updated to 1.7.1
-  - Serbo-Croatian localisation updated to 1.7.1
-  - Traditional Chinese 1.6.2 localisation
-  - Dutch 1.6.2 localisation
-  - Czech UI localisation + manual translation
+  - Simplified Chinese UI localization + manual translation
+  - French localization updated to 1.7.1
+  - Basque localization updated to 1.7.1
+  - Slovak localization updated to 1.7.1
+  - Serbo-Croatian localization updated to 1.7.1
+  - Traditional Chinese 1.6.2 localization
+  - Dutch 1.6.2 localization
+  - Czech UI localization + manual translation
 
 ----------------------------------------------------------------------
  OmegaT 1.7.1 (2007-07-03)
 ----------------------------------------------------------------------
   15 Enhancements
   19 Bug fixes
-  10 Localisation updates
+  10 Localization updates
 ----------------------------------------------------------------------
 1.7.1 vs. 1.6.1_04
 
@@ -7752,7 +7752,7 @@ Contains two new filters (XLIFF and Office 2007 XML), many bug fixes, new featur
   - Apply font to Tag Verification and Project Files windows
   https://sourceforge.net/p/omegat/feature-requests/209/
 
-  - Simplified coloring tags in tag validation window
+  - Simplified colouring tags in tag validation window
   https://sourceforge.net/p/omegat/feature-requests/329/
 
   - Executable alternative to OmegaT.bat
@@ -7841,18 +7841,18 @@ Contains two new filters (XLIFF and Office 2007 XML), many bug fixes, new featur
   - Pasting with middle mouse button allowed anywhere in editor
   https://sourceforge.net/p/omegat/bugs/315/
 
-  Localisation updates:
+  Localization updates:
 
   - German instant start tutorial
-  - Slovenian UI localisation + manual translation
-  - Basque UI localisation + manual translation
-  - Hungarian UI localisation + manual translation
-  - Turkish UI localisation + instant start tutorial
-  - Catalan UI localisation + manual translation
-  - Ukrainian UI localisation
-  - French UI localisation (update) + instant start tutorial
-  - Japanese UI localisation + manual translation
-  - Simplified Chinese UI localisation + manual translation
+  - Slovenian UI localization + manual translation
+  - Basque UI localization + manual translation
+  - Hungarian UI localization + manual translation
+  - Turkish UI localization + instant start tutorial
+  - Catalan UI localization + manual translation
+  - Ukrainian UI localization
+  - French UI localization (update) + instant start tutorial
+  - Japanese UI localization + manual translation
+  - Simplified Chinese UI localization + manual translation
 
 ----------------------------------------------------------------------
 1.6.1_04 (2007-02-03)
@@ -7873,7 +7873,7 @@ GPL-compatible.
 
 ----------------------------------------------------------------------
 1.6.1_03 ( 2007-01-07)
-Contains new and updated localisations.
+Contains new and updated localizations.
 
  Implemented requests:
 
@@ -7893,7 +7893,7 @@ Contains new and updated localisations.
 
 ----------------------------------------------------------------------
 1.6.1_02 (2006-12-09)
-Contains new and updated localisations, legacy manual translations,
+Contains new and updated localizations, legacy manual translations,
 and two bug fixes
 
  Implemented requests:
@@ -7902,11 +7902,11 @@ and two bug fixes
 
  Other enhancements:
 
-  - French localisation updated
+  - French localization updated
 
-  - Japanese localisation updated
+  - Japanese localization updated
 
-  - Serbo-Croation UI localisation + instant start guide translation
+  - Serbo-Croation UI localization + instant start guide translation
 
   - User manual language selection screen (displays only if a
   translation in the system language is unavailable)
@@ -7916,9 +7916,9 @@ and two bug fixes
 
   - Italian user manual translation
 
-  - Albanian UI localisation + instant start guide translation
+  - Albanian UI localization + instant start guide translation
 
-  - Belarusian UI localisation updated
+  - Belarusian UI localization updated
 
  Bug fixes:
 
@@ -7930,7 +7930,7 @@ and two bug fixes
 
 ----------------------------------------------------------------------
 1.6.1_01 (2006-11-27)
-Contains new localisations plus a couple bug fixes
+Contains new localizations plus a couple bug fixes
 
  Implemented requests:
 
@@ -7938,17 +7938,17 @@ Contains new localisations plus a couple bug fixes
 
  Other enhancements:
 
-  - French UI localisation + instant start guide translation
+  - French UI localization + instant start guide translation
 
-  - Brazilian Portugese full localisation
+  - Brazilian Portugese full localization
 
-  - Slovak full localisation
+  - Slovak full localization
 
   - Italian instant start guide translation
 
  Bug fixes:
 
-   - Localisation errors
+   - Localization errors
    https://sourceforge.net/p/omegat/bugs/249/
 
    - Some texts not loaded from external resource bundle
@@ -8153,7 +8153,7 @@ fixes a few regressions of RC11 and RC12.
 
  Bug fixes:
 
-  - [OpenDocument] Writer headers and footers not honored
+  - [OpenDocument] Writer headers and footers not honoured
     https://sourceforge.net/p/omegat/bugs/35/
 
   - [OpenDocument] Footnote markers break sentences
@@ -8979,7 +8979,7 @@ Modified the search mechanism to uninflect common western letters, so
 fixed bug where advance key wouldn't reset back from TAB in pref file
 fixed bugs involving text being deleted from translation area (corrupted
   and incorrect display)
-(re)added background color to source text
+(re)added background colour to source text
 
 1.3.14 rc3 (and there'll be at least one more RC relase to go)
 --------------------------------
@@ -8990,7 +8990,7 @@ added new <span> tag to HTML and XHTML file parser
 
 1.3.13 rc2
 --------------------------------
-activated colors for fuzzy match info
+activated colours for fuzzy match info
 reduced default window height to give at least 60 pixels at bottom of screen
 
 1.3.12 (1.4 release candidate 1)
@@ -9000,9 +9000,9 @@ changed window auto-sizing code (it would break on certain platforms).
 fixed potential bug in project quit routine
 allow users to select between TAB and ENTER to advance to next string
   (Asian IMEs require the ENTER key in a way that is sometimes incompatible)
-  new behavior: ENTER to advance; CTRL-ENTER to move backwards
-                TAB to advance; SHIFT-TAB to move backwards
-                SHIFT-ENTER to insert soft return
+  new behaviour: ENTER to advance; CTRL-ENTER to move backwards
+                 TAB to advance; SHIFT-TAB to move backwards
+                 SHIFT-ENTER to insert soft return
 updated help files
 removed buggy "goto next untranslated entry" feature
 deactivated 'File:Open' when project is already open to prevent accidental
@@ -9184,7 +9184,7 @@ updated manual to most current available
 bug fixes
 - keyboard shortcuts should now used preferred OS meta key
 - changed first project creation dialog to be save dialog (should resolve
-mac specific behavior problems)
+mac specific behaviour problems)
 - fixed potential bug in ignore and mapping preference system
 ----------------------------------------------------------------------
 
@@ -9226,4 +9226,4 @@ HTML will sometimes (somehow) cause a string of exceptions to arise and
 eventually freeze the application.
 ----------------------------------------------------------------------
 
-LocalWords:  localisation
+LocalWords:  localization

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2522,7 +2522,7 @@ FILENAMEPATTERNS_HELP=<html>Add patterns using wildcards (Apache Ant format): <c
 FILENAMEPATTERNS_ADD=&Add
 FILENAMEPATTERNS_REMOVE=&Remove
 
-# Color names
+# Colour names
 GUI_COLORS_SELECTION=Custom Colours Selection
 GUI_COLORS_TITLE=Custom Colours
 COLOR_BACKGROUND=Background

--- a/src/org/omegat/Bundle_us.properties
+++ b/src/org/omegat/Bundle_us.properties
@@ -4,7 +4,7 @@
 #          glossaries, and translation leveraging into updated projects.
 #
 # Copyright (C) 2000-2006 Keith Godfrey, Maxym Mykhalchuk, and Henry Pijffers
-#               2007 Didi- Briel, Zoltan Bartko, Martin Fleurke
+#               2007 Didier Briel, Zoltan Bartko, Martin Fleurke
 #               2008 Andrzej Sawula, Alex Buloichik, Didier Briel, Martin Fleurke
 #               2009 Didier Briel, Alex Buloichik, Martin Fleurke
 #               2010 Didier Briel, Wildrich Fourie, Martin Fleurke,
@@ -19,7 +19,7 @@
 #               2017 Didier Briel
 #               2020-2022 Hiroshi Miura
 #               Home page: http://www.omegat.org/
-#               Support centre: https://omegat.org/support
+#               Support center: https://omegat.org/support
 #
 # This file is part of OmegaT.
 #
@@ -1937,7 +1937,7 @@ SU_USERHOME_PROP_ACCESS_ERROR=OmegaT was refused access to the system property c
     configuration folder cannot be reliably determined. The\n\
     current folder will be used instead. This will reset all\n\
     settings to their defaults. You may therefore experience\n\
-    unexpected, but correct behaviour.
+    unexpected, but correct behavior.
 
 SU_CONFIG_DIR_CREATE_ERROR=Your operating system refused to let OmegaT\n\
     create the configuration folder. The current folder will be used\n\
@@ -2522,9 +2522,9 @@ FILENAMEPATTERNS_HELP=<html>Add patterns using wildcards (Apache Ant format): <c
 FILENAMEPATTERNS_ADD=&Add
 FILENAMEPATTERNS_REMOVE=&Remove
 
-# Colour names
-GUI_COLORS_SELECTION=Custom Colours Selection
-GUI_COLORS_TITLE=Custom Colours
+# Color names
+GUI_COLORS_SELECTION=Custom Colors Selection
+GUI_COLORS_TITLE=Custom Colors
 COLOR_BACKGROUND=Background
 COLOR_FOREGROUND=Text
 COLOR_ACTIVE_SOURCE=Active segment source
@@ -2581,8 +2581,8 @@ COLOR_ALIGNER_HIGHLIGHT=Aligner highlight
 COLOR_ALIGNER_TABLE_ROW_HIGHLIGHT=Aligner table row highlight
 COLOR_MACHINETRANSLATE_SELECTED_HIGHLIGHT=Machine translate highlight
 GUI_COLORS_COLOR=Item:
-GUI_COLORS_RESET_COLOR=&Reset Colour
-PREFS_TITLE_COLORS=Colours
+GUI_COLORS_RESET_COLOR=&Reset Color
+PREFS_TITLE_COLORS=Colors
 
 # EditorTextArea3
 ETA_WARNING_TAB_ADVANCE=<html><i>Preferences</i> &gt; <i>General</i> &gt; <i>Use TAB to advance</i> is checked</html>


### PR DESCRIPTION
I'm putting this up as a draft to get opinions first before finalizing this proposed cosmetic change.

As far as I can see, the current user facing material (manual, UI, `changes.txt`) primarily uses American spelling, with the occasional instance of British spelling sneaking up in words like colour (color).

I'd like to reflect the more international composiiton of both the OmegaT team and its community of users, and since I'm Canadian, I'd like to update all user facing material to Canadian spelling, which is most often a compromise between American and British spelling.

In practice, that means sticking to "-ize" in words like "recognize" or "realize", but using "-our" in words like "colour".

Thoughts, objections, comments?