### PR TITLE
chore(gradle): support PKCS#11 signing with HSM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -772,6 +772,7 @@ ext.makeWinTask = { args ->
         }
         doFirst {
             delete "$destinationDir/jre"
+            delete installerExe
         }
         doLast {
             project.copy {
@@ -794,39 +795,49 @@ ext.makeWinTask = { args ->
                 def exe = exePresent('iscc') ?  'iscc' : file('ci/iscc')
                 commandLine exe, "${destinationDir}/OmegaT.iss"
             }
-            ant.move file: "${destinationDir}/${installerBasename}.exe",
-                todir: distsDir
+            project.copy {
+                from("${destinationDir}/${installerBasename}.exe")
+                into(distsDir)
+            }
         }
     }
     def signedTaskName = "${args.name}Signed"
-    task(signedTaskName) {
+    def signedExe = "${distsDir}/${installerBasename}_Signed.exe"
+    task(type: Exec, signedTaskName) {
         onlyIf {
             // Set these in e.g. local.properties
-            def props = ['winCodesignFile', 'winCodesignPassword', 'winCodesignTimestampUrl']
+            def props = ['winCodesignCert', 'winCodesignPassword']
             conditions([props.every { project.hasProperty(it) }, 'Code signing properties not set'],
                        [file(installerExe).file, 'Unsigned installer not built'],
-                       [exePresent('osslsigncode') || exePresent('docker'),
-                        'osslsigncode or Docker not installed'])
+                       [exePresent('osslsigncode'), 'osslsigncode not installed'])
         }
-        def signedExe = "${distsDir}/${installerBasename}_Signed.exe"
+        def pkcs11module = project.hasProperty('pkcs11module')? project.property('pkcs11module') :
+                '/usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11.so'
+        def pkcs11time = project.hasProperty('winCodesignTimestampUrl')? project.property('winCodesignTimestampUrl') :
+                'http://time.certum.pl/'
+        def pkcs11cert = project.hasProperty('winCodesignCert')? project.property('winCodesignCert') : null
+        def pkcs11pass = project.hasProperty('winCodesignPassword')? project.property('winCodesignPassword') : null
         inputs.file installerExe
         outputs.file signedExe
-        doLast {
-            exec {
-                // You'd think we could just set the PATH, but there be dragons here
-                // https://github.com/palantir/gradle-docker/issues/162
-                def exe = exePresent('osslsigncode') ? 'osslsigncode' : file('ci/osslsigncode')
-                commandLine exe, 'sign',
-                    '-pkcs12', project.property('winCodesignFile'),
-                    '-pass', project.property('winCodesignPassword'),
-                    '-n', applicationName,
-                    '-i', omtWebsite,
-                    '-t', project.property('winCodesignTimestampUrl'),
-                    '-h', 'sha2',
-                    '-in', installerExe,
-                    '-out', signedExe
-            }
-        }
+        // You'd think we could just set the PATH, but there be dragons here
+        // https://github.com/palantir/gradle-docker/issues/162
+        // Starting from Nov 2022, certification provider force to use HSM to
+        // store private keys. Starting on June 1, 2023, at 00:00 UTC, industry
+        // standards will require private keys for standard code signing
+        // certificates to be stored on hardware certified as FIPS 140 Level 2,
+        // Common Criteria EAL 4+, or equivalent.
+        // #1179 build/release: Windows binary signature with PKCS#11 HSM
+        // https://sourceforge.net/p/omegat/bugs/1179/
+        commandLine(['osslsigncode', 'sign',
+              '-pkcs11module', pkcs11module,
+              '-certs', pkcs11cert,
+              '-pass', pkcs11pass,
+              '-t', pkcs11time,
+              '-n', applicationName,
+              '-i', omtWebsite,
+              '-h', 'sha256',
+              '-in', installerExe.toString(),
+              '-out', signedExe.toString()])
         dependsOn args.name
     }
     assemble.dependsOn args.name, signedTaskName

