### PR TITLE
Docs/UI: change local to private and global to general

### DIFF
--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -6,8 +6,8 @@
   <title id="file.filters.title">File Filters</title>
 
   <warning>
-	<para>File filters are either local and specific to a given project, or
-	global and available to all the projects that share a configuration
+	<para>File filters are either private and specific to a given project, or
+	general and available to all the projects that share a configuration
 	folder.</para>
 
 	<para>For details, see:</para>
@@ -45,19 +45,19 @@
   <para>Click the <guibutton>Restore Defaults</guibutton> button to reset the
   file filters to their default settings.</para>
 
-  <para>Modified global file filter preferences are saved in <link
+  <para>Modified general file filter preferences are saved in <link
   linkend="configuration.folder.extra.contents.filters"
   endterm="configuration.folder.extra.contents.filters.title"/>, in the
   configuration folder. See <link linkend="configuration.folder"
   endterm="configuration.folder.title"/> for details. Deleting that file also
   resets the filter preferences.</para>
 
-  <para>Modified local file filters are saved in the <link
+  <para>Modified private file filters are saved in the <link
   linkend="configuration.folder.extra.contents.filters"
   endterm="configuration.folder.extra.contents.filters.title"/> file, located in
   the project folder. See the <link linkend="chapter.project.folder"
   endterm="chapter.project.folder.title"/> chapter for details. Deleting that
-  file also resets the filter preferences and reverts the project to global file
+  file also resets the filter preferences and reverts the project to general file
   filters.</para>
 
   <section id="file.filters.general">

--- a/doc_src/en/App_PostProcessingCommands.xml
+++ b/doc_src/en/App_PostProcessingCommands.xml
@@ -11,7 +11,7 @@
   <para>See the <link
   linkend="dialogs.preferences.saving.and.output.external.post-processing.command"
   endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/>
-  preference for global commands.</para>
+  preference for general commands.</para>
 	
 
   <section id="post.processing.commands.template.variables">
@@ -116,7 +116,7 @@
     <para>
       In addition to a regular command, you can call a script. Never run
       post-processing scripts from untrusted sources. For security reasons,
-      local post-processing commands are disabled by default.
+      private post-processing commands are disabled by default.
     </para>
     <para>
         Template variables can be used with both regular commands and custom

--- a/doc_src/en/App_Segmentation.xml
+++ b/doc_src/en/App_Segmentation.xml
@@ -94,15 +94,15 @@
   </section>
   
   <section id="dialog.preferences.segmentation.setup.scope">
-	<title id="dialog.preferences.segmentation.setup.scope.title">Global or
-	local?</title>
+	<title id="dialog.preferences.segmentation.setup.scope.title">General or
+	private?</title>
 
 	<note>
-	  <para>The same mechanisms and dialogs are used to define global and local
-	  segmentation rules.</para>
+	  <para>The same mechanisms and dialogs are used to define general and
+	  private segmentation rules.</para>
 	</note>
 
-	<para>By default, segmentation settings are global and shared by all
+	<para>By default, segmentation settings are general and shared by all
 	projects.</para>
 
 	<para>Use the <link linkend="dialogs.project.properties.local.segmentation"
@@ -114,7 +114,7 @@
 	line. See the <link linkend="launch.with.command.line"
 	endterm="launch.with.command.line.title"/> how-to for details.</para>
 	
-	<para>If you use local rules, you can still access the global rules, but
+	<para>If you use private rules, you can still access the general rules, but
 	modifying them will have no effect on your project.</para>
   </section>
 

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -83,19 +83,19 @@
 		  <para>Disable this option if you prefer not to further segment the
 		  paragraphs.</para>
 
-		  <para>By default, segmentation rules are global and apply to all
+		  <para>By default, segmentation rules are general and apply to all
 		  projects.</para>
 
 		  <para>Use <link linkend="menus.options"
 		  endterm="menus.options.title"/><link
 		  linkend="menus.options.segmentation"
