### PR TITLE
chore(gradle): allow failure of chmod in winJRE(64) task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -774,6 +774,10 @@ ext.makeWinTask = { args ->
         doFirst {
             delete "$destinationDir/jre"
             delete installerExe
+            exec {
+                commandLine 'chmod', '-R', 'a+w', 'build'
+                ignoreExitValue true
+            }
         }
         doLast {
             project.copy {
@@ -789,9 +793,6 @@ ext.makeWinTask = { args ->
                 ])
                 filter(FixCrLfFilter,  eol: FixCrLfFilter.CrLf.newInstance('crlf'))
                 filteringCharset = 'UTF-8'
-            }
-            exec {
-                commandLine 'chmod', '-R', 'a+w', 'build'
             }
             exec {
                 // You'd think we could just set the PATH, but there be dragons here


### PR DESCRIPTION
iscc task run from container may sometimes different user than operator uid/gid. It can cause a chmod failure.
It allows the failure and move it to doFirst block to avoid error.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]


## What does this PR change?

- Fix weekly release task in CI

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
