### PR TITLE
docs(tips): fix shortcut key assign

### DIFF
--- a/tipoftheday/docs/tips/en/shortcut_note.html
+++ b/tipoftheday/docs/tips/en/shortcut_note.html
@@ -62,7 +62,7 @@
                           </span>+<span class="keycap">
                              <strong>A</strong>
                           </span>+<span class="keycap">
-                             <strong>N</strong>
+                             <strong>9</strong>
                           </span>
                     to enter the Notepad and add your remark.</p>
                 <p>Use <span class="guimenu">Go To</span>
@@ -72,7 +72,7 @@
                           </span>+<span class="keycap">
                              <strong>A</strong>
                           </span>+<span class="keycap">
-                             <strong>E</strong>
+                             <strong>0</strong>
                           </span>
                     to return to the Editor and resume your translation.</p>
             </li>

--- a/tipoftheday/docs/tips/ja/shortcut_note.html
+++ b/tipoftheday/docs/tips/ja/shortcut_note.html
@@ -18,7 +18,7 @@
                               </span>+<span class="keycap">
                                  <strong>A</strong>
                               </span>+<span class="keycap">
-                                 <strong>N</strong>
+                                 <strong>9</strong>
                               </span>
                 </a>を使用するとメモ帳に移動でき、そこで自分の考えを追加できます。</p>
             <p>
@@ -32,7 +32,7 @@
                               </span>+<span class="keycap">
                                  <strong>A</strong>
                               </span>+<span class="keycap">
-                                 <strong>E</strong>
+                                 <strong>0</strong>
                               </span>
                 </a>を使用して編集ウィンドウに戻り、翻訳を再開します。</p>
         </li>


### PR DESCRIPTION
- Current shortcut for note/editor pane is ctrl alt 0/9

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
