### PR TITLE
chore(ci): run integration test before weekly release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,10 +57,12 @@ stages:
   jobs:
   - job: runTest
     displayName: integration test
+    pool:
+      vmImage: 'ubuntu-22.04'
     steps:
       - script: |
-          mkdir -p .gradle build
-          chmod a+w .gradle build
+          umask a+w
+          mkdir -p .gradle build tipoftheday/build
           docker-compose up --abort-on-container-exit --exit-code-from client
         env:
           DURATION: 600
@@ -70,7 +72,6 @@ stages:
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
   dependsOn: IntegrationTest
-  condition: succeeded()
   jobs:
   - job: WeeklyBuild
     displayName: Build for master weekly

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,10 +51,26 @@ stages:
     steps:
       - template: ci/azure-pipelines/check_steps.yml
 
-# Build steps will run on the main and/or release branch, except for Pull-Request
-- stage: Weekly
-  dependsOn: Check
+  # Integration test will be triggerred by schedule on main and/or releases/* branch.
+- stage: IntegrationTest
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
+  jobs:
+  - job: runTest
+    displayName: integration test
+    steps:
+      - script: |
+          mkdir -p .gradle build
+          chmod a+w .gradle build
+          docker-compose up --abort-on-container-exit --exit-code-from client
+        env:
+          DURATION: 600
+          TYPE: GIT
+        displayName: 'Run Integration-Test(GIT)'
+
+  # Weekly release steps will be triggerred after integration-test succeeded.
+- stage: Weekly
+  dependsOn: IntegrationTest
+  condition: succeeded()
   jobs:
   - job: WeeklyBuild
     displayName: Build for master weekly
@@ -69,7 +85,7 @@ stages:
         parameters:
           omegatVersion: $(version)
 
-# Weekly release steps will be triggerred by schedule on main and/or releases/* branch.
+  # Release steps will run on the main and/or release branch with tags.
 - stage: Release
   dependsOn: Check
   condition: and(succeeded(), eq(variables.isRelease, true))
@@ -85,4 +101,3 @@ stages:
       - template: ci/azure-pipelines/publish_release.yml
         parameters:
           omegatVersion: $(version)
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,28 +51,9 @@ stages:
     steps:
       - template: ci/azure-pipelines/check_steps.yml
 
-  # Integration test will be triggerred by schedule on main and/or releases/* branch.
-- stage: IntegrationTest
-  condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
-  jobs:
-  - job: runTest
-    displayName: integration test
-    pool:
-      vmImage: 'ubuntu-22.04'
-    steps:
-      - script: |
-          umask a+w
-          mkdir -p .gradle build tipoftheday/build
-          docker-compose up --abort-on-container-exit --exit-code-from client
-        env:
-          DURATION: 600
-          TYPE: GIT
-        displayName: 'Run Integration-Test(GIT)'
-
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
-  dependsOn: IntegrationTest
-  conditions: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')))
+  condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - job: WeeklyBuild
     displayName: Build for master weekly
@@ -82,6 +63,10 @@ stages:
       - script: |
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
+      - template: ci/azure-pipelines/integ_test_steps.yml
+        parameters:
+          testType: 'GIT'
+          duration: 600
       - template: ci/azure-pipelines/build_steps.yml
       - template: ci/azure-pipelines/publish_weekly.yml
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
   dependsOn: IntegrationTest
+  conditions: and(succeeded(), or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')))
   jobs:
   - job: WeeklyBuild
     displayName: Build for master weekly

--- a/ci/azure-pipelines/integ_test_steps.yml
+++ b/ci/azure-pipelines/integ_test_steps.yml
@@ -1,0 +1,22 @@
+parameters:
+  - name: testType
+    default: 'GIT'
+  - name: duration
+    default: 600
+
+steps:
+  - task: Cache@2
+    displayName: 'Cache Gradle'
+    inputs:
+      key: 'gradle | $(Agent.OS) | $(Build.SourcesDirectory)/build.gradle'
+      path: '$(GRADLE_USER_HOME)'
+  - script: |
+      echo "Run ${{ parameters.testType }} integration test"
+      umask a+w
+      mkdir -p .gradle build tipoftheday/build
+      chmod -R a+w .
+      docker-compose up --abort-on-container-exit --exit-code-from client
+    env:
+      DURATION: ${{ parameters.duration }}
+      TYPE: ${{ parameters.testType }}
+    displayName: 'Run Integration-Test(GIT)'

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -3,7 +3,7 @@
 #           with fuzzy matching, translation memory, keyword search,
 #           glossaries, and translation leveraging into updated projects.
 #
-#  Copyright (C) 2022 Hiroshi Miura
+#  Copyright (C) 2022,2023 Hiroshi Miura
 #                Home page: https://www.omegat.org/
 #                Support center: https://omegat.org/support
 #
@@ -33,7 +33,8 @@ COPY ssh_config /home/omegat/.ssh/config
 COPY entrypoint.sh /usr/local/bin/
 RUN chown -R omegat /home/omegat && chmod 755 /usr/local/bin/entrypoint.sh && chmod 700 /home/omegat/.ssh \
     && chmod 600 /home/omegat/.ssh/config
-RUN (cd /opt && curl -LO https://services.gradle.org/distributions/gradle-7.5.1-bin.zip && unzip gradle-7.5.1-bin.zip )
+RUN (cd /opt && curl -LO https://services.gradle.org/distributions/gradle-7.5.1-bin.zip  \
+    && unzip -q gradle-7.5.1-bin.zip && rm -f gradle-7.5.1-bin.zip)
 
 USER omegat
 

--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -9,7 +9,7 @@
 #                Support center: https://omegat.org/support
 #
 #  This file is part of OmegaT.
-#
+https://dev.azure.com/omegat-org/ecb5bbf0-66ac-433d-bda1-be5bcf90716d/_apis/build/builds/5871/logs/11#
 #  OmegaT is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -44,5 +44,10 @@ fi
 ssh-keyscan -H server > /home/omegat/.ssh/known_hosts
 
 cd /code
-/opt/gradle-7.5.1/bin/gradle testIntegration clean -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
+umask a+w
+/opt/gradle-7.5.1/bin/gradle testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
        -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README
+result=$?
+chmod -R a+w .gradle || true
+find * -name build -type d -exec chmod -R a+w {} \; || true
+exit $result

--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -44,5 +44,5 @@ fi
 ssh-keyscan -H server > /home/omegat/.ssh/known_hosts
 
 cd /code
-/opt/gradle-7.5.1/bin/gradle testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
+/opt/gradle-7.5.1/bin/gradle testIntegration clean -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
        -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README


### PR DESCRIPTION
This PR try to add 10 min Integration-Test before release build.
It improve a quality of weekly release. 

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

-  Add integration test stage in azure-pipelines YAML

## Other information

