### PR TITLE
Allow DTD parsing in order to load internal entities

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -31,6 +31,9 @@
 
   Bug fixes:
 
+  - Project not loaded if it contains DTD internal entities
+  https://sourceforge.net/p/omegat/bugs/1163/
+
   - SRX conf file is produced with localized name of language
   https://sourceforge.net/p/omegat/bugs/1160/
 

--- a/src/org/omegat/util/JaxbXmlMapper.java
+++ b/src/org/omegat/util/JaxbXmlMapper.java
@@ -25,8 +25,11 @@
 
 package org.omegat.util;
 
+import javax.xml.stream.XMLInputFactory;
+
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
@@ -41,7 +44,10 @@ public final class JaxbXmlMapper {
     static {
         JacksonXmlModule xmlModule = new JacksonXmlModule();
         xmlModule.setDefaultUseWrapper(false);
-        mapper = new XmlMapper(xmlModule);
+        XmlFactory xmlFactory = new XmlFactory();
+        XMLInputFactory xmlIn = xmlFactory.getXMLInputFactory();
+        xmlIn.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.TRUE);
+        mapper = new XmlMapper(xmlFactory, xmlModule);
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);

--- a/test/data/project/entities.project
+++ b/test/data/project/entities.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE omegat [
+    <!ENTITY TARGET_LANG "fr-ZZ">
+    <!ENTITY STEP "check">
+    <!ENTITY THIS_REPO "translation_&TARGET_LANG;_&STEP;">
+]>
+<omegat>
+    <project version="1.0">
+        <source_dir>__DEFAULT__</source_dir>
+        <source_dir_excludes>
+            <mask>**/.svn/**</mask>
+            <mask>**/CVS/**</mask>
+            <mask>**/.cvs/**</mask>
+            <mask>**/desktop.ini</mask>
+            <mask>**/Thumbs.db</mask>
+            <mask>**/.DS_Store</mask>
+        </source_dir_excludes>
+        <target_dir>&THIS_REPO;</target_dir>
+        <tm_dir>__DEFAULT__</tm_dir>
+        <glossary_dir>foo</glossary_dir>
+        <glossary_file>__DEFAULT__</glossary_file>
+        <dictionary_dir>__DEFAULT__</dictionary_dir>
+        <export_tm_dir>__DEFAULT__</export_tm_dir>
+        <export_tm_levels>omegat level1 level2</export_tm_levels>
+        <source_lang>en-us</source_lang>
+        <target_lang>&TARGET_LANG;</target_lang>
+        <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+        <target_tok>org.omegat.tokenizer.LuceneFrenchTokenizer</target_tok>
+        <sentence_seg>true</sentence_seg>
+        <support_default_translations>true</support_default_translations>
+        <remove_tags>false</remove_tags>
+        <external_command></external_command>
+    </project>
+</omegat>

--- a/test/src/org/omegat/util/ProjectFileStorageTest.java
+++ b/test/src/org/omegat/util/ProjectFileStorageTest.java
@@ -363,6 +363,14 @@ public class ProjectFileStorageTest {
     }
 
     @Test
+    public void testProjectFileWithEntities() throws Exception {
+        File projFile = new File(PROJECT_DIR, "entities.project");
+        Omegat omt = ProjectFileStorage.parseProjectFile(projFile);
+        assertEquals("translation_fr-ZZ_check", omt.getProject().getTargetDir());
+        assertEquals("fr-ZZ", omt.getProject().getTargetLang());
+    }
+
+    @Test
     public void testMissingDirs() throws Exception {
         // Older project files can be missing path definitions, in which case
         // we should fall back to the default values.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Project not loaded if it contains DTD internal entities
  * https://sourceforge.net/p/omegat/bugs/1163/

## What does this PR change?

- Essentially, it sets the `XMLInputFactory.SUPPORT_DTD` flag to true when creating the XmlMapper

## Other information

See also: https://sourceforge.net/p/omegat/mailman/message/37805777/