### PR TITLE
[6.1][RFE#1169] feat: use Apache MINA SSHD for SVN transport

### DIFF
--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -496,7 +496,7 @@ public final class TestTeamIntegration {
             String predefinedUser = def.getOtherAttributes().get(new QName("svnUsername"));
             String predefinedPass = def.getOtherAttributes().get(new QName("svnPassword"));
             ISVNOptions options = SVNWCUtil.createDefaultOptions(true);
-            ISVNAuthenticationManager authManager = new SVNAuthenticationManager(url, predefinedUser,
+            ISVNAuthenticationManager authManager = new SVNAuthenticationManager(def, predefinedUser,
                     predefinedPass, null);
             ourClientManager = SVNClientManager.newInstance(options, authManager);
         }


### PR DESCRIPTION
SVNKit 1.10.5 and later support apache sshd and recommend to switch to it.

SVNKIT-759: Apache sshd based implementation for svn+ssh:// protocol as an alternative to trilead.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Feature enhancement -> [enhancement]

## Ticket

- Team: SVN support svn+ssh protocol with key authentication
    - https://sourceforge.net/p/omegat/feature-requests/1700/
    
-  Team: SVN: Replacing trilead-ssh2 with Apache sshd
    - https://sourceforge.net/p/omegat/feature-requests/1699/


## What does this PR change?

- Set System property to specify Apache MINA-SSHD for SVNKit for team subversion connections
- It supports EC cipher
- SVN/Git use a common apache ssh library for team connections

## Other information

- [x] Integration test with SVN+SSH