### PR TITLE
(final) align 6.0 and 5.8 bundle

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -502,8 +502,8 @@ Reload the project now?
 
 TF_SOURCE_LOAD_ERROR=Skipped source file {0} because it could not be loaded.
 
-TF_TM_LOAD_ERROR=Failed to load translation memory {0} for project!
-TF_LOAD_ERROR=Failed to load specified project!
+TF_TM_LOAD_ERROR=Failed to load translation memory {0} for the project!
+TF_LOAD_ERROR=Failed to load the specified project!
 TF_LOAD_ERROR_FILE_ACCESS=Failed to load the project due to a file access issue. Make sure you have \
   the correct permissions or that you can access the files if they are stored in the cloud.
 TF_LOAD_ERROR_SOURCE_LOOP_EXCEPTION=Failed to load the project because the specified source folder contains a \


### PR DESCRIPTION
This PR produces the following diff between releases/5.8 and releases/6.0:

```diff
diff --git a/src/org/omegat/Bundle.properties b/src/org/omegat/Bundle.properties
index 97cba6ebe..5bd80081b 100644
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -18,7 +18,7 @@
 #               2016 Alex Buloichik, Aaron Madlon-Kay, Didier Briel, Briac Pilpre
 #               2017 Didier Briel
 #               2020-2022 Hiroshi Miura
-#               Home page: http://www.omegat.org/
+#               Home page: https://www.omegat.org/
 #               Support centre: https://omegat.org/support
 #
 # This file is part of OmegaT.
@@ -34,7 +34,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #**************************************************************************/
 #
 #  Resources file for OmegaT
```

Which is what @kosivantsov was requesting all along.

