### PR TITLE
fix: work around for JRE 8 l10n bug

### DIFF
--- a/src/org/omegat/util/Language.java
+++ b/src/org/omegat/util/Language.java
@@ -108,11 +108,31 @@ public class Language implements Comparable<Object> {
         }
     }
 
+    private final static String ZA_IN_ZH= "\u58EE\u8BED";
+    private final static String SD_IN_ZH= "\u4FE1\u5FB7\u6587";
+    private final static String SD_IN_IN_ZH= "\u4FE1\u5FB7\u6587(\u5370\u5EA6)";
+    private final static String SD_PK_IN_ZH= "\u4FE1\u5FB7\u6587(\u5DF4\u57FA\u65AF\u5766)";
+
     /**
      * Returns a name for the language that is appropriate for display to the
      * user.
      */
     public String getDisplayName() {
+        if (Platform.getJavaVersion() == 8) {
+            // work around for java 8 JRE localization bug
+            // see https://github.com/OmegaT-L10N/zh_CN/issues/5
+            if (Locale.getDefault().equals(Locale.SIMPLIFIED_CHINESE)) {
+                if (this.equals(new Language("ZA"))) {
+                    return ZA_IN_ZH;
+                } else if (this.equals(new Language("SD"))) {
+                    return SD_IN_ZH;
+                } else if (locale.equals(new Locale("sd", "IN"))) {
+                    return SD_IN_IN_ZH;
+                } else if (locale.equals(new Locale("sd", "PK"))) {
+                    return SD_PK_IN_ZH;
+                }
+            }
+        }
         return locale.getDisplayName();
     }
 

--- a/src/org/omegat/util/Platform.java
+++ b/src/org/omegat/util/Platform.java
@@ -103,4 +103,16 @@ public final class Platform {
         }
         return false;
     }
+
+    public static int getJavaVersion() {
+        String[] versionElements = System.getProperty("java.version").split("\\.");
+        int discard = Integer.parseInt(versionElements[0]);
+        int version;
+        if (discard == 1) {
+            version = Integer.parseInt(versionElements[1]);
+        } else {
+            version = discard;
+        }
+        return version;
+    }
 }


### PR DESCRIPTION
- JRE 8 has a localization bug in Chinese
  - Locale class has wrong display name for ZA, SD, SD_IN and SD_PK
- The problem is reported at https://github.com/OmegaT-L10N/zh_CN/issues/4 and https://github.com/OmegaT-L10N/zh_CN/issues/5


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- 
## Which ticket is resolved?



- Title ex. fix...
  * URL ex. https://...
 
- SD-Sindhi language 
  https://github.com/OmegaT-L10N/zh_CN/issues/4

- ZA-Shuang language
   https://github.com/OmegaT-L10N/zh_CN/issues/5

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
