### PR TITLE
MT:  http json tests, fixes and improves error case behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,8 @@ dependencies {
         testImplementation "org.languagetool:language-${it}:${languageToolVersion}"
     }
     testRuntimeOnly "org.languagetool:language-pl:${languageToolVersion}"
+    // http connection tests
+    testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.35.0'
 
     // JAXB codegen only
     jaxb 'com.sun.xml.bind:jaxb-xjc:2.3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -891,7 +891,8 @@ tasks.jacocoTestCoverageVerification {
         rule {
             element = 'CLASS'
             includes = ['org.omegat.core.machinetranslators.*', 'org.omegat.core.dictionaries.*']
-            excludes = ['**.*.1', '**.*.2', '**.*.3']  // ignore inner classes
+            excludes = ['**.*.1', '**.*.2', '**.*.3',  // ignore inner classes
+                    'org.omegat.core.machinetranslators.MachineTranslators']  // simple plugin reg.
             limit { minimum = 0.20 }
         }
         rule {

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2155,7 +2155,8 @@ CCP_PASTE=Paste
 
 MT_AUTO_FETCH=&Automatically Fetch Translations
 MT_ONLY_UNTRANSLATED=&Untranslated Segments Only
-MT_ENGINE_ERROR=MT engine error({0}) {1}
+MT_ENGINE_ERROR=MT({0}) report error {1}
+MT_ENGINE_EXCEPTION=MT engine error happened
 
 # Machine translation engines
 MT_ENGINE_GOOGLE2=Google Translate v2
@@ -2171,6 +2172,7 @@ MT_JSON_ERROR=Error while reading MT results
 
 MT_ENGINE_MYMEMORY_EMAIL_LABEL=Email:
 MT_ENGINE_MYMEMORY_API_KEY_LABEL=API key:
+MT_ENGINE_MYMEMOROY_ERROR=Unable to get result
 
 APERTIUM_ERROR=Error {0}: {1}
 APERTIUM_CUSTOM_SERVER_LABEL=Connect to custom server instead of apertium.org

--- a/src/org/omegat/core/machinetranslators/AbstractMyMemoryTranslate.java
+++ b/src/org/omegat/core/machinetranslators/AbstractMyMemoryTranslate.java
@@ -31,6 +31,7 @@
 package org.omegat.core.machinetranslators;
 
 import java.awt.Window;
+import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -51,9 +52,19 @@ import org.omegat.util.OStrings;
  */
 public abstract class AbstractMyMemoryTranslate extends BaseCachedTranslate {
 
-    private static final String MYMEMORY_API_EMAIL = "mymemory.api.email";
-    private static final String MYMEMORY_API_KEY = "mymemory.api.key";
-    private static final String GT_URL = "https://mymemory.translated.net/api/get";
+    protected static final String MYMEMORY_API_EMAIL = "mymemory.api.email";
+    protected static final String MYMEMORY_API_KEY = "mymemory.api.key";
+    private static final String DEFAULT_GT_URL = "https://mymemory.translated.net/api/get";
+
+    private String gtURL;
+
+    public AbstractMyMemoryTranslate(String url) {
+        gtURL = url;
+    }
+
+    public AbstractMyMemoryTranslate() {
+        gtURL = DEFAULT_GT_URL;
+    }
 
     @Override
     protected abstract String getPreferenceName();
@@ -79,13 +90,13 @@ public abstract class AbstractMyMemoryTranslate extends BaseCachedTranslate {
      * Query MyMemory API and return parsed JsonNode object.
      */
     @SuppressWarnings("unchecked")
-    protected JsonNode getMyMemoryResponse(Language sLang, Language tLang, String text) throws Exception {
+    protected JsonNode getMyMemoryResponse(Language sLang, Language tLang, String text) throws IOException {
 
         String targetLang = tLang.getLocaleLCID();
         String sourceLang = sLang.getLocaleLCID();
 
-        String apiKey = getCredential(MYMEMORY_API_KEY);
-        String email = getCredential(MYMEMORY_API_EMAIL);
+        String apiKey = System.getProperty(MYMEMORY_API_KEY, getCredential(MYMEMORY_API_KEY));
+        String email = System.getProperty(MYMEMORY_API_EMAIL, getCredential(MYMEMORY_API_EMAIL));
 
         Map<String, String> params = new TreeMap<>();
 
@@ -125,7 +136,7 @@ public abstract class AbstractMyMemoryTranslate extends BaseCachedTranslate {
 
         // Get the results from MyMemory
         ObjectMapper mapper = new ObjectMapper();
-        String response = HttpConnectionUtils.get(GT_URL, params, headers);
+        String response = HttpConnectionUtils.get(gtURL, params, headers);
         return mapper.readTree(response);
     }
 

--- a/src/org/omegat/core/machinetranslators/DeepLTranslate.java
+++ b/src/org/omegat/core/machinetranslators/DeepLTranslate.java
@@ -108,7 +108,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
         String apiKey = getCredential(PROPERTY_API_KEY);
         if (apiKey == null || apiKey.isEmpty()) {
             if (temporaryKey == null) {
-                throw new Exception(OStrings.getString("DEEPL_API_KEY_NOTFOUND"));
+                throw new MachineTranslateError(OStrings.getString("DEEPL_API_KEY_NOTFOUND"));
             }
             apiKey = temporaryKey;
         }
@@ -154,7 +154,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
      * @return translation, or null when API returns empty result, or error
      *         message when parse failed.
      */
-    protected String getJsonResults(String json) throws TranslationException {
+    protected String getJsonResults(String json) throws TranslationException, MachineTranslateError {
         ObjectMapper mapper = new ObjectMapper();
         try {
             // { "translations": [ { "detected_source_language": "DE", "text":
@@ -163,21 +163,22 @@ public class DeepLTranslate extends BaseCachedTranslate {
             JsonNode translations = rootNode.get("translations");
             if (translations == null) {
                 Log.logErrorRB("MT_JSON_ERROR");
-                throw new Exception(OStrings.getString("MT_JSON_ERROR"));
+                throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
             }
             if (translations.has(0)) {
                 JsonNode textNode = translations.get(0).get("text");
                 if (textNode == null) {
                     Log.logErrorRB("MT_JSON_ERROR");
-                    throw new Exception(OStrings.getString("MT_JSON_ERROR"));
+                    throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
                 }
                 return translations.get(0).get("text").asText();
             }
         } catch (Exception e) {
             Log.logErrorRB(e, "MT_JSON_ERROR");
-            throw new TranslationException(OStrings.getString("MT_JSON_ERROR"));
+            throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
         }
-        return null;
+        Log.logErrorRB( "MT_JSON_ERROR");
+        throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
     }
 
     @Override

--- a/src/org/omegat/core/machinetranslators/DeepLTranslate.java
+++ b/src/org/omegat/core/machinetranslators/DeepLTranslate.java
@@ -60,6 +60,9 @@ import org.omegat.util.Preferences;
 public class DeepLTranslate extends BaseCachedTranslate {
     protected static final String PROPERTY_API_KEY = "deepl.api.key";
     private String temporaryKey = null;
+
+    private static final String DEEPL_V1_URL = "https://api.deepl.com/v1/translate";
+
     // DO NOT MOVE TO THE V2 API until it becomes available for CAT tool
     // integration.
     //
@@ -73,7 +76,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
     private final static int MAX_TEXT_LENGTH = 5000;
 
     public DeepLTranslate() {
-        deepLUrl = "https://api.deepl.com/v1/translate";
+        deepLUrl = DEEPL_V1_URL;
     }
 
     /**

--- a/src/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/src/org/omegat/core/machinetranslators/Google2Translate.java
@@ -190,7 +190,8 @@ public class Google2Translate extends BaseCachedTranslate {
             Log.logErrorRB(e, "MT_JSON_ERROR");
             throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
         }
-        return null;
+        Log.logErrorRB( "MT_JSON_ERROR");
+        throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
     }
 
     /**

--- a/src/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/src/org/omegat/core/machinetranslators/Google2Translate.java
@@ -62,8 +62,25 @@ import org.omegat.util.Preferences;
 public class Google2Translate extends BaseCachedTranslate {
     protected static final String PROPERTY_PREMIUM_KEY = "google.api.premium";
     protected static final String PROPERTY_API_KEY = "google.api.key";
-    protected static final String GT_URL = "https://translation.googleapis.com/language/translate/v2";
+    protected static final String GT_DEFAULT_URL = "https://translation.googleapis.com";
+    protected static final String GT_PATH = "/language/translate/v2";
+    private String googleTranslateUrl;
+    private String temporaryKey;
     private static final int MAX_TEXT_LENGTH = 5000;
+
+    public Google2Translate() {
+        googleTranslateUrl = GT_DEFAULT_URL + GT_PATH;
+    }
+
+    /**
+     * Constructor for test.
+     * @param baseUrl custom url.
+     * @param key temprary key.
+     */
+    public Google2Translate(String baseUrl, String key) {
+        googleTranslateUrl = baseUrl + GT_PATH;
+        temporaryKey = key;
+    }
 
     /**
      * Return GOOGLE2 preference constant.
@@ -117,9 +134,11 @@ public class Google2Translate extends BaseCachedTranslate {
         }
 
         String googleKey = getCredential(PROPERTY_API_KEY);
-
         if (googleKey == null || googleKey.isEmpty()) {
-            throw new MachineTranslateError(OStrings.getString("GOOGLE_API_KEY_NOTFOUND"));
+            if (temporaryKey == null) {
+                throw new MachineTranslateError(OStrings.getString("GOOGLE_API_KEY_NOTFOUND"));
+            }
+            googleKey = temporaryKey;
         }
 
         Map<String, String> params = new TreeMap<String, String>();
@@ -141,7 +160,7 @@ public class Google2Translate extends BaseCachedTranslate {
         Map<String, String> headers = new TreeMap<String, String>();
         headers.put("X-HTTP-Method-Override", "GET");
 
-        String v = HttpConnectionUtils.post(GT_URL, params, headers);
+        String v = HttpConnectionUtils.post(googleTranslateUrl, params, headers);
         String tr = getJsonResults(v);
         if (tr == null) {
             return null;
@@ -159,7 +178,6 @@ public class Google2Translate extends BaseCachedTranslate {
      *            response string.
      * @return translation text.
      */
-    @SuppressWarnings("unchecked")
     protected String getJsonResults(String json) throws MachineTranslateError {
         ObjectMapper mapper = new ObjectMapper();
         try {

--- a/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
+++ b/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
@@ -174,19 +174,23 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
      * @return translated text.
      */
     @SuppressWarnings("unchecked")
-    protected String getJsonResults(String json) {
+    protected String getJsonResults(String json) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode;
         try {
-            JsonNode rootNode = mapper.readTree(json);
-            JsonNode translations = rootNode.get("translations");
-            if (translations.has(0)) {
-                return translations.get(0).get("translation").asText();
-            }
+            rootNode = mapper.readTree(json);
         } catch (Exception e) {
             Log.logErrorRB(e, "MT_JSON_ERROR");
-            return OStrings.getString("MT_JSON_ERROR");
+            throw new Exception(OStrings.getString("MT_JSON_ERROR"));
         }
-        return null;
+        JsonNode translations = rootNode.get("translations");
+        if (translations != null && translations.has(0)) {
+            if (translations.get(0) != null && translations.get(0).get("translation") != null) {
+                return translations.get(0).get("translation").asText();
+            }
+        }
+        Log.logErrorRB( "MT_JSON_ERROR");
+        throw new Exception(OStrings.getString("MT_JSON_ERROR"));
     }
 
     @Override

--- a/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
+++ b/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
@@ -95,7 +95,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
         String apiPassword = getCredential(PROPERTY_PASSWORD);
 
         if (apiLogin == null || apiLogin.isEmpty()) {
-            throw new Exception(OStrings.getString("IBMWATSON_API_KEY_NOTFOUND"));
+            throw new MachineTranslateError(OStrings.getString("IBMWATSON_API_KEY_NOTFOUND"));
         }
 
         // If the instance uses IAM authentication
@@ -181,7 +181,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
             rootNode = mapper.readTree(json);
         } catch (Exception e) {
             Log.logErrorRB(e, "MT_JSON_ERROR");
-            throw new Exception(OStrings.getString("MT_JSON_ERROR"));
+            throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
         }
         JsonNode translations = rootNode.get("translations");
         if (translations != null && translations.has(0)) {
@@ -190,7 +190,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
             }
         }
         Log.logErrorRB( "MT_JSON_ERROR");
-        throw new Exception(OStrings.getString("MT_JSON_ERROR"));
+        throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
     }
 
     @Override

--- a/src/org/omegat/core/machinetranslators/MyMemoryHumanTranslate.java
+++ b/src/org/omegat/core/machinetranslators/MyMemoryHumanTranslate.java
@@ -29,6 +29,8 @@
 
 package org.omegat.core.machinetranslators;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.omegat.util.Language;
@@ -43,6 +45,13 @@ import org.omegat.util.Preferences;
  * @author Hiroshi Miura
  */
 public final class MyMemoryHumanTranslate extends AbstractMyMemoryTranslate {
+
+    public MyMemoryHumanTranslate(final String url) {
+        super(url);
+    }
+
+    public MyMemoryHumanTranslate() {
+    }
 
     @Override
     protected String getPreferenceName() {
@@ -68,13 +77,20 @@ public final class MyMemoryHumanTranslate extends AbstractMyMemoryTranslate {
         }
 
         JsonNode jsonResponse;
+        try {
+            // Get MyMemory response in JSON format
+            jsonResponse = getMyMemoryResponse(sLang, tLang, text);
 
-        // Get MyMemory response in JSON format
-        jsonResponse = getMyMemoryResponse(sLang, tLang, text);
-
-        // responseData/translatedText contains the best match.
-        String translation = jsonResponse.get("responseData").get("translatedText").asText();
-        putToCache(sLang, tLang, text, translation);
-        return translation;
+            // responseData/translatedText contains the best match.
+            JsonNode responseData = jsonResponse.get("responseData");
+            if (responseData != null) {
+                String translation = responseData.get("translatedText").asText();
+                putToCache(sLang, tLang, text, translation);
+                return translation;
+            }
+        } catch (IOException e) {
+            throw new MachineTranslateError("MT_ENGINE_MYMEMORY_ERROR", e);
+        }
+        throw new MachineTranslateError("MT_ENGINE_MYMEMORY_ERROR");
     }
 }

--- a/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
+++ b/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
@@ -132,9 +132,9 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
             String errorMessage = extractErrorMessage(e.body);
             if (errorMessage == null) {
                 errorMessage = OStrings.getString("MT_ENGINE_YANDEX_CLOUD_BAD_TRANSLATE_RESPONSE");
-                throw new Exception(errorMessage);
+                throw new MachineTranslateError(errorMessage);
             }
-            throw e;
+            throw new MachineTranslateError(e.getMessage());
         }
         if (response == null) {
             return null;
@@ -232,7 +232,7 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
     }
 
     @SuppressWarnings("unchecked")
-    protected String extractTranslation(final String json) {
+    protected String extractTranslation(final String json) throws MachineTranslateError {
         JsonNode rootNode;
         ObjectMapper mapper = new ObjectMapper();
         try {
@@ -240,7 +240,8 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
             return rootNode.get("translations").get(0).get("text").asText();
         } catch (Exception e) {
             Log.logErrorRB(e, "MT_JSON_ERROR");
-            return OStrings.getString("MT_ENGINE_YANDEX_CLOUD_BAD_TRANSLATE_RESPONSE");
+            throw new MachineTranslateError(OStrings.getString(
+                    "MT_ENGINE_YANDEX_CLOUD_BAD_TRANSLATE_RESPONSE"));
         }
     }
 

--- a/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
@@ -51,6 +51,7 @@ import org.omegat.core.Core;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
+import org.omegat.core.machinetranslators.MachineTranslateError;
 import org.omegat.core.machinetranslators.MachineTranslators;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.common.EntryInfoSearchThread;
@@ -273,10 +274,13 @@ public class MachineTranslateTextArea extends EntryInfoThreadPane<MachineTransla
             }
             try {
                 return translator.getTranslation(source, target, src);
-            } catch (Exception e) {
+            } catch (MachineTranslateError e) {
                 Log.log(e);
                 Core.getMainWindow()
                         .showTimedStatusMessageRB("MT_ENGINE_ERROR", translator.getName(), e.getLocalizedMessage());
+                return null;
+            } catch (Exception e) {
+                Log.logErrorRB(e, "MT_ENGINE_EXCEPTION");
                 return null;
             }
         }

--- a/test/src/org/omegat/core/machinetranslators/ApertiumTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/ApertiumTranslateTest.java
@@ -5,7 +5,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2021 Hiroshi Miura.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -21,7 +21,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  *************************************************************************
  *
  */

--- a/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
@@ -5,7 +5,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2021 Hiroshi Miura.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -21,7 +21,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  *************************************************************************
  *
  */

--- a/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
@@ -29,6 +29,7 @@
 package org.omegat.core.machinetranslators;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,14 +43,21 @@ import org.omegat.util.Preferences;
 
 public class DeepLTranslateTest extends TestMachineTranslatorBase {
 
-
     @Test
-    public void testGetJsonResults() {
+    public void testGetJsonResults() throws Exception {
         Preferences.setPreference(Preferences.ALLOW_DEEPL_TRANSLATE, true);
         DeepLTranslate deepLTranslate = new DeepLTranslate();
         String json = "{ \"translations\": [ { \"detected_source_language\": \"DE\", \"text\": \"Hello World!\" } ] }";
         String result = deepLTranslate.getJsonResults(json);
         assertEquals("Hello World!", result);
+    }
+
+    @Test
+    public void testGetJsonResultsWithWrongJson() {
+        Preferences.setPreference(Preferences.ALLOW_DEEPL_TRANSLATE, true);
+        DeepLTranslate deepLTranslate = new DeepLTranslate();
+        String json = "{ \"response\": \"failed\" }";
+        assertThrows(Exception.class, () -> { deepLTranslate.getJsonResults(json); });
     }
 
     @Test

--- a/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/DeepLTranslateTest.java
@@ -30,12 +30,18 @@ package org.omegat.core.machinetranslators;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import org.junit.Test;
 
-import org.omegat.core.TestCore;
+import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
-public class DeepLTranslateTest extends TestCore {
+public class DeepLTranslateTest extends TestMachineTranslatorBase {
+
 
     @Test
     public void testGetJsonResults() {
@@ -43,6 +49,33 @@ public class DeepLTranslateTest extends TestCore {
         DeepLTranslate deepLTranslate = new DeepLTranslate();
         String json = "{ \"translations\": [ { \"detected_source_language\": \"DE\", \"text\": \"Hello World!\" } ] }";
         String result = deepLTranslate.getJsonResults(json);
+        assertEquals("Hello World!", result);
+    }
+
+    @Test
+    public void testResponse() throws Exception {
+        Preferences.setPreference(Preferences.ALLOW_DEEPL_TRANSLATE, true);
+        String key = "deepl8api8key";
+
+        Map<String, StringValuePattern> params = new HashMap<>();
+        params.put("text", WireMock.equalTo("source text"));
+        params.put("source_lang", WireMock.equalTo("DE"));
+        params.put("target_lang", WireMock.equalTo("EN"));
+        params.put("tag_handling", WireMock.equalTo("xml"));
+        params.put("auth_key", WireMock.matching("\\w+"));
+        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/v1/translate"))
+                .withQueryParams(params)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"translations\":[ "
+                                + "{ \"detected_source_language\": \"DE\", \"text\": \"Hello World!\" }"
+                                + " ] }")));
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d", port);
+        String sourceText = "source text";
+        DeepLTranslate deepLTranslate = new DeepLTranslate(url, key);
+        String result = deepLTranslate.translate(new Language("DE"), new Language("EN"), sourceText);
         assertEquals("Hello World!", result);
     }
 }

--- a/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
@@ -5,7 +5,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2021 Hiroshi Miura.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -21,7 +21,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  *************************************************************************
  *
  */

--- a/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
@@ -31,33 +31,60 @@ package org.omegat.core.machinetranslators;
 
 import static org.junit.Assert.assertEquals;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.Test;
 
-import org.omegat.core.TestCore;
+import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
-public class Google2TranslateTest extends TestCore {
+public class Google2TranslateTest extends TestMachineTranslatorBase {
+
+    private static final String json = "{\n"
+            + "  \"data\": {\n"
+            + "    \"translations\": [\n"
+            + "      {\n"
+            + "        \"translatedText\": \"Hallo Welt\",\n"
+            + "        \"detectedSourceLanguage\": \"en\"\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"translatedText\": \"Mein Name ist Jeff\",\n"
+            + "        \"detectedSourceLanguage\": \"en\"\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
 
     @Test
     public void testGetJsonResults() throws Exception {
         Preferences.setPreference(Preferences.ALLOW_GOOGLE2_TRANSLATE, true);
         Google2Translate google2Translate = new Google2Translate();
-        String json = "{\n"
-                + "  \"data\": {\n"
-                + "    \"translations\": [\n"
-                + "      {\n"
-                + "        \"translatedText\": \"Hallo Welt\",\n"
-                + "        \"detectedSourceLanguage\": \"en\"\n"
-                + "      },\n"
-                + "      {\n"
-                + "        \"translatedText\": \"Mein Name ist Jeff\",\n"
-                + "        \"detectedSourceLanguage\": \"en\"\n"
-                + "      }\n"
-                + "    ]\n"
-                + "  }\n"
-                + "}";
         String translation = google2Translate.getJsonResults(json);
         assertEquals("Hallo Welt", translation);
     }
 
+    @Test
+    public void testResponse() throws Exception {
+        Preferences.setPreference(Preferences.ALLOW_GOOGLE2_TRANSLATE, true);
+        String key = "google8api8key";
+        String sourceText = "source text";
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d", port);
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/language/translate/v2"))
+                        .withHeader("Content-Type", WireMock.equalTo("application/x-www-form-urlencoded"))
+                        .withRequestBody(WireMock.and(
+                                WireMock.containing("q=source+text"),
+                                WireMock.containing("source=en"),
+                                WireMock.containing("target=de")
+                        ))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(json)
+                )
+        );
+        Google2Translate google2Translate = new Google2Translate(url, key);
+        String result = google2Translate.translate(new Language("EN"), new Language("DE"), sourceText);
+        assertEquals("Hallo Welt", result);
+    }
 }

--- a/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/Google2TranslateTest.java
@@ -55,7 +55,7 @@ public class Google2TranslateTest extends TestMachineTranslatorBase {
             + "}";
 
     @Test
-    public void testGetJsonResults() throws Exception {
+    public void testGetJsonResults() throws MachineTranslateError {
         Preferences.setPreference(Preferences.ALLOW_GOOGLE2_TRANSLATE, true);
         Google2Translate google2Translate = new Google2Translate();
         String translation = google2Translate.getJsonResults(json);

--- a/test/src/org/omegat/core/machinetranslators/IBMWatsonTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/IBMWatsonTranslateTest.java
@@ -5,7 +5,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2021 Hiroshi Miura.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -21,7 +21,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  *************************************************************************
  *
  */

--- a/test/src/org/omegat/core/machinetranslators/IBMWatsonTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/IBMWatsonTranslateTest.java
@@ -32,16 +32,16 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.Test;
 
-import org.omegat.core.TestCore;
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
-public class IBMWatsonTranslateTest extends TestCore {
+public class IBMWatsonTranslateTest extends TestMachineTranslatorBase {
 
     @Test
-    public void getJsonResults() {
+    public void getJsonResults() throws Exception {
         Preferences.setPreference(Preferences.ALLOW_IBMWATSON_TRANSLATE, true);
         IBMWatsonTranslate ibmWatsonTranslate = new IBMWatsonTranslate();
         String json = "{\"translations\": ["
@@ -64,5 +64,42 @@ public class IBMWatsonTranslateTest extends TestCore {
         String expected = "{\"model_id\":\"MODEL\",\"source\":\"EN\","
                 + "\"target\":\"FR\",\"text\":[\"Translation text.\"]}";
         assertEquals(mapper.readTree(expected), mapper.readTree(json));
+    }
+
+    @Test
+    public void testResponse() throws Exception {
+        Preferences.setPreference(Preferences.ALLOW_IBMWATSON_TRANSLATE, true);
+
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/language-translator/api/v3/translate", port);
+        System.setProperty(IBMWatsonTranslate.PROPERTY_URL, url);
+        System.setProperty(IBMWatsonTranslate.PROPERTY_LOGIN, "watson4api8key");
+
+        String sourceText = "Hello, how are you today?";
+
+        WireMock.stubFor(WireMock.post(WireMock.anyUrl())   //WireMock.urlPathEqualTo
+                // ("/language-translator/api/v3/translate"))
+                        .withQueryParam("version", WireMock.equalTo("2018-05-01"))
+                        .withRequestBody(WireMock.equalToJson(
+                                "{\"source\":\"EN\",\"target\":\"ES\",\"text\":[\"" + sourceText + "\"]}"))
+                        .withHeader("Accept", WireMock.equalTo("application/json"))
+                        .withHeader("Authorization", WireMock.containing("Basic "))
+                        .withHeader("X-Watson-Learning-Opt-Out", WireMock.equalTo("true"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n"
+                                + "  \"translations\": [\n"
+                                + "    {\n"
+                                + "      \"translation\": \"Hola, \u00BFc\u00F3mo est\u00E1s hoy?\"\n"
+                                + "    }\n"
+                                + "  ],\n"
+                                + "  \"word_count\": 7,\n"
+                                + "  \"character_count\": 25\n"
+                                + "}")));
+
+        IBMWatsonTranslate ibmWatsonTranslate = new IBMWatsonTranslate();
+        String result = ibmWatsonTranslate.translate(new Language("EN"), new Language("ES"), sourceText);
+        assertEquals("Hola, \u00BFc\u00F3mo est\u00E1s hoy?", result);
     }
 }

--- a/test/src/org/omegat/core/machinetranslators/MyMemoryTranslationTest.java
+++ b/test/src/org/omegat/core/machinetranslators/MyMemoryTranslationTest.java
@@ -4,7 +4,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2023 Hiroshi Miura
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -20,7 +20,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package org.omegat.core.machinetranslators;

--- a/test/src/org/omegat/core/machinetranslators/MyMemoryTranslationTest.java
+++ b/test/src/org/omegat/core/machinetranslators/MyMemoryTranslationTest.java
@@ -1,0 +1,141 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: http://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.omegat.core.machinetranslators;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import org.junit.Test;
+
+import org.omegat.util.Language;
+import org.omegat.util.Preferences;
+
+public class MyMemoryTranslationTest extends TestMachineTranslatorBase {
+
+    @Test
+    public void testMMMTResponse() throws Exception {
+        Preferences.setPreference(Preferences.ALLOW_MYMEMORY_MACHINE_TRANSLATE, true);
+
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/get", port);
+        System.setProperty(AbstractMyMemoryTranslate.MYMEMORY_API_KEY, "apikey");
+        System.setProperty(AbstractMyMemoryTranslate.MYMEMORY_API_EMAIL, "api@mail");
+
+        String sourceText = "Hello, how are you today?";
+        Map<String, StringValuePattern> params = new HashMap<>();
+        params.put("q", WireMock.equalTo("Hello World!"));
+        params.put("of", WireMock.equalTo("json"));
+        params.put("langpair", WireMock.equalTo("en|it"));
+        params.put("mt", WireMock.equalTo("1"));
+        params.put("key", WireMock.equalTo("apikey"));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/get"))
+                .withQueryParams(params)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"responseData\":"
+                                + "{\"translatedText\":\"Ciao Mondo!\",\"match\":1},"
+                                + "\"quotaFinished\":false,"
+                                + "\"mtLangSupported\":null,"
+                                + "\"responseDetails\":\"\","
+                                + "\"responseStatus\":200,"
+                                + "\"responderId\":null,"
+                                + "\"exception_code\":null,"
+                                + "\"matches\":"
+                                + "["
+                                + "{\"id\":\"708671558\",\"segment\":\"Hello World!\","
+                                + "\"translation\":\"Ciao Mondo!\",\"source\":\"en-GB\",\"target\":\"it-IT\","
+                                + "\"quality\":\"74\",\"reference\":null,\"usage-count\":95,"
+                                + "\"subject\":\"All\",\"created-by\":\"MateCat\","
+                                + "\"last-updated-by\":\"MateCat\","
+                                + "\"create-date\":\"2023-02-04 09:39:47\","
+                                + "\"last-update-date\":\"2023-02-04 09:39:47\","
+                                + "\"match\":1"
+                                + "}]"
+                                + "}")
+                ));
+
+        MyMemoryMachineTranslate myMemoryMachineTranslate = new MyMemoryMachineTranslate(url);
+        String result = myMemoryMachineTranslate.translate(new Language("EN"), new Language("IT"),
+                "Hello World!");
+        assertEquals("Ciao Mondo!", result);
+    }
+
+    @Test
+    public void testMMHTResponse() throws Exception {
+        Preferences.setPreference(Preferences.ALLOW_MYMEMORY_MACHINE_TRANSLATE, true);
+
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/get", port);
+        System.setProperty(AbstractMyMemoryTranslate.MYMEMORY_API_KEY, "apikey");
+        System.setProperty(AbstractMyMemoryTranslate.MYMEMORY_API_EMAIL, "api@mail");
+
+        String sourceText = "Hello, how are you today?";
+        Map<String, StringValuePattern> params = new HashMap<>();
+        params.put("q", WireMock.equalTo("Hello World!"));
+        params.put("of", WireMock.equalTo("json"));
+        params.put("langpair", WireMock.equalTo("en|it"));
+        params.put("mt", WireMock.equalTo("0"));
+        params.put("key", WireMock.equalTo("apikey"));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/get"))
+                .withQueryParams(params)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"responseData\":"
+                                + "{\"translatedText\":\"Ciao Mondo!\",\"match\":1},"
+                                + "\"quotaFinished\":false,"
+                                + "\"mtLangSupported\":null,"
+                                + "\"responseDetails\":\"\","
+                                + "\"responseStatus\":200,"
+                                + "\"responderId\":null,"
+                                + "\"exception_code\":null,"
+                                + "\"matches\":"
+                                + "["
+                                + "{\"id\":\"708671558\",\"segment\":\"Hello World!\","
+                                + "\"translation\":\"Ciao Mondo!\",\"source\":\"en-GB\",\"target\":\"it-IT\","
+                                + "\"quality\":\"74\",\"reference\":null,\"usage-count\":95,"
+                                + "\"subject\":\"All\",\"created-by\":\"MateCat\","
+                                + "\"last-updated-by\":\"MateCat\","
+                                + "\"create-date\":\"2023-02-04 09:39:47\","
+                                + "\"last-update-date\":\"2023-02-04 09:39:47\","
+                                + "\"match\":1"
+                                + "}]"
+                                + "}")
+                ));
+
+        MyMemoryHumanTranslate myMemoryMachineTranslate = new MyMemoryHumanTranslate(url);
+        String result = myMemoryMachineTranslate.translate(new Language("EN"), new Language("IT"),
+                "Hello World!");
+        assertEquals("Ciao Mondo!", result);
+    }
+}

--- a/test/src/org/omegat/core/machinetranslators/TestMachineTranslatorBase.java
+++ b/test/src/org/omegat/core/machinetranslators/TestMachineTranslatorBase.java
@@ -1,0 +1,40 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura.
+ *                Home page: http://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.omegat.core.machinetranslators;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+
+import org.omegat.core.TestCore;
+
+public class TestMachineTranslatorBase extends TestCore {
+
+    @Rule
+    public WireMockRule wireMockRule =
+            new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+}

--- a/test/src/org/omegat/core/machinetranslators/TestMachineTranslatorBase.java
+++ b/test/src/org/omegat/core/machinetranslators/TestMachineTranslatorBase.java
@@ -4,7 +4,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2023 Hiroshi Miura.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -20,7 +20,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package org.omegat.core.machinetranslators;

--- a/test/src/org/omegat/core/machinetranslators/YandexCloudTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/YandexCloudTranslateTest.java
@@ -44,7 +44,7 @@ import org.omegat.util.Preferences;
 public class YandexCloudTranslateTest extends TestCore {
 
     @Test
-    public void getJsonResults() {
+    public void getJsonResults() throws MachineTranslateError {
         YandexCloudTranslate yandexCloudTranslate = new YandexCloudTranslate();
         String json = "{\"translations\": [{\"text\": \"translated text goes here.\" }]}";
         String translation = yandexCloudTranslate.extractTranslation(json);

--- a/test/src/org/omegat/core/machinetranslators/YandexCloudTranslateTest.java
+++ b/test/src/org/omegat/core/machinetranslators/YandexCloudTranslateTest.java
@@ -5,7 +5,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2022.
- *                Home page: http://www.omegat.org/
+ *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
  *  This file is part of OmegaT.
@@ -21,7 +21,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *  *************************************************************************
  *
  */


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?


- #1141 MT engines show JSON parser error as translated text
  * https://sourceforge.net/p/omegat/bugs/1141
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Add tests to make http connection,  check request and send back mock response. 
  - Apertium
  - DeepL
  - IBMWatson
  - Google2
  - MyMemory (Human, Machine)
- Fix bugs that produce NPE,  send error message to translate pane.
- Throw MachineTranslateError instead of generic java.lang.Exception when http connection error

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
