### PR TITLE
docs_devel: release procedure: bump after publishVersion

### DIFF
--- a/docs_devel/docs/90.ReleaseProcedure.md
+++ b/docs_devel/docs/90.ReleaseProcedure.md
@@ -241,17 +241,7 @@ Some releases will impact the website structure. Make sure the website is up to 
   - [Example](https://sourceforge.net/p/omegat/mailman/omegat-users/thread/CAHvKJZsm4ZSOmvCOpfbtss0z9uo0z7q--bDowRkyAQ5e2zNJJg%40.../#msg36855627)
 
 
-## 18. Cleanup
-
-- Bump version in `Version.properties`, `changes.txt`
-- Set fixed bug tickets and implemented RFEs to `closed-fixed`
-- Update ticket milestones if necessary
-
-Note: Don't "clean up" old releases by moving them out of the way. It is
-important that distfile URLs remain stable.
-
-
-## 19. Push a new version for version check
+## 18. Push a new version for version check
 
 If no catastrophic problems are reported with the new version, once the
 [website](https://github.com/omegat-org/omegat-website/) has been updated, bump
@@ -262,3 +252,12 @@ the version check master file:
 ```
 
 Consider opening a ticket on the website to coordinate timing.
+
+## 19. Cleanup
+
+- Bump version in `Version.properties`, `changes.txt`
+- Set fixed bug tickets and implemented RFEs to `closed-fixed`
+- Update ticket milestones if necessary
+
+Note: Don't "clean up" old releases by moving them out of the way. It is
+important that distfile URLs remain stable.


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]


## What does this PR change?

- update document
- publishVersion task uploads Version.properties file. It should not be changed before publishedVersion task.
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
