### PR TITLE
[5.8][BUGS#1168] feat: error message for loop link

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -502,21 +502,21 @@ Reload the project now?
 
 TF_SOURCE_LOAD_ERROR=Skipped source file {0} because it could not be loaded.
 
-TF_TM_LOAD_ERROR=Failed to load translation memory {0} for the project.
-TF_LOAD_ERROR=Failed to load the specified project.
+TF_TM_LOAD_ERROR=Failed to load translation memory {0} for the project!
+TF_LOAD_ERROR=Failed to load the specified project!
 TF_LOAD_ERROR_FILE_ACCESS=Failed to load the project due to a file access issue. Make sure you have \
   the correct permissions or that you can access the files if they are stored in the cloud.
 TF_LOAD_ERROR_SOURCE_LOOP_EXCEPTION=Failed to load the project because the specified source folder contains a \
   symbolic or hard link that points back to itself or one of its subfolders.\n
   Make sure all links are outside the source folder and subfolders.
 
-TF_COMPILE_ERROR=Failed to create the translated files.
+TF_COMPILE_ERROR=Failed to create the translated files!
 
 TF_MESSAGE_COMPILE=Unable to create the translated files due to missing or damaged tags.\n\
 Use Tools > Check Issues... to correct the tag errors and try again.
 
-TF_COMMIT_ERROR=Failed to commit source files.
-TF_COMMIT_TARGET_ERROR=Failed to commit target files.
+TF_COMMIT_ERROR=Failed to commit source files!
+TF_COMMIT_TARGET_ERROR=Failed to commit target files!
 TF_COMMIT_START=Committing source files
 TF_COMMIT_DONE=Source files committed
 TF_COMMIT_TARGET_START=Committing target files

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -507,7 +507,7 @@ TF_LOAD_ERROR=Failed to load the specified project!
 TF_LOAD_ERROR_FILE_ACCESS=Failed to load the project due to a file access issue. Make sure you have \
   the correct permissions or that you can access the files if they are stored in the cloud.
 TF_LOAD_ERROR_SOURCE_LOOP_EXCEPTION=Failed to load the project because the specified source folder contains a \
-  symbolic or hard link that points back to itself or one of its subfolders.\n
+  symbolic or hard link that points back to itself or one of its subfolders.\n\
   Make sure all links are outside the source folder and subfolders.
 
 TF_COMPILE_ERROR=Failed to create the translated files!

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -502,16 +502,21 @@ Reload the project now?
 
 TF_SOURCE_LOAD_ERROR=Skipped source file {0} because it could not be loaded.
 
-TF_TM_LOAD_ERROR=Failed to load translation memory {0} for project!
-TF_LOAD_ERROR=Failed to load specified project!
+TF_TM_LOAD_ERROR=Failed to load translation memory {0} for the project.
+TF_LOAD_ERROR=Failed to load the specified project.
+TF_LOAD_ERROR_FILE_ACCESS=Failed to load the project due to a file access issue. Make sure you have \
+  the correct permissions or that you can access the files if they are stored in the cloud.
+TF_LOAD_ERROR_SOURCE_LOOP_EXCEPTION=Failed to load the project because the specified source folder contains a \
+  symbolic or hard link that points back to itself or one of its subfolders.\n
+  Make sure all links are outside the source folder and subfolders.
 
-TF_COMPILE_ERROR=Failed to create the translated files!
+TF_COMPILE_ERROR=Failed to create the translated files.
 
 TF_MESSAGE_COMPILE=Unable to create the translated files due to missing or damaged tags.\n\
 Use Tools > Check Issues... to correct the tag errors and try again.
 
-TF_COMMIT_ERROR=Failed to commit source files!
-TF_COMMIT_TARGET_ERROR=Failed to commit target files!
+TF_COMMIT_ERROR=Failed to commit source files.
+TF_COMMIT_TARGET_ERROR=Failed to commit target files.
 TF_COMMIT_START=Committing source files
 TF_COMMIT_DONE=Source files committed
 TF_COMMIT_TARGET_START=Committing target files


### PR DESCRIPTION
Backport error message enhance from 6.0/6.1

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- OmegaT cannot load a project and error dialog with FileSystemLoopException
   * https://sourceforge.net/p/omegat/bugs/1168

## What does this PR change?

- Improve behavior on BUGS#1168 by @miurahr "OmegaT cannot load a project and error dialog with FileSystemLoopException"
- style: Reword new error messages by @kazephil: I rephrased the new error messages a little, and replaced a few unnecessary exclamation marks I happened to notice at the same time. (I thought I'd cleaned them all up a little while back, but I guess I missed a few.)
- style: Update file loop error message by @kazephil: I changed the message again to make it easier to understand for people less familiar with computers.

## Other information

The change here is squashed  changes propoesd in #589
