### PR TITLE
fix: don't display preamble line in search results if no filename set

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1087,8 +1087,8 @@ ST_NOTHING_FOUND=No matches returned by search.
 SW_NR_OF_RESULTS=Matching segments: {0}
 
 SW_GLOSSARY_RESULT=Glossary
-# 0 Number of additional search results. There is a non-breaking space between {0} and more.
-SW_NR_OF_MORE=+{0}\u00A0more
+# 0 Number of search results. There is a non-breaking space between {0} and matches.
+SW_NR_MATCHES={0}\u00A0matches
 # 0 Search result preamble (usually filename)
 # 1 Number of additional search results.
 # There is a non-breaking space between {1} and more.

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -149,29 +149,30 @@ public class Searcher {
             // function can be called multiple times after search
             // results preprocess should occur only one time
             m_preprocessResults = false;
-            if (!searchExpression.allResults && searchExpression.fileNames) {
+            if (!searchExpression.allResults) {
                 for (SearchResultEntry entry : m_searchResults) {
                     String key = entry.getSrcText() + entry.getTranslation();
                     if (entry.getEntryNum() == ENTRY_ORIGIN_TRANSLATION_MEMORY) {
                         if (m_tmxMap.containsKey(key) && (m_tmxMap.get(key) > 0)) {
-                            String newPreamble = StringUtil.format(OStrings.getString("SW_FILE_AND_NR_OF_MORE"),
-                                    entry.getPreamble(), m_tmxMap.get(key));
-                            entry.setPreamble(newPreamble);
+                            entry.setPreamble(updatePreamble(entry, m_tmxMap.get(key)));
                         }
                     } else if (entry.getEntryNum() > ENTRY_ORIGIN_PROJECT_MEMORY) {
                         // at this stage each PM entry num is increased by 1
                         if (m_entryMap.containsKey(key) && (m_entryMap.get(key) > 0)) {
-                            String newPreamble = StringUtil.isEmpty(entry.getPreamble())
-                                    ? StringUtil.format(OStrings.getString("SW_NR_OF_MORE"), m_entryMap.get(key))
-                                    : StringUtil.format(OStrings.getString("SW_FILE_AND_NR_OF_MORE"),
-                                            entry.getPreamble(), m_entryMap.get(key));
-                            entry.setPreamble(newPreamble);
+                            entry.setPreamble(updatePreamble(entry, m_entryMap.get(key)));
                         }
                     }
                 }
             }
         }
         return m_searchResults;
+    }
+
+    private String updatePreamble(SearchResultEntry entry, int matchNumber) {
+        return StringUtil.isEmpty(entry.getPreamble())
+                ? StringUtil.format(OStrings.getString("SW_NR_MATCHES"), 1 + matchNumber)
+                : StringUtil.format(OStrings.getString("SW_FILE_AND_NR_OF_MORE"),
+                        entry.getPreamble(), matchNumber);
     }
 
     /**

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -149,7 +149,7 @@ public class Searcher {
             // function can be called multiple times after search
             // results preprocess should occur only one time
             m_preprocessResults = false;
-            if (!searchExpression.allResults) {
+            if (!searchExpression.allResults && searchExpression.fileNames) {
                 for (SearchResultEntry entry : m_searchResults) {
                     String key = entry.getSrcText() + entry.getTranslation();
                     if (entry.getEntryNum() == ENTRY_ORIGIN_TRANSLATION_MEMORY) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Fixed "null" file names in search results when "Display: file names" checkbox was unchecked
  * https://sourceforge.net/p/omegat/bugs/1154/
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- only display the preamble line (e.g. `filename.xxx +3 more`) when the "Display: file names" option is checked

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

See https://sourceforge.net/p/omegat/bugs/1154/#9b36 for screenshots of the different search results