-		  endterm="menus.options.segmentation.title"/> to access the global
+		  endterm="menus.options.segmentation.title"/> to access the general
 		  segmentation rules.</para>
 		  
 		  <para>Click on <link
 		  linkend="dialogs.project.properties.local.segmentation"
 		  endterm="dialogs.project.properties.local.segmentation.title"/> to use
-		  project-specific (local) segmentation rules rather than the global
+		  project-specific (private) segmentation rules rather than the general
 		  rules. You can also start OmegaT from the command line with a project
 		  specific configuration setting to achieve a similar result.</para>
 
@@ -103,7 +103,7 @@
 		  endterm="launch.with.command.line.title"/> section for details.</para>
 
 		  <note>
-			<para>If you use local rules, you can still access the global rules,
+			<para>If you use private rules, you can still access the general rules,
 			but modifying them will have no effect on your project.</para>
 		  </note>
 		  
@@ -125,19 +125,19 @@
 		  will still be in the project memory.</para>
 
 		  <para>See the <link linkend="app.segmentation"
-		  endterm="app.segmentation.title"/> appendix for general explanations about
-		  segmentation (global or local, paragraph or sentence, settings,
-		  and so on).</para>
+		  endterm="app.segmentation.title"/> appendix for general explanations
+		  about segmentation (private or general, paragraph or sentence,
+		  settings, and so on).</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.local.segmentation">
         <term
-        id="dialogs.project.properties.local.segmentation.title"><guibutton>Local
+        id="dialogs.project.properties.local.segmentation.title"><guibutton>Private
         Segmentation Rules...</guibutton></term>
 
 		<listitem>
-		  <para>By default, segmentation rules are global and apply to all
+		  <para>By default, segmentation rules are general and apply to all
 		  projects.</para>
 		  
 			<para>The segmentation rules presented when you open the <link
@@ -146,11 +146,11 @@
 			(using <link linkend="menus.options"
 			endterm="menus.options.title"/><link
 			linkend="menus.options.segmentation"
-			endterm="menus.options.segmentation.title"/>) are the global
+			endterm="menus.options.segmentation.title"/>) are the general
 			rules.</para>
 
-		  <para>Use this button to create local rules specific to your
-		  project. Check the <option>Use local segmentation rules</option>
+		  <para>Use this button to create private rules specific to your
+		  project. Check the <option>Use private segmentation rules</option>
 		  box, and adjust the segmentation rules as desired.</para>
 		  
 		  <para>The project will store the new set of rules in the <link
@@ -158,20 +158,20 @@
 		  endterm="project.folder.omegat.segmentation.title"/> file located in
 		  its <link linkend="project.folder.omegat.folder"
 		  endterm="project.folder.omegat.folder.title"/> folder. These rules
-		  will supersede the global segmentation rules.</para>
+		  will supersede the general segmentation rules.</para>
 		  
-		  <para>To disable local segmentation rules, disable this option or
+		  <para>To disable private segmentation rules, disable this option or
 		  remove that file.</para>
 
 		  <warning>
-			<para>If you use local rules, you can still access the global rules,
+			<para>If you use private rules, you can still access the general rules,
 			but modifying them will have no effect on your project.</para>
 		  </warning>
 
 		  <para>See the <link linkend="app.segmentation"
 		  endterm="app.segmentation.title"/> appendix for general explanations
-		  about segmentation (global or local, paragraph or sentence, settings,
-		  and so on).</para>
+		  about segmentation (private or general, paragraph or sentence,
+		  settings, and so on).</para>
         </listitem>
       </varlistentry>
 	  
@@ -231,12 +231,12 @@
 
       <varlistentry id="dialogs.project.properties.external.processing.command">
         <term
-        id="dialogs.project.properties.external.processing.command.title"><option>Local
+        id="dialogs.project.properties.external.processing.command.title"><option>Private
         post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
-			<para>For security reasons, local post-processing commands are
+			<para>For security reasons, private post-processing commands are
 			disabled by default.</para>
 
 			<para>See the <link
