### PR TITLE
fix: always try to calculate the third TM match score (untokenized)

### DIFF
--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -419,9 +419,6 @@ public class FindMatches {
      * @return true if we have chance
      */
     protected boolean haveChanceToAdd(final int simStem, final int simNoStem, final int simExactly) {
-        if (simStem < fuzzyMatchThreshold && simNoStem < fuzzyMatchThreshold) {
-            return false;
-        }
         if (result.size() < maxCount) {
             return true;
         }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Title Matches containing non-alphabetical text are ignored in TM leverage
  * https://sourceforge.net/p/omegat/bugs/1003/
 
## What does this PR change?

- Removes the test that prevents the third percentage to be calculated if the first two are below the threshold.

