### PR TITLE
[6.1] feat/style: check malformed character in java source

### DIFF
--- a/docs_devel/docs/30.CodingStyles.md
+++ b/docs_devel/docs/30.CodingStyles.md
@@ -26,7 +26,7 @@ OmegaT project uses following coding style rules and coding policy.
 - OmegaT project uses UTF-8 characters for comments in java source file in general.
 - You should use English for comment language.
 - You should use ASCII characters and 7bit clean for variable names, method names et. al.
-- You are allowed to use String laterals in UTF-8 encoding.
+- You are allowed to use String literals in UTF-8 encoding.
 - You should use Bundle for localization strings.
 - You can not use Right-to-Left direction characters in comments.
 - You can not use invisible characters such as non-breakable-space.
@@ -46,7 +46,7 @@ You can check your code with;
 You can check your code with Checkstyle linting tool.
 A project configuration is stored in `config/checkstyle/checkstyle.xml`
 We treat checkstyle lint error as warning, but you are recommended to
-improve your code before sending your patch to a core team.
+improve your code before sending your patch to the core team.
 
 ### Spotless code formatter
 

--- a/docs_devel/docs/30.CodingStyles.md
+++ b/docs_devel/docs/30.CodingStyles.md
@@ -2,14 +2,13 @@
 
 OmegaT project uses following coding style rules and coding policy.
 
-* Each java file has a GPL3 copyright header. OmegaT has an unit test to check header.
-* Source code has maximum 120 characters in each line.
-* Maximum line length of comments in sources is 80 characters 
+* Each java file has a GPL3 copyright header. OmegaT has a unit test to check header.
+* Source code has a maximum 120 characters in each line.
+* The Maximum line length of comments in sources is 80 characters 
 * Indentation is 4 spaces. Don't use TAB character.
-* Source code should be ASCII code, 7bit clean. When you want to add your name in header, please escape.  
 * We don't use asterisk import. You should expand all individual imports.
 * You are recommended to put javadoc comments for all your public methods.
-* We don't set method arguments "final", but you are recommend to treat it as final.
+* We don't set method arguments "final", but you are recommended to treat it as final.
 * Bundle properties should be ASCII, 7bit clean. All translations should be escaped.
   * It will change to be UTF-8 after OmegaT 6.1 development.
 * Stable APIs should be under "org.omegat.core" package.
@@ -18,9 +17,18 @@ OmegaT project uses following coding style rules and coding policy.
   * Use NetBeans GUI builder
 * We don't accept other GUI builder materials;
   * such as JetBrains IntelliJ GUI builder, JForm Designer, Eclipse Window builder.