@@ -262,7 +262,7 @@
 		  <para>Commands specified here are only available to this project. They
 		  are saved in the <link linkend="project.folder.omegat.project.file"
 		  endterm="project.folder.omegat.project.file.title"/> file. Only enable
-		  local post-processing commands if you trust the source of that
+		  private post-processing commands if you trust the source of that
 		  file.</para>
 		
 		  <para>The template variables list gives you access to various project
@@ -272,7 +272,7 @@
 		  endterm="post.processing.commands.title"/> appendix for
 		  details.</para>
 
-		  <para>You can also define global post-processing commands available to
+		  <para>You can also define general post-processing commands available to
 		  all projects that share the same configuration folder. Such commands
 		  are defined in the <link
 		  linkend="dialogs.preferences.saving.and.output.external.post-processing.command"
@@ -280,31 +280,31 @@
 		  preference.</para>
 
 		  <note>
-			<para>Local commands are run before global commands.</para>
+			<para>Private commands are run before general commands.</para>
 		  </note>
         </listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.filters">
-        <term id="dialogs.project.properties.filters.title"><guibutton>Local
+        <term id="dialogs.project.properties.filters.title"><guibutton>Private
         File Filters...</guibutton></term>
 
         <listitem>
-          <para>By default, file filter settings are global and shared by
+          <para>By default, file filter settings are general and shared by
           all projects. They are found in the <link
           linkend="dialogs.preferences.file.filters"
           endterm="dialogs.preferences.file.filters.title"/> preferences.</para>
 
-		  <para>Use this button to create local file filters specific to your
-		  project. Check the <option>Use local file filter
+		  <para>Use this button to create private file filters specific to your
+		  project. Check the <option>Use private file filter
 		  settings</option> box, and adjust the settings as desired.</para>
 
 		  <para>The project will store the new set of file filters in the <link
 		  linkend="project.folder.omegat.filters"
 		  endterm="project.folder.omegat.filters.title"/> file located in its
 		  <link linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder. These settings will supersede the global file filter
-		  settings.</para>
+		  endterm="project.folder.omegat.folder.title"/> folder. These settings
+		  will supersede the general file filter settings.</para>
 
 		  <note>
 			<para>To disable project-specific file filters, uncheck the
@@ -335,17 +335,17 @@
 
       <varlistentry id="dialogs.project.properties.external.searches">
         <term
-        id="dialogs.project.properties.external.searches.title"><guibutton>Local
+        id="dialogs.project.properties.external.searches.title"><guibutton>Private
         External Searches</guibutton></term>
 
         <listitem>
-          <para>By default, external searches are global and are shared by all
+          <para>By default, external searches are general and are shared by all
           projects. They are defined in the <link
           linkend="dialogs.preferences.external.searches"
           endterm="dialogs.preferences.external.searches.title"/>
           preferences.</para>
 
-		  <para>Use this button to create local external searches specific to your
+		  <para>Use this button to create private external searches specific to your
 		  project and adjust the settings as desired.</para>
 
 		  <para>The project will store the new set of external searches in the
@@ -353,7 +353,7 @@
 		  endterm="project.folder.omegat.finder.title"/> file located in its
 		  <link linkend="project.folder.omegat.folder"
 		  endterm="project.folder.omegat.folder.title"/> folder. These
-		  settings will supersede the global external searches settings.</para>
+		  settings will supersede the general external searches settings.</para>
 
 		  <para>To delete project specific external searches, click on the
 		  <guibutton>Remove</guibutton> button or remove that file.</para>
@@ -363,7 +363,7 @@
 		  for details.</para>
 
 		  <note>
-			<para>For security purposes, local project-based external searches
+			<para>For security purposes, private external searches
 			are disabled by default. To enable them, check <link
 			linkend="dialogs.preferences.external.search.enable.project.specific.commands"
 			endterm="dialogs.preferences.external.search.enable.project.specific.commands.title"/>

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -79,7 +79,7 @@
 			<para>Choose the appropriate settings</para>
 
 			<para>Make the necessary changes to the project properties at this
