### PR TITLE
Remove change orientation shortcut from appendix

### DIFF
--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -1342,12 +1342,6 @@
             </row>
 
             <row>
-              <entry>Switch RtL/LtR Orientation</entry>
-              <entry>editorSwitchOrientation</entry>
-              <entry namest="3" nameend="4">ctrl shift O</entry>
-            </row>
-
-            <row>
               <entry>Delete Previous Token</entry>
               <entry>editorDeletePrevToken</entry>
               <entry>ctrl BACK_SPACE</entry>


### PR DESCRIPTION
The appendix still had info about the shortcut.