### PR TITLE
[BUGS#1169] fix: supress useless warnings

### DIFF
--- a/src/org/omegat/logger.properties
+++ b/src/org/omegat/logger.properties
@@ -20,6 +20,9 @@ org.omegat.util.logging.OmegaTFileHandler.formatter = org.omegat.util.logging.Om
 org.omegat.util.logging.OmegaTFileHandler.size=1048576
 org.omegat.util.logging.OmegaTFileHandler.count=10
 
+# Suppress warning from depndency jStyleParser
+cz.vutbr.web.level = SEVERE
+org.fit.net.level = SEVERE
 
 # We can enable specific logging level for some classes 
 #org.omegat.core.data.SaveThread.level = FINEST


### PR DESCRIPTION
- Suppress jStyleParser warnings

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Useless warning log from CSS parser library
  *https://sourceforge.net/p/omegat/bugs/1169
 

## What does this PR change?

- Add log level configuration in logger.properties

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