-			stage, including local file filters or segmentation settings. See
+			stage, including private file filters or segmentation settings. See
 			the <link linkend="dialogs.project.properties"
 			endterm="dialogs.project.properties.title"/> dialog for
 			details.</para>

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -100,7 +100,7 @@
 
         <para>Use <link linkend="menus.project"
         endterm="menus.project.title"/><link linkend="menus.project.properties"
-        endterm="menus.project.properties.title"/> to access the local file
+        endterm="menus.project.properties.title"/> to access the private file
         filter preferences.</para>
       </listitem>
     </varlistentry>
@@ -115,7 +115,7 @@
 
         <para>Use <link linkend="menus.project"
         endterm="menus.project.title"/><link linkend="menus.project.properties"
-        endterm="menus.project.properties.title"/> to access the local
+        endterm="menus.project.properties.title"/> to access the private
         segmentation rules preferences.</para>
       </listitem>
     </varlistentry>

--- a/doc_src/en/OmegaT5_EditorsPanes.xml
+++ b/doc_src/en/OmegaT5_EditorsPanes.xml
@@ -571,33 +571,33 @@ When enabled, all the formatting tags are removed from source segments.</program
 			</listitem>
 
 			<listitem>
-        <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
-        <guilabel>Paste</guilabel> functions,</para>
-      </listitem>
+			  <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
+			  <guilabel>Paste</guilabel> functions,</para>
+			</listitem>
 
-      <listitem>
-        <para><guilabel>Go To Segment</guilabel> (to jump to the segment
-        under the pointer).</para>
-      </listitem>
+			<listitem>
+			  <para><guilabel>Go To Segment</guilabel> (to jump to the segment
+			  under the pointer).</para>
+			</listitem>
 
-      <listitem>
-        <para><guilabel>Search Dictionaries</guilabel> (to search for the
-        selected term in an installed dictionary).</para>
-      </listitem>
+			<listitem>
+			  <para><guilabel>Search Dictionaries</guilabel> (to search for the
+			  selected term in an installed dictionary).</para>
+			</listitem>
 
-      <listitem>
-        <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
-        <link endterm="menus.edit.title" linkend="menus.edit"/><link
-        endterm="menus.edit.create.glossary.entry.title"
-        linkend="menus.edit.create.glossary.entry"/>).</para>
-      </listitem>
+			<listitem>
+			  <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
+			  <link endterm="menus.edit.title" linkend="menus.edit"/><link
+			  endterm="menus.edit.create.glossary.entry.title"
+			  linkend="menus.edit.create.glossary.entry"/>).</para>
+			</listitem>
 
-      </itemizedlist>
+		  </itemizedlist>
 
           <para>If you have selected text and defined entries in the <link
           endterm="dialogs.preferences.external.searches.title"
           linkend="dialogs.preferences.external.searches"/> preferences, they
-          will also be displayed in this menu (as will local searches).</para>
+          will also be displayed in this menu (as will private searches).</para>
         </listitem>
       </varlistentry>
 

--- a/doc_src/en/OmegaT5_Preferences.xml
+++ b/doc_src/en/OmegaT5_Preferences.xml
@@ -432,35 +432,35 @@
   </section>
 
   <section id="dialogs.preferences.file.filters">
-	<title id="dialogs.preferences.file.filters.title"><guilabel>Global File
+	<title id="dialogs.preferences.file.filters.title"><guilabel>General File
 	Filters</guilabel></title>
 
 	<para>This dialog lists the file filters available to projects that do not
-	use local file filters.</para>
+	use private file filters.</para>
 
 	<para>The contents of this preference are identical to the contents of the
-	<link linkend="dialogs.project.properties.filters">local file filters</link>
+	<link linkend="dialogs.project.properties.filters">private file filters</link>
 	dialog. See the <link linkend="file.filters" endterm="file.filters.title"/>
 	appendix for details.</para>
 
 	<note>
-	  <para>If local file filters are used, modifying global file filters will
+	  <para>If private file filters are used, modifying general file filters will
 	  have no effect on the project.</para>
 	</note>
   </section>
 
 
   <section id="dialogs.preferences.segmentation.setup">
