### PR TITLE
docs(first step): remove version string from First_Step

### DIFF
--- a/doc_src/ca/First_Steps.xml
+++ b/doc_src/ca/First_Steps.xml
@@ -5,7 +5,7 @@
 %manualvariables;
 ]>
 <article lang="ca" id="first.steps">
-  <title>OmegaT &vernb;</title>
+  <title>OmegaT</title>
   <section>
 	<title id="first-steps">Primers passos</title>
 	<para>Premeu <keycap>F1</keycap> o accediu al menú <guimenu>&gt; Ajuda</guimenu> per a obrir el manual d'usuari. Inclou una introducció detallada a l'OmegaT. Per a començar a utilitzar l'OmegaT amb una configuració mínima, feu el següent:<orderedlist id="first-step-list">

--- a/doc_src/en/First_Steps.xml
+++ b/doc_src/en/First_Steps.xml
@@ -3,7 +3,7 @@
 "../../../docbook-xml-4.5/docbookx.dtd"
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 <article lang="en" id="first.steps">
-  <title>OmegaT &vernb;</title>
+  <title>OmegaT</title>
   <section>
 	<title id="first-steps">First steps</title>
 	<para>Hit <keycap>F1</keycap> or access the <guimenu>> Help</guimenu> menu

--- a/doc_src/ja/First_Steps.xml
+++ b/doc_src/ja/First_Steps.xml
@@ -5,7 +5,7 @@
 %manualvariables;
 ]>
 <article lang="ja" id="first.steps">
-  <title>OmegaT &vernb;</title>
+  <title>OmegaT</title>
   <section>
 	<title id="first-steps">最初の一歩</title>
 	<para>取扱説明書を開くには、 <keycap>F1</keycap> キーを押すか、 <guimenu>&gt; ヘルプ</guimenu>メニューにアクセスします。取扱説明書には、OmegaTの徹底入門が含まれています。最低限の構成でOmegaTを使いはじめるには、次のようにします。<orderedlist id="first-step-list">

--- a/docs/ca/first_steps.html
+++ b/docs/ca/first_steps.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
    
-      <title>OmegaT 5.8.0</title>
+      <title>OmegaT</title>
       <link rel="stylesheet" type="text/css" href="OmegaT.css">
       <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
    </head>
@@ -11,7 +11,7 @@
          <div class="titlepage">
             <div>
                <div>
-                  <h2 class="title"><a name="first.steps"></a>OmegaT 5.8.0
+                  <h2 class="title"><a name="first.steps"></a>OmegaT
                   </h2>
                </div>
             </div>

--- a/docs/en/first_steps.html
+++ b/docs/en/first_steps.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
    
-      <title>OmegaT 5.8.0</title>
+      <title>OmegaT</title>
       <link rel="stylesheet" type="text/css" href="OmegaT.css">
       <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
    </head>
@@ -11,7 +11,7 @@
          <div class="titlepage">
             <div>
                <div>
-                  <h2 class="title"><a name="first.steps"></a>OmegaT 5.8.0
+                  <h2 class="title"><a name="first.steps"></a>OmegaT
                   </h2>
                </div>
             </div>

--- a/docs/ja/first_steps.html
+++ b/docs/ja/first_steps.html
@@ -2,7 +2,7 @@
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
    
-      <title>OmegaT 6.0.0</title>
+      <title>OmegaT</title>
       <link rel="stylesheet" type="text/css" href="OmegaT.css">
       <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
    </head>
@@ -11,7 +11,7 @@
          <div class="titlepage">
             <div>
                <div>
-                  <h2 class="title"><a name="first.steps"></a>OmegaT 6.0.0
+                  <h2 class="title"><a name="first.steps"></a>OmegaT
                   </h2>
                </div>
             </div>


### PR DESCRIPTION
When show on OmegaT version number in First step article, it should be as same as OmegaT release version.
Current version number is set from manual version, that is incorrect.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

-  First step document show wrong OmegaT version
  * https://sourceforge.net/p/omegat/documentation/409/


## What does this PR change?

- Remove referece to manual version.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
