### PR TITLE
fix: drop xml-apis dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ dependencies {
         }
 
         // dependencies in submodules, you should put it as compileOnly in subprojects
-        runtimeOnly "tokyo.northside:tipoftheday:0.4.0"
+        runtimeOnly "tokyo.northside:tipoftheday:0.4.1"
         runtimeOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4"
     }
 

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -27,7 +27,7 @@ dependencies {
         compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
     } else {
         // runtime dependencies should be in main project
-        compileOnly "tokyo.northside:tipoftheday:0.4.0"
+        compileOnly "tokyo.northside:tipoftheday:0.4.1"
         compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4"
     }
 }


### PR DESCRIPTION
Bump tipoftheday@0.4.1 that drop xml-apis
and update transient dependencies
- swingbox@1.2.4
   - jstyleparser@4.1.1
   - cssbox4@4.21 which drop xml-apis deps

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Title ex. fix...
  * URL ex. https://...
 
- Title
  * URL

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Bump tipoftheday library to vresion 0.4.1

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

An alternative fix for #553 

