### PR TITLE
[6.1] fix NPE when team project with glossary outside

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1050,7 +1050,6 @@ public class RealProject implements IProject {
         if (processGlossary) {
             final String glossaryPath = config.getWritableGlossaryFile().getUnderRoot();
             final File glossaryFile = config.getWritableGlossaryFile().getAsFile();
-            new File(config.getProjectRootDir(), glossaryPath);
             if (glossaryPath != null && remoteRepositoryProvider.isUnderMapping(glossaryPath)) {
                 final List<GlossaryEntry> glossaryEntries;
                 if (glossaryFile.exists()) {


### PR DESCRIPTION
Current OmegaT raises NPE when the mandatory writable glossary file is out of project root.  ~~This change to show warning dialog and gracefully  throws exception with a clear reason.~~  This proposal remove a dead line which raise NPE.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

 
- [OmTdev] [BUG] build/install/OmegaT/OmegaT
  * https://sourceforge.net/p/omegat/mailman/message/37842271/

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

-  Remove dead code which raise NPE when glossaryPath is null

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
