### PR TITLE
[6.0]  [BUGS#1181] feat: add support for XDXF article in StarDict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ dependencies {
         implementation 'com.github.takawitter:trie4j:0.9.8'
         implementation 'io.github.eb4j:dsl4j:0.5.3'
         implementation 'tokyo.northside:stardict4j:0.5.0'
+        implementation 'org.jsoup:jsoup:1.15.3'
 
         // Encoding detections
         implementation 'com.github.albfernandez:juniversalchardet:2.4.0'

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,8 +2,13 @@
  OmegaT 6.0.1
 ----------------------------------------------------------------------
   0 Enhancement
-  0 Bug fixes
+  1 Bug fixes
 ----------------------------------------------------------------------
+
+  Bug fixes:
+
+  - Dictionary displays apostrophe as html entitty code
+  https://sourceforge.net/p/omegat/bugs/1181
 
 ----------------------------------------------------------------------
  OmegaT 6.0.0 (2023-06-22)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Other (describe below)

Backport

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->


- Dictionary displays apostrophe as html entitty code
       * https://sourceforge.net/p/omegat/bugs/1181

## What does this PR change?

- Quick and darty hack to support XDXF type of article
      (cherry picked from commit 5cde153b7bacf37ad8a16ceddd8d061875bb1aed)
- feat(stardict): support styles for XDXF type
      (cherry picked from commit fd285e049fb1485a6f4fb8cda83f9f2862617305)
- feat(stardict/xdxf): support link/image/audio
        - Support iref, rref tags
        - remove kref
     (cherry picked from commit b5c24a1029c8469bb22c7ee919135fbe51cd9218)
    

## Other information

Back port from https://github.com/omegat-org/omegat/pull/628