### PR TITLE
chore(ci): no use of artifact upload

### DIFF
--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -36,8 +36,3 @@ steps:
       # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
       ./gradlew --stop
     displayName: Gradlew stop
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish Artifact: drop'
-    inputs:
-      targetPath: '$(system.defaultworkingdirectory)/build/distributions/'
-      artifactName: 'drop'

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -14,12 +14,3 @@ steps:
     displayName: 'Publish Test Results build/reports/**/*.xml'
     inputs:
       testResultsFiles: 'build/reports/**/*.xml'
-#  - task: CopyFiles@2
-#    displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
-#    inputs:
-#      SourceFolder: '$(system.defaultworkingdirectory)/build/distributions'
-#      TargetFolder: '$(build.artifactstagingdirectory)'
-#  - task: PublishBuildArtifacts@1
-#    displayName: 'Publish Artifact: drop'
-#    inputs:
-#      PathtoPublish: '$(build.artifactstagingdirectory)'

--- a/ci/azure-pipelines/publish_release.yml
+++ b/ci/azure-pipelines/publish_release.yml
@@ -3,16 +3,12 @@ parameters:
     default: ''
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download Artifact: drop'
-    inputs:
-      targetPath: $(Pipeline.Workspace)
   - task: Bash@3
     displayName: 📂 SCP upload to sourceforge file management
     inputs:
       targetType: 'inline'
       script: |
-        srcdir=$(Pipeline.Workspace)/drop
+        srcdir=$(system.defaultworkingdirectory)/build/distributions/
         dest=$(SOURCEFORGE_FILE_USER)@frs.sourceforge.net
         destdir="/home/frs/project/omegat/OmegaT\\ -\\ Latest/OmegaT\\ ${{ parameters.omegatVersion }}/"
         echo "mkdir $destdir" | SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e sftp -v $dest || true

--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -3,17 +3,13 @@ parameters:
     default: ''
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download Artifact: drop'
-    inputs:
-      targetPath: $(Pipeline.Workspace)
   - task: Bash@3
     displayName: 📂 SCP upload to sourceforge file management
     inputs:
       targetType: 'inline'
       script: |
         echo "Push OmegaT ${{ parameters.omegatVersion }} files to SourceForge file manager"
-        srcdir=$(Pipeline.Workspace)/drop
+        srcdir=$(system.defaultworkingdirectory)/build/distributions/
         dest=$(SOURCEFORGE_FILE_USER)@frs.sourceforge.net
         destdir=/home/frs/project/omegat/Weekly
         echo "mkdir $destdir" | SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e sftp -v $dest || true


### PR DESCRIPTION

## Pull request type


- Build and release changes -> [build/release]

## What changed

Current CI/CD use artifact publish feature of Azure pipelines. This storage area is limited for free account.
Uploading sourceforege site can be failed, and rerun can failed when uploading artifact.

We can skip upload/download artifact so this skip procedure.
It reduce build duration and stability in weekly and release Ci/CD.