-	<title id="dialogs.preferences.segmentation.setup.title"><guilabel>Global
+	<title id="dialogs.preferences.segmentation.setup.title"><guilabel>General
 	Segmentation Rules</guilabel></title>
 
 	<para>See the <link linkend="app.segmentation"
 	endterm="app.segmentation.title"/> appendix for a general explanation of
-	segmentation (global or local, paragraph or sentence, etc.)</para>
+	segmentation (private or general, paragraph or sentence, etc.)</para>
 
 	<warning>
-	  <para>This dialog only accesses the global segmentation rules. If you have
-	  set local rules in the <link linkend="dialogs.project.properties"
+	  <para>This dialog only accesses the general segmentation rules. If you have
+	  set private rules in the <link linkend="dialogs.project.properties"
 	  endterm="dialogs.project.properties.title"/> dialog, modifications here
 	  will not be taken into account.</para>
 	</warning>
@@ -746,7 +746,7 @@
   </section>
 
   <section id="dialogs.preferences.external.searches">
-	<title id="dialogs.preferences.external.searches.title"><guilabel>Global External
+	<title id="dialogs.preferences.external.searches.title"><guilabel>General External
 	Searches</guilabel></title>
 	<para>External searches are either web searches or local commands that take
 	the string selected in the Editor as a parameter. The web searches are
@@ -757,16 +757,16 @@
 	  <varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
 		<term
 		id="dialogs.preferences.external.search.enable.project.specific.commands.title"><option>Allow
-		local external search commands</option></term>
+		private external search commands</option></term>
 
 		<listitem>
 		  <warning>
 			<para>For security reasons, <link
-			linkend="dialogs.project.properties.external.searches">local
+			linkend="dialogs.project.properties.external.searches">private
 			externam searches</link> are disabled by default.</para>
 		  </warning>
 
-		  <para>Local external search commands are saved in the <link
+		  <para>Private external search commands are saved in the <link
 		  linkend="project.folder.omegat.filters"
 		  endterm="project.folder.omegat.filters.title"/> file. Only activate
 		  this option if you trust the source of that file.</para>
@@ -1591,7 +1591,7 @@ ${filePath}></programlisting></para>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
 		<term
-		id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>Global
+		id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>General
 		post-processing commands</option></term>
 
 		<listitem>
@@ -1622,28 +1622,28 @@ ${filePath}></programlisting></para>
 	  <varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
 		<term
 		id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><option>Allow
-		local post-processing commands</option></term>
+		private post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
 			<para>For security reasons, the <link
-			linkend="dialogs.project.properties.external.processing.command">local
+			linkend="dialogs.project.properties.external.processing.command">private
 			post-processing commands</link> are disabled by default.</para>
 		  </warning>
 
-		  <para>You can also define local post-processing commands available
+		  <para>You can also define private post-processing commands available
 		  only to a given project. Such commands are defined in the <link
 		  linkend="dialogs.project.properties.external.processing.command"
 		  endterm="dialogs.project.properties.external.processing.command.title"/>
 		  window.</para>
 
-		  <para>Local post-processing commands are saved in the <link
+		  <para>Private post-processing commands are saved in the <link
 		  linkend="project.folder.omegat.project.file"
 		  endterm="project.folder.omegat.project.file.title"/> file. Only
 		  activate this option if you trust the source of that file.</para>
 
 	  	  <note>
-			<para>Local commands are run before global commands.</para>
+			<para>Private commands are run before general commands.</para>
 		  </note>
 
 		</listitem>

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -237,7 +237,7 @@
             <para>If you modify the segmentation rules, you will be asked if you
             want to save those changes when you exit the aligner. The default
             choice is <guibutton>Yes</guibutton>, which may not be what you want
-            if you edited the global OmegaT segmentation rules.</para>
+            if you edited the general OmegaT segmentation rules.</para>
           </warning>
         </listitem>
       </varlistentry>
