### PR TITLE
Add left thick border to glossary pane mock-up

### DIFF
--- a/doc_src/OmegaT_new.css
+++ b/doc_src/OmegaT_new.css
@@ -908,7 +908,12 @@ dd {
 	color:var(--term-match);
 }
 
-/* Glossary match */ 
+/* Glossary match */
+
+#glossary\.matches > div.example-contents > pre {
+	border-left: 10px solid lightgrey;
+	border-radius: 5px;
+}
 
 #glossary\.matches .token {
 	font-weight:bold;


### PR DESCRIPTION
This is intended to create the same L&F among various pane mock-ups (cf. Editor pane, fuzzy match pane).