### PR TITLE
Correct double negations

### DIFF
--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -293,7 +293,8 @@ public class SegmentBuilder {
                 //translation exist
                 translationText = trans.translation;
             } else {
-                boolean insertSource = Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT,
+                // Double negation - insertSource = true if Preferences.DONT_INSERT_SOURCE_TEXT = false
+                boolean insertSource = !Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT,
                         DONT_INSERT_SOURCE_TEXT_DEFAULT);
                 if (controller.entriesFilter != null && controller.entriesFilter.isSourceAsEmptyTranslation()) {
                     insertSource = true;

--- a/src/org/omegat/gui/preferences/view/EditingBehaviorController.java
+++ b/src/org/omegat/gui/preferences/view/EditingBehaviorController.java
@@ -73,7 +73,8 @@ public class EditingBehaviorController extends BasePreferencesController {
 
     @Override
     protected void initFromPrefs() {
-        boolean prefInsertSource = Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT, SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
+        // Double negation? then prefInsertSource is the contrary of Preferences.DONT_INSERT_SOURCE_TEXT 
+        boolean prefInsertSource = !Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT, SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
         panel.defaultRadio.setSelected(prefInsertSource);
         panel.leaveEmptyRadio.setSelected(!prefInsertSource);
 
@@ -104,8 +105,8 @@ public class EditingBehaviorController extends BasePreferencesController {
 
     @Override
     public void restoreDefaults() {
-        panel.defaultRadio.setSelected(SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
-        panel.leaveEmptyRadio.setSelected(!SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
+        panel.defaultRadio.setSelected(!SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
+        panel.leaveEmptyRadio.setSelected(SegmentBuilder.DONT_INSERT_SOURCE_TEXT_DEFAULT);
 
         panel.insertFuzzyCheckBox.setSelected(true);
         panel.similaritySpinner.setValue(Preferences.BEST_MATCH_MINIMAL_SIMILARITY_DEFAULT);
@@ -134,7 +135,7 @@ public class EditingBehaviorController extends BasePreferencesController {
 
     @Override
     public void persist() {
-        Preferences.setPreference(Preferences.DONT_INSERT_SOURCE_TEXT, panel.defaultRadio.isSelected());
+        Preferences.setPreference(Preferences.DONT_INSERT_SOURCE_TEXT, panel.leaveEmptyRadio.isSelected());
 
         Preferences.setPreference(Preferences.BEST_MATCH_INSERT, panel.insertFuzzyCheckBox.isSelected());
         if (panel.insertFuzzyCheckBox.isSelected()) {


### PR DESCRIPTION
 Commit b06f906e6f contains some mistaken double negations between insertSource and DONT_INSERT_SOURCE_TEXT:

if DONT_INSERT_SOURCE_TEXT_DEFAULT = false then defaultRadio = true and leaveEmptyRadio = false 
if DONT_INSERT_SOURCE_TEXT_DEFAULT = true then defaultRadio = false and leaveEmptyRadio = true 
Also in SegmentBuilder, isInsertSource is true if DONT_INSERT_SOURCE_TEXT_DEFAULT is false, not the contrary!

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

https://sourceforge.net/p/omegat/bugs/1155/

Note: bug absent from last published 5.7.1, but present in 5.8, 6.0 and 6.1