### PR TITLE
fix: FiltersCustomizer consistency

### DIFF
--- a/src/org/omegat/gui/filters2/FiltersCustomizerController.java
+++ b/src/org/omegat/gui/filters2/FiltersCustomizerController.java
@@ -84,6 +84,8 @@ public class FiltersCustomizerController extends BasePreferencesController {
     /** Project-specific filters */
     private final Filters projectFilters;
 
+    private FiltersTableModel model;
+
     /** Filters which editable now. */
     private Filters editableFilters;
 
@@ -192,12 +194,14 @@ public class FiltersCustomizerController extends BasePreferencesController {
         if (!isEditable()) {
             return;
         }
+        List<Filter> filters = editableFilters.getFilters();
         Filter filter = getFilterAtRow(row);
         FilterEditor editor = new FilterEditor(SwingUtilities.windowForComponent(panel), filter);
         editor.setVisible(true);
         if (editor.result != null) {
-            List<Filter> filters = editableFilters.getFilters();
-            filters.set(filters.indexOf(filter), editor.result);
+            Filter f = editor.result;
+            filters.set(filters.indexOf(filter), f);
+            model.setFilter(f);
         }
     }
 
@@ -211,7 +215,8 @@ public class FiltersCustomizerController extends BasePreferencesController {
         editableFilters = isProjectSpecific && projectFilters != null
                 ? FilterMaster.cloneConfig(projectFilters)
                 : FilterMaster.cloneConfig(userFilters);
-        panel.filtersTable.setModel(new FiltersTableModel(editableFilters));
+        model = new FiltersTableModel(editableFilters);
+        panel.filtersTable.setModel(model);
         TableRowSorter<TableModel> sorter = new TableRowSorter<>(panel.filtersTable.getModel());
         panel.filtersTable.setRowSorter(sorter);
         List<RowSorter.SortKey> sortkeys = new ArrayList<>();
@@ -240,7 +245,8 @@ public class FiltersCustomizerController extends BasePreferencesController {
     public void restoreDefaults() {
         if (isEditable()) {
             editableFilters = FilterMaster.cloneConfig(defaultFilters);
-            panel.filtersTable.setModel(new FiltersTableModel(editableFilters));
+            model = new FiltersTableModel(editableFilters);
+            panel.filtersTable.setModel(model);
             panel.cbRemoveTags.setSelected(editableFilters.isRemoveTags());
             panel.cbRemoveSpacesNonseg.setSelected(editableFilters.isRemoveSpacesNonseg());
             panel.cbPreserveSpaces.setSelected(editableFilters.isPreserveSpaces());


### PR DESCRIPTION
- Update Filter customizer change when next edit
- resolve BUGS#1045

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Changes in "Edit Filter"dialog window not reflected when the window is called up again
  * https://sourceforge.net/p/omegat/bugs/1045/ 

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Update FiltersCustomizer table model class with data POJO class
- Set updated config in FiltersCustomizer table when edit
- Add `setFilter` method for table model  

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
