### PR TITLE
fix: catch plugin load error

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1225,6 +1225,7 @@ PLUGIN_MARKER_INITIALIZE=Error initializing marker '{0}'
 
 PLUGIN_LOAD_ERROR=Error loading plugin from class '{0}': {1}: {2}
 PLUGIN_UNLOAD_ERROR=Error unloading plugin from class '{0}': {1}
+PLUGIN_JAVA_VERSION_ERROR=Error loading : {0}
 
 PLUGIN_LOAD_JAR=Jar used for plugins: {0}
 PLUGIN_LOAD_OK=Plugin successfully loaded from class '{0}'

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -181,6 +182,10 @@ public final class PluginUtils {
                     }
                 } catch (ClassNotFoundException e) {
                     Log.log(e);
+                } catch (UnsupportedClassVersionError e) {
+                    JarURLConnection connection = (JarURLConnection) mu.openConnection();
+                    URL url = connection.getJarFileURL();
+                    Log.logWarningRB("PLUGIN_JAVA_VERSION_ERROR", url);
                 }
             }
         } catch (IOException ex) {


### PR DESCRIPTION
When starting OmegaT on JRE 8 with okapi plugin which requires Java 11, OmegaT fails to start.
This catch load error with Java version mismatch, and continue starting with leaving log.

## Pull request type

- Other (describe below)

improve error handling

## Which ticket is resolved?


## What does this PR change?

- catch `UnsupportedClassVersionError` and leave log

## Other information


