### PR TITLE
[6.1]fix: dependency inconsistency in lucene-gosen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies {
         implementation 'com.google.guava:guava:31.0.1-jre'
         runtimeOnly("org.languagetool:language-all:${languageToolVersion}") {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen'
+            exclude module: 'lucene-gosen-ipadic'
         }
         runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0:ipadic'
 


### PR DESCRIPTION
Refactoring in PR#570, tweaking to reduce duplication of multiple libraries versions. PR#570 passed the check, but I might make mistake at lucene-gosen dependency.

The issue is reported at dev ML
https://sourceforge.net/p/omegat/mailman/message/37843223/

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->
- Reported at development ML
  https://sourceforge.net/p/omegat/mailman/message/37843223/
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

-  Revert exclude line of lucene-gosen to be lucene-gosen-ipa

## Other information