--- a/build.gradle
+++ b/build.gradle
@@ -815,8 +815,8 @@ ext.makeWinTask = { args ->
                 '/usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11.so'
         def pkcs11time = project.hasProperty('winCodesignTimestampUrl')? project.property('winCodesignTimestampUrl') :
                 'http://time.certum.pl/'
-        def pkcs11cert = project.hasProperty('winCodesignCert')? project.property('winCodesignCert') : null
-        def pkcs11pass = project.hasProperty('winCodesignPassword')? project.property('winCodesignPassword') : null
+        def pkcs11cert = project.hasProperty('winCodesignCert')? project.property('winCodesignCert') : ''
+        def pkcs11pass = project.hasProperty('winCodesignPassword')? project.property('winCodesignPassword') : ''
         inputs.file installerExe
         outputs.file signedExe
         // You'd think we could just set the PATH, but there be dragons here

--- a/build.gradle
+++ b/build.gradle
@@ -804,21 +804,6 @@ ext.makeWinTask = { args ->
     def signedTaskName = "${args.name}Signed"
     def signedExe = "${distsDir}/${installerBasename}_Signed.exe"
     task(type: Exec, signedTaskName) {
-        onlyIf {
-            // Set these in e.g. local.properties
-            def props = ['winCodesignCert', 'winCodesignPassword']
-            conditions([props.every { project.hasProperty(it) }, 'Code signing properties not set'],
-                       [file(installerExe).file, 'Unsigned installer not built'],
-                       [exePresent('osslsigncode'), 'osslsigncode not installed'])
-        }
-        def pkcs11module = project.hasProperty('pkcs11module')? project.property('pkcs11module') :
-                '/usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11.so'
-        def pkcs11time = project.hasProperty('winCodesignTimestampUrl')? project.property('winCodesignTimestampUrl') :
-                'http://time.certum.pl/'
-        def pkcs11cert = project.hasProperty('winCodesignCert')? project.property('winCodesignCert') : ''
-        def pkcs11pass = project.hasProperty('winCodesignPassword')? project.property('winCodesignPassword') : ''
-        inputs.file installerExe
-        outputs.file signedExe
         // You'd think we could just set the PATH, but there be dragons here
         // https://github.com/palantir/gradle-docker/issues/162
         // Starting from Nov 2022, certification provider force to use HSM to
@@ -828,16 +813,34 @@ ext.makeWinTask = { args ->
         // Common Criteria EAL 4+, or equivalent.
         // #1179 build/release: Windows binary signature with PKCS#11 HSM
         // https://sourceforge.net/p/omegat/bugs/1179/
-        commandLine(['osslsigncode', 'sign',
-              '-pkcs11module', pkcs11module,
-              '-certs', pkcs11cert,
-              '-pass', pkcs11pass,
-              '-t', pkcs11time,
-              '-n', applicationName,
-              '-i', omtWebsite,
-              '-h', 'sha256',
-              '-in', installerExe.toString(),
-              '-out', signedExe.toString()])
+        // requires osslsigncode version 2.5 or later.
+        onlyIf {
+            // Set these in e.g. local.properties
+            def props = ['pkcs11module', 'winCodesignPassword']
+            conditions([props.every { project.hasProperty(it) }, 'Code signing properties not set'],
+                       [file(installerExe).file, 'Unsigned installer not built'],
+                       [exePresent('osslsigncode'), 'osslsigncode not installed'])
+        }
+        inputs.file installerExe
+        outputs.file signedExe
+        def commandArgs = ['osslsigncode', 'sign', '-pkcs11module', project.hasProperty('pkcs11module')?
+                project.property('pkcs11module') : 'dummy(it should specified)']
+        if (project.hasProperty('winCodesignCert')) {
+            commandArgs.addAll('-certs', project.property('winCodesignCert'))
+        }
+        if (project.hasProperty('pkcs11cert')) {
+            commandArgs.addAll('-pkcs11cert', project.property('pkcs11cert'))
+        }
+        if (project.hasProperty('winCodesignPassword')) {
+            commandArgs.addAll('-pass', project.property('winCodesignPassword'))
+        }
+        commandArgs.addAll(
+                '-t', project.hasProperty('winCodesignTimestampUrl')? project.property('winCodesignTimestampUrl') :
+                        'http://time.certum.pl/',
+                '-n', applicationName, '-i', omtWebsite, '-h', 'sha256',
+                '-in', installerExe.toString(),
+                '-out', signedExe.toString())
+        commandLine(commandArgs)
         dependsOn args.name
     }
     assemble.dependsOn args.name, signedTaskName

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,5 +1,12 @@
 ## Windows code signing
-winCodesignFile=
+# ex.
+# pkcs11engine=/usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
+# pkcs11module=/usr/lib/libcrypto3PKCS.so
+# winCodesignTimestampUrl=http://time.certum.pl/
+# winCodesignCert=/home/user/a-provided-certification.pem
+#
+pkcs11module=
+winCodesignCert=
 winCodesignPassword=
 winCodesignTimestampUrl=
 
@@ -8,28 +15,6 @@ macCodesignIdentity=
 
 ## Mac notarization
 macNotarizationUsername=
-
-## Java Web Start code signing
-# Base URL for all Web Start files
-jwsCodebase=
-# Setup key information for signing jar
-# - keystore:  keystore file
-# - storetype: the type of keystore; specify 'pkcs12' if not default ('jks')
-# - alias:     alias of private key in keystore file
-# - storepass: password for access to keystore
-# - keypass:   password for private key (comment out when equal to storepass)
-#
-# You can create a key for testing by command:
-#  keytool -genkey -alias <alias> -keystore <keystore>
-# e.g.,
-#  keytool -genkey -alias webstart -keystore OmegaT.keystore
-#jwsKeystore=
-#jwsStoretype=
-#jwsAlias=
-#jwsStorepass=
-#jwsKeypass=
-# URL for timestamp. See: https://ant.apache.org/manual/Tasks/signjar.html
-#jwsTsaurl=
 
 ## Sonatype OSSRH publishing (synced to Maven Central)
 ossrhUser=
@@ -46,6 +31,10 @@ signing.keyId=
 signing.password=
 # Exported as e.g. `gpg --export-secret-keys > secring.gpg`
 signing.secretKeyRingFile=
+
+## example with GnuPG
+#signing.gnupg.keyName=<KeyHashHex>
+#signing.gnupg.executable=gpg
 
 ## SourceForge web
 sourceforgeWebUser=

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,9 +1,16 @@
 ## Windows code signing
 # ex.
 # pkcs11engine=/usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
+#
+## when using Certum
 # pkcs11module=/usr/lib/libcrypto3PKCS.so
-# pkcs11cert='pkcs11:type=cert'
+## when using Safenet e-token/Digicert
+## see https://www.digicert.com/StaticFiles/SAC_10_7_Linux_GA.zip
+# pkcs11module=/usr/lib64/libeToken.so
+#
 # winCodesignTimestampUrl=http://time.certum.pl/
+# winCodesignTimestampUrl=http://timestamp.digicert.com
+# pkcs11cert='pkcs11:type=cert'
 # winCodesignCert=/home/user/a-provided-certification.pem
 #
 # mandatory

--- a/local.properties.example
+++ b/local.properties.example
@@ -2,12 +2,16 @@
 # ex.
 # pkcs11engine=/usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
 # pkcs11module=/usr/lib/libcrypto3PKCS.so
+# pkcs11cert='pkcs11:type=cert'
 # winCodesignTimestampUrl=http://time.certum.pl/
 # winCodesignCert=/home/user/a-provided-certification.pem
 #
+# mandatory
 pkcs11module=
-winCodesignCert=
 winCodesignPassword=
+# optional
+pkcs11cert=
+winCodesignCert=
 winCodesignTimestampUrl=
 
 ## Mac code signing


### PR DESCRIPTION
## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- #1179 build/release: Windows binary signature with PKCS#11 HSM
  *  https://sourceforge.net/p/omegat/bugs/1179

## What does this PR change?

- Remove a way to sign with Docker because of supporting HSM
- Update local.properties keys for PKCS#11
- Improve unsigned/signed exe generation
   - make unsigned exe generation task not using ant task and use copy and delete task for moving artifact
   - signed exe generation task as Exec type, not sequence of procedure for keeping idempotency.
   - Fix error with GString conversion
 - Tested with my private key stored in HSM with ACR37U-A1 usb dongle
   - I use a proprietary pkcs11 access module

## Other information

When you have private key and certs in HSM, you can test new config wit `winNoJRESigned` task.
