### PR TITLE
Change "guide" to "manual"

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -86,7 +86,7 @@ app-version-template-pretty-update={0} {1}_{2}
 COMMAND_LINE_HELP=\n\
 Usage: java -jar [<java options>] OmegaT.jar [<OmegaT options>] [<project path>]\n\
 \n\
-See Help > User Guide for details, including available Java options.\n\
+See Help > User Manual for details, including available Java options.\n\
 \n\
 OmegaT options:\n\
 \n\
@@ -231,7 +231,7 @@ OUT_OF_MEMORY=OmegaT ran out of memory and will close when you click OK.\n\
     line or in the OmegaT start script;\n\
     The current setting is {0}MB;\n\
     \n\
-    See "How To... Run OmegaT" in the user guide.\n\
+    See "How To... Run OmegaT" in the user manual.\n\
 
 # 0: JVM version number e.g. 1.6.0_65
 # 1: JVM bitness (32 or 64)
@@ -476,7 +476,7 @@ MW_OPTIONSMENU_ACCESS_CONFIG_DIR=Access &Configuration Folder
 # HELP MENU
 TF_MENU_HELP=&Help
 
-TF_MENU_HELP_CONTENTS=&User Guide...
+TF_MENU_HELP_CONTENTS=&User Manual...
 TF_MENU_HELP_ABOUT=&About...
 TF_MENU_HELP_LAST_CHANGES=&Last Changes...
 TF_MENU_HELP_LOG=L&og...
@@ -1047,7 +1047,7 @@ SW_VIEWER_TEXT=Scope:\n\
     Exact searches match the whole search string.\n\
     Keyword searches match all space-separated keywords in any order.\n\
     Regular expression searches match Java regular expressions as documented in \
-    the user guide.\n\n\
+    the user manual.\n\n\
     Wildcards:\n\
     Both exact and keyword searches support the * and ? wildcards.\n\
     '*' matches zero or more characters ('run*' matches 'run', 'runs', \
@@ -2184,16 +2184,16 @@ APERTIUM_MARKUNKNOWN_LABEL=Mark unknown words
 
 MT_ENGINE_GOOGLE2_API_KEY_LABEL=API key:
 MT_ENGINE_GOOGLE2_PREMIUM_LABEL=Premium Edition
-GOOGLE_API_KEY_NOTFOUND=Google API key not available. See the user guide for instructions.
+GOOGLE_API_KEY_NOTFOUND=Google API key not available. See the user manual for instructions.
 
 MT_ENGINE_DEEPL_API_KEY_LABEL=API key:
-DEEPL_API_KEY_NOTFOUND=DeepL API key not available. See the user guide for instructions.
+DEEPL_API_KEY_NOTFOUND=DeepL API key not available. See the user manual for instructions.
 
 MT_ENGINE_IBMWATSON_LOGIN_LABEL=Username or API key:
 MT_ENGINE_IBMWATSON_PASSWORD_LABEL=Password:
 MT_ENGINE_IBMWATSON_MODELID_LABEL=Model ID:
 MT_ENGINE_IBMWATSON_URL=URL:
-IBMWATSON_API_KEY_NOTFOUND=IBM Watson not available. See the user guide for instructions.
+IBMWATSON_API_KEY_NOTFOUND=IBM Watson not available. See the user manual for instructions.
 MT_ENGINE_IBMWATSON_IAM_AUTHENTICATION:(Leave the Password empty if you are using an API key.)
 
 MT_ENGINE_YANDEX_CLOUD_FOLDER_ID_LABEL=Folder ID


### PR DESCRIPTION
The UI still had instances of "guide" instead of "manual"