### PR TITLE
[6.1][BUGS#1191] fix: jackson custom serializer for ProjectFileStorage

### DIFF
--- a/test/data/project/team.project
+++ b/test/data/project/team.project
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<omegat>
+    <project version="1.0">
+        <repositories>
+          <repository type="git" url="https://example.com/example.git" branch="main">
+            <mapping local="" repository=""/>
+          </repository>
+        </repositories>
+        <source_dir>__DEFAULT__</source_dir>
+        <source_dir_excludes>
+            <mask>**/.svn/**</mask>
+            <mask>**/CVS/**</mask>
+            <mask>**/.cvs/**</mask>
+            <mask>**/.git/**</mask>
+            <mask>**/.hg/**</mask>
+            <mask>**/.repositories/**</mask>
+            <mask>**/desktop.ini</mask>
+            <mask>**/Thumbs.db</mask>
+            <mask>**/.DS_Store</mask>
+            <mask>**/~$*</mask>
+        </source_dir_excludes>
+        <target_dir>__DEFAULT__</target_dir>
+        <tm_dir>__DEFAULT__</tm_dir>
+        <glossary_dir>__DEFAULT__</glossary_dir>
+        <glossary_file>__DEFAULT__</glossary_file>
+        <dictionary_dir>__DEFAULT__</dictionary_dir>
+        <export_tm_dir>__DEFAULT__</export_tm_dir>
+        <export_tm_levels>omegat level1 level2</export_tm_levels>
+        <source_lang>en-US</source_lang>
+        <target_lang>fr-FR</target_lang>
+        <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+        <target_tok>org.omegat.tokenizer.LuceneFrenchTokenizer</target_tok>
+        <sentence_seg>true</sentence_seg>
+        <support_default_translations>true</support_default_translations>
+        <remove_tags>false</remove_tags>
+    </project>
+</omegat>

--- a/test/data/project/teamMapWithExclude.project
+++ b/test/data/project/teamMapWithExclude.project
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<omegat>
+    <project version="1.0">
+        <repositories>
+          <repository type="git" url="https://example.com/example.git" branch="main">
+            <mapping local="" repository="">
+                <excludes>exclude1</excludes>
+                <excludes>exclude2</excludes>
+            </mapping>
+          </repository>
+        </repositories>
+        <source_dir>__DEFAULT__</source_dir>
+        <source_dir_excludes>
+            <mask>**/.svn/**</mask>
+            <mask>**/CVS/**</mask>
+            <mask>**/.cvs/**</mask>
+            <mask>**/.git/**</mask>
+            <mask>**/.hg/**</mask>
+            <mask>**/.repositories/**</mask>
+            <mask>**/desktop.ini</mask>
+            <mask>**/Thumbs.db</mask>
+            <mask>**/.DS_Store</mask>
+            <mask>**/~$*</mask>
+        </source_dir_excludes>
+        <target_dir>__DEFAULT__</target_dir>
+        <tm_dir>__DEFAULT__</tm_dir>
+        <glossary_dir>__DEFAULT__</glossary_dir>
+        <glossary_file>__DEFAULT__</glossary_file>
+        <dictionary_dir>__DEFAULT__</dictionary_dir>
+        <export_tm_dir>__DEFAULT__</export_tm_dir>
+        <export_tm_levels>omegat level1 level2</export_tm_levels>
+        <source_lang>en-US</source_lang>
+        <target_lang>fr-FR</target_lang>
+        <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+        <target_tok>org.omegat.tokenizer.LuceneFrenchTokenizer</target_tok>
+        <sentence_seg>true</sentence_seg>
+        <support_default_translations>true</support_default_translations>
+        <remove_tags>false</remove_tags>
+    </project>
+</omegat>

--- a/test/data/project/teamWithMap.project
+++ b/test/data/project/teamWithMap.project
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<omegat>
+    <project version="1.0">
+        <source_dir>__DEFAULT__</source_dir>
+        <source_dir_excludes>
+            <mask>**/.svn/**</mask>
+            <mask>**/CVS/**</mask>
+            <mask>**/.cvs/**</mask>
+            <mask>**/.git/**</mask>
+            <mask>**/.hg/**</mask>
+            <mask>**/.repositories/**</mask>
+            <mask>**/desktop.ini</mask>
+            <mask>**/Thumbs.db</mask>
+            <mask>**/.DS_Store</mask>
+            <mask>**/~$*</mask>
+        </source_dir_excludes>
+        <target_dir>__DEFAULT__</target_dir>
+        <tm_dir>__DEFAULT__</tm_dir>
+        <glossary_dir>__DEFAULT__</glossary_dir>
+        <glossary_file>__DEFAULT__</glossary_file>
+        <dictionary_dir>__DEFAULT__</dictionary_dir>
+        <export_tm_dir>__DEFAULT__</export_tm_dir>
+        <export_tm_levels>omegat level1 level2</export_tm_levels>
+        <source_lang>en-US</source_lang>
+        <target_lang>fr-FR</target_lang>
+        <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+        <target_tok>org.omegat.tokenizer.LuceneFrenchTokenizer</target_tok>
+        <sentence_seg>true</sentence_seg>
+        <support_default_translations>true</support_default_translations>
+        <remove_tags>false</remove_tags>
+        <repositories>
+           <repository type="git" url="https://example.com/example.git" branch="main">
+             <mapping local="" repository=""/>
+           </repository>
+           <repository type="git" url="git@example.com:example.git" branch="main">
+             <mapping local="source" repository="/docs"/>
+             <mapping local="source/manual" repository="/manual"/>
+           </repository>
+         </repositories>
+    </project>
+</omegat>


### PR DESCRIPTION
ProjectFileStorage class is use to read and write `omegat.project` file.
This PR change Jackson object mapper configuration using custom serializer for `otherAttributes` attribute.
Current master branch produce `<otherAttributes/>` node in `omegat.project` when there is no attribute, and fix it with custom selializer.

I've added test cases that is as same as `releases/6.0`, so it guarantee a compaitibility between versions.

## Pull request type

- Bug fix -> [bug]


## Which ticket is resolved?
 
- ProjectFile has unwanted XML element otherAttributes
  * https://sourceforge.net/p/omegat/bugs/1191/

## What does this PR change?

- Add test as same as  #662
- Add custom serializer for `Map<QName, String> otherAttributes` object.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
