### PR TITLE
Enhance/Fix bug: SRX reader/writer, support buggy CONF file to migrate correct SRX file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,9 +106,6 @@ dependencies {
         // macOS integration
         implementation 'org.madlonkay:desktopsupport:0.6.0'
 
-        api 'javax.xml.bind:jaxb-api:2.3.1'
-        implementation 'com.sun.xml.bind:jaxb-impl:2.3.4'
-
         // Data: inline data URL handler
         implementation 'tokyo.northside:url-protocol-handler:0.1.4'
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1713,6 +1713,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Default
 CORE_SRX_RULES_FORMATTING_TEXT=Text files segmentation
 CORE_SRX_RULES_FORMATTING_HTML=HTML, XHTML, ODF and Infix segmentation
 
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unknown language code {} specified
 
 # org.omegat.segmentation.SegmentationCustomizer
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1713,7 +1713,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Default
 CORE_SRX_RULES_FORMATTING_TEXT=Text files segmentation
 CORE_SRX_RULES_FORMATTING_HTML=HTML, XHTML, ODF and Infix segmentation
 
-CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unknown language code {} specified
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unknown language code {0} specified
 
 # org.omegat.segmentation.SegmentationCustomizer
 

--- a/src/org/omegat/core/segmentation/LanguageCodes.java
+++ b/src/org/omegat/core/segmentation/LanguageCodes.java
@@ -84,7 +84,7 @@ public final class LanguageCodes {
     public static final String F_HTML_KEY = "CORE_SRX_RULES_FORMATTING_HTML";
 
     /** A Map from language codes to language keys. */
-    private static Map<String, String> codeKeyHash = new HashMap<String, String>();
+    private static Map<String, String> codeKeyHash = new HashMap<>();
 
     static {
         codeKeyHash.put(CATALAN_CODE, CATALAN_KEY);
@@ -119,5 +119,18 @@ public final class LanguageCodes {
         }
         String key = codeKeyHash.get(code);
         return OStrings.getString(key);
+    }
+
+    public static boolean isLanguageCodeKnown(String code) {
+        return codeKeyHash.containsKey(code);
+    }
+
+    public static String getLanguageCodeByName(String name) {
+        for (Map.Entry<String, String> entry: codeKeyHash.entrySet()) {
+            if (OStrings.getString(entry.getValue()).equals(name)) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 }

--- a/src/org/omegat/core/segmentation/MapRule.java
+++ b/src/org/omegat/core/segmentation/MapRule.java
@@ -28,10 +28,12 @@ package org.omegat.core.segmentation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import gen.core.segmentation.Languagemap;
+import org.omegat.util.Log;
 import org.omegat.util.StringUtil;
 
 /**
@@ -50,7 +52,7 @@ public class MapRule implements Serializable {
 
     /** creates an initialized MapRule */
     public MapRule(String language, String pattern, List<Rule> rules) {
-        this.setLanguage(language);
+        this.setLanguageCode(language);
         this.setPattern(pattern);
         this.setRules(rules);
     }
@@ -59,20 +61,29 @@ public class MapRule implements Serializable {
     private String languageCode;
 
     public MapRule(Languagemap languagemap, List<Rule> rules) {
-        this.setLanguage(languagemap.getLanguagerulename());
+        this.setLanguageCode(languagemap.getLanguagerulename());
         this.setPattern(languagemap.getLanguagepattern());
         this.setRules(rules);
     }
 
     /** Returns Language Name (to display it in a dialog). */
-    public String getLanguage() {
+    public String getLanguageName() {
         String res = LanguageCodes.getLanguageName(languageCode);
         return StringUtil.isEmpty(res) ? languageCode : res;
     }
 
-    /** Sets Language Name */
-    public void setLanguage(String language) {
-        this.languageCode = language;
+    /** Sets Language Code */
+    public void setLanguageCode(String code) {
+        if (!LanguageCodes.isLanguageCodeKnown(code)) {
+            String alt = LanguageCodes.getLanguageCodeByName(code);
+            if (alt != null) {
+                languageCode = alt;
+                return;
+            } else {
+                Log.logWarningRB("CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE", code);
+            }
+        }
+        languageCode = code;
     }
 
     /** Returns Language Code for programmatic usage. */
@@ -139,17 +150,17 @@ public class MapRule implements Serializable {
         }
         MapRule that = (MapRule) obj;
         return this.getPattern().equals(that.getPattern())
-                && this.getLanguage().equals(that.getLanguage())
+                && this.getLanguageCode().equals(that.getLanguageCode())
                 && this.getRules().equals(that.getRules());
     }
 
     /** Returns a hash code value for the object. */
     public int hashCode() {
-        return this.getPattern().hashCode() + this.getLanguage().hashCode() + this.getRules().hashCode();
+        return this.getPattern().hashCode() + this.getLanguageCode().hashCode() + this.getRules().hashCode();
     }
 
     /** Returns a string representation of the MapRule for debugging purposes. */
     public String toString() {
-        return getLanguage() + " (" + getPattern() + ") " + getRules().toString();
+        return getLanguageCode() + " (" + getPattern() + ") " + getRules().toString();
     }
 }

--- a/src/org/omegat/core/segmentation/MapRule.java
+++ b/src/org/omegat/core/segmentation/MapRule.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import gen.core.segmentation.Languagemap;
 import org.omegat.util.StringUtil;
 
 /**
@@ -56,6 +57,12 @@ public class MapRule implements Serializable {
 
     /** Language Name */
     private String languageCode;
+
+    public MapRule(Languagemap languagemap, List<Rule> rules) {
+        this.setLanguage(languagemap.getLanguagerulename());
+        this.setPattern(languagemap.getLanguagepattern());
+        this.setRules(rules);
+    }
 
     /** Returns Language Name (to display it in a dialog). */
     public String getLanguage() {

--- a/src/org/omegat/core/segmentation/MapRule.java
+++ b/src/org/omegat/core/segmentation/MapRule.java
@@ -28,7 +28,6 @@ package org.omegat.core.segmentation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -52,7 +51,7 @@ public class MapRule implements Serializable {
 
     /** creates an initialized MapRule */
     public MapRule(String language, String pattern, List<Rule> rules) {
-        this.setLanguageCode(language);
+        this.setLanguage(language);
         this.setPattern(pattern);
         this.setRules(rules);
     }
@@ -61,7 +60,7 @@ public class MapRule implements Serializable {
     private String languageCode;
 
     public MapRule(Languagemap languagemap, List<Rule> rules) {
-        this.setLanguageCode(languagemap.getLanguagerulename());
+        this.setLanguage(languagemap.getLanguagerulename());
         this.setPattern(languagemap.getLanguagepattern());
         this.setRules(rules);
     }
@@ -73,7 +72,7 @@ public class MapRule implements Serializable {
     }
 
     /** Sets Language Code */
-    public void setLanguageCode(String code) {
+    public void setLanguage(String code) {
         if (!LanguageCodes.isLanguageCodeKnown(code)) {
             String alt = LanguageCodes.getLanguageCodeByName(code);
             if (alt != null) {
@@ -87,7 +86,7 @@ public class MapRule implements Serializable {
     }
 
     /** Returns Language Code for programmatic usage. */
-    public String getLanguageCode() {
+    public String getLanguage() {
         return languageCode;
     }
 
@@ -150,17 +149,17 @@ public class MapRule implements Serializable {
         }
         MapRule that = (MapRule) obj;
         return this.getPattern().equals(that.getPattern())
-                && this.getLanguageCode().equals(that.getLanguageCode())
+                && this.getLanguage().equals(that.getLanguage())
                 && this.getRules().equals(that.getRules());
     }
 
     /** Returns a hash code value for the object. */
     public int hashCode() {
-        return this.getPattern().hashCode() + this.getLanguageCode().hashCode() + this.getRules().hashCode();
+        return this.getPattern().hashCode() + this.getLanguage().hashCode() + this.getRules().hashCode();
     }
 
     /** Returns a string representation of the MapRule for debugging purposes. */
     public String toString() {
-        return getLanguageCode() + " (" + getPattern() + ") " + getRules().toString();
+        return getLanguage() + " (" + getPattern() + ") " + getRules().toString();
     }
 }

--- a/src/org/omegat/core/segmentation/Rule.java
+++ b/src/org/omegat/core/segmentation/Rule.java
@@ -49,6 +49,12 @@ public class Rule implements Serializable {
         setAfterbreak(afterbreak);
     }
 
+    public Rule(gen.core.segmentation.Rule s) {
+        setBreakRule("yes".equalsIgnoreCase(s.getBreak()));
+        setBeforebreak(s.getBeforebreak().getContent());
+        setAfterbreak(s.getAfterbreak().getContent());
+    }
+
     public Rule copy() {
         Rule result = new Rule();
         result.breakRule = breakRule;

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -78,11 +78,16 @@ public class SRX implements Serializable {
 
     public SRX copy() {
         SRX result = new SRX();
+        result.setVersion(version);
+        result.setCascade(cascade);
+        result.setSegmentSubflows(segmentSubflows);
+        result.setIncludeIsolatedTags(includeIsolatedTags);
+        result.setIncludeStartingTags(includeStartingTags);
+        result.setIncludeEndingTags(includeEndingTags);
         result.mappingRules = new ArrayList<>(mappingRules.size());
         for (MapRule rule : mappingRules) {
             result.mappingRules.add(rule.copy());
-        }
-        return result;
+        }        return result;
     }
 
     /**

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -219,8 +219,8 @@ public class SRX implements Serializable {
                             .collect(Collectors.toList()));
         }
         SRX res = new SRX();
-        res.setSegmentSubflows("yes".equalsIgnoreCase(srx.getHeader().getSegmentsubflows()));
-        res.setCascade("yes".equalsIgnoreCase(srx.getHeader().getCascade()));
+        res.setSegmentSubflows(!"no".equalsIgnoreCase(srx.getHeader().getSegmentsubflows()));
+        res.setCascade(!"no".equalsIgnoreCase(srx.getHeader().getCascade()));
         res.setVersion(srx.getVersion());
         res.setMappingRules(srx.getBody().getMaprules().getLanguagemap()
                 .stream()

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -110,11 +110,11 @@ public class SRX implements Serializable {
         jaxbObject.getBody().setLanguagerules(factory.createLanguagerules());
         for (MapRule mr : srx.getMappingRules()) {
             Languagemap map = new Languagemap();
-            map.setLanguagerulename(mr.getLanguage());
+            map.setLanguagerulename(mr.getLanguageCode());
             map.setLanguagepattern(mr.getPattern());
             jaxbObject.getBody().getMaprules().getLanguagemap().add(map);
             Languagerule lr = new Languagerule();
-            lr.setLanguagerulename(mr.getLanguage());
+            lr.setLanguagerulename(mr.getLanguageCode());
             jaxbObject.getBody().getLanguagerules().getLanguagerule().add(lr);
             for (Rule rule : mr.getRules()) {
                 gen.core.segmentation.Rule jaxbRule = factory.createRule();
@@ -150,8 +150,7 @@ public class SRX implements Serializable {
             if (inFile.exists()) {
                 return loadSrxFile(inFile.toURI());
             }
-        } catch (Exception o2) {
-
+        } catch (Exception ignored) {
         }
 
         // If file was not present or not readable
@@ -172,8 +171,7 @@ public class SRX implements Serializable {
     }
 
     /**
-     * Loads segmentation rules from an XML file. If there's an error loading a
-     * file, it calls <code>getDefaultFromJar</code>.
+     * Loads segmentation rules from an XML file.
      * <p>
      * Since 1.6.0 RC8 it also checks if the version of segmentation rules saved
      * is older than that of the current OmegaT, and tries to merge the two sets
@@ -309,7 +307,7 @@ public class SRX implements Serializable {
             for (int i = 0; i < current.getMappingRules().size(); i++) {
                 MapRule maprule = current.getMappingRules().get(i);
                 if (def.equals(maprule.getLanguageCode())) {
-                    maprule.setLanguage(LanguageCodes.DEFAULT_CODE);
+                    maprule.setLanguageCode(LanguageCodes.DEFAULT_CODE);
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.ENGLISH_CODE));
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.F_TEXT_CODE));
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.F_HTML_CODE));
@@ -337,34 +335,6 @@ public class SRX implements Serializable {
         return null;
     }
 
-    /**
-     * My Own Class to listen to exceptions, occured while loading filters
-     * configuration.
-     */
-    static class MyExceptionListener implements ExceptionListener {
-        private List<Exception> exceptionsList = new ArrayList<Exception>();
-        private boolean exceptionOccured = false;
-
-        public void exceptionThrown(Exception e) {
-            exceptionOccured = true;
-            exceptionsList.add(e);
-        }
-
-        /**
-         * Returns whether any exceptions occured.
-         */
-        public boolean isExceptionOccured() {
-            return exceptionOccured;
-        }
-
-        /**
-         * Returns the list of occured exceptions.
-         */
-        public List<Exception> getExceptionsList() {
-            return exceptionsList;
-        }
-    }
-
     // Patterns
     private static final String DEFAULT_RULES_PATTERN = ".*";
 
@@ -383,7 +353,7 @@ public class SRX implements Serializable {
     /**
      * Finds the rules for a certain language.
      * <p>
-     * Usually (if the user didn't screw up the setup) there're a default
+     * Usually (if the user didn't screw up the setup) there are default
      * segmentation rules, so it's a good idea to rely on this method always
      * returning at least some rules.
      * <p>
@@ -391,7 +361,7 @@ public class SRX implements Serializable {
      * rules.
      */
     public List<Rule> lookupRulesForLanguage(Language srclang) {
-        List<Rule> rules = new ArrayList<Rule>();
+        List<Rule> rules = new ArrayList<>();
         for (int i = 0; i < getMappingRules().size(); i++) {
             MapRule maprule = getMappingRules().get(i);
             if (maprule.getCompiledPattern().matcher(srclang.getLanguage()).matches()) {

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -221,6 +221,7 @@ public class SRX implements Serializable {
         SRX res = new SRX();
         res.setSegmentSubflows("yes".equalsIgnoreCase(srx.getHeader().getSegmentsubflows()));
         res.setCascade("yes".equalsIgnoreCase(srx.getHeader().getCascade()));
+        res.setVersion(srx.getVersion());
         res.setMappingRules(srx.getBody().getMaprules().getLanguagemap()
                 .stream()
                 .map(s -> new MapRule(s, mapping.get(s.getLanguagerulename())))

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -118,11 +118,11 @@ public class SRX implements Serializable {
         jaxbObject.getBody().setLanguagerules(factory.createLanguagerules());
         for (MapRule mr : srx.getMappingRules()) {
             Languagemap map = new Languagemap();
-            map.setLanguagerulename(mr.getLanguageCode());
+            map.setLanguagerulename(mr.getLanguage());
             map.setLanguagepattern(mr.getPattern());
             jaxbObject.getBody().getMaprules().getLanguagemap().add(map);
             Languagerule lr = new Languagerule();
-            lr.setLanguagerulename(mr.getLanguageCode());
+            lr.setLanguagerulename(mr.getLanguage());
             jaxbObject.getBody().getLanguagerules().getLanguagerule().add(lr);
             for (Rule rule : mr.getRules()) {
                 gen.core.segmentation.Rule jaxbRule = factory.createRule();
@@ -273,14 +273,14 @@ public class SRX implements Serializable {
         int defaultMapRulesN = defaults.getMappingRules().size();
         for (int i = 0; i < defaultMapRulesN; i++) {
             MapRule dmaprule = defaults.getMappingRules().get(i);
-            String dcode = dmaprule.getLanguageCode();
+            String dcode = dmaprule.getLanguage();
             // trying to find
             boolean found = false;
             int currentMapRulesN = merged.getMappingRules().size();
             MapRule cmaprule = null;
             for (int j = 0; j < currentMapRulesN; j++) {
                 cmaprule = merged.getMappingRules().get(j);
-                String ccode = cmaprule.getLanguageCode();
+                String ccode = cmaprule.getLanguage();
                 if (dcode.equals(ccode)) {
                     found = true;
                     break;
@@ -336,8 +336,8 @@ public class SRX implements Serializable {
             String def = "Default (English)";
             for (int i = 0; i < current.getMappingRules().size(); i++) {
                 MapRule maprule = current.getMappingRules().get(i);
-                if (def.equals(maprule.getLanguageCode())) {
-                    maprule.setLanguageCode(LanguageCodes.DEFAULT_CODE);
+                if (def.equals(maprule.getLanguage())) {
+                    maprule.setLanguage(LanguageCodes.DEFAULT_CODE);
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.ENGLISH_CODE));
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.F_TEXT_CODE));
                     maprule.getRules().removeAll(getRulesForLanguage(defaults, LanguageCodes.F_HTML_CODE));
@@ -358,7 +358,7 @@ public class SRX implements Serializable {
      */
     private static List<Rule> getRulesForLanguage(final SRX source, String langName) {
         for (MapRule mr : source.getMappingRules()) {
-            if (langName.equals(mr.getLanguageCode())) {
+            if (langName.equals(mr.getLanguage())) {
                 return mr.getRules();
             }
         }

--- a/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
+++ b/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
@@ -58,7 +58,7 @@ public class MappingRulesModel extends AbstractTableModel {
         MapRule maprule = srx.getMappingRules().get(rowIndex);
         switch (columnIndex) {
         case 0:
-            return maprule.getLanguageCode();
+            return maprule.getLanguage();
         case 1:
             return maprule.getPattern();
         }
@@ -93,9 +93,9 @@ public class MappingRulesModel extends AbstractTableModel {
             String target = (String) aValue;
             String code = LanguageCodes.getLanguageCodeByName(target);
             if (code != null) {
-                maprule.setLanguageCode(code);
+                maprule.setLanguage(code);
             } else {
-                maprule.setLanguageCode(target);
+                maprule.setLanguage(target);
             }
             break;
         case 1:

--- a/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
+++ b/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
@@ -32,6 +32,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.swing.table.AbstractTableModel;
 
+import org.omegat.core.segmentation.LanguageCodes;
 import org.omegat.core.segmentation.MapRule;
 import org.omegat.core.segmentation.Rule;
 import org.omegat.core.segmentation.SRX;
@@ -57,7 +58,7 @@ public class MappingRulesModel extends AbstractTableModel {
         MapRule maprule = srx.getMappingRules().get(rowIndex);
         switch (columnIndex) {
         case 0:
-            return maprule.getLanguage();
+            return maprule.getLanguageCode();
         case 1:
             return maprule.getPattern();
         }
@@ -89,7 +90,13 @@ public class MappingRulesModel extends AbstractTableModel {
         MapRule maprule = srx.getMappingRules().get(rowIndex);
         switch (columnIndex) {
         case 0:
-            maprule.setLanguage((String) aValue);
+            String target = (String) aValue;
+            String code = LanguageCodes.getLanguageCodeByName(target);
+            if (code != null) {
+                maprule.setLanguageCode(code);
+            } else {
+                maprule.setLanguageCode(target);
+            }
             break;
         case 1:
             try {

--- a/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
+++ b/src/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
@@ -58,7 +58,7 @@ public class MappingRulesModel extends AbstractTableModel {
         MapRule maprule = srx.getMappingRules().get(rowIndex);
         switch (columnIndex) {
         case 0:
-            return maprule.getLanguage();
+            return maprule.getLanguageName();
         case 1:
             return maprule.getPattern();
         }

--- a/src/org/omegat/gui/segmentation/SegmentationCustomizerController.java
+++ b/src/org/omegat/gui/segmentation/SegmentationCustomizerController.java
@@ -33,6 +33,7 @@ import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
 
 import org.omegat.core.Core;
+import org.omegat.core.segmentation.LanguageCodes;
 import org.omegat.core.segmentation.MapRule;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
@@ -226,8 +227,9 @@ public class SegmentationCustomizerController extends BasePreferencesController 
             commitTableEdits();
             MappingRulesModel model = (MappingRulesModel) panel.mapTable.getModel();
             String set = model.getValueAt(panel.mapTable.getSelectedRow(), 0).toString();
+            String setName = LanguageCodes.getLanguageName(set);
             String title = OStrings.getString("CONFIRM_DIALOG_TITLE");
-            String message = StringUtil.format(OStrings.getString("SEG_CONFIRM_REMOVE_SENTSEG_SET"), set);
+            String message = StringUtil.format(OStrings.getString("SEG_CONFIRM_REMOVE_SENTSEG_SET"), setName);
             if (JOptionPane.showConfirmDialog(panel, message, title,
                     JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
                 model.removeRow(panel.mapTable.getSelectedRow());

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -94,7 +94,7 @@ public class SRXTest {
         for (MapRule mapRule : mapRuleList) {
             if (mapRule.getPattern().equals("JA.*")) {
                 assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguageCode());
-                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguage());
+                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
             }
         }
         assertEquals("2.0", srx.getVersion());
@@ -144,7 +144,7 @@ public class SRXTest {
         for (MapRule mapRule: mapRuleList) {
             if (mapRule.getPattern().equals("JA.*")) {
                 assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguageCode());
-                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguage());
+                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
             }
         }
         assertEquals("2.0", srx1.getVersion());

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -32,9 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.Test;
 import org.omegat.util.OStrings;
 
@@ -93,7 +91,7 @@ public class SRXTest {
         assertEquals(18, mapRuleList.size());
         for (MapRule mapRule : mapRuleList) {
             if (mapRule.getPattern().equals("JA.*")) {
-                assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguageCode());
+                assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguage());
                 assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
             }
         }
@@ -143,14 +141,13 @@ public class SRXTest {
         assertEquals(18, mapRuleList.size());
         for (MapRule mapRule: mapRuleList) {
             if (mapRule.getPattern().equals("JA.*")) {
-                assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguageCode());
+                assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguage());
                 assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
             }
         }
         assertEquals("2.0", srx1.getVersion());
         assertTrue(srx1.isCascade());
         assertTrue(srx1.isSegmentSubflows());
-        Files.deleteIfExists(segmentSrxPath);
     }
 
     @AfterClass


### PR DESCRIPTION
## Pull request type

- BUG fix
- Feature enhancement -> [enhancement]

## Which ticket is resolved?
 
-  SRX conf file is produced with localized name of language
   -  https://sourceforge.net/p/omegat/bugs/1160/
   
- Use Jackson library as XML parser
   - https://sourceforge.net/p/omegat/feature-requests/1582/
   
## What does this PR change?

- Use Jackson XML mapper to write SRX file.
- Use XMLStreamInput to read SRX and conf file.
- Fix MapRule#setLanguage to store Language Code instead of Language name
- Add org.omegat.core.segmentation.LanguageCodes.getLanguageCodeByName static method to get the code
- Rename MapRule#getLanguage to MapRule#getLanguageName
- Rename MapRUle#getLanguageCode to MapRule#getLanguage
- Fix SRX#copy method to copy also a version, or other attributes
- Set  segmentSubFlows and cascade is true in default
- Drop JAXB dependency from runtime
- Fix SRX parser to store src->header->version attribute into SRX#version properly.
- When CONF reader encounter a language name with UNKOWN name value, OmegaT leave a log message with it.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
