### PR TITLE
Exclude `xml-apis` from tipoftheday dependencies in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,9 @@ dependencies {
         }
 
         // dependencies in submodules, you should put it as compileOnly in subprojects
-        runtimeOnly "tokyo.northside:tipoftheday:0.4.0"
+        runtimeOnly ("tokyo.northside:tipoftheday:0.4.0"){
+            exclude module: 'xml-apis'
+        }
         runtimeOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4"
     }
 


### PR DESCRIPTION
Otherwise, Eclipse is confused as the javax.xml.* modules are duplicated: `The package [...] is accessible from more than one module: <unnamed>, java.xml`

