### PR TITLE
[backport 6.0] Improve handling of backup file of omegat.project

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -889,19 +889,13 @@ PP_REPOSITORIES=Re&pository Mapping...
 
 PP_EXTERNALFINDER=Local External Searc&hes...
 
-PP_MESSAGE_BADPROJ=Some project folders seem to have been moved. \
-    Specify their new location or recreate them.
-
-#TODO remove that
-PP_MESSAGE_CONFIGPROJ=
-
 PP_SAVE_PROJECT_FILE=Create Project Folder
 
 PP_MED_OPEN=Choose MED project
 PP_MED_OPEN_FILTER=ZIP files
 
 PP_PROJECT_FILES_DESC=OmegaT Project Files
-
+PP_ERROR_UNABLE_TO_CREATE_BACKUP_FILE=Unable to create a backup file of {0}
 PP_ERROR_UNABLE_TO_READ_PROJECT_FILE=Unable to read project file! \n
 PP_ERROR_UNABLE_TO_READ_PROJECT_FILE_BACK=Unable to read project file! Trying with backup file\n
 PP_REMOTE_PROJECT_CONTENT_OVERRIDES_THE_CURRENT_PROJECT=Current project configuration will be overridden \

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -606,9 +606,12 @@ public final class ProjectUICommands {
                         throw e;
                     }
                 }
+                // non-exist directories could be created
+                props.autocreateDirectories();
             } else {
                 // not a team project
                 File projectFile = new File(projectRootFolder, OConsts.FILE_PROJECT);
+                props.autocreateDirectories();
                 while (!props.isProjectValid()) {
                     // something wrong with the project.
                     // We display open dialog to fix it.
@@ -625,8 +628,6 @@ public final class ProjectUICommands {
                     needToSaveProperties = true;
                 }
             }
-            // non-exist directories could be created
-            props.autocreateDirectories();
             // Critical section, create backup and save
             // properties.
             final ProjectProperties propsP = props;

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -91,7 +91,7 @@ public final class FileUtil {
                             && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
         } catch (Exception ignored) {
         }
-        if (bakFiles == null) {
+        if (bakFiles == null || bakFiles.length == 0) {
             return null;
         }
         Arrays.sort(bakFiles, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -84,13 +84,9 @@ public final class FileUtil {
      *            target original file name.
      */
     public static File getRecentBackup(final File originalFile) {
-        File[] bakFiles = null;
-        try {
-            bakFiles = originalFile.getParentFile()
-                    .listFiles(f -> !f.isDirectory() && f.getName().startsWith(originalFile.getName())
-                            && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
-        } catch (Exception ignored) {
-        }
+        File[] bakFiles = originalFile.getParentFile()
+                .listFiles(f -> !f.isDirectory() && f.getName().startsWith(originalFile.getName())
+                        && f.getName().endsWith(OConsts.BACKUP_EXTENSION));
         if (bakFiles == null || bakFiles.length == 0) {
             return null;
         }
@@ -130,11 +126,15 @@ public final class FileUtil {
      *            a file to copy as backup file.
      * @return Backup file.
      */
-    public static File backupFile(File original) throws IOException {
+    public static File backupFile(File original) {
         long fileMillis = original.lastModified();
         String str = new SimpleDateFormat("yyyyMMddHHmm").format(new Date(fileMillis));
         File backup = new File(original.getPath() + "." + str + OConsts.BACKUP_EXTENSION);
-        FileUtils.copyFile(original, backup);
+        try {
+            FileUtils.copyFile(original, backup);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_CREATE_BACKUP_FILE", original.getName());
+        }
         return backup;
     }
 


### PR DESCRIPTION
backport https://github.com/omegat-org/omegat/pull/509 into releases/6.0 release branch.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Backup file does not created in no-team project
  * https://sourceforge.net/p/omegat/bugs/1159/


<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Fix degrade on https://github.com/omegat-org/omegat/pull/415
- ref; https://github.com/omegat-org/omegat/pull/415#issuecomment-1449046191
- When project is not a team project, there does not produce a backup file when user does not change property.
- Backport from 6.1 development master branch.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
