### PR TITLE
Check that a segmentation rule has beforeBreak/afterBreak attributes

### DIFF
--- a/src/org/omegat/core/segmentation/Rule.java
+++ b/src/org/omegat/core/segmentation/Rule.java
@@ -51,8 +51,12 @@ public class Rule implements Serializable {
 
     public Rule(gen.core.segmentation.Rule s) {
         setBreakRule("yes".equalsIgnoreCase(s.getBreak()));
-        setBeforebreak(s.getBeforebreak().getContent());
-        setAfterbreak(s.getAfterbreak().getContent());
+        if (s.getBeforebreak() != null) {
+            setBeforebreak(s.getBeforebreak().getContent());
+        }
+        if (s.getAfterbreak() != null) {
+            setAfterbreak(s.getAfterbreak().getContent());
+        }
     }
 
     public Rule copy() {


### PR DESCRIPTION
There's nothing preventing the segmentation configuration (`.srx` or `.conf`) from having undefined `beforebreak` and `afterbreak` elements. If there's such an empty rule:

```xml
      <languagerule languagerulename="New language and country">
        <rule/>
      </languagerule>
```

a NullPointerException is thrown when loading a project.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

