### PR TITLE
chore: allow UTF-8 character as source file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ allprojects {
         (options as StandardJavadocDocletOptions).addStringOption("Xmaxwarns", "1")
     }
     tasks.withType(JavaCompile) {
+       options.encoding = "UTF-8"
        options.compilerArgs.addAll '-Xlint', '-Werror'
     }
 


### PR DESCRIPTION
- Allow UTF-8 character for comments, especially for author name

## Pull request type


- Build and release changes -> [build/release]
- Other (describe below)

## What does this PR change?

- Add compiler flag to allow UTF-8 in java source files
- Update test case not to check US-ASCII
- A check should be done by spotless and checkstyle, instead of crafted one

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

### Related topic:  UTF-8 in Bundle.properties

Here is a Dev-ML discussion thread about BUNDLE file.

https://sourceforge.net/p/omegat/mailman/omegat-development/thread/8zfUNKLS058FYMIUPADGzNmrOOu_73IQWvrNRLFGTbfPmZke8l6fR9yAtLT2j1cGOo6ZpeQ4j-hNbT8fNAfgAtaEb2kmScQffrmXhGtZmx4%3D%40northside.tokyo/#msg37844491
