### PR TITLE
[RFE#1615]feat(html): preserve html entities

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1666,6 +1666,7 @@ HTML_TRANSLATE_BUTTON_VALUE=value (of button, &submit and reset input)
 
 HTML_COMPRESS_WHITESPACE=Compress whitespace in translated file
 HTML_REMOVE_COMMENTS=Remove HTML comments
+HTML_PRESERVE_HTML_ENTITIES=Preserve HTML entities
 
 HTML_PARAGRAPH_ON=Start a new segment on:
 HTML_PARAGRAPH_ON_BR=<&br> (breaks)

--- a/src/org/omegat/filters2/html2/EditOptionsDialog.form
+++ b/src/org/omegat/filters2/html2/EditOptionsDialog.form
@@ -242,6 +242,13 @@
             </Property>
           </Properties>
         </Component>
+        <Component class="javax.swing.JCheckBox" name="preserveControlEntitiesCB">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="HTML_PRESERVE_HTML_ENTITIES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+        </Component>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/org/omegat/filters2/html2/EditOptionsDialog.java
+++ b/src/org/omegat/filters2/html2/EditOptionsDialog.java
@@ -89,6 +89,7 @@ public class EditOptionsDialog extends javax.swing.JDialog {
         ignoreTagsTF.setText(options.getIgnoreTags());
         removeCommentsCB.setSelected(options.getRemoveComments());
         compressWhitespaceCB.setSelected(options.getCompressWhitespace());
+        preserveControlEntitiesCB.setSelected(options.getPreserveEntities());
 
         StaticUIUtils.setEscapeAction(this, new AbstractAction() {
             @Override
@@ -148,6 +149,7 @@ public class EditOptionsDialog extends javax.swing.JDialog {
         ignoreTagsTF = new javax.swing.JTextField();
         compressWhitespaceCB = new javax.swing.JCheckBox();
         removeCommentsCB = new javax.swing.JCheckBox();
+        preserveControlEntitiesCB = new javax.swing.JCheckBox();
 
         setTitle(OStrings.getString("HTML_Filter_Options")); // NOI18N
         setResizable(false);
@@ -251,6 +253,9 @@ public class EditOptionsDialog extends javax.swing.JDialog {
         org.openide.awt.Mnemonics.setLocalizedText(removeCommentsCB, OStrings.getString("HTML_REMOVE_COMMENTS")); // NOI18N
         jPanel1.add(removeCommentsCB);
 
+        org.openide.awt.Mnemonics.setLocalizedText(preserveControlEntitiesCB, OStrings.getString("HTML_PRESERVE_HTML_ENTITIES")); // NOI18N
+        jPanel1.add(preserveControlEntitiesCB);
+
         getContentPane().add(jPanel1, java.awt.BorderLayout.CENTER);
 
         pack();
@@ -301,6 +306,7 @@ public class EditOptionsDialog extends javax.swing.JDialog {
         options.setParagraphOnBr(paragraphOnBrCB.isSelected());
         options.setCompressWhitespace(compressWhitespaceCB.isSelected());
         options.setRemoveComments(removeCommentsCB.isSelected());
+        options.setPreserveEntites(preserveControlEntitiesCB.isSelected());
         options.setSkipRegExp(skipRegExpTF.getText());
         options.setSkipMeta(skipMetaTF.getText());
         options.setIgnoreTags(ignoreTagsTF.getText());
@@ -342,6 +348,7 @@ public class EditOptionsDialog extends javax.swing.JDialog {
     private javax.swing.JRadioButton neverRB;
     private javax.swing.JButton okButton;
     private javax.swing.JCheckBox paragraphOnBrCB;
+    private javax.swing.JCheckBox preserveControlEntitiesCB;
     private javax.swing.JCheckBox removeCommentsCB;
     private javax.swing.JTextField skipMetaTF;
     private javax.swing.JTextField skipRegExpTF;

--- a/src/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/org/omegat/filters2/html2/FilterVisitor.java
@@ -285,8 +285,14 @@ public class FilterVisitor extends NodeVisitor {
     public void visitStringNode(Text string) {
         recurseSelf = true;
         recurseChildren = true;
-        // nbsp is special case - process it like usual spaces
-        String textAsCleanedString = HTMLUtils.entitiesToChars(string.getText()).replace((char) 160, ' ');
+        String textAsCleanedString;
+        if (!options.getPreserveEntities()) {
+            // nbsp is special case - process it like usual spaces
+            textAsCleanedString = HTMLUtils.entitiesToChars(string.getText()).replace((char) 160, ' ');
+        } else {
+            textAsCleanedString = string.getText();
+        }
+
         if (hasMoreThanJustWhitepaces(textAsCleanedString)) {
             // Hack around HTMLParser not being able to handle XHTML
             // RFE:

--- a/src/org/omegat/filters2/html2/HTMLOptions.java
+++ b/src/org/omegat/filters2/html2/HTMLOptions.java
@@ -97,6 +97,7 @@ public class HTMLOptions extends AbstractOptions {
     public static final String OPTION_IGNORE_TAGS = "ignoreTags";
     public static final String OPTION_REMOVE_COMMENTS = "removeComments";
     public static final String OPTION_COMPRESS_WHITESPACE = "compressWhitespace";
+    public static final String OPTION_PRESERVE_ENTITIES = "preserveEntities";
 
     public HTMLOptions(Map<String, String> options) {
         super(options);
@@ -297,6 +298,20 @@ public class HTMLOptions extends AbstractOptions {
      */
     public void setCompressWhitespace(boolean compressWhitespace) {
         setBoolean(OPTION_COMPRESS_WHITESPACE, compressWhitespace);
+    }
+
+    /**
+     * @return whether preserve HTML entities of control characters.
+     */
+    public boolean getPreserveEntities() {
+        return getBoolean(OPTION_PRESERVE_ENTITIES, false);
+    }
+
+    /**
+     * Set whether preserve HTML entities.
+     */
+    public void setPreserveEntites(boolean preserveEntites) {
+        setBoolean(OPTION_PRESERVE_ENTITIES, preserveEntites);
     }
 
 }

--- a/src/org/omegat/filters2/html2/HTMLUtils.java
+++ b/src/org/omegat/filters2/html2/HTMLUtils.java
@@ -33,7 +33,7 @@ package org.omegat.filters2.html2;
 
 import java.util.Collection;
 
-@Deprecated
+@Deprecated(since = "5.8", forRemoval = true)
 public final class HTMLUtils {
 
     private HTMLUtils() {


### PR DESCRIPTION
Add option to preserve HTML entities.
When translator want to see HTML entities as-is, this is the option and skip HTML entities conversions.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Feature requests: https://sourceforge.net/p/omegat/feature-requests/1615
- show entity unicode character instead delete it

## What does this PR change?

- Add option
- Skip conversion when option enabled

## Other information

I'm not sure the feature is useful.
