### PR TITLE
fix(xml): serialize without empty list

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
                 <td>
                     <p class="lang"><a href="ca/index.html">català</a></p>
                 </td>
-                <td>(<span class="up-to-date">5.8.0</span>)</td>
+                <td>(<span class="out-of-date">5.8.0</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%205.8.0/OmegaT_documentation_ca.PDF/download">PDF</a>
                 </td>
@@ -63,19 +63,9 @@
         
             <tr>
                 <td>
-                    <p class="lang"><a href="cy/index.html">Cymraeg</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_cy.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
                     <p class="lang"><a href="de/index.html">Deutsch</a></p>
                 </td>
-                <td>(<span class="up-to-date">5.8.0</span>)</td>
+                <td>(<span class="out-of-date">5.8.0</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%205.8.0/OmegaT_documentation_de.PDF/download">PDF</a>
                 </td>
@@ -95,9 +85,9 @@
                 <td>
                     <p class="lang"><a href="en/index.html">English</a></p>
                 </td>
-                <td>(<span class="up-to-date">5.8.0</span>)</td>
+                <td>(<span class="up-to-date">6.1.0</span>)</td>
                 <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%205.8.0/OmegaT_documentation_en.PDF/download">PDF</a>
+                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%206.1.0/OmegaT_documentation_en.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -108,16 +98,6 @@
                 <td>(<span class="out-of-date">2.3.0</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_es.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="eu/index.html">Euskara</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_eu.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -135,9 +115,9 @@
                 <td>
                     <p class="lang"><a href="fr/index.html">français</a></p>
                 </td>
-                <td>(<span class="out-of-date">4.2.0</span>)</td>
+                <td>(<span class="up-to-date">6.1.0</span>)</td>
                 <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.2.0/OmegaT_documentation_fr.PDF/download">PDF</a>
+                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%206.1.0/OmegaT_documentation_fr.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -158,16 +138,6 @@
                 <td>(<span class="out-of-date">3.5.0</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.5.0/OmegaT_documentation_hr.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="hu/index.html">magyar</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_hu.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -195,29 +165,9 @@
                 <td>
                     <p class="lang"><a href="ja/index.html">日本語</a></p>
                 </td>
-                <td>(<span class="up-to-date">5.8.0</span>)</td>
+                <td>(<span class="out-of-date">6.0.0</span>)</td>
                 <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%205.8.0/OmegaT_documentation_ja.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="ko/index.html">한국어</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_ko.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="mfe/index.html">kreol morisien</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_mfe.PDF/download">PDF</a>
+                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%206.0.0/OmegaT_documentation_ja.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -228,16 +178,6 @@
                 <td>(<span class="out-of-date">4.2.0</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%204.2.0/OmegaT_documentation_nl.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="no/index.html">norsk</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_no.PDF/download">PDF</a>
                 </td>
             </tr>
         
@@ -268,26 +208,6 @@
                 <td>(<span class="out-of-date">3.0.2</span>)</td>
                 <td><a target="blank"
                         href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%203.0.2/OmegaT_documentation_ru.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="sc/index.html">Sardinian</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_sc.PDF/download">PDF</a>
-                </td>
-            </tr>
-        
-            <tr>
-                <td>
-                    <p class="lang"><a href="sv/index.html">svenska</a></p>
-                </td>
-                <td>(<span class="out-of-date">2.3.0</span>)</td>
-                <td><a target="blank"
-                        href="https://sourceforge.net/projects/omegat/files/OmegaT%20-%20Standard/OmegaT%202.3.0/OmegaT_documentation_sv.PDF/download">PDF</a>
                 </td>
             </tr>
         

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -92,6 +92,7 @@ public class SRX implements Serializable {
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -91,7 +91,6 @@ public class SRX implements Serializable {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -121,7 +121,6 @@ public class FilterMaster {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
@@ -120,6 +121,8 @@ public class FilterMaster {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -85,6 +85,7 @@ public final class ProjectFileStorage {
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -84,7 +84,6 @@ public final class ProjectFileStorage {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         mapper.registerModule(new JaxbAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }

--- a/test/src/org/omegat/filters2/master/FilterMasterTest.java
+++ b/test/src/org/omegat/filters2/master/FilterMasterTest.java
@@ -137,8 +137,7 @@ public class FilterMasterTest {
 
         List<Option> option = fm.getConfig().getFilters().get(0).getOption();
         assertNotNull("Filter option is not null", option);
-        assertFalse("Filter option is not empty", option.isEmpty());
-        assertNull(option.get(0).getName());
+        assertTrue("Filter option is not empty", option.isEmpty());
     }
 
     private static void loadFile(FilterMaster fm) throws IOException, TranslationException, Exception {


### PR DESCRIPTION
- OmegaT produce several empty tags in project files 
     - we can observe `<otherAttributes/>, <include/> and <exclude/>` in omegat.properties
     - `<formathandle/>` in segmentation.srx file 
     -  `<option/>` in filters.xml

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?


- Title
  * URL

## What does this PR change?

-  Add `Include.Include.NON_EMPTY` paremter to XmlMapper

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
