### PR TITLE
Make the method loadScreenLayout public

### DIFF
--- a/src/org/omegat/gui/main/MainWindowUI.java
+++ b/src/org/omegat/gui/main/MainWindowUI.java
@@ -321,7 +321,7 @@ public final class MainWindowUI {
     /**
      * Load the main window layout from the specified file. Will reset to defaults if an error occurs.
      */
-    private static void loadScreenLayout(MainWindow mainWindow, File uiLayoutFile) {
+    public static void loadScreenLayout(MainWindow mainWindow, File uiLayoutFile) {
         try (InputStream in = new FileInputStream(uiLayoutFile)) {
             mainWindow.desktop.readXML(in);
         } catch (Exception ex) {


### PR DESCRIPTION
Making public the following method allows updating the layout with an external file.

I don't think there's a good reason to have it private, since the `resetDesktopLayout` is doing more or less the same thing and is public.

https://github.com/omegat-org/omegat/blob/a8d2077008ab5eb54439346dac75d2e4beaeb29b/src/org/omegat/gui/main/MainWindowUI.java#L324
