### PR TITLE
fix(gui/filter): wrong target selection on filter customizer table

### DIFF
--- a/src/org/omegat/gui/filters2/FiltersCustomizerController.java
+++ b/src/org/omegat/gui/filters2/FiltersCustomizerController.java
@@ -202,7 +202,8 @@ public class FiltersCustomizerController extends BasePreferencesController {
     }
 
     private Filter getFilterAtRow(int row) {
-        return ((FiltersTableModel) panel.filtersTable.getModel()).getFilterAtRow(row);
+        return ((FiltersTableModel) panel.filtersTable.getModel())
+                .getFilterAtRow(panel.filtersTable.convertRowIndexToModel(row));
     }
 
     @Override


### PR DESCRIPTION

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

ref: https://sourceforge.net/p/omegat/mailman/message/37770101/

## What does this PR change?

- We add a sorter at commit bb8f181998e73a1b023e9e3942d84830e18cacd8  in #423
- When the table is sorted, the indices of the rows in the view don't match with the indices in the model anymore.
- This add `convertRowIndexToModel` method to convert from a sorter index to model index.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
