### PR TITLE
refactor: improve LanguageToolTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,6 +266,7 @@ dependencies {
     testImplementation 'org.xmlunit:xmlunit-legacy:2.8.3'
     testImplementation("org.languagetool:languagetool-server:${languageToolVersion}") {
         exclude group: 'org.slf4j'
+        exclude group: 'ch.qos.logback'
     }
     // LanguageTool unit tests exercise these languages
     ['be', 'en', 'fr'].each {

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -28,8 +28,8 @@ package org.omegat.languagetools;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -99,14 +99,10 @@ public class LanguageToolTest {
         try {
             server.run();
 
-            try {
-                new LanguageToolNetworkBridge(SOURCE_LANG, TARGET_LANG, "http://localhost:8081");
-                fail("URL not specifying API v2 should fail due to XML response instead of JSON");
-                // TODO: LanguageTool will drop XML entirely in version 3.6; this
-                // test might need to be adjusted then.
-            } catch (Exception e) {
-                // OK
-            }
+            assertThrows("URL not specifying API actions should fail due to missing argument.",
+                    java.lang.Exception.class,
+                    () -> new LanguageToolNetworkBridge(SOURCE_LANG, TARGET_LANG, "http://localhost:8081")
+            );
 
             ILanguageToolBridge bridge = new LanguageToolNetworkBridge(SOURCE_LANG, TARGET_LANG,
                     "http://localhost:8081/v2/check");


### PR DESCRIPTION
- exclude duplicated slf4j logging module
- use Assert.assertThrows for error check test
- improve a test message because an old XML API was removed in LanguageTool 3.7 and later.

## Pull request type
- Other (describe below)

refactoring