@@ -255,7 +255,7 @@
             <para>If you modify the file filters, you will be asked if you want
             to save those changes when you exit the aligner. The default choice
             is <guibutton>Yes</guibutton>, which may not be what you want if you
-            edited the global OmegaT file filters.</para>
+            edited the general OmegaT file filters.</para>
           </warning>
         </listitem>
       </varlistentry>

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -255,8 +255,8 @@ To add files to the project you can:\n\n\
 If the project contains files but their content is not displayed here:\n\n\
 \t- verify that their format is supported by OmegaT:\n\
 \t  if per-project filter settings are enabled\n\
-\t  use Project > Properties... > Local File Filters...,\n\
-\t  otherwise use Options > Global File Filters...;\n\
+\t  use Project > Properties... > Private File Filters...,\n\
+\t  otherwise use Options > General File Filters...;\n\
 \t- open them in their original application and verify that they are not empty.
 
 # Editor pane title when there are no supported source files
@@ -466,8 +466,8 @@ MW_OPTIONSMENU_AUTOCOMPLETE_SHOW_AUTOMATICALLY=&Show Relevant Suggestions Automa
 MW_OPTIONSMENU_AUTOCOMPLETE_HISTORY_COMPLETION=History &Completion
 MW_OPTIONSMENU_AUTOCOMPLETE_HISTORY_PREDICTION=History &Prediction
 
-TF_MENU_DISPLAY_GLOBAL_FILTERS=Global File &Filters...
-MW_OPTIONSMENU_GLOBAL_SENTSEG=Global &Segmentation Rules...
+TF_MENU_DISPLAY_GLOBAL_FILTERS=General File &Filters...
+MW_OPTIONSMENU_GLOBAL_SENTSEG=General &Segmentation Rules...
 MW_OPTIONSMENU_WORKFLOW=&Editor...
 
 MW_OPTIONSMENU_ACCESS_CONFIG_DIR=Access &Configuration Folder
@@ -810,8 +810,8 @@ PP_OPTIONS=Options
 
 PP_DIRECTORIES=File locations
 
-TF_MENU_DISPLAY_LOCAL_FILTERS=Local File &Filters...
-MW_OPTIONSMENU_LOCAL_SENTSEG=Local Segmentation R&ules...
+TF_MENU_DISPLAY_LOCAL_FILTERS=Private File &Filters...
+MW_OPTIONSMENU_LOCAL_SENTSEG=Private Segmentation R&ules...
 
 PP_CHECKBOX_PROJECT_SPECIFIC_SEGMENTATION_RULES=Use local &segmentation rules
 
@@ -848,11 +848,11 @@ PP_ALLOW_DEFAULTS=&Auto-propagation of translations
 
 PP_REMOVE_TAGS=Remove ta&gs
 
-PP_EXTERNAL_COMMAND=Local post-processing commands
+PP_EXTERNAL_COMMAND=Private post-processing commands
 
-PP_EXTERN_CMD_DISABLED=Local post-processing commands (disabled):
+PP_EXTERN_CMD_DISABLED=Private post-processing commands (disabled):
 
-PP_EXTERN_CMD_DISABLED_TOOLTIP=Local post-processing commands are disabled and will not be executed. Enable them in Preferences > Saving and Output....
+PP_EXTERN_CMD_DISABLED_TOOLTIP=Private post-processing commands are disabled and will not be executed. Enable them in Preferences > Saving and Output....
 
 PP_BUTTON_BROWSE_SRC=&Browse...
 PP_BUTTON_BROWSE_SRC_EXCLUDES=E&xclusions...
@@ -884,7 +884,7 @@ PP_BROWSE_W_GLOS=Writable Glossary File
 
 PP_REPOSITORIES=Re&pository Mapping...
 
-PP_EXTERNALFINDER=Local External Searc&hes...
+PP_EXTERNALFINDER=Private External Searc&hes...
 
 PP_MESSAGE_BADPROJ=Some project folders seem to have been moved. \
     Specify their new location or recreate them.
