### PR TITLE
fix(git): Grab hostkey fingerprint message from apache sshd

### DIFF
--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -252,7 +252,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 String promptedFingerprint = extractFingerprint(promptText);
                 if (promptedFingerprint == null) {
                     throw new UnsupportedCredentialItem(uri,
-                            String.format("Wrong fingerprint pattern: %s", promptText));
+                            String.format("Unknown pattern to ask acceptance of host key fingerprint "
+                                    + "\n%s", promptText));
                 }
                 if (predefinedFingerprint != null) {
                     ((CredentialItem.YesNoType) item)
@@ -266,8 +267,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 askYesNo(item, promptText, uri, promptedFingerprint);
                 continue;
             } else if (item instanceof CredentialItem.InformationalMessage) {
-                Log.logInfoRB("GIT_CREDENTIAL_MESSAGE", item.getPromptText());
-                Core.getMainWindow().showTimedStatusMessageRB("GIT_CREDENTIAL_MESSAGE", item.getPromptText());
+                sb.append(item.getPromptText()).append("\n");
                 continue;
             }
             throw new UnsupportedCredentialItem(uri, item.getClass().getName() + ":" + item.getPromptText());


### PR DESCRIPTION
- Apache SSHD change a behavior in recent version

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Team(git): when connecting new server, connection failed
   - https://sourceforge.net/p/omegat/bugs/1177

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- When connecting new server, OmegaT failed to connect because of unknown fingerprint message.
- In previous versions, Apache MINA SSHD put message in YesNoType item, but now it send message in information type.
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
