### PR TITLE
[BUGS#1181] feat: add support for XDXF article in StarDict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,7 @@ dependencies {
         // Explicit specification of annotations version
         implementation 'org.jetbrains:annotations:23.0.0'
         implementation 'tokyo.northside:stardict4j:0.5.0'
+        implementation 'org.jsoup:jsoup:1.15.3'
 
         // Encoding detections
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/src/org/omegat/core/dictionaries/StarDict.java
+++ b/src/org/omegat/core/dictionaries/StarDict.java
@@ -204,6 +204,38 @@ public class StarDict implements IDictionaryFactory {
                 Safelist safelist = new Safelist()
                         .addTags("sup", "sub", "i", "b", "tt", "big", "small", "span");
                 safelist.addAttributes("span", "style");
+                Elements kref = document.select("kref");
+                kref.tagName("span");
+                kref.attr("style", "font-style: italic;");
+                kref.removeAttr("idref");
+                Elements iref = document.select("iref");
+                iref.tagName("a");
+                Elements rref = document.select("rref");
+                for (Element e: rref) {
+                    String type = e.attr("type");
+                    if (type.isEmpty()) {
+                        e.remove();
+                        continue;
+                    }
+                    String resource = e.attr("lctn");
+                    e.removeAttr("lctn");
+                    if (type.startsWith("audio")) {
+                        e.tagName("a");
+                        e.removeAttr("start");
+                        e.removeAttr("size");
+                        e.attr("href", resource);
+                        e.text("Play");
+                    } else if (type.startsWith("image")) {
+                        e.tagName("img");
+                        e.attr("src", resource);
+                    } else if (type.startsWith("video")) {
+                        e.tagName("video");
+                        e.appendChild(new Element("source").attr("src", resource).attr("type", type));
+                        e.removeAttr("type");
+                    } else {
+                        e.remove();
+                    }
+                }
                 if (!condensed) {
                     safelist.addTags("blockquote");
                     Cleaner cleaner = new Cleaner(safelist);


### PR DESCRIPTION
Adding support for Stardict XDXF type of dictionaryu format.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

## What does this PR change?

- Add XDXF as allowed text type
- Add converter from XDXF content to HTML



## Other information

Releated issue: 

- Dictionary displays apostrophe as html entitty code
    https://sourceforge.net/p/omegat/bugs/1181

### Support following tags

#### XDXF tags

``` 
    <c c="xxxxxx">...</c> (c c stands for Color Code)  Marks text with a given color.
       The syntax for "c" attribute is the same as for "color" attribute of "font" tag in HTML.
       If the color attribute is omitted, the default color is implied.  The default color is
        chosen by the dictionary program.

    <k> Key phrase is a phrase by which an article containing it can be found.
        Article may contain more than one key phrase.
        Tag <k> may not be nested in another <k>.

    <def>  This tag marks a definition or a group of definitions which fall into a certain category.
        For English language those categories could be parts of speech. For example: noun, verb,
        adverb, etc. Note that <def> tags can be nested.  For articles that have logical format
        shells may use <def> tag in a similar way as <blockquote> tag is used in HTML, or may also
        put '1)','2)'... or 1.','2.'... or 'A.','B.'... etc. before each definition, and increase
        the font size of '1)','2)'... etc. according to the nesting level.
        The <def> tag is optional. If the article is simple and there is nothing to group - don't
        use it.
        In articles with visual format <def> tags do not effect the formatting.

    <ex> Marks the text of an example. (usually shown in a different color by the program)

    <co> Marks the text of an editorial comment.
      (comments are usually shown in a different color by the program)

    <su> Marks a sub-article. Sub-articles are used to represent nested articles. [TODO: Add more
        description, and an example]

    <rref>  Reference to a Resource file, which is located in the same folder.

    <rref start="xxx" size="xxx">  Optional attributes are necessary for audio and video files,
        when the reference points to a certain part of a large file. The attribute "start"
        specifies position in the file of the first byte of the chunk of interest, and "size"
        specifies its length in bytes.  If the "start" attribute is omitted then it is assumed
        that it is 0.  If the "size" attribute is omitted then it is assumed that the file
        should be played up to the end.

    <iref href="http://www.somewebsite.com">  Reference to an Internet resource.


```

#### Non-XDXF Tags

For visually formatted articles in addition to XDXF tags, the following XHTML tags are allowed:
`  <sup>, <sub>, <i>, <b>, <tt>, <big>, <small>,  <blockquote>`

#### Not supported

```
    <opt> Marks optional part of key-phrase, if any.
        Tag <opt> might be used only in between <k></k> tags.

    <nu> Marks part of key-phrase that is not used for identification, but affects only the
        appearance. That is when the key-phrase is visually presented it should
        include the content of <nu> tag, but for searching and indexing content of <nu> tag
        should be stripped away. Tag <nu> can be used only in between <k></k> tags.

    <pos>   specifies the Part Of Speech like: noun, verb, adverb, etc.

    <tense> The tense. For example: past, present, future, past participle, etc.

    <tr>    Marks transcription.

    <dtrn>  This tag marks Direct Translation of the key-phrase.

    <kref>  Reference to another key-phrase, which is located in the same file.

    <abr>   Marks an abbreviation that is listed in the <abbreviations> section.

```