@@ -1582,8 +1582,8 @@ FILTEREDITOR_DESC=Customize the processed source filename patterns, the translat
 
 # FiltersCustomizer.java
 
-FILTERSCUSTOMIZER_TITLE=Global File Filters
-FILTERSCUSTOMIZER_TITLE_PROJECTSPECIFIC=Local File Filters
+FILTERSCUSTOMIZER_TITLE=General File Filters
+FILTERSCUSTOMIZER_TITLE_PROJECTSPECIFIC=Private File Filters
 
 FILTERSCUSTOMIZER_CHECKBOX_PROJECTSPECIFIC=Use local file fil&ter settings
 
@@ -1718,8 +1718,8 @@ CORE_SRX_RULES_FORMATTING_HTML=HTML, XHTML, ODF and Infix segmentation
 
 # org.omegat.segmentation.SegmentationCustomizer
 
-GUI_SEGMENTATION_TITLE=Global Segmentation Rules
-GUI_SEGMENTATION_TITLE_PROJECTSPECIFIC=Local Segmentation Rules
+GUI_SEGMENTATION_TITLE=General Segmentation Rules
+GUI_SEGMENTATION_TITLE_PROJECTSPECIFIC=Private Segmentation Rules
 
 GUI_SEGMENTATION_NOTE=Specific sets should be put above general sets:\n\
 	"FR-CA" should be above "FR.*", which should be above ".*".\n\
@@ -2384,7 +2384,7 @@ PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output
 SAVE_DIALOG_DESCRIPTION=Project data saving interval
 SAVE_DIALOG_MINUTES=Minutes:
 SAVE_DIALOG_SECONDS=Seconds:
-EXTERNAL_COMMAND_LABEL=Global post-processing commands
+EXTERNAL_COMMAND_LABEL=General post-processing commands
 EXTERNAL_COMMAND_DESCRIPTION=
 ALLOW_PROJECT_EXTERN_CMD=&Allow local post-processing commands
 
@@ -2903,7 +2903,7 @@ EXTERNALFINDER_TARGET_ASCII_ONLY=ASCII Only
 EXTERNALFINDER_TARGET_NON_ASCII_ONLY=Non-ASCII Only
 EXTERNALFINDER_TARGET_BOTH=Both
 
-EXTERNALFINDER_PROJECT_COMMANDS_DISALLOWED_MESSAGE=Local project commands are disabled for security reasons. Go to Preferences > Global External Searches to enable them.
+EXTERNALFINDER_PROJECT_COMMANDS_DISALLOWED_MESSAGE=Private project commands are disabled for security reasons. Go to Preferences > General External Searches to enable them.
 
 EXTERNALFINDER_ITEM_ERROR_NAME=Item name is empty or missing
 # 0: Name of ExternalFinder item
@@ -2929,8 +2929,8 @@ EXTERNALFINDER_CONTENT_COMMANDS=Commands
 EXTERNALFINDER_CONTENT_TEMPLATE={0} x{1}
 EXTERNALFINDER_CONTENT_DELIMITER=,\ 
 
-PREFS_TITLE_GLOBAL_EXTERNALFINDER=Global External Searches
-PREFS_TITLE_LOCAL_EXTERNALFINDER=Local External Searches
+PREFS_TITLE_GLOBAL_EXTERNALFINDER=General External Searches
+PREFS_TITLE_LOCAL_EXTERNALFINDER=Private External Searches
 PREFS_EXTERNALFINDER_ITEMS_LABEL=Sets
 PREFS_EXTERNALFINDER_COL_NAME=Name
 PREFS_EXTERNALFINDER_COL_SUMMARY=Summary


### PR DESCRIPTION
Create a better alternative than local/global for preferences:


> The difference is between "stored in the configuration folder" or "stored in the project folder".
> And we also have internal/external (searches) and local/remote (projects)

> Would "private" vs "general" work?

> - private/general settings,
> - private post-processing commands / general post processing commands

> - internal/external searches,
> - private external searches / general external searches

> - local/remote projects