### PR TITLE
Refactor(MT):  handle maxTextLength in BaseTranslate

### DIFF
--- a/src/org/omegat/core/machinetranslators/ApertiumTranslate.java
+++ b/src/org/omegat/core/machinetranslators/ApertiumTranslate.java
@@ -111,13 +111,6 @@ public class ApertiumTranslate extends BaseCachedTranslate {
 
     @Override
     protected String translate(Language sLang, Language tLang, String text) throws Exception {
-        String prev = getFromCache(sLang, tLang, text);
-        if (prev != null) {
-            return prev;
-        }
-
-        String trText = text;
-
         String sourceLang = apertiumCode(sLang);
         String targetLang = apertiumCode(tLang);
 
@@ -129,7 +122,7 @@ public class ApertiumTranslate extends BaseCachedTranslate {
             apiKey = APERTIUM_SERVER_KEY_DEFAULT;
         }
         String markUnknownVal = useMarkUnknown() ? "yes" : "no";
-        String url = String.format(APERTIUM_SERVER_URL_FORMAT, server, URLEncoder.encode(trText, "UTF-8"),
+        String url = String.format(APERTIUM_SERVER_URL_FORMAT, server, URLEncoder.encode(text, "UTF-8"),
                 markUnknownVal, sourceLang, targetLang, apiKey);
         String v;
         try {
@@ -139,10 +132,7 @@ public class ApertiumTranslate extends BaseCachedTranslate {
             throw new Exception(OStrings.getString("APERTIUM_CUSTOM_SERVER_NOTFOUND"));
         }
 
-        String tr = getJsonResults(v);
-
-        putToCache(sLang, tLang, trText, tr);
-        return tr;
+        return getJsonResults(v);
     }
 
     /**
@@ -199,9 +189,8 @@ public class ApertiumTranslate extends BaseCachedTranslate {
      * Get the custom server URL.
      */
     private String getCustomServerUrl() {
-        String value = System.getProperty(PROPERTY_APERTIUM_SERVER_URL,
+        return System.getProperty(PROPERTY_APERTIUM_SERVER_URL,
                 Preferences.getPreference(PROPERTY_APERTIUM_SERVER_URL));
-        return value;
     }
 
     /**

--- a/src/org/omegat/core/machinetranslators/BaseCachedTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BaseCachedTranslate.java
@@ -115,7 +115,8 @@ public abstract class BaseCachedTranslate extends BaseTranslate implements IMach
     @Override
     public final String getTranslation(Language sLang, Language tLang, String text) throws Exception {
         if (enabled) {
-            return translate(sLang, tLang, text);
+            String trText = getTruncateText(text);
+            return putCache(sLang, tLang, trText, translate(sLang, tLang, trText));
         } else {
             return null;
         }
@@ -127,7 +128,7 @@ public abstract class BaseCachedTranslate extends BaseTranslate implements IMach
     @Override
     public final String getCachedTranslation(Language sLang, Language tLang, String text) {
         if (enabled) {
-            return getCache(sLang, tLang, text);
+            return getCache(sLang, tLang, getTruncateText(text));
         } else {
             return null;
         }
@@ -136,7 +137,6 @@ public abstract class BaseCachedTranslate extends BaseTranslate implements IMach
     protected abstract String getPreferenceName();
 
     protected abstract String translate(Language sLang, Language tLang, String text) throws Exception;
-
 
     private String getCache(Language sLang, Language tLang, String text) {
         return cache.get(sLang + "/" + tLang + "/" + text);
@@ -153,7 +153,7 @@ public abstract class BaseCachedTranslate extends BaseTranslate implements IMach
      * {@inheritDoc}
      */
     @Override
-    // @Deprecated(since="6.1")
+    @Deprecated
     protected String getFromCache(Language sLang, Language tLang, String text) {
         return getCache(sLang, tLang, text);
     }
@@ -162,7 +162,7 @@ public abstract class BaseCachedTranslate extends BaseTranslate implements IMach
      * {@inheritDoc}
      */
     @Override
-    // @Deprecated(since="6.1")
+    @Deprecated
     protected String putToCache(Language sLang, Language tLang, String text, String result) {
         return putCache(sLang, tLang, text, result);
     }

--- a/src/org/omegat/core/machinetranslators/BaseTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BaseTranslate.java
@@ -183,7 +183,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      *            source text.
      * @return translated text if exists in cache, otherwise null.
      */
-    // @Deprecated(since="6.1")
+    @Deprecated(since="6.1")
     protected String getFromCache(Language sLang, Language tLang, String text) {
         return null;
     }
@@ -209,7 +209,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      *            translation.
      * @return given translation.
      */
-    // @Deprecated(since="6.1")
+    @Deprecated(since="6.1")
     protected String putToCache(Language sLang, Language tLang, String text, String result) {
         return result;
     }

--- a/src/org/omegat/core/machinetranslators/BaseTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BaseTranslate.java
@@ -27,6 +27,7 @@
 
 package org.omegat.core.machinetranslators;
 
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 
 import javax.swing.JCheckBoxMenuItem;
@@ -50,6 +51,9 @@ import org.omegat.util.Preferences;
  * @author Hiroshi Miura
  */
 public abstract class BaseTranslate implements IMachineTranslation {
+
+    private static final String FILLER = "...";
+    private static final int FILLER_LEN = FILLER.length();
 
     protected boolean enabled;
     protected IMTGlossarySupplier glossarySupplier;
@@ -103,7 +107,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
     @Override
     public String getTranslation(Language sLang, Language tLang, String text) throws Exception {
         if (enabled) {
-            return translate(sLang, tLang, text);
+            return translate(sLang, tLang, getTruncateText(text));
         } else {
             return null;
         }
@@ -125,7 +129,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * Attempt to clean spaces added around tags by machine translators. Do it
      * by comparing spaces between the source text and the machine translated
      * text.
-     *
+     * 
      * @param machineText
      *            The text returned by the machine translator
      * @param sourceText
@@ -170,6 +174,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * {@link org.omegat.core.machinetranslators.BaseCachedTranslate} class
      * instead.
      * </p>
+     * 
      * @param sLang
      *            Source langauge.
      * @param tLang
@@ -188,11 +193,12 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * <p>
      * {@link org.omegat.core.machinetranslators.BaseTranslate} class do
      * nothing. When connector want to use cache layer, it can inherit
-     * {@link org.omegat.core.machinetranslators.BaseCachedTranslate} class
-     * and implement
+     * {@link org.omegat.core.machinetranslators.BaseCachedTranslate} class and
+     * implement
      * {@link org.omegat.core.machinetranslators.BaseCachedTranslate#translate}
      * method.
      * </p>
+     * 
      * @param sLang
      *            source langauge.
      * @param tLang
@@ -214,8 +220,8 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * {@link org.omegat.core.machinetranslators.BaseTranslate} class do
      * nothing. When connector want to use cache layer, it can use
      * {@link org.omegat.core.machinetranslators.BaseCachedTranslate} class
-     * instead.
-     * You can all it when you want to clear cache; ex. change server config.
+     * instead. You can all it when you want to clear cache; ex. change server
+     * config.
      * </p>
      */
     protected void clearCache() {
@@ -243,6 +249,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * and, if <code>temporary</code> is <code>false</code>, in the program's
      * persistent preferences encoded in Base64. Retrieve a credential with
      * {@link #getCredential(String)}.
+     * 
      * @param id
      *            ID or key of the credential to store
      * @param value
@@ -261,6 +268,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
      * the definition in {@link #setCredential(String, String, boolean)}. The
      * result will be <code>false</code> if the credential is not stored at all,
      * or if it is stored permanently.
+     * 
      * @param id
      *            ID or key of credential
      * @return <code>true</code> only if the credential is stored temporarily
@@ -269,6 +277,62 @@ public abstract class BaseTranslate implements IMachineTranslation {
      */
     protected boolean isCredentialStoredTemporarily(String id) {
         return !CredentialsManager.getInstance().isStored(id) && !System.getProperty(id, "").isEmpty();
+    }
+
+    /**
+     * Give maximum limit of text bytes which API accepted. 0 means no limit.
+     * 
+     * @return max bytes.
+     */
+    protected int getMaxTextBytes() {
+        return 0;
+    }
+
+    /**
+     * Give maximum limit of text codepoints which API accepted. 0 means no
+     * limit.
+     * 
+     * @return max codepoints.
+     */
+    protected int getMaxTextLength() {
+        return 0;
+    }
+
+    /**
+     * Get truncated text into maximum text length that MT engine API allowed.
+     * 
+     * @param text
+     *            original source text.
+     * @return truncated text.
+     */
+    protected String getTruncateText(String text) {
+        if (getMaxTextBytes() <= 0) {
+            return text;
+        }
+        if (getMaxTextLength() <= 0) {
+            return text;
+        }
+        String result;
+        if (getMaxTextBytes() > 0) {
+            int bytesLength = getTextBytes(text);
+            if (bytesLength <= getMaxTextBytes()) {
+                return text;
+            }
+            final int overflow = bytesLength - getMaxTextBytes();
+            int ind = text.length() - (overflow >> 2) - FILLER_LEN;
+            int start = text.length() - overflow + FILLER_LEN;
+            do {
+                result = text.substring(0, ind) + FILLER;
+                ind--;
+            } while (ind > start && getTextBytes(result) > getMaxTextBytes());
+        } else {
+            result = text.substring(0, getMaxTextLength() - FILLER_LEN) + FILLER;
+        }
+        return result;
+    }
+
+    private int getTextBytes(String text) {
+        return text.getBytes(StandardCharsets.UTF_8).length;
     }
 
     /** Convert entities to character. Ex: "&#39;" to "'". */

--- a/src/org/omegat/core/machinetranslators/BelazarTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BelazarTranslate.java
@@ -57,22 +57,37 @@ public class BelazarTranslate extends BaseCachedTranslate {
     public static void unloadPlugins() {
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected String getPreferenceName() {
         return Preferences.ALLOW_BELAZAR_TRANSLATE;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getName() {
         return OStrings.getString("MT_ENGINE_BELAZAR");
     }
 
+    /**
+     * Query Belazar translation API and return translation.
+     * 
+     * @param sLang
+     *            source language.
+     * @param tLang
+     *            target language.
+     * @param text
+     *            source text.
+     * @return translation.
+     * @throws Exception
+     *             when communication error.
+     */
     @Override
     protected String translate(Language sLang, Language tLang, String text) throws Exception {
-        String prev = getFromCache(sLang, tLang, text);
-        if (prev != null) {
-            return prev;
-        }
-
         String mode;
         if ("be".equalsIgnoreCase(sLang.getLanguageCode())
                 && "ru".equalsIgnoreCase(tLang.getLanguageCode())) {
@@ -96,16 +111,10 @@ public class BelazarTranslate extends BaseCachedTranslate {
         conn.setUseCaches(false);
         conn.setDoInput(true);
         conn.setDoOutput(true);
-        String result;
         try (OutputStream out = conn.getOutputStream(); InputStream in = conn.getInputStream()) {
             out.write(db);
             out.flush();
-            result = IOUtils.toString(in, CHARSET);
+            return IOUtils.toString(in, CHARSET);
         }
-        if (result == null) {
-            return null;
-        }
-        putToCache(sLang, tLang, text, result);
-        return result;
     }
 }

--- a/src/org/omegat/core/machinetranslators/DeepLTranslate.java
+++ b/src/org/omegat/core/machinetranslators/DeepLTranslate.java
@@ -74,6 +74,11 @@ public class DeepLTranslate extends BaseCachedTranslate {
     protected final String deepLUrl;
 
     private final static int MAX_TEXT_BYTES = 128 * 1024; // Max limit is 128KiB
+    protected static final String DEEPL_URL = "https://api.deepl.com/v1/translate";
+    // See https://support.deepl.com/hc/en-us/articles/4405712799250-Character-count-for-translation-within
+    // -applications
+    // max application limit is 5000 characters.
+    private final static int MAX_TEXT_LENGTH = 5000;
 
     public DeepLTranslate() {
         deepLUrl = DEEPL_V1_URL;
@@ -106,8 +111,8 @@ public class DeepLTranslate extends BaseCachedTranslate {
     }
 
     @Override
-    protected int getMaxTextBytes() {
-        return MAX_TEXT_BYTES;
+    protected int getMaxTextLength() {
+        return MAX_TEXT_LENGTH;
     }
 
     @Override

--- a/src/org/omegat/core/machinetranslators/DeepLTranslate.java
+++ b/src/org/omegat/core/machinetranslators/DeepLTranslate.java
@@ -61,7 +61,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
     protected static final String PROPERTY_API_KEY = "deepl.api.key";
     private String temporaryKey = null;
 
-    private static final String DEEPL_V1_URL = "https://api.deepl.com/v1/translate";
+    protected static final String DEEPL_V1_URL = "https://api.deepl.com/v1/translate";
 
     // DO NOT MOVE TO THE V2 API until it becomes available for CAT tool
     // integration.
@@ -73,7 +73,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
     protected static final String DEEPL_PATH = "/v1/translate";
     protected final String deepLUrl;
 
-    private final static int MAX_TEXT_LENGTH = 5000;
+    private final static int MAX_TEXT_BYTES = 128 * 1024; // Max limit is 128KiB
 
     public DeepLTranslate() {
         deepLUrl = DEEPL_V1_URL;
@@ -89,25 +89,29 @@ public class DeepLTranslate extends BaseCachedTranslate {
         temporaryKey = key;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected String getPreferenceName() {
         return Preferences.ALLOW_DEEPL_TRANSLATE;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getName() {
         return OStrings.getString("MT_ENGINE_DEEPL");
     }
 
     @Override
-    protected String translate(Language sLang, Language tLang, String text) throws Exception {
-        String trText = text.length() > MAX_TEXT_LENGTH ? text.substring(0, MAX_TEXT_LENGTH - 3) + "..." :
-                text;
-        String prev = getFromCache(sLang, tLang, trText);
-        if (prev != null) {
-            return prev;
-        }
+    protected int getMaxTextBytes() {
+        return MAX_TEXT_BYTES;
+    }
 
+    @Override
+    protected String translate(Language sLang, Language tLang, String text) throws Exception {
         String apiKey = getCredential(PROPERTY_API_KEY);
         if (apiKey == null || apiKey.isEmpty()) {
             if (temporaryKey == null) {
@@ -121,7 +125,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
         // No check is done, but only "EN", "DE", "FR", "ES", "IT", "NL", "PL"
         // are supported right now.
 
-        params.put("text", trText);
+        params.put("text", text);
         params.put("source_lang", sLang.getLanguageCode().toUpperCase());
         params.put("target_lang", tLang.getLanguageCode().toUpperCase());
         params.put("tag_handling", "xml");
@@ -145,9 +149,7 @@ public class DeepLTranslate extends BaseCachedTranslate {
             return null;
         }
         tr = unescapeHTML(tr);
-        tr = cleanSpacesAroundTags(tr, trText);
-        putToCache(sLang, tLang, trText, tr);
-        return tr;
+        return cleanSpacesAroundTags(tr, text);
     }
 
     /**
@@ -184,6 +186,11 @@ public class DeepLTranslate extends BaseCachedTranslate {
         throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
     }
 
+    /**
+     * Engine is configurable.
+     *
+     * @return true
+     */
     @Override
     public boolean isConfigurable() {
         return true;

--- a/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
+++ b/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
@@ -72,6 +72,8 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
 
     protected static final String WATSON_URL = "https://gateway.watsonplatform.net/language-translator/api/v3/translate";
     protected static final String WATSON_VERSION = "2018-05-01";
+    // API limit: 50 KB (51,200 bytes) of text
+    // See https://cloud.ibm.com/apidocs/language-translator#translate
     private static final int MAX_BYTES_TEXT = 51200;
 
     @Override

--- a/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
+++ b/src/org/omegat/core/machinetranslators/IBMWatsonTranslate.java
@@ -72,6 +72,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
 
     protected static final String WATSON_URL = "https://gateway.watsonplatform.net/language-translator/api/v3/translate";
     protected static final String WATSON_VERSION = "2018-05-01";
+    private static final int MAX_BYTES_TEXT = 51200;
 
     @Override
     protected String getPreferenceName() {
@@ -84,13 +85,12 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
     }
 
     @Override
-    protected String translate(Language sLang, Language tLang, String text) throws Exception {
-        String trText = text.length() > 5000 ? text.substring(0, 4997) + "..." : text;
-        String prev = getFromCache(sLang, tLang, trText);
-        if (prev != null) {
-            return prev;
-        }
+    protected int getMaxTextBytes() {
+        return MAX_BYTES_TEXT;
+    }
 
+    @Override
+    protected String translate(Language sLang, Language tLang, String text) throws Exception {
         String apiLogin = getCredential(PROPERTY_LOGIN);
         String apiPassword = getCredential(PROPERTY_PASSWORD);
 
@@ -108,7 +108,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
             apiPassword = apiLogin;
             apiLogin = "apikey";
         }
-        String json = createJsonRequest(sLang, tLang, trText);
+        String json = createJsonRequest(sLang, tLang, text);
 
         Map<String, String> headers = new TreeMap<>();
 
@@ -133,9 +133,7 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
             return null;
         }
         tr = unescapeHTML(tr);
-        tr = cleanSpacesAroundTags(tr, trText);
-        putToCache(sLang, tLang, trText, tr);
-        return tr;
+        return cleanSpacesAroundTags(tr, text);
     }
 
     private String getModelId() {
@@ -167,8 +165,8 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
     }
 
     /**
-     * Parse Watson response and return translated text.sed
-     * 
+     * Parse Watson response and return translated text.
+     *
      * @param json
      *            response.
      * @return translated text.
@@ -193,6 +191,11 @@ public class IBMWatsonTranslate extends BaseCachedTranslate {
         throw new MachineTranslateError(OStrings.getString("MT_JSON_ERROR"));
     }
 
+    /**
+     * Engine is configurable.
+     *
+     * @return true
+     */
     @Override
     public boolean isConfigurable() {
         return true;

--- a/src/org/omegat/core/machinetranslators/MyMemoryHumanTranslate.java
+++ b/src/org/omegat/core/machinetranslators/MyMemoryHumanTranslate.java
@@ -71,22 +71,13 @@ public final class MyMemoryHumanTranslate extends AbstractMyMemoryTranslate {
     @SuppressWarnings("unchecked")
     @Override
     protected String translate(final Language sLang, final Language tLang, final String text) throws Exception {
-        String prev = getFromCache(sLang, tLang, text);
-        if (prev != null) {
-            return prev;
-        }
-
-        JsonNode jsonResponse;
         try {
             // Get MyMemory response in JSON format
-            jsonResponse = getMyMemoryResponse(sLang, tLang, text);
-
+            JsonNode jsonResponse = getMyMemoryResponse(sLang, tLang, text);
             // responseData/translatedText contains the best match.
             JsonNode responseData = jsonResponse.get("responseData");
             if (responseData != null) {
-                String translation = responseData.get("translatedText").asText();
-                putToCache(sLang, tLang, text, translation);
-                return translation;
+                return responseData.get("translatedText").asText();
             }
         } catch (IOException e) {
             throw new MachineTranslateError("MT_ENGINE_MYMEMORY_ERROR", e);

--- a/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
+++ b/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
@@ -96,9 +96,7 @@ public final class MyMemoryMachineTranslate extends AbstractMyMemoryTranslate {
                 bestEntry = mtEntry;
             }
             assert bestEntry != null;
-            String translation = StringEscapeUtils.unescapeHtml4(bestEntry.get("translation").asText());
-            putToCache(sLang, tLang, text, translation);
-            return translation;
+            return StringEscapeUtils.unescapeHtml4(bestEntry.get("translation").asText());
         } catch (IOException e) {
             throw new MachineTranslateError(OStrings.getString("MT_ENGINE_MYMEMOROY_ERROR"), e);
         }

--- a/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
+++ b/src/org/omegat/core/machinetranslators/MyMemoryMachineTranslate.java
@@ -70,15 +70,11 @@ public final class MyMemoryMachineTranslate extends AbstractMyMemoryTranslate {
     }
 
     @Override
-    protected String translate(final Language sLang, final Language tLang, final String text) throws Exception {
-        String prev = getFromCache(sLang, tLang, text);
-        if (prev != null) {
-            return prev;
-        }
-        JsonNode jsonResponse;
+    protected String translate(final Language sLang, final Language tLang, final String text)
+            throws Exception {
         try {
             // Get MyMemory response in JSON format
-            jsonResponse = getMyMemoryResponse(sLang, tLang, text);
+            JsonNode jsonResponse = getMyMemoryResponse(sLang, tLang, text);
 
             // Find the best Human translation if no MT translation is provided for
             // this text. If there is a MT translation, it will always take

--- a/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
+++ b/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
@@ -75,6 +75,9 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
     private static final String PROPERTY_KEEP_TAGS = "yandex.cloud.keep-tags";
 
     private static final int MAX_GLOSSARY_TERMS = 50;
+
+    // API limit
+    // see https://cloud.yandex.com/en/docs/translate/concepts/limits
     private static final int MAX_TEXT_LENGTH = 10000;
     private static final int IAM_TOKEN_TTL_SECONDS = 3600; // Recommended value
 

--- a/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
+++ b/src/org/omegat/core/machinetranslators/YandexCloudTranslate.java
@@ -96,15 +96,13 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
     }
 
     @Override
+    protected int getMaxTextLength() {
+        return MAX_TEXT_LENGTH;
+    }
+
+    @Override
     protected String translate(final Language sLang, final Language tLang, final String text)
             throws Exception {
-        String trText = text.length() > MAX_TEXT_LENGTH ? text.substring(0, MAX_TEXT_LENGTH - 3) + "..."
-                : text;
-        String prev = getFromCache(sLang, tLang, trText);
-        if (prev != null) {
-            return prev;
-        }
-
         String oAuthToken = getCredential(PROPERTY_OAUTH_TOKEN);
         if (oAuthToken == null || oAuthToken.isEmpty()) {
             throw new Exception(OStrings.getString("MT_ENGINE_YANDEX_CLOUD_OAUTH_TOKEN_NOT_FOUND"));
@@ -120,7 +118,7 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
             throw new Exception(IAMErrorMessage);
         }
 
-        String request = createJsonRequest(sLang, tLang, trText, folderId);
+        String request = createJsonRequest(sLang, tLang, text, folderId);
 
         Map<String, String> headers = new TreeMap<>();
         headers.put("Authorization", "Bearer " + IAMToken);
@@ -143,9 +141,7 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
         if (tr == null) {
             return null;
         }
-        tr = cleanSpacesAroundTags(tr, trText);
-        putToCache(sLang, tLang, trText, tr);
-        return tr;
+        return cleanSpacesAroundTags(tr, text);
     }
 
     @Override
@@ -247,7 +243,7 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
 
     @SuppressWarnings("unchecked")
     private String getIAMToken(final String oAuthToken) {
-        if (System.currentTimeMillis() - lastIAMTokenTime > IAM_TOKEN_TTL_SECONDS * 1000) {
+        if (System.currentTimeMillis() - lastIAMTokenTime > IAM_TOKEN_TTL_SECONDS * 1_000) {
 
             String request = "{\"yandexPassportOauthToken\":\"" + oAuthToken + "\"}";
             String response;

--- a/src/org/omegat/gui/exttrans/IMachineTranslation.java
+++ b/src/org/omegat/gui/exttrans/IMachineTranslation.java
@@ -44,7 +44,7 @@ public interface IMachineTranslation {
     String getName();
 
     /**
-     * Determine whether or not the MT provider has been enabled by the user.
+     * Determine whether the MT provider has been enabled by the user.
      */
     boolean isEnabled();
 
@@ -55,17 +55,17 @@ public interface IMachineTranslation {
         // Nothing
     }
 
-	/**
-	 * Set a glossary supplier to provide relevant glossary terms if desired. The
-	 * terms are provided as a map with keys being the source terms and values being
-	 * the target terms.
-	 *
-	 * @param glossarySupplier
-	 */
-	default void setGlossarySupplier(IMTGlossarySupplier glossarySupplier) {
-		Logger.getLogger(IMachineTranslation.class.getName())
-				.warning("IMachineTranslation.setGlossaryProvider default (empty) implementation called");
-	}
+    /**
+     * Set a glossary supplier to provide relevant glossary terms if desired.
+     * The terms are provided as a map with keys being the source terms and
+     * values being the target terms.
+     *
+     * @param glossarySupplier
+     */
+    default void setGlossarySupplier(IMTGlossarySupplier glossarySupplier) {
+        Logger.getLogger(IMachineTranslation.class.getName())
+                .warning("IMachineTranslation.setGlossaryProvider default (empty) implementation called");
+    }
 
     /**
      * Translate.


### PR DESCRIPTION
## Pull request type

- Other (describe below)

refactor

## Which ticket is resolved?

Suggested in PR #470

## What does this PR change?

- Introduce `BaseCachedTranslate` class that has Cache layer.
- Change `BaseTranslate` not to handle cache
- Introduce `BaseTranslate#getTruncateText`  and handle source text max length in common
- Add constructor with maxTextLength

## Other information