-  * If you want, you are recommended to implement it as plugin.
+  * If you want, you are recommended to implement it as a plugin.
 * We move XML parser to be StAX based instead of JAXB because of performance.
   * We use [Jackson](https://github.com/FasterXML/jackson) XML serialization library.
+
+## language and characters
+
+- OmegaT project uses UTF-8 characters for comments in java source file in general.
+- You should use English for comment language.
+- You should use ASCII characters and 7bit clean for variable names, method names et. al.
+- You are allowed to use String laterals in UTF-8 encoding.
+- You should use Bundle for localization strings.
+- You can not use Right-to-Left direction characters in comments.
 
 ## Lint check
 
@@ -36,11 +44,11 @@ You can check your code with;
 You can check your code with Checkstyle linting tool.
 A project configuration is stored in `config/checkstyle/checkstyle.xml`
 We treat checkstyle lint error as warning, but you are recommended to
-improve your code before sending your patch to core team.
+improve your code before sending your patch to a core team.
 
 ### Spotless code formatter
 
-Spotless is general purpose code formatting tool that make code spotless.
+Spotless is a general purpose code formatting tool that makes code spotless.
 It will help you to format your changed code just a command
 
 ```bash

--- a/docs_devel/docs/30.CodingStyles.md
+++ b/docs_devel/docs/30.CodingStyles.md
@@ -10,7 +10,7 @@ OmegaT project uses following coding style rules and coding policy.
 * You are recommended to put javadoc comments for all your public methods.
 * We don't set method arguments "final", but you are recommended to treat it as final.
 * Bundle properties should be ASCII, 7bit clean. All translations should be escaped.
-  * It will change to be UTF-8 after OmegaT 6.1 development.
+  * It will change to be UTF-8 after OmegaT version 6.1 beta release.
 * Stable APIs should be under "org.omegat.core" package.
 * GUI parts can be;
   * written by hand, or

--- a/docs_devel/docs/30.CodingStyles.md
+++ b/docs_devel/docs/30.CodingStyles.md
@@ -29,6 +29,8 @@ OmegaT project uses following coding style rules and coding policy.
 - You are allowed to use String laterals in UTF-8 encoding.
 - You should use Bundle for localization strings.
 - You can not use Right-to-Left direction characters in comments.
+- You can not use invisible characters such as non-breakable-space.
+- When you need invisible characters in literals, please use unicode escape.
 
 ## Lint check
 

--- a/src/org/omegat/core/team2/impl/GITExternalGpgSigner.java
+++ b/src/org/omegat/core/team2/impl/GITExternalGpgSigner.java
@@ -61,11 +61,10 @@ import org.omegat.util.Platform;
 public class GITExternalGpgSigner extends GpgSigner {
 
     // A GPG environment variable name. We remove this environment variable when calling gpg.
-	private static final String PINENTRY_USER_DATA = "PINENTRY_USER_DATA";
+    private static final String PINENTRY_USER_DATA = "PINENTRY_USER_DATA";
 
     // For sanity checking the returned signature.
-	private static final byte[] SIGNATURE_START = "-----BEGIN PGP SIGNATURE-----"
-			.getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] SIGNATURE_START = "-----BEGIN PGP SIGNATURE-----".getBytes(StandardCharsets.US_ASCII);
     private static final PathScanner FROM_PATH = new PathScanner();
 
     // error message keys
@@ -82,7 +81,7 @@ public class GITExternalGpgSigner extends GpgSigner {
     private static final String ExternalGpgSigner_gpgNotFound = "GPG_EXTERNAL_SIGNER_GPG_NOT_FOUND";
 
     private interface ResultHandler {
-		void accept(TemporaryBuffer b) throws IOException, CanceledException;
+        void accept(TemporaryBuffer b) throws IOException, CanceledException;
     }
 
     private static void runProcess(final ProcessBuilder process, final InputStream in,

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -57,11 +57,13 @@ import org.omegat.util.gui.StaticUIUtils;
 import org.omegat.util.gui.UIThreadsUtil;
 
 /**
- * Class for store information about displayed segment, and for show segment in editor.
+ * Class for store information about displayed segment, and for show segment in
+ * editor.
  *
  * RTL and Bidirectional support: see good description at
- * http://www.iamcal.com/understanding-bidirectional-text/. Java support of RTL/bidi depends on supported
- * Unicode version. You can usually find supported Unicode version in the Character class comments.
+ * http://www.iamcal.com/understanding-bidirectional-text/. Java support of
+ * RTL/bidi depends on supported Unicode version. You can usually find supported
+ * Unicode version in the Character class comments.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Didier Briel
@@ -99,9 +101,14 @@ public class SegmentBuilder {
      * time when entry drawn, and when user edits it (for active entry).
      */
     private volatile long displayVersion;
-    /** Source text of entry with internal bidi chars, or null if not displayed. */
+    /**
+     * Source text of entry with internal bidi chars, or null if not displayed.
+     */
     private String sourceText;
-    /** Translation text of entry with internal bidi chars, or null if not displayed. */
+    /**
+     * Translation text of entry with internal bidi chars, or null if not
+     * displayed.
+     */
     private String translationText;
     /** True if entry is active. */
     private boolean active;
@@ -130,7 +137,7 @@ public class SegmentBuilder {
     protected Position posTranslationBeg;
     protected int posTranslationLength;
 
-    /** current offset in document to insert new stuff*/
+    /** current offset in document to insert new stuff */
     protected int offset;
 
     /**
@@ -147,8 +154,9 @@ public class SegmentBuilder {
      */
     protected final boolean hasRTL;
 
-    public SegmentBuilder(final EditorController controller, final Document3 doc, final EditorSettings settings,
-            final SourceTextEntry ste, final int segmentNumberInProject, final boolean hasRTL) {
+    public SegmentBuilder(final EditorController controller, final Document3 doc,
+            final EditorSettings settings, final SourceTextEntry ste, final int segmentNumberInProject,
+            final boolean hasRTL) {
         this.controller = controller;
         this.doc = doc;
         this.settings = settings;
@@ -176,7 +184,8 @@ public class SegmentBuilder {
         createSegmentElement(isActive, doc.getLength(), trans, trans.defaultTranslation);
     }
 
-    public void createSegmentElement(final boolean isActive, TMXEntry trans, final boolean defaultTranslation) {
+    public void createSegmentElement(final boolean isActive, TMXEntry trans,
+            final boolean defaultTranslation) {
         createSegmentElement(isActive, doc.getLength(), trans, defaultTranslation);
     }
 
@@ -184,7 +193,8 @@ public class SegmentBuilder {
         createSegmentElement(isActive, 0, trans, trans.defaultTranslation);
     }
 
-    public void createSegmentElement(final boolean isActive, int initialOffset, TMXEntry trans, final boolean defaultTranslation) {
+    public void createSegmentElement(final boolean isActive, int initialOffset, TMXEntry trans,
+            final boolean defaultTranslation) {
         UIThreadsUtil.mustBeSwingThread();
 
         displayVersion = globalVersions.incrementAndGet();
@@ -267,8 +277,8 @@ public class SegmentBuilder {
     private void createActiveSegmentElement(TMXEntry trans) throws BadLocationException {
         try {
             if (EditorSettings.DISPLAY_MODIFICATION_INFO_ALL.equals(settings.getDisplayModificationInfo())
-                    || EditorSettings.DISPLAY_MODIFICATION_INFO_SELECTED.equals(settings
-                            .getDisplayModificationInfo())) {
+                    || EditorSettings.DISPLAY_MODIFICATION_INFO_SELECTED
+                            .equals(settings.getDisplayModificationInfo())) {
                 addModificationInfoPart(trans);
             }
 
@@ -291,13 +301,15 @@ public class SegmentBuilder {
             posSourceLength = sourceText.length();
 
             if (trans.isTranslated()) {
-                //translation exist
+                // translation exist
                 translationText = trans.translation;
             } else {
-                // Double negation - insertSource = true if Preferences.DONT_INSERT_SOURCE_TEXT = false
+                // Double negation - insertSource = true if
+                // Preferences.DONT_INSERT_SOURCE_TEXT = false
                 boolean insertSource = !Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT,
                         DONT_INSERT_SOURCE_TEXT_DEFAULT);
-                if (controller.entriesFilter != null && controller.entriesFilter.isSourceAsEmptyTranslation()) {
+                if (controller.entriesFilter != null
+                        && controller.entriesFilter.isSourceAsEmptyTranslation()) {
                     insertSource = true;
                 }
                 if (insertSource) {
@@ -341,7 +353,9 @@ public class SegmentBuilder {
 
     /**
      * Create method for inactive segment.
-     * @param trans TMX entry with translation
+     * 
+     * @param trans
+     *            TMX entry with translation
      * @throws BadLocationException
      */
     private void createInactiveSegmentElement(TMXEntry trans) throws BadLocationException {
@@ -401,12 +415,18 @@ public class SegmentBuilder {
         return active;
     }
 
-    /** Get source text of entry with internal bidi chars, or null if not displayed. */
+    /**
+     * Get source text of entry with internal bidi chars, or null if not
+     * displayed.
+     */
     public String getSourceText() {
         return sourceText;
     }
 
-    /** Get translation text of entry with internal bidi chars, or null if not displayed. */
+    /**
+     * Get translation text of entry with internal bidi chars, or null if not
+     * displayed.
+     */
     public String getTranslationText() {
         return translationText;
     }
@@ -481,13 +501,13 @@ public class SegmentBuilder {
     /**
      * Add inactive segment part, without segment begin/end marks.
      *
-     * @param isSource is text the source text (true) or translation text (false)
+     * @param isSource
+     *            is text the source text (true) or translation text (false)
      * @param text
      *            segment part text
      * @throws BadLocationException
      */
-    private String addInactiveSegPart(boolean isSource, String text)
-            throws BadLocationException {
+    private String addInactiveSegPart(boolean isSource, String text) throws BadLocationException {
         int prevOffset = offset;
         boolean rtl = isSource ? controller.sourceLangIsRTL : controller.targetLangIsRTL;
         insertDirectionEmbedding(rtl);
@@ -501,11 +521,11 @@ public class SegmentBuilder {
     /**
      * Add inactive segment part, without segment begin/end marks.
      *
-     * @param text other language translation text
+     * @param text
+     *            other language translation text
      * @throws BadLocationException
      */
-    private void addOtherLanguagePart(String text, Language language)
-            throws BadLocationException {
+    private void addOtherLanguagePart(String text, Language language) throws BadLocationException {
         int prevOffset = offset;
         boolean rtl = Language.isRTL(language.getLanguageCode());
         insertDirectionEmbedding(false);
@@ -535,7 +555,7 @@ public class SegmentBuilder {
         }
         String text;
         if (Preferences.isPreference(Preferences.VIEW_OPTION_TEMPLATE_ACTIVE)) {
-             text = ModificationInfoManager.apply(trans);
+            text = ModificationInfoManager.apply(trans);
         } else {
             String author = (trans.changer == null ? OStrings.getString("TF_CUR_SEGMENT_UNKNOWN_AUTHOR")
                     : trans.changer);
@@ -574,7 +594,7 @@ public class SegmentBuilder {
     private String addActiveSegPart(String text) throws BadLocationException {
         int prevOffset = offset;
 
-        //write translation part
+        // write translation part
         boolean rtl = controller.targetLangIsRTL;
 
         insertDirectionEmbedding(rtl);
@@ -585,17 +605,19 @@ public class SegmentBuilder {
 
         insertDirectionEndEmbedding();
 
-        //write segment marker
-        //we want the marker AFTER the translated text, so use same direction as target text.
+        // write segment marker
+        // we want the marker AFTER the translated text, so use same direction
+        // as target text.
         insertDirectionMarker(rtl);
 
-        //the marker itself is in user language
+        // the marker itself is in user language
         insertDirectionEmbedding(Language.localeIsRTL());
         AttributeSet attrSegmentMark = settings.getSegmentMarkerAttributeSet();
         insert(createSegmentMarkText(), attrSegmentMark);
         insertDirectionEndEmbedding();
 
-        //we want the marker AFTER the translated text, so embed in same direction as target text.
+        // we want the marker AFTER the translated text, so embed in same
+        // direction as target text.
         insertDirectionMarker(rtl);
 
         insert("\n", null);
@@ -622,13 +644,12 @@ public class SegmentBuilder {
     private String createSegmentMarkText() {
         String text = OConsts.SEGMENT_MARKER_STRING;
 
-        //replace placeholder with actual segment number
+        // replace placeholder with actual segment number
         if (text.contains("0000")) {
             String replacement = NUMBER_FORMAT.format(segmentNumberInProject);
             if (Preferences.isPreference(Preferences.MARK_NON_UNIQUE_SEGMENTS)
                     && ste.getDuplicate() != SourceTextEntry.DUPLICATE.NONE) {
-                replacement = StringUtil.format(OStrings.getString("SW_FILE_AND_NR_OF_MORE"),
-                        replacement,
+                replacement = StringUtil.format(OStrings.getString("SW_FILE_AND_NR_OF_MORE"), replacement,
                         ste.getNumberOfDuplicates());
             }
             text = text.replace("0000", replacement);
@@ -659,8 +680,8 @@ public class SegmentBuilder {
      * @param isSource
      *            is it a source segment or a target segment
      * @param isPlaceholder
-     *            is it for a placeholder (OmegaT tag or sprintf-variable etc.) or regular text inside the
-     *            segment?
+     *            is it for a placeholder (OmegaT tag or sprintf-variable etc.)
+     *            or regular text inside the segment?
      * @param isRemoveText
      *            is it text that should be removed in the translation?
      * @param isNBSP
@@ -674,8 +695,11 @@ public class SegmentBuilder {
 
     /**
      * Inserts the texts and formats the text
-     * @param text source or translation text
-     * @param isSource true if it is a source text, false if it is a translation
+     * 
+     * @param text
+     *            source or translation text
+     * @param isSource
+     *            true if it is a source text, false if it is a translation
      * @throws BadLocationException
      */
     private String insertTextWithTags(String text, boolean isSource) throws BadLocationException {
@@ -715,8 +739,12 @@ public class SegmentBuilder {
     }
 
     /**
-     * Writes (if necessary) an RTL or LTR marker. Use it before writing text in some language.
-     * @param isRTL is the language that has to be written a right-to-left language?
+     * Writes (if necessary) an RTL or LTR marker. Use it before writing text in
+     * some language.
+     * 
+     * @param isRTL
+     *            is the language that has to be written a right-to-left
+     *            language?
      * @throws BadLocationException
      */
     private void insertDirectionEmbedding(boolean isRTL) throws BadLocationException {
@@ -726,7 +754,9 @@ public class SegmentBuilder {
     }
 
     /**
-     * Writes (if necessary) an end-of-embedding marker. Use it after writing text in some language.
+     * Writes (if necessary) an end-of-embedding marker. Use it after writing
+     * text in some language.
+     * 
      * @throws BadLocationException
      */
     private void insertDirectionEndEmbedding() throws BadLocationException {
@@ -736,8 +766,12 @@ public class SegmentBuilder {
     }
 
     /**
-     * Writes (if necessary) an RTL or LTR marker. Use it before writing text in some language.
-     * @param isRTL is the language that has to be written a right-to-left language?
+     * Writes (if necessary) an RTL or LTR marker. Use it before writing text in
+     * some language.
+     * 
+     * @param isRTL
+     *            is the language that has to be written a right-to-left
+     *            language?
      * @throws BadLocationException
      */
     private void insertDirectionMarker(boolean isRTL) throws BadLocationException {

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -301,7 +301,7 @@ public class SegmentBuilder {
             posSourceLength = sourceText.length();
 
             if (trans.isTranslated()) {
-                // translation exist
+                // translation exists
                 translationText = trans.translation;
             } else {
                 // Double negation - insertSource = true if

--- a/src/org/omegat/gui/exttrans/IMTGlossarySupplier.java
+++ b/src/org/omegat/gui/exttrans/IMTGlossarySupplier.java
@@ -28,5 +28,5 @@ package org.omegat.gui.exttrans;
 import java.util.Map;
 
 public interface IMTGlossarySupplier {
-	Map<String, String> get();
+    Map<String, String> get();
 }

--- a/src/org/omegat/gui/notes/NotesTextArea.java
+++ b/src/org/omegat/gui/notes/NotesTextArea.java
@@ -143,6 +143,6 @@ public class NotesTextArea extends EntryInfoPane<String> implements INotes, IPan
     @Override
     public void requestFocus() {
         StaticUIUtils.requestVisible(scrollPane);
-    	scrollPane.getViewport().getView().requestFocusInWindow();
+        scrollPane.getViewport().getView().requestFocusInWindow();
     }
 }

--- a/src/org/omegat/gui/preferences/view/EditingBehaviorPanel.java
+++ b/src/org/omegat/gui/preferences/view/EditingBehaviorPanel.java
@@ -9,7 +9,7 @@
                2012 Didier Briel
                2016 Aaron Madlon-Kay
                2019 Briac Pilpre
-	       2022 Hiroshi Miura
+               2022 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 

--- a/src/org/omegat/tokenizer/LuceneGermanTokenizer.java
+++ b/src/org/omegat/tokenizer/LuceneGermanTokenizer.java
@@ -63,7 +63,7 @@ public class LuceneGermanTokenizer extends BaseTokenizer {
      * Lucene 3.0 and earlier.
      *
      * @see <a href=
-	 *      "https://groups.yahoo.com/neo/groups/OmegaT/conversations/messages/28395">
+     *      "https://groups.yahoo.com/neo/groups/OmegaT/conversations/messages/28395">
      *      User group discussion</a>
      * @see <a href="https://sourceforge.net/p/omegat/mailman/message/36839317/">Sourceforge archive</a>
      * @see <a href=

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -697,7 +697,7 @@ public final class Preferences {
 
         File srxDir = new File(StaticUtils.getConfigDir());
         try {
-            SRX.saveToSrx(srx, srxDir);	// save to segmentation.srx in the given directory
+            SRX.saveToSrx(srx, srxDir); // save to segmentation.srx in the given directory
         } catch (IOException ex) {
             ex.printStackTrace();
         }
@@ -741,11 +741,14 @@ public final class Preferences {
      * <li>user filter settings
      * <li>user segmentation settings
      * </ul>
-     * from existing files in {@link StaticUtils#getConfigDir()} (and others for general prefs; see
-     * {@link #getPreferencesFile()}) and set things up to create them via {@link #save()} if they don't yet exist.
+     * from existing files in {@link StaticUtils#getConfigDir()} (and others
+     * for general prefs; see {@link #getPreferencesFile()}) and set things up
+     * to create them via {@link #save()} if they don't yet exist.
      * <p>
-     * When the preferences system is required but actual user preferences shouldn't be loaded or altered (testing
-     * scenarios), use {@link TestPreferencesInitializer} methods or be sure to set the config dir with
+     * When the preferences system is required but actual user preferences
+     * shouldn't be loaded or altered (testing scenarios),
+     * use {@link org.omegat.util.TestPreferencesInitializer} methods or be sure
+     * to set the config dir with
      * {@link RuntimePreferences#setConfigDir(String)} before calling this method.
      */
     public static synchronized void init() {

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -136,7 +136,7 @@ public class FindMatchesTest {
         Core.setSegmenter(new Segmenter(new SRX()));
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, OConsts.MAX_NEAR_STRINGS, true, false);
-	// Search source "XXx" in en-US
+        // Search source "XXx" in en-US
         List<NearString> result = finder.search("XXX", true, true, iStopped);
         // There should be three entries.
         assertEquals("XXx", result.get(0).source);  // should be en-US.

--- a/test/src/org/omegat/core/team2/SVNRemoteRepository2IT.java
+++ b/test/src/org/omegat/core/team2/SVNRemoteRepository2IT.java
@@ -47,63 +47,63 @@ import gen.core.project.RepositoryDefinition;
 @RunWith(Parameterized.class)
 public class SVNRemoteRepository2IT extends AbstractRemoteRepository2IT {
 
-	String svnSubPath;
-	SVNURL tgtURL;
+    String svnSubPath;
+    SVNURL tgtURL;
 
-	@Parameterized.Parameters
-	public static Collection<String> subPath() {
-		return Arrays.asList("", "/asubrepo");
-	}
-
-	public SVNRemoteRepository2IT(String subPath) {
-		this.svnSubPath = subPath;
-	}
-
-	@Override
-	void prepareLocalRepo() throws Exception {
-		SVNRepositoryFactoryImpl.setup();
-		tgtURL = SVNRepositoryFactory.createLocalRepository( tempRepoDir.toFile(), true , false );
-		prepareFilesInLocalRepository(tgtURL.toString());
-	}
-
-	private void prepareFilesInLocalRepository(String url) throws Exception {
-		Path tempSVNClientDir = Files.createTempDirectory("omegat-team-svnc");
-
-		SVNRemoteRepository2 rr2 = new SVNRemoteRepository2();
-
-		RepositoryDefinition repositoryDefinition = new RepositoryDefinition();
-		repositoryDefinition.setType("SVN");
-		repositoryDefinition.setUrl(url);
-
-		ProjectTeamSettings projectTeamSettings = new ProjectTeamSettings(tempSVNClientDir.toFile());
-
-		File svnCheckoutDir = new File(tempSVNClientDir.toFile(), "mysvnrepo");
-		rr2.init(repositoryDefinition, svnCheckoutDir, projectTeamSettings);
-		rr2.switchToVersion(null);
-
-		String newFile = createFileInSubdir(svnCheckoutDir, "asubrepo");
-		rr2.addForCommit(newFile);
-		rr2.commit(null, "init");
-
-		FileUtils.deleteDirectory(tempSVNClientDir.toFile());
-	}
-
-	@Override
-	IRemoteRepository2 getRr2() {
-		return new SVNRemoteRepository2();
-	}
-
-	@Override
-	void configureRepositoryDefinition() {
-		repositoryDefinition.setType("SVN");
-		repositoryDefinition.setUrl(tgtURL.toString() + svnSubPath);
-	}
-
-    void assertFileOrDirDeleted(String dir, String fileInDir, String actual) {
-	    assertEquals("the directory itself is deleted", dir, actual);
+    @Parameterized.Parameters
+    public static Collection<String> subPath() {
+        return Arrays.asList("", "/asubrepo");
     }
 
-	String toRr2Notation(String file) {
-		return file;
-	}
+    public SVNRemoteRepository2IT(String subPath) {
+        this.svnSubPath = subPath;
+    }
+
+    @Override
+    void prepareLocalRepo() throws Exception {
+        SVNRepositoryFactoryImpl.setup();
+        tgtURL = SVNRepositoryFactory.createLocalRepository( tempRepoDir.toFile(), true , false );
+        prepareFilesInLocalRepository(tgtURL.toString());
+    }
+
+    private void prepareFilesInLocalRepository(String url) throws Exception {
+        Path tempSVNClientDir = Files.createTempDirectory("omegat-team-svnc");
+
+        SVNRemoteRepository2 rr2 = new SVNRemoteRepository2();
+
+        RepositoryDefinition repositoryDefinition = new RepositoryDefinition();
+        repositoryDefinition.setType("SVN");
+        repositoryDefinition.setUrl(url);
+
+        ProjectTeamSettings projectTeamSettings = new ProjectTeamSettings(tempSVNClientDir.toFile());
+
+        File svnCheckoutDir = new File(tempSVNClientDir.toFile(), "mysvnrepo");
+        rr2.init(repositoryDefinition, svnCheckoutDir, projectTeamSettings);
+        rr2.switchToVersion(null);
+
+        String newFile = createFileInSubdir(svnCheckoutDir, "asubrepo");
+        rr2.addForCommit(newFile);
+        rr2.commit(null, "init");
+
+        FileUtils.deleteDirectory(tempSVNClientDir.toFile());
+    }
+
+    @Override
+    IRemoteRepository2 getRr2() {
+        return new SVNRemoteRepository2();
+    }
+
+    @Override
+    void configureRepositoryDefinition() {
+        repositoryDefinition.setType("SVN");
+        repositoryDefinition.setUrl(tgtURL.toString() + svnSubPath);
+    }
+
+    void assertFileOrDirDeleted(String dir, String fileInDir, String actual) {
+        assertEquals("the directory itself is deleted", dir, actual);
+    }
+
+    String toRr2Notation(String file) {
+        return file;
+    }
 }

--- a/test/src/org/omegat/util/HTMLUtilsTest.java
+++ b/test/src/org/omegat/util/HTMLUtilsTest.java
@@ -1,98 +1,96 @@
-/**************************************************************************
- OmegaT - Computer Assisted Translation (CAT) tool
- with fuzzy matching, translation memory, keyword search,
- glossaries, and translation leveraging into updated projects.
-
- Copyright (C) 2009 Alex Buloichik
- 2015 Didier Briel
- Home page: https://www.omegat.org/
- Support center: https://omegat.org/support
-
- This file is part of OmegaT.
-
- OmegaT is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- OmegaT is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2009 Alex Buloichik
+ *                2015 Didier Briel
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class HTMLUtilsTest {
+    @Test
+    public void getSpacePrefix() {
+        //no blank prefix
+        assertEquals("", HTMLUtils.getSpacePrefix("a", true));
+        assertEquals("", HTMLUtils.getSpacePrefix("\u0301a", true));
+        assertEquals("", HTMLUtils.getSpacePrefix("\u00A0a", true));
+        assertEquals("", HTMLUtils.getSpacePrefix("\u2007a", true));
+        assertEquals("", HTMLUtils.getSpacePrefix("\u202Fa", true));
 
-	@Test
-	public void getSpacePrefix() {
-		//no whitespace prefix
-		assertEquals("", HTMLUtils.getSpacePrefix("a", true));
-		assertEquals("", HTMLUtils.getSpacePrefix("\u0301a", true));
-		assertEquals("", HTMLUtils.getSpacePrefix("\u00A0a", true));
-		assertEquals("", HTMLUtils.getSpacePrefix("\u2007a", true));
-		assertEquals("", HTMLUtils.getSpacePrefix("\u202Fa", true));
+        //all sorts of space characters
+        assertEquals("\n", HTMLUtils.getSpacePrefix("\na", true));
+        assertEquals("\r", HTMLUtils.getSpacePrefix("\ra", true));
+        assertEquals("\u2028", HTMLUtils.getSpacePrefix("\u2028a", true)); //line separator
+        assertEquals("\u2029", HTMLUtils.getSpacePrefix("\u2029a", true)); //paragraph separator
+        assertEquals("\u0009", HTMLUtils.getSpacePrefix("\u0009a", true)); //h tab
+        assertEquals("\u000B", HTMLUtils.getSpacePrefix("\u000Ba", true)); //v tab
+        assertEquals("\f", HTMLUtils.getSpacePrefix("\fa", true)); //form feed
+        assertEquals("\u001C", HTMLUtils.getSpacePrefix("\u001Ca", true)); //file separator
+        assertEquals("\u001D", HTMLUtils.getSpacePrefix("\u001Da", true)); //group separator
+        assertEquals("\u001E", HTMLUtils.getSpacePrefix("\u001Ea", true)); //record separator
+        assertEquals("\u001F", HTMLUtils.getSpacePrefix("\u001Fa", true)); //unit separator
 
-		//all sorts of whitespace characters
-		assertEquals("\n", HTMLUtils.getSpacePrefix("\na", true));
-		assertEquals("\r", HTMLUtils.getSpacePrefix("\ra", true));
-		assertEquals("\u2028", HTMLUtils.getSpacePrefix("\u2028a", true)); //line separator
-		assertEquals("\u2029", HTMLUtils.getSpacePrefix("\u2029a", true)); //paragraph separator
-		assertEquals("\u0009", HTMLUtils.getSpacePrefix("\u0009a", true)); //h tab
-		assertEquals("\u000B", HTMLUtils.getSpacePrefix("\u000Ba", true)); //v tab
-		assertEquals("\f", HTMLUtils.getSpacePrefix("\fa", true)); //form feed
-		assertEquals("\u001C", HTMLUtils.getSpacePrefix("\u001Ca", true)); //file separator
-		assertEquals("\u001D", HTMLUtils.getSpacePrefix("\u001Da", true)); //group separator
-		assertEquals("\u001E", HTMLUtils.getSpacePrefix("\u001Ea", true)); //record separator
-		assertEquals("\u001F", HTMLUtils.getSpacePrefix("\u001Fa", true)); //unit separator
+        //\u0301 is an accent, in a multi-code point character.
+        assertEquals("one space is one space", " ", HTMLUtils.getSpacePrefix(" \u0301a", true));
+        assertEquals("multiple spaces is compressed to one", " ", HTMLUtils.getSpacePrefix("  \u0301a", true));
+        assertEquals("multiple spaces stay multiple spaces uncompressed", "    ", HTMLUtils.getSpacePrefix("    \u0301ap", false));
+        String allWhite = "\n\r\u2028\u2029\t\n\u000B\f\n\u001C\u001D\u001E\u001F ";
+        assertEquals("multiple different space types compress to the first whitespace character", "\n", HTMLUtils.getSpacePrefix(allWhite + "a", true));
+        assertEquals("multiple different whtiespace characters stay that uncompressed", allWhite, HTMLUtils.getSpacePrefix(allWhite + "a", false));
+    }
 
-		//\u0301 is an accent, in a multi-code point character.
-		assertEquals("one space is one space", " ", HTMLUtils.getSpacePrefix(" \u0301a", true));
-		assertEquals("multiple spaces is compressed to one", " ", HTMLUtils.getSpacePrefix("  \u0301a", true));
-		assertEquals("multiple spaces stay multiple spaces uncompressed", "    ", HTMLUtils.getSpacePrefix("    \u0301ap", false));
-		String allWhite = "\n\r\u2028\u2029\t\n\u000B\f\n\u001C\u001D\u001E\u001F ";
-		assertEquals("multiple different space types compress to the first whitespace character", "\n", HTMLUtils.getSpacePrefix(allWhite+"a", true));
-		assertEquals("multiple different whtiespace characters stay that uncompressed" , allWhite, HTMLUtils.getSpacePrefix(allWhite+"a", false));
+    @Test
+    public void getSpacePostfix() {
+//no whitespace prefix
+        assertEquals("", HTMLUtils.getSpacePostfix("a", true));
+        assertEquals("", HTMLUtils.getSpacePostfix("a\u0301", true));
+        assertEquals("", HTMLUtils.getSpacePostfix("a\u00A0", true));
+        assertEquals("", HTMLUtils.getSpacePostfix("a\u2007", true));
+        assertEquals("", HTMLUtils.getSpacePostfix("a\u202F", true));
 
-	}
+//all sorts of whitespace characters
+        assertEquals("\n", HTMLUtils.getSpacePostfix("a\n", true));
+        assertEquals("\r", HTMLUtils.getSpacePostfix("a\r", true));
+        assertEquals("\u2028", HTMLUtils.getSpacePostfix("a\u2028", true)); //line separator
+        assertEquals("\u2029", HTMLUtils.getSpacePostfix("a\u2029", true)); //paragraph separator
+        assertEquals("\u0009", HTMLUtils.getSpacePostfix("a\u0009", true)); //h tab
+        assertEquals("\u000B", HTMLUtils.getSpacePostfix("a\u000B", true)); //v tab
+        assertEquals("\f", HTMLUtils.getSpacePostfix("a\f", true)); //form feed
+        assertEquals("\u001C", HTMLUtils.getSpacePostfix("a\u001C", true)); //file separator
+        assertEquals("\u001D", HTMLUtils.getSpacePostfix("a\u001D", true)); //group separator
+        assertEquals("\u001E", HTMLUtils.getSpacePostfix("a\u001E", true)); //record separator
+        assertEquals("\u001F", HTMLUtils.getSpacePostfix("a\u001F", true)); //unit separator
 
-	@Test
-	public void getSpacePostfix() {
-		//no whitespace prefix
-		assertEquals("", HTMLUtils.getSpacePostfix("a", true));
-		assertEquals("", HTMLUtils.getSpacePostfix("a\u0301", true));
-		assertEquals("", HTMLUtils.getSpacePostfix("a\u00A0", true));
-		assertEquals("", HTMLUtils.getSpacePostfix("a\u2007", true));
-		assertEquals("", HTMLUtils.getSpacePostfix("a\u202F", true));
+        //\u0301 is an accent, in a multi-code point character.
+        assertEquals("one space is one space", " ", HTMLUtils.getSpacePostfix("a\u0065\u0301 ", true));
+        assertEquals("multiple spaces is compressed to one", " ", HTMLUtils.getSpacePostfix("a\u0065\u0301  ", true));
+        assertEquals("multiple spaces stay multiple spaces uncompressed", "    ", HTMLUtils.getSpacePostfix("a\u0065\u0301    ", false));
+        String allWhite = "\n\r\u2028\u2029\t\n\u000B\f\n\u001C\u001D\u001E\u001F ";
+        assertEquals("multiple different space types compress to the first whitespace character", "\n", HTMLUtils.getSpacePostfix("a\u0065\u0301" + allWhite, true));
+        assertEquals("multiple different whtiespace characters stay that uncompressed", allWhite, HTMLUtils.getSpacePostfix("a\u0065\u0301" + allWhite, false));
 
-		//all sorts of whitespace characters
-		assertEquals("\n", HTMLUtils.getSpacePostfix("a\n", true));
-		assertEquals("\r", HTMLUtils.getSpacePostfix("a\r", true));
-		assertEquals("\u2028", HTMLUtils.getSpacePostfix("a\u2028", true)); //line separator
-		assertEquals("\u2029", HTMLUtils.getSpacePostfix("a\u2029", true)); //paragraph separator
-		assertEquals("\u0009", HTMLUtils.getSpacePostfix("a\u0009", true)); //h tab
-		assertEquals("\u000B", HTMLUtils.getSpacePostfix("a\u000B", true)); //v tab
-		assertEquals("\f", HTMLUtils.getSpacePostfix("a\f", true)); //form feed
-		assertEquals("\u001C", HTMLUtils.getSpacePostfix("a\u001C", true)); //file separator
-		assertEquals("\u001D", HTMLUtils.getSpacePostfix("a\u001D", true)); //group separator
-		assertEquals("\u001E", HTMLUtils.getSpacePostfix("a\u001E", true)); //record separator
-		assertEquals("\u001F", HTMLUtils.getSpacePostfix("a\u001F", true)); //unit separator
-
-		//\u0301 is an accent, in a multi-code point character.
-		assertEquals("one space is one space", " ", HTMLUtils.getSpacePostfix("a\u0065\u0301 ", true));
-		assertEquals("multiple spaces is compressed to one", " ", HTMLUtils.getSpacePostfix("a\u0065\u0301  ", true));
-		assertEquals("multiple spaces stay multiple spaces uncompressed", "    ", HTMLUtils.getSpacePostfix("a\u0065\u0301    ", false));
-		String allWhite = "\n\r\u2028\u2029\t\n\u000B\f\n\u001C\u001D\u001E\u001F ";
-		assertEquals("multiple different space types compress to the first whitespace character", "\n", HTMLUtils.getSpacePostfix("a\u0065\u0301"+allWhite, true));
-		assertEquals("multiple different whtiespace characters stay that uncompressed" , allWhite, HTMLUtils.getSpacePostfix("a\u0065\u0301"+allWhite, false));
-
-	}
+    }
 
 }

--- a/test/src/svn/BundleTest.java
+++ b/test/src/svn/BundleTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2015 Aaron Madlon-Kay
+               2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -65,8 +66,10 @@ import org.omegat.util.OStrings;
 public class BundleTest {
 
     /**
-     * Ensure that all UI string bundles have either US-ASCII encoding or ISO-8859-1 encoding. The spec requires the
-     * latter, but ISO-8859-1 is a superset of ASCII so ASCII is also acceptable (and is widely used in practice).
+     * Ensure that all UI string bundles have either US-ASCII encoding or
+     * ISO-8859-1 encoding. The spec requires the latter, but ISO-8859-1 is a
+     * superset of ASCII, so ASCII is also acceptable (and is widely used in
+     * practice).
      *
      * @see <a href=
      *      "https://docs.oracle.com/javase/8/docs/api/java/util/PropertyResourceBundle.html">PropertyResourceBundle</a>
@@ -98,10 +101,10 @@ public class BundleTest {
 
     @Test
     public void testBundleLoading() {
-        // We must set the default locale to English first because we provide our
-        // English bundle as the empty-locale default. If we don't do so, the
-        // English bundle will never be tested in the case that the "default default"
-        // is a language we provide a bundle for.
+        // We must set the default locale to English first because we provide
+        // our English bundle as the empty-locale default. If we don't do so,
+        // the English bundle will never be tested in the case that the
+        // "default" is a language we provide a bundle for.
         Locale.setDefault(Locale.ENGLISH);
 
         for (Language lang : Language.getLanguages()) {
@@ -186,15 +189,17 @@ public class BundleTest {
         Files.write(p, Collections.singletonList(badChars), StandardCharsets.UTF_8, StandardOpenOption.WRITE);
         CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         try {
-            checkFileContent(p, decoder, (path, chars) -> {});
+            checkFileContent(p, decoder, (path, chars) -> {
+            });
         } catch (Exception e) {
             throw new Exception(e);
         }
     }
 
     /**
-     * Process the text content of all .java files under /src.
-     * Also check DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE for security reason.
+     * Process the text content of all .java files under /src. Also check
+     * DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE for security reasons.
+     * And check invisible space character.
      *
      * @param consumer
      *            A function that accepts the file path and content
@@ -222,15 +227,20 @@ public class BundleTest {
     }
 
     public static void checkFileContent(Path p, CharsetDecoder decoder,
-                                        BiConsumer<Path, CharSequence> consumer) throws Exception {
+            BiConsumer<Path, CharSequence> consumer) throws Exception {
         try {
             byte[] bytes = Files.readAllBytes(p);
             CharBuffer chars = decoder.decode(ByteBuffer.wrap(bytes));
-            for (int i =0; i < chars.limit(); i++) {
+            for (int i = 0; i < chars.limit(); i++) {
                 int c = chars.charAt(i);
                 if (c == 0x202e) {
                     // found Right-to-left-override: unicode 202e
                     throw new Exception("File contains Right-to-Left-Override (RLTO) character: " + p);
+                }
+                if (c == 0x0009 || c == 0x00a0 || c == 0x00ad || c == 0x034f || c == 0x061c
+                        || c >= 0x2000 && c < 0x200b || c == 0x2028 || c >= 0x205f && c <= 0x206f
+                        || c == 0x2800 || c == 0x3000 || c == 0x3164) {
+                    throw new Exception("File contains invisible character: " + p);
                 }
             }
             chars.clear();


### PR DESCRIPTION
Allowing UTF-8 in Java code has a risk of malformded commits that is hard to detect in review process.
It is known as “Trojan Source” Attack.
[The answer is proper review](https://research.swtch.com/trojan#review)
Making LTR/RTL code points visible is particularly important for review tools. The proposal here
is improve review process to check dangerous character in source code when Pull-Request.

The PR also update developer note about coding sytle.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- test: check a existence of Right-to-Left-Override "\u202e" character that is used to inject malformded code in the code
- test: check a existence of invisible characters such as  TAB, Zenkaku-Space, Non breakable space in the coee

## Other information

- Please see https://attack.mitre.org/techniques/T1036/002/
for detailed attack procedure description.

- Please see GitHub warns RtL text
https://github.blog/changelog/2021-10-31-warning-about-bidirectional-unicode-text/

- Thesis: "Trojan Source: Invisible Vulnerabilities" https://trojansource.codes/trojan-source.pdf
