### PR TITLE
[6.1] feat: disable newUI configuration

### DIFF
--- a/src/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/org/omegat/gui/preferences/view/AppearanceController.java
@@ -85,11 +85,20 @@ public class AppearanceController extends BasePreferencesController {
         // TODO: Properly abstract the restore function
         panel.restoreWindowButton
                 .addActionListener(e -> MainWindowUI.resetDesktopLayout((MainWindow) Core.getMainWindow()));
-        panel.newUICheckBox.addActionListener(actionEvent -> {
+        /*panel.newUICheckBox.addActionListener(actionEvent -> {
             setRestartRequired(isModified());
-        });
+        });*/
     }
 
+    private boolean isModified() {
+        Object selected = panel.cbThemeSelect.getSelectedItem();
+        if (selected != null) {
+            return !UIManager.getLookAndFeel().getClass().getName().equals(selected.toString());
+        }
+        return false;
+    }
+
+/*
     private boolean isModified() {
         boolean changeNewUI = panel.newUICheckBox.isSelected()
                 ^ Preferences.isPreference(Preferences.APPLY_BURGER_SELECTOR_UI);
@@ -99,11 +108,12 @@ public class AppearanceController extends BasePreferencesController {
         }
         return !UIManager.getLookAndFeel().getClass().getName().equals(selected.toString()) || changeNewUI;
     }
+*/
 
     @Override
     protected void initFromPrefs() {
         panel.cbThemeSelect.setSelectedItem(UIManager.getLookAndFeel().getClass().getName());
-        panel.newUICheckBox.setSelected(Preferences.isPreference(Preferences.APPLY_BURGER_SELECTOR_UI));
+        // panel.newUICheckBox.setSelected(Preferences.isPreference(Preferences.APPLY_BURGER_SELECTOR_UI));
         previousFileListDialog = Preferences.isPreferenceDefault(Preferences.PROJECT_FILES_SHOW_ON_LOAD,
                 true);
     }
@@ -111,18 +121,19 @@ public class AppearanceController extends BasePreferencesController {
     @Override
     public void restoreDefaults() {
         panel.cbThemeSelect.setSelectedItem(Preferences.THEME_CLASS_NAME_DEFAULT);
-        panel.newUICheckBox.setSelected(false);
+        // panel.newUICheckBox.setSelected(false);
         Preferences.setPreference(Preferences.PROJECT_FILES_SHOW_ON_LOAD, previousFileListDialog);
     }
 
     @Override
     public void persist() {
         Preferences.setPreference(Preferences.THEME_CLASS_NAME, panel.cbThemeSelect.getSelectedItem().toString());
+/*
         Preferences.setPreference(Preferences.APPLY_BURGER_SELECTOR_UI, panel.newUICheckBox.isSelected());
         if (panel.newUICheckBox.isSelected()) {
             Preferences.setPreference(Preferences.PROJECT_FILES_SHOW_ON_LOAD, false);
         } else {
             Preferences.setPreference(Preferences.PROJECT_FILES_SHOW_ON_LOAD, previousFileListDialog);
-        }
+        }*/
     }
 }

--- a/src/org/omegat/gui/preferences/view/AppearancePreferencesPanel.form
+++ b/src/org/omegat/gui/preferences/view/AppearancePreferencesPanel.form
@@ -64,15 +64,6 @@
         </Component>
       </SubComponents>
     </Container>
-    <Component class="javax.swing.JCheckBox" name="newUICheckBox">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Apply newUI(Experimental)"/>
-        <Property name="actionCommand" type="java.lang.String" value="newUI"/>
-      </Properties>
-      <AuxValues>
-        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
-      </AuxValues>
-    </Component>
     <Component class="javax.swing.Box$Filler" name="filler1">
       <Properties>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">

--- a/src/org/omegat/gui/preferences/view/AppearancePreferencesPanel.java
+++ b/src/org/omegat/gui/preferences/view/AppearancePreferencesPanel.java
@@ -51,7 +51,6 @@ public class AppearancePreferencesPanel extends JPanel {
         jPanel1 = new javax.swing.JPanel();
         jLabel1 = new javax.swing.JLabel();
         cbThemeSelect = new javax.swing.JComboBox<>();
-        newUICheckBox = new javax.swing.JCheckBox();
         filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 8), new java.awt.Dimension(0, 8), new java.awt.Dimension(32767, 8));
         restoreWindowButton = new javax.swing.JButton();
 
@@ -70,10 +69,6 @@ public class AppearancePreferencesPanel extends JPanel {
         jPanel1.add(cbThemeSelect, java.awt.BorderLayout.CENTER);
 
         add(jPanel1);
-
-        org.openide.awt.Mnemonics.setLocalizedText(newUICheckBox, "Apply newUI(Experimental)");
-        newUICheckBox.setActionCommand("newUI");
-        add(newUICheckBox);
         add(filler1);
 
         org.openide.awt.Mnemonics.setLocalizedText(restoreWindowButton, OStrings.getString("MW_OPTIONSMENU_RESTORE_GUI")); // NOI18N
@@ -85,7 +80,6 @@ public class AppearancePreferencesPanel extends JPanel {
     private javax.swing.Box.Filler filler1;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JPanel jPanel1;
-    javax.swing.JCheckBox newUICheckBox;
     javax.swing.JButton restoreWindowButton;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
According to devevelpment ML discussion and result, disable newUI feature configuraiton.

## Pull request type

- Other (describe below)

Disable newUI experimental UI for 6.1 release

## What does this PR change?

-  remove preference option


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
