### PR TITLE
Clarify tmx2source use

### DIFF
--- a/doc_src/en/HowTo_UseTM.xml
+++ b/doc_src/en/HowTo_UseTM.xml
@@ -331,53 +331,85 @@
   endterm="panes.fuzzy.matches.title"/> pane. Such matches are by default
   limited to the source and target languages defined in the <link
   linkend="dialogs.project.properties"
-  endterm="dialogs.project.properties.title"/> dialog, but you can also add
-  matches in languages that are not the target language. See the <link
-  linkend="dialog.preferences.tm.matches.other.languages"
+  endterm="dialogs.project.properties.title"/> dialog.</para>
+
+  <para>You can add matches in languages that are not the target language. See
+  the <link linkend="dialog.preferences.tm.matches.other.languages"
   endterm="dialog.preferences.tm.matches.other.languages.title"/> preference for
   details.</para>
 
-  <para>With OmegaT, you can also display a third language <emphasis>right
-  under</emphasis> the source segment to use as an alternative language
-  reference for the source text.</para>
+  <para>If you have a TMX that corresponds to your source document and that
+  includes a translation to a different language, you can also display that
+  language <emphasis>right under</emphasis> the source segment to use it as a
+  second reference language.</para>
 
-  <example id="bridge.english.and.french.with.japanese">
-	<title id="replace.with.allemand.title">Bridge English and French with
-	Japanese</title>
-	<para>
-	  <programlisting>— ¶ —————————————————————
-<token>A whitespace character: [ \t\n\x0B\f\r]
-fr-ZB: Un caractère d'espacement (espace, tabulation, etc.) :  [ \t\n\x0B\f\r]
-ja-RV: 空白文字：[ \t\n\x0B\f\r]</token>
-Un caractère d'espacement : [ \t\n\r\f\x0B]<token>&lt;segment 3075 ¶></token>
-— ¶ —————————————————————</programlisting></para>
-<para>The first line is the original English, the second an old French version
-with an arbitrary language code, the third the Japanese version with an equally
-arbitrary language code, and the 4th the current translation to French.</para>
-  </example>
-  
-    <para>To achieve this:</para>
+  <para>To achieve this:</para>
 
 	<orderedlist>
 	  <listitem>
-		<para>Create a folder called <filename
-		class="directory">tmx2source</filename> in the <link
-		linkend="project.folder.tm" endterm="project.folder.tm.title"/>
+		<para>Copy the translation memory thave contains that third reference
+		language into <filename class="directory">tmx2source</filename> in the
+		<link linkend="project.folder.tm" endterm="project.folder.tm.title"/>
 		folder.</para>
 	  </listitem>
 
 	  <listitem>
-		<para>Copy your “first-third” language translation memory there.</para>
-	  </listitem>
-
-	  <listitem>
-		<para>Rename the memory <filename>LL_CC.tmx</filename> or
-		<filename>LL-CC.tmx</filename>, where <emphasis>LL</emphasis> is the
-		internal code of the language you want to display as reference and
+		<para>Rename the memory file:
+		<itemizedlist>
+		  <listitem>
+			<para>
+			  <filename>LL_CC.tmx</filename>,
+			</para>
+		  </listitem>
+		  <listitem>
+			<para>
+			  <filename>LL-CC.tmx</filename>, or
+			</para>
+		  </listitem>
+		  <listitem>
+			<para>
+			  <filename>LL.tmx</filename>,
+			</para>
+		  </listitem>
+		</itemizedlist>
+		where <emphasis>LL</emphasis> is the internal language code of the
+		langage that you want to display as reference, and
 		<emphasis>CC</emphasis> is an arbitrary 2-letter code.</para>
+		<warning>
+		  <itemizedlist>
+			<listitem>
+			  <para>All the letters must be capital letters.</para>
+			</listitem>
+			<listitem>
+			  <para>Only segments that exactly match the source will be
+			  displayed.</para>
+			</listitem>
+		  </itemizedlist>
+		</warning>
 	  </listitem>
 	</orderedlist>
-	
+
+  <example id="bridge.english.and.french.with.japanese">
+	<title id="replace.with.allemand.title">Use a Japanese reference under the
+	English source</title>
+	<para>If you have a TMX that contains the Japanese translation of the
+	English document that you must translate to French, you can use the Japanese
+	translation as an alternative source, or as an alternative exact reference,
+	by displaying it under the English to translate to French.</para>
+	<para>Just put the English-Japanese file in <filename
+	class="directory">tm/tmx2source</filename> under the name
+	<filename>JA-JP.tmx</filename>:</para>
+	<para>
+	  <programlisting>— ¶ —————————————————————
+<token>A whitespace character: [ \t\n\x0B\f\r]
+ja-JP: 空白文字：[ \t\n\x0B\f\r]</token>
+Un caractère d'espacement : [ \t\n\r\f\x0B]<token>&lt;segment 3075 ¶></token>
+— ¶ —————————————————————</programlisting></para>
+<para>The first line is the original English, the second line is the "bridging"
+language that you also find useful to create your translation from, and the
+third line is the current translation to French.</para>
+  </example>
+  
     <note>
 	  <para>You can use any number of TMX files containing as many different “bridge” language pairs as you want.</para>	  
 	</note>


### PR DESCRIPTION
This PR clarifies the use of the `tmx2source` folder.

Once accepted in `master` it will eventually have to be merged in the 2 release branches that we have.