### PR TITLE
fix(Xliff2filter): startElement process dup

### DIFF
--- a/src/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -181,26 +181,25 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
             try {
                 strReader = iFactory.createXMLStreamReader(inReader);
                 eventReader = iFactory.createXMLEventReader(strReader);
-                isEventMode = false; // always start like this, even with new
-                                     // file
+                // always start like this, even with new file
+                isEventMode = false;
                 if (writer == null) {
                     while (strReader.hasNext()) {
                         if (!isEventMode) {
                             checkCurrentCursorPosition(strReader, false);
-                        }
-                        if (isEventMode) { // calculated after
-                                           // checkCurrentCursorPosition, may
-                                           // have changed!
-                            XMLEvent event = eventReader.nextEvent();
-                            if (event.isStartElement()) {
-                                processStartElement(event.asStartElement(), null);
-                            } else if (event.isEndElement()) {
-                                processEndElement(event.asEndElement(), null);
-                            } else if (event.isCharacters()) {
-                                processCharacters(event.asCharacters(), null);
-                            }
-                        } else {
                             strReader.next();
+                            continue;
+                        }
+                        // calculated after
+                        // checkCurrentCursorPosition, may
+                        // have changed!
+                        XMLEvent event = eventReader.nextEvent();
+                        if (event.isStartElement()) {
+                            processStartElement(event.asStartElement(), null);
+                        } else if (event.isEndElement()) {
+                            processEndElement(event.asEndElement(), null);
+                        } else if (event.isCharacters()) {
+                            processCharacters(event.asCharacters(), null);
                         }
                     }
                 } else {


### PR DESCRIPTION
When reaching `group` tag, Xliff2Filter#checkCurrentCursorPosition calls AbstractXliffFilter#checkCurrentCursorPosition that call `processStartElement`, then update isEventMode=true.

When back to caller AbstractXmlFilter#processFile, it calls `procesStartElement` again.

The change avoid multiple call of processStartElement on same element.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

https://github.com/omegat-org/omegat/pull/239#issuecomment-1407349578
