### PR TITLE
[RFE#1364] feat(preference): Disable restore button when no feature

### DIFF
--- a/src/org/omegat/gui/dialogs/PreferencesDialog.java
+++ b/src/org/omegat/gui/dialogs/PreferencesDialog.java
@@ -89,6 +89,7 @@ public class PreferencesDialog {
         });
         panel.cancelButton.addActionListener(e -> StaticUIUtils.closeWindowByEvent(dialog));
         panel.undoButton.addActionListener(e -> undoCurrentView());
+        panel.resetButton.setEnabled(view.canRestoreDefaults());
         panel.resetButton.addActionListener(e -> resetCurrentView());
 
         dialog.addWindowListener(new WindowAdapter() {

--- a/src/org/omegat/gui/preferences/IPreferencesController.java
+++ b/src/org/omegat/gui/preferences/IPreferencesController.java
@@ -119,4 +119,11 @@ public interface IPreferencesController {
      * Restore preferences controlled by this view to their default state.
      */
     void restoreDefaults();
+
+    /**
+     * Whether supporting `restoreDefaults` feature.
+     */
+    default boolean canRestoreDefaults() {
+        return true;
+    }
 }

--- a/src/org/omegat/gui/preferences/PreferencesWindowController.java
+++ b/src/org/omegat/gui/preferences/PreferencesWindowController.java
@@ -476,6 +476,7 @@ public class PreferencesWindowController implements FurtherActionListener {
         innerPanel.innerViewHolder.add(newView.getGui(), BorderLayout.CENTER);
         innerPanel.selectedPrefsScrollPane.setViewportView(innerPanel.viewHolder);
         currentView = newView;
+        innerPanel.resetButton.setEnabled(currentView.canRestoreDefaults());
         SwingUtilities.invokeLater(() -> {
             adjustSize();
             searchCurrentView();

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -107,4 +107,9 @@ public class PluginsPreferencesController extends BasePreferencesController {
     @Override
     public void persist() {
     }
+
+    @Override
+    public boolean canRestoreDefaults() {
+        return false;
+    }
 }

--- a/src/org/omegat/gui/preferences/view/SecureStoreController.java
+++ b/src/org/omegat/gui/preferences/view/SecureStoreController.java
@@ -107,4 +107,9 @@ public class SecureStoreController extends BasePreferencesController {
     @Override
     public void persist() {
     }
+
+    @Override
+    public boolean canRestoreDefaults() {
+        return false;
+    }
 }


### PR DESCRIPTION
 When there is no field to restore, OmegaT disable restore button.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Remove "Restore defaults" button where it has no function
    * https://sourceforge.net/p/omegat/feature-requests/1364/

## What does this PR change?

-  IPreferencesController: add default method canRestoreDefaults
-  Return false when controller do not have restore function.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
