### PR TITLE
chore(deps): Bump svnkit@1.10.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
         implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:6.5.0.202303070854-r'
 
         // For subversion
-        implementation 'org.tmatesoft.svnkit:svnkit:1.10.9'
+        implementation 'org.tmatesoft.svnkit:svnkit:1.10.11'
 
         // Team project conflict resolution
         implementation 'org.madlonkay:supertmxmerge:2.0.3'


### PR DESCRIPTION
Changes from 1.10.9
- Apache SSHD libraries upgraded to version 2.9.2
- SVNKIT-770: Support "aarch64" (M1) architecture for Mac.

## Pull request type

- Other (describe below)

## What does this PR change?

- SVNKit 1.10.9 was a  first version that SQLJet become GPL3 compatible. It depends on JNA 3.3.0 which was very old.
- SVNKit 1.10.11 update its JNA dependency to 5.8.0.
- It also update Apache SSHD dependency on wihch OmegaT 6.1 depends.
- M1/M2 mac support 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
