### PR TITLE
fix(linux): suppress illegal reflective access warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1108,13 +1108,16 @@ instantStartXmls.each { xml ->
     instantStartGuides.dependsOn taskName
 }
 
-
+tasks.getByName("run") {
+    jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
+}
 
 task debug(type: JavaExec) {
     description = 'Launch app for debugging.' // Special debug task for NetBeans
     group = 'application'
     mainClass = mainClassName
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs(["--illegal-access=warn"])
     debug true
 }
 
@@ -1125,6 +1128,7 @@ task runOnJava17(type: JavaExec) {
     }
     mainClass = application.mainClass
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
     group = 'application'
 }
 

--- a/release/linux-specific/OmegaT
+++ b/release/linux-specific/OmegaT
@@ -7,4 +7,4 @@ JAVA="java"
 BUNDLED_JAVA="${REALOMEGATPATH}/jre/bin/java"
 [ -f "${BUNDLED_JAVA}" ] && JAVA="${BUNDLED_JAVA}"
 
-"${JAVA}" -jar -Xmx1024M "${REALOMEGATPATH}/@JAR_SUBST@" "$@"
+"${JAVA}" -jar -Xmx1024M --add-opens java.desktop/sun.awt.X11=ALL-UNNAMED "${REALOMEGATPATH}/@JAR_SUBST@" "$@"

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -319,11 +319,11 @@ public final class Main {
         try {
             if (cls.getName().equals("sun.awt.X11.XToolkit")) {
                 Field field = cls.getDeclaredField("awtAppClassName");
-                field.setAccessible(true);
-                field.set(toolkit, "OmegaT");
+                if (field.trySetAccessible()) {
+                    field.set(toolkit, "OmegaT");
+                }
             }
-        } catch (Exception e) {
-            // do nothing
+        } catch (Exception ignored) {
         }
 
         System.setProperty("swing.aatext", "true");


### PR DESCRIPTION
- There is a hack to change application name on Gnome shell, committed in 2013, that use reflective access to sun.awt.X11.XToolKit class. This causes warning log on Java 9-16.
- Java 17 and ongoing, there is no "--illegal-access=permit" JVM option, so "--add-opens" is a only way to handle it.
- Change launcher script, build.gradle run options
- There is also a minor fix to deal `setAccesible` method become unrecommended, so use `trySetAccessible` method.

Fix the issue about JVM print warning in stderr 

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.omegat.Main (file:/opt/omegat/OmegaT_5.8.0/OmegaT.jar) to field sun.awt.X11.XToolkit.awtAppClassName
WARNING: Please consider reporting this to the maintainers of org.omegat.Main
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

## Pull request type
- Other (describe below)

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
