### PR TITLE
chore(gradle): fix winJRE binary build permission error(again)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -791,6 +791,9 @@ ext.makeWinTask = { args ->
                 filteringCharset = 'UTF-8'
             }
             exec {
+                commandLine 'chmod', '-R', 'a+w', 'build'
+            }
+            exec {
                 // You'd think we could just set the PATH, but there be dragons here
                 // https://github.com/palantir/gradle-docker/issues/162
                 def exe = exePresent('iscc') ?  'iscc' : file('ci/iscc')

--- a/ci/iscc
+++ b/ci/iscc
@@ -12,15 +12,5 @@ bindpaths() {
     done
 }
 
-cat << __EOF__ | docker build -t omegat/innosetup:innosetup6 - || true
-FROM docker.io/amake/innosetup
-USER root
-ENV HOME /home/xclient
-ENV WINEPREFIX /home/xclient/.wine
-ENV WINEARCH win32
-RUN chown -R root /home
-WORKDIR /work
-ENTRYPOINT ["iscc"]
-__EOF__
-
-exec docker run --rm -i -v "$PWD":/work $(bindpaths "$@") omegat/innosetup:innosetup6 $(relpaths "$@")
+umask a+w
+exec docker run --rm -i -v "$PWD":/work $(bindpaths "$@") amake/innosetup:innosetup6 $(relpaths "$@")


### PR DESCRIPTION
Previous workaround PR #605 has sub-effect a resulted binary are owned by root user. This causes a permission error when launching a `clean` job. The commit fixes it again by another approach.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- Do not run tasks as root in container
- chmod a+w and umask a+w before run iscc task instead

## Other information

Previous change is #605