### PR TITLE
refactor(filters4): avoid catching NPE

### DIFF
--- a/src/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -71,9 +71,12 @@ import org.omegat.util.StaticUtils;
  * This class is more low-level than 'filters3' API, but this is necessary to
  * implement bilingual or very complex XML formats. <br/>
  * To implement your own filter based on this class you must implement
- * {@link org.omegat.filters4.xml.AbstractXmlFilter#processStartElement processStartElement},
- * {@link org.omegat.filters4.xml.AbstractXmlFilter#processEndElement processEndElement} and
- * {@link org.omegat.filters4.xml.AbstractXmlFilter#processCharacters processCharacters} <br/>
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processStartElement
+ * processStartElement},
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processEndElement
+ * processEndElement} and
+ * {@link org.omegat.filters4.xml.AbstractXmlFilter#processCharacters
+ * processCharacters} <br/>
  * Boolean return value will be ignored during reading process (when event
  * writer is null), while during project compilation, it says whenever the event
  * must be kept in the result or not (generally, parts of the XML file which are
@@ -173,8 +176,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     /**
      * Processes a buffer.
      * <p>
-     * This method works only if buffered reader and writer
-     * are already configured with correct encoding and EOL.
+     * This method works only if buffered reader and writer are already
+     * configured with correct encoding and EOL.
      **/
     @Override
     public void processFile(BufferedReader inReader, BufferedWriter writer, FilterContext fc)
@@ -283,8 +286,8 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     /**
      * Indicates whenever we are in event mode or not.
      * <p>
-     * We always start with
-     * false, and checkCurrentCursorPosition may set it to true
+     * We always start with false, and checkCurrentCursorPosition may set it to
+     * true
      **/
     protected boolean isEventMode = false;
 

--- a/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
@@ -213,7 +213,8 @@ class OpenXmlFilter extends AbstractXmlFilter {
                 return true;
             }
             if ("r".equals(name.getLocalPart())) {
-                if (currentBuffer != null) { // run which almost contains some text
+                if (currentBuffer != null) {
+                    // run which almost contains some text
                     currentBuffer.add(endElement);
                     currentBuffer = new LinkedList<>();
                     currentPara.add(currentBuffer);
@@ -340,8 +341,8 @@ class OpenXmlFilter extends AbstractXmlFilter {
                 }
             } else {
                 if (i == 0) {
-                    if ((run.size() > 1) && run.get(1).isStartElement() && run.get(1)
-                            .asStartElement().getName().getLocalPart().equals("pPr")) {
+                    if ((run.size() > 1) && run.get(1).isStartElement()
+                            && run.get(1).asStartElement().getName().getLocalPart().equals("pPr")) {
                         defaultsForParagraph = run; // looks like defaults,
                                                     // but...
                         LOOP2: for (int j = 1; j < currentPara.size(); j++) {
@@ -480,20 +481,20 @@ class OpenXmlFilter extends AbstractXmlFilter {
                 final int idx = runIter.previousIndex();
                 String name = next.asStartElement().getName().getLocalPart();
                 switch (name) {
-                    case "footnoteRef":
-                        prefixInt = 'n';
-                        break;
-                    case "tab":
-                    case "br":
-                        prefixInt = 'd';
-                        break;
-                    case "drawing":
-                        prefixInt = 'g';
-                        break;
-                    case "t":
-                        continue;
-                    default:
-                        prefixInt = 'e';
+                case "footnoteRef":
+                    prefixInt = 'n';
+                    break;
+                case "tab":
+                case "br":
+                    prefixInt = 'd';
+                    break;
+                case "drawing":
+                    prefixInt = 'g';
+                    break;
+                case "t":
+                    continue;
+                default:
+                    prefixInt = 'e';
                 }
                 while (!(next.isEndElement() && next.asEndElement().getName().getLocalPart().equals(name))) {
                     next = runIter.next();
@@ -510,7 +511,7 @@ class OpenXmlFilter extends AbstractXmlFilter {
                 nList.add(eFactory.createEndElement(qR, null));
                 res.append("<" + prefixInt + tcInt + "/>");
                 tagsMap.put("" + prefixInt + tcInt, nList);
-            } else if (next.isCharacters()){
+            } else if (next.isCharacters()) {
                 res.append(next.asCharacters().getData());
             }
         }

--- a/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -25,13 +25,14 @@
 
 package org.omegat.filters4.xml.xliff;
 
-import java.util.List;
-import java.util.LinkedList;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
@@ -45,6 +46,7 @@ import org.omegat.util.OStrings;
  * @author Thomas Cordonnier
  */
 public class Xliff2Filter extends AbstractXliffFilter {
+    private Pattern intPattern = Pattern.compile("-?\\d+");
 
     // --------------------------- IFilter API ----------------------------
 
@@ -62,10 +64,12 @@ public class Xliff2Filter extends AbstractXliffFilter {
     @Override
     protected void checkCurrentCursorPosition(javax.xml.stream.XMLStreamReader reader, boolean doWrite) {
         if (reader.getEventType() == StartElement.START_ELEMENT) {
-            // XLIFF 2 has no body, so we must start on another markup
+            // XLIFF 2 has no "body", so we must start on another
+            // markup
             // Warning: this solution works for pure XLIFF 2 only:
-            // if later we write a derivative (like SDLXLIFF inheriting from XLIFF 1)
-            // then the derivative may need a finer algorithm.
+            // if later we write a derivative (like SDLXLIFF inheriting
+            // from XLIFF 1) then the derivative may need a finer
+            // algorithm.
             if (reader.getLocalName().equals("xliff")) {
                 this.isEventMode = true;
                 if (namespace == null) {
@@ -91,29 +95,27 @@ public class Xliff2Filter extends AbstractXliffFilter {
         case "file":
         case "group":
         case "unit":
-            try {
-                path += "/" + startElement.getAttributeByName(new QName("id")).getValue();
-            } catch (NullPointerException noid) { // Note: in spec, id is
-                                                  // REQUIRED
+            Attribute idAttr = startElement.getAttributeByName(new QName(("id")));
+            if (idAttr != null) {
+                path += "/" + idAttr.getValue();
+            } else {
+                // id is REQUIRED in spec, so we treat as error.
                 throw new XMLStreamException(OStrings.getString("XLIFF_MANDATORY_ORIGINAL_MISSING", "id",
                         startElement.getName().getLocalPart()));
             }
             updateIgnoreScope(startElement);
             break;
         case "segment":
-            try {
-                segId = startElement.getAttributeByName(new QName("id")).getValue();
-            } catch (NullPointerException noid) { // Note: in spec, id is
-                                                  // OPTIONAL
-                if (segId == null) {
-                    segId = "1";
-                } else {
-                    try {
-                        segId = Integer.toString(Integer.parseInt(segId) + 1);
-                    } catch (NumberFormatException fmt) {
-                        segId = "1";
-                    }
-                }
+            idAttr = startElement.getAttributeByName(new QName("id"));
+            // because id is OPTIONAL in spec, it can be null
+            if (idAttr != null) {
+                segId = idAttr.getValue();
+            } else if (segId == null) {
+                segId = "1";
+            } else if (intPattern.matcher(segId).matches()) {
+                segId = Integer.toString(Integer.parseInt(segId) + 1);
+            } else {
+                segId = "1";
             }
             flushedSegment = false;
             break;


### PR DESCRIPTION
Xliff2Filter use  `try { ... } catch (NPE e) { ..} `. This type of block is not recommended,
 and update as `if (foo !=null) { ...} else {... }`.   

## Pull request type

refactor

## What does this PR change?

- Refactor Xliff2Filter to avoid catch NPE to process.
- Update javadoc/comments

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
