### PR TITLE
fix(team): override team URL specified in local

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -523,7 +523,8 @@ TF_COMMIT_TARGET_START=Committing target files
 TF_COMMIT_TARGET_DONE=Target files committed
 
 TF_PROJECT_PROPERTIES_ERROR=Failed to update project properties
-TF_REMOTE_PROJECT_LACKS_GIT_SETTING=There are no Git settings in the remote project file. Check whether this is intentional.
+TF_REMOTE_PROJECT_LACKS_REPOSITORY_SETTING=There are no Git or Subversion settings in the remote project file.\
+  Check whether this is intentional.
 
 MW_PROMPT_SEG_NR_MSG=Enter the segment number:
 

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -349,11 +349,11 @@ public final class ProjectUICommands {
                     // so we add root repository mapping
                     props.setRepositories(repos);
                 } else {
-                    RepositoryDefinition remoteRepo = getRootGitRepositoryMapping(props.getRepositories());
-                    if (isRepositoryEquals(remoteRepo, repo)) {
+                    RepositoryDefinition remoteRepo = getRootRepositoryMapping(props.getRepositories());
+                    if (!isRepositoryEquals(remoteRepo, repo)) {
                         // when remote repository config is different with
                         // opening url, respect local one
-                        setRootGitRepositoryMapping(props.getRepositories(), repo);
+                        setRootRepositoryMapping(props.getRepositories(), repo);
                     }
                 }
                 // We write in all cases, because we might have added default
@@ -579,19 +579,18 @@ public final class ProjectUICommands {
                         if (props.getRepositories() == null) {
                             // We have a project without mapping
                             // So we restore the mapping we just lost
-                            Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_GIT_SETTING");
+                            Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_REPOSITORY_SETTING");
                             props.setRepositories(localRepos);
                         } else {
                             // use mapping from remote configuration but
-                            // override repository URL when project URL is git
-                            // type when there is difference between local and
-                            // remote config.
-                            RepositoryDefinition localRootRepository = getRootGitRepositoryMapping(
+                            // override repository URL when there is difference
+                            // between local and remote config.
+                            RepositoryDefinition localRootRepository = getRootRepositoryMapping(
                                     localRepos);
-                            RepositoryDefinition newRepository = getRootGitRepositoryMapping(
+                            RepositoryDefinition newRepository = getRootRepositoryMapping(
                                     props.getRepositories());
                             if (!isRepositoryEquals(localRootRepository, newRepository)) {
-                                setRootGitRepositoryMapping(props.getRepositories(), localRootRepository);
+                                setRootRepositoryMapping(props.getRepositories(), localRootRepository);
                             }
                         }
                         needToSaveProperties = !isIdenticalOmegatProjectProperties(props, localProps);
@@ -731,12 +730,11 @@ public final class ProjectUICommands {
                 .append(my.getDictRoot(), that.getDictRoot()).isEquals();
     }
 
-    private static RepositoryDefinition getRootGitRepositoryMapping(List<RepositoryDefinition> repos) {
+    private static RepositoryDefinition getRootRepositoryMapping(List<RepositoryDefinition> repos) {
         RepositoryDefinition repositoryDefinition = null;
         for (RepositoryDefinition definition : repos) {
             if (definition.getMapping().get(0).getLocal().equals("/")
-                    && definition.getMapping().get(0).getRepository().equals("/")
-                    && definition.getType().equals("git")) {
+                    && definition.getMapping().get(0).getRepository().equals("/")) {
                 repositoryDefinition = definition;
                 break;
             }
@@ -744,12 +742,12 @@ public final class ProjectUICommands {
         return repositoryDefinition;
     }
 
-    private static void setRootGitRepositoryMapping(List<RepositoryDefinition> repos,
-            RepositoryDefinition repositoryDefinition) {
+    private static void setRootRepositoryMapping(List<RepositoryDefinition> repos,
+                                                 RepositoryDefinition repositoryDefinition) {
         if (repositoryDefinition == null) {
             return;
         }
-        RepositoryDefinition originalRepositoryDefinition = getRootGitRepositoryMapping(repos);
+        RepositoryDefinition originalRepositoryDefinition = getRootRepositoryMapping(repos);
         if (originalRepositoryDefinition == null) {
             return;
         }

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -749,7 +749,13 @@ public final class ProjectUICommands {
         }
         RepositoryDefinition originalRepositoryDefinition = getRootRepositoryMapping(repos);
         if (originalRepositoryDefinition == null) {
-            return;
+            originalRepositoryDefinition = new RepositoryDefinition();
+        }
+        if (originalRepositoryDefinition.getMapping().size() == 0) {
+            RepositoryMapping mapping = new RepositoryMapping();
+            mapping.setLocal("/");
+            mapping.setRepository("/");
+            originalRepositoryDefinition.getMapping().add(mapping);
         }
         originalRepositoryDefinition.setType(repositoryDefinition.getType());
         originalRepositoryDefinition.setUrl(repositoryDefinition.getUrl());

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -581,7 +581,13 @@ public final class ProjectUICommands {
                             // We have a project without mapping
                             // So we restore the mapping we just lost
                             Log.logInfoRB("TF_REMOTE_PROJECT_LACKS_REPOSITORY_SETTING");
-                            props.setRepositories(localRepos);
+                            if (localRepos.size() == 1) {
+                                setRootRepositoryMapping(localRepos, localRepos.get(0));
+                                props.setRepositories(localRepos);
+                            } else if (localRepos.size() > 1) {
+                                setRootRepositoryMapping(localRepos, getRootRepositoryMapping(localRepos));
+                                props.setRepositories(localRepos);
+                            }
                         } else {
                             // use mapping from remote configuration but
                             // override repository URL when there is difference
@@ -733,8 +739,10 @@ public final class ProjectUICommands {
     static RepositoryDefinition getRootRepositoryMapping(List<RepositoryDefinition> repos) {
         RepositoryDefinition repositoryDefinition = null;
         for (RepositoryDefinition definition : repos) {
-            if (definition.getMapping().get(0).getLocal().equals("/")
-                    && definition.getMapping().get(0).getRepository().equals("/")) {
+            if ((definition.getMapping().get(0).getLocal().equals("/")
+                    || definition.getMapping().get(0).getLocal().equals(""))
+                    && (definition.getMapping().get(0).getRepository().equals("/")
+                            || definition.getMapping().get(0).getRepository().equals(""))) {
                 repositoryDefinition = definition;
                 break;
             }
@@ -756,6 +764,7 @@ public final class ProjectUICommands {
         originalRepositoryDefinition.setBranch(repositoryDefinition.getBranch());
         if (hasRepositoryDefinitionEmptyMapping(originalRepositoryDefinition)) {
             RepositoryMapping mapping = new RepositoryMapping();
+            originalRepositoryDefinition.getMapping().clear();
             mapping.setLocal("/");
             mapping.setRepository("/");
             originalRepositoryDefinition.getMapping().add(mapping);
@@ -772,10 +781,8 @@ public final class ProjectUICommands {
 
     static boolean hasRepositoryDefinitionEmptyMapping(RepositoryDefinition def) {
         return def.getMapping() == null || def.getMapping().size() == 0
-                || def.getMapping().get(0).getLocal() == null
-                || def.getMapping().get(0).getRepository() == null
-                || def.getMapping().get(0).getLocal().isEmpty()
-                || def.getMapping().get(0).getRepository().isEmpty();
+                || StringUtil.isEmpty(def.getMapping().get(0).getLocal())
+                || StringUtil.isEmpty(def.getMapping().get(0).getRepository());
     }
 
     /**

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -486,7 +486,7 @@ public final class ProjectUICommands {
         return true;
     }
 
-    private static ProjectProperties checkProjectProperties(File projectRootFolder) {
+    static ProjectProperties checkProjectProperties(File projectRootFolder) {
         // check if project okay
         ProjectProperties props;
         try {
@@ -667,7 +667,7 @@ public final class ProjectUICommands {
      *            local omegat.project.
      * @return true if identical, otherwise false.
      */
-    private static boolean isIdenticalOmegatProjectProperties(ProjectProperties that, ProjectProperties my) {
+    static boolean isIdenticalOmegatProjectProperties(ProjectProperties that, ProjectProperties my) {
         if (my == that) {
             return true;
         }
@@ -730,7 +730,7 @@ public final class ProjectUICommands {
                 .append(my.getDictRoot(), that.getDictRoot()).isEquals();
     }
 
-    private static RepositoryDefinition getRootRepositoryMapping(List<RepositoryDefinition> repos) {
+    static RepositoryDefinition getRootRepositoryMapping(List<RepositoryDefinition> repos) {
         RepositoryDefinition repositoryDefinition = null;
         for (RepositoryDefinition definition : repos) {
             if (definition.getMapping().get(0).getLocal().equals("/")
@@ -742,8 +742,8 @@ public final class ProjectUICommands {
         return repositoryDefinition;
     }
 
-    private static void setRootRepositoryMapping(List<RepositoryDefinition> repos,
-                                                 RepositoryDefinition repositoryDefinition) {
+    static void setRootRepositoryMapping(List<RepositoryDefinition> repos,
+                                         RepositoryDefinition repositoryDefinition) {
         if (repositoryDefinition == null) {
             return;
         }
@@ -762,7 +762,7 @@ public final class ProjectUICommands {
         originalRepositoryDefinition.setBranch(repositoryDefinition.getBranch());
     }
 
-    private static boolean isRepositoryEquals(RepositoryDefinition a, RepositoryDefinition b) {
+    static boolean isRepositoryEquals(RepositoryDefinition a, RepositoryDefinition b) {
         if (a == null || b == null) {
             return false;
         }

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -12,7 +12,7 @@
                2016 Alex Buloichik             
                2017 Didier Briel
                2021 ISHIKAWA,chiaki
-               2022 Hiroshi Miura
+               2022,2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -350,7 +350,8 @@ public final class ProjectUICommands {
                     props.setRepositories(repos);
                 } else {
                     RepositoryDefinition remoteRepo = getRootRepositoryMapping(props.getRepositories());
-                    if (!isRepositoryEquals(remoteRepo, repo)) {
+                    if (!isRepositoryEquals(remoteRepo, repo)
+                            || hasRepositoryDefinitionEmptyMapping(remoteRepo)) {
                         // when remote repository config is different with
                         // opening url, respect local one
                         setRootRepositoryMapping(props.getRepositories(), repo);
@@ -585,8 +586,7 @@ public final class ProjectUICommands {
                             // use mapping from remote configuration but
                             // override repository URL when there is difference
                             // between local and remote config.
-                            RepositoryDefinition localRootRepository = getRootRepositoryMapping(
-                                    localRepos);
+                            RepositoryDefinition localRootRepository = getRootRepositoryMapping(localRepos);
                             RepositoryDefinition newRepository = getRootRepositoryMapping(
                                     props.getRepositories());
                             if (!isRepositoryEquals(localRootRepository, newRepository)) {
@@ -743,7 +743,7 @@ public final class ProjectUICommands {
     }
 
     static void setRootRepositoryMapping(List<RepositoryDefinition> repos,
-                                         RepositoryDefinition repositoryDefinition) {
+            RepositoryDefinition repositoryDefinition) {
         if (repositoryDefinition == null) {
             return;
         }
@@ -751,15 +751,15 @@ public final class ProjectUICommands {
         if (originalRepositoryDefinition == null) {
             originalRepositoryDefinition = new RepositoryDefinition();
         }
-        if (originalRepositoryDefinition.getMapping().size() == 0) {
+        originalRepositoryDefinition.setType(repositoryDefinition.getType());
+        originalRepositoryDefinition.setUrl(repositoryDefinition.getUrl());
+        originalRepositoryDefinition.setBranch(repositoryDefinition.getBranch());
+        if (hasRepositoryDefinitionEmptyMapping(originalRepositoryDefinition)) {
             RepositoryMapping mapping = new RepositoryMapping();
             mapping.setLocal("/");
             mapping.setRepository("/");
             originalRepositoryDefinition.getMapping().add(mapping);
         }
-        originalRepositoryDefinition.setType(repositoryDefinition.getType());
-        originalRepositoryDefinition.setUrl(repositoryDefinition.getUrl());
-        originalRepositoryDefinition.setBranch(repositoryDefinition.getBranch());
     }
 
     static boolean isRepositoryEquals(RepositoryDefinition a, RepositoryDefinition b) {
@@ -768,6 +768,14 @@ public final class ProjectUICommands {
         }
         return new EqualsBuilder().append(a.getType(), b.getType()).append(a.getUrl(), b.getUrl())
                 .append(a.getBranch(), b.getBranch()).isEquals();
+    }
+
+    static boolean hasRepositoryDefinitionEmptyMapping(RepositoryDefinition def) {
+        return def.getMapping() == null || def.getMapping().size() == 0
+                || def.getMapping().get(0).getLocal() == null
+                || def.getMapping().get(0).getRepository() == null
+                || def.getMapping().get(0).getLocal().isEmpty()
+                || def.getMapping().get(0).getRepository().isEmpty();
     }
 
     /**

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -84,7 +84,7 @@ public final class ProjectFileStorage {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -237,8 +237,8 @@ public final class ProjectFileStorage {
         om.getProject().getSourceDirExcludes().getMask().addAll(props.getSourceRootExcludes());
         om.getProject().setTargetDir(getPathForStoring(root, props.getTargetRoot(), OConsts.DEFAULT_TARGET));
         om.getProject().setTmDir(getPathForStoring(root, props.getTMRoot(), OConsts.DEFAULT_TM));
-        om.getProject().setExportTmDir(
-                getPathForStoring(root, props.getExportTMRoot(), OConsts.DEFAULT_EXPORT_TM));
+        om.getProject()
+                .setExportTmDir(getPathForStoring(root, props.getExportTMRoot(), OConsts.DEFAULT_EXPORT_TM));
         om.getProject().setExportTmLevels(String.join(" ", props.getExportTmLevels()));
         String glossaryDir = getPathForStoring(root, props.getGlossaryRoot(), OConsts.DEFAULT_GLOSSARY);
         om.getProject().setGlossaryDir(glossaryDir);

--- a/test/data/gui/main/omegat-l10n-ja/omegat.project
+++ b/test/data/gui/main/omegat-l10n-ja/omegat.project
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<omegat>
+  <project version="1.0">
+    <repositories>
+      <repository type="git" url="git@github.com:OmegaT-L10N/ja.git">
+        <mapping local="/" repository="/"/>
+        <otherAttributes/>
+      </repository>
+      <repository type="git" url="https://github.com/OmegaT-L10N/doc_src.git">
+        <mapping local="source/doc_src/" repository="en"/>
+        <otherAttributes/>
+      </repository>
+      <repository type="http" url="https://github.com/omegat-org/omegat/raw/master/">
+        <mapping local="source/Bundle.properties" repository="src/org/omegat/Bundle.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/readme_ja.txt" repository="release/readme.txt">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/release/win32-specific/CustomMessages_ja.ini" repository="release/win32-specific/CustomMessages.ini">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/release/mac-specific/OmegaT.app/Contents/Resources/ja.lproj/Localizable.strings" repository="release/mac-specific/OmegaT.app/Contents/Resources/en.lproj/Localizable.strings">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/check_rules.properties" repository="scripts/properties/check_rules.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/spellcheck.properties" repository="scripts/properties/spellcheck.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/svn_cleanup_selected.properties" repository="scripts/properties/svn_cleanup_selected.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/search_replace.properties" repository="scripts/properties/search_replace.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/replace_strip_tags.properties" repository="scripts/properties/replace_strip_tags.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/strip_bidi_marks.properties" repository="scripts/properties/strip_bidi_marks.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/nbsp.properties" repository="scripts/properties/nbsp.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <mapping local="source/scripts/tagwipe.properties" repository="scripts/properties/tagwipe.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <otherAttributes/>
+      </repository>
+      <repository type="http" url="https://raw.githubusercontent.com/omegat-org/omegat/releases/">
+        <mapping local="source/5.8/Bundle.properties" repository="5.8/src/org/omegat/Bundle.properties">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <otherAttributes/>
+      </repository>
+      <repository type="svn" url="https://github.com/omegat-org/omegat-website.git/trunk/_i18n/en/">
+        <mapping local="source/website/" repository="/">
+          <excludes>**/howtos/**</excludes>
+        </mapping>
+        <otherAttributes/>
+      </repository>
+      <repository type="http" url="https://github.com/omegat-org/omegat-website/">
+        <mapping local="source/website/yml/ja.yml" repository="raw/master/_i18n/en.yml">
+          <excludes/>
+          <includes/>
+        </mapping>
+        <otherAttributes/>
+      </repository>
+    </repositories>
+    <source_dir>__DEFAULT__</source_dir>
+    <source_dir_excludes>
+      <mask>**/.svn/**</mask>
+      <mask>**/CVS/**</mask>
+      <mask>**/.cvs/**</mask>
+      <mask>**/desktop.ini</mask>
+      <mask>**/Thumbs.db</mask>
+      <mask>/doc_src/en/license.txt</mask>
+      <mask>/doc_src/en/version.properties</mask>
+    </source_dir_excludes>
+    <target_dir>__DEFAULT__</target_dir>
+    <tm_dir>__DEFAULT__</tm_dir>
+    <glossary_dir>__DEFAULT__</glossary_dir>
+    <glossary_file>__DEFAULT__</glossary_file>
+    <dictionary_dir>__DEFAULT__</dictionary_dir>
+    <export_tm_dir>__DEFAULT__</export_tm_dir>
+    <export_tm_levels>omegat level1 level2</export_tm_levels>
+    <source_lang>en</source_lang>
+    <target_lang>ja</target_lang>
+    <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+    <target_tok>org.omegat.tokenizer.LuceneJapaneseTokenizer</target_tok>
+    <sentence_seg>true</sentence_seg>
+    <support_default_translations>true</support_default_translations>
+    <remove_tags>false</remove_tags>
+    <external_command></external_command>
+  </project>
+</omegat>

--- a/test/src/org/omegat/gui/main/ProjectUICommandsTest.java
+++ b/test/src/org/omegat/gui/main/ProjectUICommandsTest.java
@@ -1,0 +1,131 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.omegat.gui.main;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.omegat.core.TestCore;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.util.ProjectFileStorage;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * @author Hiroshi Miura
+ */
+public class ProjectUICommandsTest extends TestCore {
+
+    @Test
+    public void testIsIdenticalOmegatProjectProperties0() throws Exception {
+        final File projectRootFolder = new File("test/data/gui/main/omegat-l10n-ja");
+        ProjectProperties props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
+        ProjectProperties another =
+                ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
+        assertTrue(ProjectUICommands.isIdenticalOmegatProjectProperties(props, another));
+        another.setExportTmLevels(false, false, false);
+        assertFalse(ProjectUICommands.isIdenticalOmegatProjectProperties(props, another));
+    }
+
+    /**
+     * Test normal path of getRootRepositoryMapping.
+     */
+    @Test
+    public void testGetRootRepositoryMapping0() {
+        List<RepositoryDefinition> repos = new ArrayList<>();
+        repos.add(createRootDef());
+        // Prepare source mapping
+        final RepositoryDefinition sourceDef = new RepositoryDefinition();
+        sourceDef.setType("http");
+        sourceDef.setUrl("https://example.com/");
+        RepositoryMapping sourceMap = new RepositoryMapping();
+        sourceMap.setRepository("some_source");
+        sourceMap.setLocal("source/some");
+        sourceDef.getMapping().add(sourceMap);
+        // check ProjectUICommands.getRootRepositoryMapping
+        RepositoryDefinition rootDef = ProjectUICommands.getRootRepositoryMapping(repos);
+        assertEquals("main", rootDef.getBranch());
+        assertEquals("git", rootDef.getType());
+        assertEquals("git@github.com:omegat-L10N/ja.git", rootDef.getUrl());
+        assertEquals(1, rootDef.getMapping().size());
+        assertEquals("/", rootDef.getMapping().get(0).getLocal());
+        assertEquals("/", rootDef.getMapping().get(0).getRepository());
+    }
+
+    /**
+     * Test normal path of setRootRepositoryMapping.
+     */
+    @Test
+    public void testSetRootRepositoryMapping0() {
+        List<RepositoryDefinition> repos = new ArrayList<>();
+        repos.add(createRootDef());
+        // Prepare local definition of repository argument
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setBranch("main");
+        def.setType("git");
+        def.setUrl("https://github.com/omegat-L10N/ja.git");
+        ProjectUICommands.setRootRepositoryMapping(repos, def);
+        assertEquals(1, repos.size());
+        assertEquals("git", repos.get(0).getType());
+        assertEquals("main", repos.get(0).getBranch());
+        assertEquals(1, repos.get(0).getMapping().size());
+        assertEquals("/", repos.get(0).getMapping().get(0).getRepository());
+        assertEquals("/", repos.get(0).getMapping().get(0).getLocal());
+    }
+
+    @Test
+    public void testIsRepositoryEqual() {
+        RepositoryDefinition repo = createRootDef();
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setBranch("main");
+        def.setType("git");
+        def.setUrl("https://github.com/omegat-L10N/ja.git");
+        assertFalse(ProjectUICommands.isRepositoryEquals(repo, def));
+        // XXX: isRepositoryEquals ignores difference in mapping
+        assertTrue(ProjectUICommands.isRepositoryEquals(repo, repo));
+    }
+
+    private RepositoryDefinition createRootDef() {
+        // Prepare team root mapping
+        RepositoryDefinition teamDef = new RepositoryDefinition();
+        teamDef.setBranch("main");
+        teamDef.setType("git");
+        teamDef.setUrl("git@github.com:omegat-L10N/ja.git");
+        RepositoryMapping map = new RepositoryMapping();
+        map.setRepository("/");
+        map.setLocal("/");
+        teamDef.getMapping().add(map);
+        return teamDef;
+    }
+}

--- a/test/src/org/omegat/gui/main/ProjectUICommandsTest.java
+++ b/test/src/org/omegat/gui/main/ProjectUICommandsTest.java
@@ -50,9 +50,10 @@ public class ProjectUICommandsTest extends TestCore {
     @Test
     public void testIsIdenticalOmegatProjectProperties0() throws Exception {
         final File projectRootFolder = new File("test/data/gui/main/omegat-l10n-ja");
-        ProjectProperties props = ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
-        ProjectProperties another =
-                ProjectFileStorage.loadProjectProperties(projectRootFolder.getAbsoluteFile());
+        ProjectProperties props = ProjectFileStorage
+                .loadProjectProperties(projectRootFolder.getAbsoluteFile());
+        ProjectProperties another = ProjectFileStorage
+                .loadProjectProperties(projectRootFolder.getAbsoluteFile());
         assertTrue(ProjectUICommands.isIdenticalOmegatProjectProperties(props, another));
         another.setExportTmLevels(false, false, false);
         assertFalse(ProjectUICommands.isIdenticalOmegatProjectProperties(props, another));
@@ -114,6 +115,27 @@ public class ProjectUICommandsTest extends TestCore {
         assertFalse(ProjectUICommands.isRepositoryEquals(repo, def));
         // XXX: isRepositoryEquals ignores difference in mapping
         assertTrue(ProjectUICommands.isRepositoryEquals(repo, repo));
+    }
+
+    @Test
+    public void testHasRepositoryDefinitionEmptyMapping() {
+        RepositoryDefinition repoOk = createRootDef();
+        RepositoryDefinition repoNg = new RepositoryDefinition();
+        repoNg.setBranch("main");
+        repoNg.setType("git");
+        repoNg.setUrl("https://github.com/omegat-L10N/ja.git");
+        assertFalse(ProjectUICommands.hasRepositoryDefinitionEmptyMapping(repoOk));
+        assertTrue(ProjectUICommands.hasRepositoryDefinitionEmptyMapping(repoNg));
+        //
+        RepositoryDefinition repoEmpty = new RepositoryDefinition();
+        repoEmpty.setBranch("main");
+        repoEmpty.setType("git");
+        repoEmpty.setUrl("https://github.com/omegat-L10N/ja.git");
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setRepository(null);
+        mapping.setLocal(null);
+        repoEmpty.getMapping().add(mapping);
+        assertTrue(ProjectUICommands.hasRepositoryDefinitionEmptyMapping(repoEmpty));
     }
 
     private RepositoryDefinition createRootDef() {


### PR DESCRIPTION
- Current team feature only override when repository type is git
- Changed to allow SVN also support it

When remote project don't have team repository mapping, leave error message. Current message is said about git repository, but it can also be a svn repository.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:


- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->



<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Change a part of method name from *GitRepository* to generic *Repository*
- Remove condition `definition.getType().equals("git")` to be generic
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
