### PR TITLE
[1135] Avoid mnemonics in context menus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ dependencies {
         runtimeOnly 'org.slf4j:slf4j-jdk14:1.7.32' // needed by vldocking
         implementation 'org.omegat:htmlparser:1.6-20230203'
         implementation 'org.omegat:gnudiff4j:1.15'
-        implementation 'org.omegat:lib-mnemonics:1.0'
+        implementation 'org.omegat:lib-mnemonics:1.1'
         implementation 'org.omegat:jmyspell-core:1.0.0-beta-2'
 
         // LanguageTool

--- a/src/org/omegat/gui/dictionaries/DictionaryPopup.java
+++ b/src/org/omegat/gui/dictionaries/DictionaryPopup.java
@@ -32,6 +32,8 @@ import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
 import org.omegat.util.OStrings;
 
+import org.openide.awt.Mnemonics;
+
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.text.JTextComponent;
@@ -51,7 +53,7 @@ public class DictionaryPopup implements IPopupMenuConstructor {
         }
 
         JMenuItem searchMenuItem = new JMenuItem();
-        searchMenuItem.setText(EditorPopups.translateMenu("TF_MENU_EDIT_SEARCH_DICTIONARY"));
+        searchMenuItem.setText(Mnemonics.removeMnemonics(OStrings.getString("TF_MENU_EDIT_SEARCH_DICTIONARY")));
         searchMenuItem.addActionListener(e -> Core.getDictionaries().searchText(searchedText));
         menu.add(searchMenuItem);
         menu.addSeparator();

--- a/src/org/omegat/gui/dictionaries/DictionaryPopup.java
+++ b/src/org/omegat/gui/dictionaries/DictionaryPopup.java
@@ -27,6 +27,7 @@ package org.omegat.gui.dictionaries;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.editor.EditorPopups;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
 import org.omegat.util.OStrings;
@@ -50,7 +51,7 @@ public class DictionaryPopup implements IPopupMenuConstructor {
         }
 
         JMenuItem searchMenuItem = new JMenuItem();
-        searchMenuItem.setText(OStrings.getString("TF_MENU_EDIT_SEARCH_DICTIONARY"));
+        searchMenuItem.setText(EditorPopups.translateMenu("TF_MENU_EDIT_SEARCH_DICTIONARY"));
         searchMenuItem.addActionListener(e -> Core.getDictionaries().searchText(searchedText));
         menu.add(searchMenuItem);
         menu.addSeparator();

--- a/src/org/omegat/gui/editor/EditorPopups.java
+++ b/src/org/omegat/gui/editor/EditorPopups.java
@@ -7,6 +7,7 @@
                2010 Wildrich Fourie
                2011 Alex Buloichik, Didier Briel
                2015 Aaron Madlon-Kay
+               2023 Thomas Cordonnier
                Home page: http://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -62,6 +63,7 @@ import org.omegat.util.gui.UIThreadsUtil;
  * @author Wildrich Fourie
  * @author Didier Briel
  * @author Aaron Madlon-Kay
+ * @author Thomas Cordonnier
  */
 public final class EditorPopups {
     public static void init(EditorController ec) {
@@ -75,6 +77,14 @@ public final class EditorPopups {
     }
 
     private EditorPopups() {
+    }
+    
+    /** 
+     * Translate menu item but ensuring it does not contain mnemonics,
+     * because they do not work with context menus
+     **/
+    public static String translateMenu(String id) {
+        return OStrings.getString(id).replace("&","");
     }
 
     /**
@@ -150,7 +160,7 @@ public final class EditorPopups {
 
                 // what if no action is done?
                 if (suggestions.isEmpty()) {
-                    JMenuItem item = menu.add(OStrings.getString("SC_NO_SUGGESTIONS"));
+                    JMenuItem item = menu.add(translateMenu("SC_NO_SUGGESTIONS"));
                     item.addActionListener(new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             // just hide the menu
@@ -161,7 +171,7 @@ public final class EditorPopups {
                 menu.addSeparator();
 
                 // let us ignore it
-                JMenuItem item = menu.add(OStrings.getString("SC_IGNORE_ALL"));
+                JMenuItem item = menu.add(translateMenu("SC_IGNORE_ALL"));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         addIgnoreWord(word, wordStart, false);
@@ -169,7 +179,7 @@ public final class EditorPopups {
                 });
 
                 // or add it to the dictionary
-                item = menu.add(OStrings.getString("SC_ADD_TO_DICTIONARY"));
+                item = menu.add(translateMenu("SC_ADD_TO_DICTIONARY"));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         addIgnoreWord(word, wordStart, true);
@@ -233,7 +243,7 @@ public final class EditorPopups {
             }
 
             // Cut
-            JMenuItem cutContextItem = menu.add(OStrings.getString("CCP_CUT"));
+            JMenuItem cutContextItem = menu.add(translateMenu("CCP_CUT"));
             if (cutEnabled) {
                 cutContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -245,7 +255,7 @@ public final class EditorPopups {
             }
 
             // Copy
-            JMenuItem copyContextItem = menu.add(OStrings.getString("CCP_COPY"));
+            JMenuItem copyContextItem = menu.add(translateMenu("CCP_COPY"));
             if (copyEnabled) {
                 copyContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -257,7 +267,7 @@ public final class EditorPopups {
             }
 
             // Paste
-            JMenuItem pasteContextItem = menu.add(OStrings.getString("CCP_PASTE"));
+            JMenuItem pasteContextItem = menu.add(translateMenu("CCP_PASTE"));
             if (pasteEnabled) {
                 pasteContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -271,7 +281,7 @@ public final class EditorPopups {
             menu.addSeparator();
 
             // Add glossary entry
-            JMenuItem item = menu.add(OStrings.getString("GUI_GLOSSARYWINDOW_addentry"));
+            JMenuItem item = menu.add(translateMenu("GUI_GLOSSARYWINDOW_addentry"));
             item.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     Core.getGlossary()
@@ -301,7 +311,7 @@ public final class EditorPopups {
                 return;
             }
 
-            JMenuItem item = menu.add(OStrings.getString("MW_PROMPT_SEG_NR_TITLE"));
+            JMenuItem item = menu.add(translateMenu("MW_PROMPT_SEG_NR_TITLE"));
             item.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     comp.setCaretPosition(mousepos);
@@ -332,12 +342,12 @@ public final class EditorPopups {
                 return;
             }
             JMenuItem header = menu
-                    .add(StringUtil.format(OStrings.getString("MW_GO_TO_DUPLICATE_HEADER"), dups.size()));
+                    .add(StringUtil.format(translateMenu("MW_GO_TO_DUPLICATE_HEADER"), dups.size()));
             header.setEnabled(false);
             MenuItemPager pager = new MenuItemPager(menu);
             for (SourceTextEntry entry : dups) {
                 int entryNum = entry.entryNum();
-                String label = StringUtil.format(OStrings.getString("MW_GO_TO_DUPLICATE_ITEM"), entryNum);
+                String label = StringUtil.format(translateMenu("MW_GO_TO_DUPLICATE_ITEM"), entryNum);
                 JMenuItem item = pager.add(new JMenuItem(label));
                 item.addActionListener(e -> ec.gotoEntry(entryNum));
             }
@@ -361,19 +371,19 @@ public final class EditorPopups {
                 return;
             }
 
-            menu.add(OStrings.getString("TRANS_POP_EMPTY_TRANSLATION")).addActionListener(
+            menu.add(translateMenu("TRANS_POP_EMPTY_TRANSLATION")).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerEmptyTranslation();
                         }
                     });
-            menu.add(OStrings.getString("TRANS_POP_REMOVE_TRANSLATION")).addActionListener(
+            menu.add(translateMenu("TRANS_POP_REMOVE_TRANSLATION")).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerUntranslated();
                         }
                     });
-            menu.add(OStrings.getString("TRANS_POP_IDENTICAL_TRANSLATION")).addActionListener(
+            menu.add(translateMenu("TRANS_POP_IDENTICAL_TRANSLATION")).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerIdenticalTranslation();
@@ -397,7 +407,7 @@ public final class EditorPopups {
             }
 
             for (final Tag tag : TagUtil.getAllTagsMissingFromTarget()) {
-                JMenuItem item = menu.add(StringUtil.format(OStrings.getString("TF_MENU_EDIT_TAG_INSERT_N"), tag.tag));
+                JMenuItem item = menu.add(StringUtil.format(translateMenu("TF_MENU_EDIT_TAG_INSERT_N"), tag.tag));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         Core.getEditor().insertTag(tag.tag);
@@ -424,9 +434,9 @@ public final class EditorPopups {
             if (!isInActiveTranslation) {
                 return;
             }
-            JMenu submenu = new JMenu(OStrings.getString("TF_MENU_EDIT_INSERT_CHARS"));
+            JMenu submenu = new JMenu(translateMenu("TF_MENU_EDIT_INSERT_CHARS"));
             for (int i = 0; i < names.length; i++) {
-                JMenuItem item = new JMenuItem(OStrings.getString(names[i]));
+                JMenuItem item = new JMenuItem(translateMenu(names[i]));
                 final String insertText = inserts[i];
                 item.addActionListener(new ActionListener() {
                     @Override

--- a/src/org/omegat/gui/editor/EditorPopups.java
+++ b/src/org/omegat/gui/editor/EditorPopups.java
@@ -43,6 +43,8 @@ import javax.swing.text.AbstractDocument;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 
+import org.openide.awt.Mnemonics;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.spellchecker.SpellCheckerMarker;
@@ -84,7 +86,7 @@ public final class EditorPopups {
      * because they do not work with context menus
      **/
     public static String translateMenu(String id) {
-        return OStrings.getString(id).replace("&","");
+        return Mnemonics.removeMnemonics(OStrings.getString(id));
     }
 
     /**

--- a/src/org/omegat/gui/editor/EditorPopups.java
+++ b/src/org/omegat/gui/editor/EditorPopups.java
@@ -81,14 +81,6 @@ public final class EditorPopups {
     private EditorPopups() {
     }
     
-    /** 
-     * Translate menu item but ensuring it does not contain mnemonics,
-     * because they do not work with context menus
-     **/
-    public static String translateMenu(String id) {
-        return Mnemonics.removeMnemonics(OStrings.getString(id));
-    }
-
     /**
      * create the spell checker popup menu - suggestions for a wrong word, add
      * and ignore. Works only for the active segment, for the translation
@@ -162,7 +154,7 @@ public final class EditorPopups {
 
                 // what if no action is done?
                 if (suggestions.isEmpty()) {
-                    JMenuItem item = menu.add(translateMenu("SC_NO_SUGGESTIONS"));
+                    JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_NO_SUGGESTIONS")));
                     item.addActionListener(new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             // just hide the menu
@@ -173,7 +165,7 @@ public final class EditorPopups {
                 menu.addSeparator();
 
                 // let us ignore it
-                JMenuItem item = menu.add(translateMenu("SC_IGNORE_ALL"));
+                JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_IGNORE_ALL")));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         addIgnoreWord(word, wordStart, false);
@@ -181,7 +173,7 @@ public final class EditorPopups {
                 });
 
                 // or add it to the dictionary
-                item = menu.add(translateMenu("SC_ADD_TO_DICTIONARY"));
+                item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_ADD_TO_DICTIONARY")));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         addIgnoreWord(word, wordStart, true);
@@ -245,7 +237,7 @@ public final class EditorPopups {
             }
 
             // Cut
-            JMenuItem cutContextItem = menu.add(translateMenu("CCP_CUT"));
+            JMenuItem cutContextItem = menu.add(Mnemonics.removeMnemonics(OStrings.getString("CCP_CUT")));
             if (cutEnabled) {
                 cutContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -257,7 +249,7 @@ public final class EditorPopups {
             }
 
             // Copy
-            JMenuItem copyContextItem = menu.add(translateMenu("CCP_COPY"));
+            JMenuItem copyContextItem = menu.add(Mnemonics.removeMnemonics(OStrings.getString("CCP_COPY")));
             if (copyEnabled) {
                 copyContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -269,7 +261,7 @@ public final class EditorPopups {
             }
 
             // Paste
-            JMenuItem pasteContextItem = menu.add(translateMenu("CCP_PASTE"));
+            JMenuItem pasteContextItem = menu.add(Mnemonics.removeMnemonics(OStrings.getString("CCP_PASTE")));
             if (pasteEnabled) {
                 pasteContextItem.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
@@ -283,7 +275,7 @@ public final class EditorPopups {
             menu.addSeparator();
 
             // Add glossary entry
-            JMenuItem item = menu.add(translateMenu("GUI_GLOSSARYWINDOW_addentry"));
+            JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("GUI_GLOSSARYWINDOW_addentry")));
             item.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     Core.getGlossary()
@@ -313,7 +305,7 @@ public final class EditorPopups {
                 return;
             }
 
-            JMenuItem item = menu.add(translateMenu("MW_PROMPT_SEG_NR_TITLE"));
+            JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("MW_PROMPT_SEG_NR_TITLE")));
             item.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     comp.setCaretPosition(mousepos);
@@ -344,12 +336,14 @@ public final class EditorPopups {
                 return;
             }
             JMenuItem header = menu
-                    .add(StringUtil.format(translateMenu("MW_GO_TO_DUPLICATE_HEADER"), dups.size()));
+                    .add(StringUtil.format(Mnemonics.removeMnemonics(OStrings.getString("MW_GO_TO_DUPLICATE_HEADER")), 
+                    dups.size()));
             header.setEnabled(false);
             MenuItemPager pager = new MenuItemPager(menu);
             for (SourceTextEntry entry : dups) {
                 int entryNum = entry.entryNum();
-                String label = StringUtil.format(translateMenu("MW_GO_TO_DUPLICATE_ITEM"), entryNum);
+                String label = StringUtil.format(Mnemonics.removeMnemonics(OStrings.getString("MW_GO_TO_DUPLICATE_ITEM")), 
+                    entryNum);
                 JMenuItem item = pager.add(new JMenuItem(label));
                 item.addActionListener(e -> ec.gotoEntry(entryNum));
             }
@@ -373,19 +367,19 @@ public final class EditorPopups {
                 return;
             }
 
-            menu.add(translateMenu("TRANS_POP_EMPTY_TRANSLATION")).addActionListener(
+            menu.add(Mnemonics.removeMnemonics(OStrings.getString("TRANS_POP_EMPTY_TRANSLATION"))).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerEmptyTranslation();
                         }
                     });
-            menu.add(translateMenu("TRANS_POP_REMOVE_TRANSLATION")).addActionListener(
+            menu.add(Mnemonics.removeMnemonics(OStrings.getString("TRANS_POP_REMOVE_TRANSLATION"))).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerUntranslated();
                         }
                     });
-            menu.add(translateMenu("TRANS_POP_IDENTICAL_TRANSLATION")).addActionListener(
+            menu.add(Mnemonics.removeMnemonics(OStrings.getString("TRANS_POP_IDENTICAL_TRANSLATION"))).addActionListener(
                     new ActionListener() {
                         public void actionPerformed(ActionEvent e) {
                             ec.registerIdenticalTranslation();
@@ -409,7 +403,8 @@ public final class EditorPopups {
             }
 
             for (final Tag tag : TagUtil.getAllTagsMissingFromTarget()) {
-                JMenuItem item = menu.add(StringUtil.format(translateMenu("TF_MENU_EDIT_TAG_INSERT_N"), tag.tag));
+                JMenuItem item = menu.add(StringUtil.format(Mnemonics.removeMnemonics(
+                    OStrings.getString("TF_MENU_EDIT_TAG_INSERT_N")), tag.tag));
                 item.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         Core.getEditor().insertTag(tag.tag);
@@ -436,9 +431,9 @@ public final class EditorPopups {
             if (!isInActiveTranslation) {
                 return;
             }
-            JMenu submenu = new JMenu(translateMenu("TF_MENU_EDIT_INSERT_CHARS"));
+            JMenu submenu = new JMenu(Mnemonics.removeMnemonics(OStrings.getString("TF_MENU_EDIT_INSERT_CHARS")));
             for (int i = 0; i < names.length; i++) {
-                JMenuItem item = new JMenuItem(translateMenu(names[i]));
+                JMenuItem item = new JMenuItem(Mnemonics.removeMnemonics(OStrings.getString(names[i])));
                 final String insertText = inserts[i];
                 item.addActionListener(new ActionListener() {
                     @Override

--- a/src/org/omegat/gui/multtrans/MultipleTransPane.java
+++ b/src/org/omegat/gui/multtrans/MultipleTransPane.java
@@ -47,6 +47,7 @@ import javax.swing.text.JTextComponent;
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.common.EntryInfoThreadPane;
+import org.omegat.gui.editor.EditorPopups;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
 import org.omegat.gui.main.DockableScrollPane;
@@ -93,8 +94,8 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
                     boolean isInActiveTranslation, final SegmentBuilder sb) {
                 if (isInActiveEntry
                         && Core.getProject().getProjectProperties().isSupportDefaultTranslations()) {
-                    JMenuItem miDefault = menu.add(OStrings.getString("MULT_MENU_DEFAULT"));
-                    JMenuItem miMultiple = menu.add(OStrings.getString("MULT_MENU_MULTIPLE"));
+                    JMenuItem miDefault = menu.add(EditorPopups.translateMenu("MULT_MENU_DEFAULT"));
+                    JMenuItem miMultiple = menu.add(EditorPopups.translateMenu("MULT_MENU_MULTIPLE"));
                     miDefault.setEnabled(!sb.isDefaultTranslation());
                     miMultiple.setEnabled(sb.isDefaultTranslation());
 

--- a/src/org/omegat/gui/multtrans/MultipleTransPane.java
+++ b/src/org/omegat/gui/multtrans/MultipleTransPane.java
@@ -44,6 +44,8 @@ import javax.swing.KeyStroke;
 import javax.swing.text.Caret;
 import javax.swing.text.JTextComponent;
 
+import org.openide.awt.Mnemonics;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.common.EntryInfoThreadPane;
@@ -94,8 +96,10 @@ public class MultipleTransPane extends EntryInfoThreadPane<List<MultipleTransFou
                     boolean isInActiveTranslation, final SegmentBuilder sb) {
                 if (isInActiveEntry
                         && Core.getProject().getProjectProperties().isSupportDefaultTranslations()) {
-                    JMenuItem miDefault = menu.add(EditorPopups.translateMenu("MULT_MENU_DEFAULT"));
-                    JMenuItem miMultiple = menu.add(EditorPopups.translateMenu("MULT_MENU_MULTIPLE"));
+                    JMenuItem miDefault = menu.add(Mnemonics.removeMnemonics(
+                        OStrings.getString("MULT_MENU_DEFAULT")));
+                    JMenuItem miMultiple = menu.add(Mnemonics.removeMnemonics(
+                        OStrings.getString("MULT_MENU_MULTIPLE")));
                     miDefault.setEnabled(!sb.isDefaultTranslation());
                     miMultiple.setEnabled(sb.isDefaultTranslation());
 


### PR DESCRIPTION
## Pull request type

[bug]

## Which ticket is resolved?

https://sourceforge.net/p/omegat/bugs/1135

## What does this PR change?

- Remove & in contextual menus, since they do not support mnemonics

