### PR TITLE
[6.1] feat: not include tipoftheday module into release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -446,9 +446,9 @@ distributions {
             from('releases/modules-specific') {
                 into 'modules'
             }
-            from(subprojects.collect {it.tasks.withType(Jar)}) {
+            /*from(subprojects.collect {it.tasks.withType(Jar)}) {
                 into 'modules'
-            }
+            }*/
             eachFile {
                 // Move main JAR up one level from lib.
                 if (it.name == jar.archiveName) {

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayController.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayController.java
@@ -46,7 +46,7 @@ import org.omegat.util.Preferences;
 public final class TipOfTheDayController {
 
     static final String INDEX_YAML = "tips.yaml";
-    private static final String TIPOFTHEDAY_SHOW_ON_STARTUP = "tipoftheday_show_on_startup";
+    private static final String TIPOFTHEDAY_SHOW_ON_STARTUP = "tipoftheday_show_on_start";
     private static final String TIPOFTHEDAY_CURRENT_TIP = "tipoftheday_current_tip";
 
     public static void loadPlugins() {
@@ -55,7 +55,8 @@ public final class TipOfTheDayController {
             public void onApplicationStartup() {
                 if (TipOfTheDayUtils.hasIndex()) {
                     initUI();
-                    initMenu();
+                    // FIXME: disable temporary for 6.1 release
+                    // initMenu();
                     SwingUtilities.invokeLater(() -> {
                         TipOfTheDayController.start(false);
                     });
@@ -96,7 +97,8 @@ public final class TipOfTheDayController {
         if (force) {
             showComponent();
         }
-        if (Preferences.isPreferenceDefault(TIPOFTHEDAY_SHOW_ON_STARTUP, true)) {
+        // FIXME: temporary default to be false in 6.1 development.
+        if (Preferences.isPreferenceDefault(TIPOFTHEDAY_SHOW_ON_STARTUP, false)) {
             showComponent();
         }
     }


### PR DESCRIPTION
## Pull request type

- Other (describe below)

Disable tipoftheday plugin bundle into releaase package


## What does this PR change?

- change config key
- no bundle tipofheday module

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
