### PR TITLE
[BUGS#558] fix: incorrect display of rtl segments in fuzzy match pane

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -100,6 +100,9 @@
   - Lucene 5.2 does not work under WebStart
   https://sourceforge.net/p/omegat/bugs/813/
 
+  - Incorrect display of RTL segments in the Fuzzy Matches pane
+  https://sourceforge.net/p/omegat/bugs/558/
+
 ----------------------------------------------------------------------
  OmegaT 6.0.0 (2023-06-19)
 ----------------------------------------------------------------------

--- a/src/org/omegat/filters3/xml/XMLTag.java
+++ b/src/org/omegat/filters3/xml/XMLTag.java
@@ -29,6 +29,7 @@ package org.omegat.filters3.xml;
 
 import org.omegat.filters3.Attribute;
 import org.omegat.filters3.Tag;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Language;
 
 /**
@@ -57,7 +58,7 @@ public class XMLTag extends Tag {
     public String toOriginal() {
         StringBuilder buf = new StringBuilder();
 
-        boolean isRtl = Language.isRTL(targetLanguage.getLanguageCode());
+        boolean isRtl = BiDiUtils.isRtl(targetLanguage.getLanguageCode());
         boolean differentDir = isDifferentDirection(isRtl);
         boolean isSpecialDocxTagLTR = isSpecialDocxBidiTag(false);
         boolean isSpecialDocxTagRTL = isSpecialDocxBidiTag(true);
@@ -135,7 +136,7 @@ public class XMLTag extends Tag {
             return false;
         }
 
-        return isRtl != Language.isRTL(sourceLanguage.getLanguageCode());
+        return isRtl != BiDiUtils.isRtl(sourceLanguage.getLanguageCode());
     }
 
     private boolean isSpecialDocxBidiTag(boolean complex) {

--- a/src/org/omegat/gui/common/EntryInfoPane.java
+++ b/src/org/omegat/gui/common/EntryInfoPane.java
@@ -33,6 +33,7 @@ import javax.swing.JTextPane;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.events.IProjectEventListener;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.gui.FontFallbackListener;
 import org.omegat.util.gui.StaticUIUtils;
 import org.omegat.util.gui.Styles;
@@ -91,6 +92,7 @@ public abstract class EntryInfoPane<T> extends JTextPane implements IProjectEven
         UIThreadsUtil.mustBeSwingThread();
         setText(null);
         scrollRectToVisible(new Rectangle());
+        setComponentOrientation(BiDiUtils.getInitialOrientation());
     }
 
     protected void onProjectOpen() {

--- a/src/org/omegat/gui/editor/AlphabeticalMarkers.java
+++ b/src/org/omegat/gui/editor/AlphabeticalMarkers.java
@@ -47,7 +47,7 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
 import org.omegat.core.Core;
-import org.omegat.util.Language;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.gui.UIThreadsUtil;
@@ -79,7 +79,7 @@ public abstract class AlphabeticalMarkers extends JPanel {
         this.scrollPane = scrollPane;
         String sourceLang = Core.getProject().getProjectProperties()
                 .getSourceLanguage().getLanguageCode();
-        this.sourceLangIsRTL = Language.isRTL(sourceLang);
+        this.sourceLangIsRTL = BiDiUtils.isRtl(sourceLang);
         this.colorScheme = createColorScheme(scrollPane.getViewport().getView().getBackground());
     }
 

--- a/src/org/omegat/gui/editor/Document3.java
+++ b/src/org/omegat/gui/editor/Document3.java
@@ -51,17 +51,6 @@ import org.omegat.util.gui.Styles;
  */
 @SuppressWarnings("serial")
 public class Document3 extends DefaultStyledDocument {
-    public enum ORIENTATION {
-        /** All text is left-to-right oriented. */
-        ALL_LTR,
-        /** All text is right-to-left oriented. */
-        ALL_RTL,
-        /**
-         * different texts/segments have different orientation, depending on
-         * language/locale.
-         */
-        DIFFER
-    };
 
     protected final EditorController controller;
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -659,11 +659,11 @@ public class EditorController implements IEditor {
         }
 
         // check if RTL support required for document
-        boolean hasRTL = sourceLangIsRTL || targetLangIsRTL || Language.localeIsRTL()
+        boolean hasRTL = sourceLangIsRTL || targetLangIsRTL || BiDiUtils.isLocaleRtl()
                 || currentOrientation != BiDiUtils.ORIENTATION.ALL_LTR;
         Map<Language, ProjectTMX> otherLanguageTMs = Core.getProject().getOtherTargetLanguageTMs();
         for (Map.Entry<Language, ProjectTMX> entry : otherLanguageTMs.entrySet()) {
-            hasRTL = hasRTL || Language.isRTL(entry.getKey().getLanguageCode().toLowerCase(Locale.ENGLISH));
+            hasRTL = hasRTL || BiDiUtils.isRtl(entry.getKey().getLanguageCode().toLowerCase(Locale.ENGLISH));
         }
 
         Document3 doc = new Document3(this);
@@ -1930,7 +1930,7 @@ public class EditorController implements IEditor {
             String language = detectFirstStepsLanguage();
             introPane = new JTextPane();
             introPane
-                    .setComponentOrientation(Language.isRTL(language) ? ComponentOrientation.RIGHT_TO_LEFT
+                    .setComponentOrientation(BiDiUtils.isRtl(language) ? ComponentOrientation.RIGHT_TO_LEFT
                             : ComponentOrientation.LEFT_TO_RIGHT);
             introPane.setEditable(false);
             DragTargetOverlay.apply(introPane, dropInfo);

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -570,45 +570,11 @@ public class EditorController implements IEditor {
      * Decide what document orientation should be default for source/target languages.
      */
     private void setInitialOrientation() {
-        String sourceLang = Core.getProject().getProjectProperties().getSourceLanguage().getLanguageCode();
-        String targetLang = Core.getProject().getProjectProperties().getTargetLanguage().getLanguageCode();
-
-        sourceLangIsRTL = Language.isRTL(sourceLang);
-        targetLangIsRTL = Language.isRTL(targetLang);
-
-        if (sourceLangIsRTL != targetLangIsRTL || sourceLangIsRTL != Language.localeIsRTL()) {
-            currentOrientation = BiDiUtils.ORIENTATION.DIFFER;
-        } else {
-            if (sourceLangIsRTL) {
-                currentOrientation = BiDiUtils.ORIENTATION.ALL_RTL;
-            } else {
-                currentOrientation = BiDiUtils.ORIENTATION.ALL_LTR;
-            }
-        }
-        applyOrientationToEditor();
-    }
-
-    /**
-     * Define editor's orientation by target language orientation.
-     */
-    private void applyOrientationToEditor() {
-        ComponentOrientation targetOrientation = null;
-        switch (currentOrientation) {
-        case ALL_LTR:
-            targetOrientation = ComponentOrientation.LEFT_TO_RIGHT;
-            break;
-        case ALL_RTL:
-            targetOrientation = ComponentOrientation.RIGHT_TO_LEFT;
-            break;
-        case DIFFER:
-            if (targetLangIsRTL) { //using target lang direction gives better result when user starts editing.
-                targetOrientation = ComponentOrientation.RIGHT_TO_LEFT;
-            } else {
-                targetOrientation = ComponentOrientation.LEFT_TO_RIGHT;
-            }
-        }
-        // set editor's orientation by target language
-        editor.setComponentOrientation(targetOrientation);
+        sourceLangIsRTL = BiDiUtils.isSourceLangRtl();
+        targetLangIsRTL = BiDiUtils.isTargetLangRtl();
+        currentOrientation = BiDiUtils.getOrientationType();
+        // Define editor's orientation by target language orientation.
+        editor.setComponentOrientation(BiDiUtils.getOrientation(currentOrientation));
     }
 
     /**

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -110,6 +110,7 @@ import org.omegat.gui.main.MainWindow;
 import org.omegat.gui.main.MainWindowUI;
 import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.help.Help;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
@@ -207,7 +208,7 @@ public class EditorController implements IEditor {
         INTRO, EMPTY_PROJECT, FIRST_ENTRY, NO_CHANGE
     };
 
-    Document3.ORIENTATION currentOrientation;
+    BiDiUtils.ORIENTATION currentOrientation;
     protected boolean sourceLangIsRTL;
     protected boolean targetLangIsRTL;
 
@@ -576,12 +577,12 @@ public class EditorController implements IEditor {
         targetLangIsRTL = Language.isRTL(targetLang);
 
         if (sourceLangIsRTL != targetLangIsRTL || sourceLangIsRTL != Language.localeIsRTL()) {
-            currentOrientation = Document3.ORIENTATION.DIFFER;
+            currentOrientation = BiDiUtils.ORIENTATION.DIFFER;
         } else {
             if (sourceLangIsRTL) {
-                currentOrientation = Document3.ORIENTATION.ALL_RTL;
+                currentOrientation = BiDiUtils.ORIENTATION.ALL_RTL;
             } else {
-                currentOrientation = Document3.ORIENTATION.ALL_LTR;
+                currentOrientation = BiDiUtils.ORIENTATION.ALL_LTR;
             }
         }
         applyOrientationToEditor();
@@ -611,13 +612,11 @@ public class EditorController implements IEditor {
     }
 
     /**
-     * returns the orientation of the document
-     * (so we can decide what way of tag colouring we need;
-     * if that has been fixed in an other way, this method can be removed again.).
-     * @return
+     * The orientation of the document is all LtR.
+     * @return true when the orientation is all RtL. otherwise false.
      */
-    public Document3.ORIENTATION getOrientation() {
-        return currentOrientation;
+    public boolean isOrientationAllLtr() {
+        return currentOrientation.equals(BiDiUtils.ORIENTATION.ALL_LTR);
     }
 
     /**
@@ -695,7 +694,7 @@ public class EditorController implements IEditor {
 
         // check if RTL support required for document
         boolean hasRTL = sourceLangIsRTL || targetLangIsRTL || Language.localeIsRTL()
-                || currentOrientation != Document3.ORIENTATION.ALL_LTR;
+                || currentOrientation != BiDiUtils.ORIENTATION.ALL_LTR;
         Map<Language, ProjectTMX> otherLanguageTMs = Core.getProject().getOtherTargetLanguageTMs();
         for (Map.Entry<Language, ProjectTMX> entry : otherLanguageTMs.entrySet()) {
             hasRTL = hasRTL || Language.isRTL(entry.getKey().getLanguageCode().toLowerCase(Locale.ENGLISH));

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -47,6 +47,7 @@ import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.gui.editor.MarkerController.MarkInfo;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
@@ -366,7 +367,7 @@ public class SegmentBuilder {
 
     /**
      * Create method for inactive segment.
-     * 
+     *
      * @param trans
      *            TMX entry with translation
      * @throws BadLocationException
@@ -540,7 +541,7 @@ public class SegmentBuilder {
      */
     private void addOtherLanguagePart(String text, Language language) throws BadLocationException {
         int prevOffset = offset;
-        boolean rtl = Language.isRTL(language.getLanguageCode());
+        boolean rtl = BiDiUtils.isRtl(language.getLanguageCode());
         insertDirectionEmbedding(false);
         AttributeSet normal = attrs(true, false, false, false);
         insert(language.getLanguage() + ": ", normal);
@@ -588,7 +589,7 @@ public class SegmentBuilder {
         }
 
         int prevOffset = offset;
-        boolean rtl = Language.localeIsRTL();
+        boolean rtl = BiDiUtils.isLocaleRtl();
         insertDirectionEmbedding(rtl);
         AttributeSet attrs = settings.getModificationInfoAttributeSet();
         insert(text, attrs);
@@ -624,7 +625,7 @@ public class SegmentBuilder {
         insertDirectionMarker(rtl);
 
         // the marker itself is in user language
-        insertDirectionEmbedding(Language.localeIsRTL());
+        insertDirectionEmbedding(BiDiUtils.isLocaleRtl());
         AttributeSet attrSegmentMark = settings.getSegmentMarkerAttributeSet();
         insert(createSegmentMarkText(), attrSegmentMark);
         insertDirectionEndEmbedding();
@@ -781,7 +782,7 @@ public class SegmentBuilder {
     /**
      * Writes (if necessary) an RTL or LTR marker. Use it before writing text in
      * some language.
-     * 
+     *
      * @param isRTL
      *            is the language that has to be written a right-to-left
      *            language?

--- a/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -34,10 +34,10 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.apache.commons.text.StringEscapeUtils;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.gui.editor.Document3;
 import org.omegat.gui.editor.EditorController;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
@@ -60,7 +60,7 @@ public class ProtectedPartsMarker implements IMarker {
             throws Exception {
         HighlightPainter painter;
         AttributeSet attrs;
-        if (((EditorController) Core.getEditor()).getOrientation() == Document3.ORIENTATION.ALL_LTR) {
+        if (((EditorController) Core.getEditor()).isOrientationAllLtr()) {
             attrs = ATTRIBUTES_LTR;
             painter = null;
         } else {

--- a/src/org/omegat/gui/editor/mark/RemoveTagMarker.java
+++ b/src/org/omegat/gui/editor/mark/RemoveTagMarker.java
@@ -32,7 +32,6 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
-import org.omegat.gui.editor.Document3;
 import org.omegat.gui.editor.EditorController;
 import org.omegat.util.OStrings;
 import org.omegat.util.PatternConsts;
@@ -67,7 +66,7 @@ public class RemoveTagMarker extends AbstractMarker {
 
     @Override
     protected void initDrawers(boolean isSource, boolean isActive) {
-        if (((EditorController) Core.getEditor()).getOrientation() == Document3.ORIENTATION.ALL_LTR) {
+        if (((EditorController) Core.getEditor()).isOrientationAllLtr()) {
             attributes = isSource ? attributesLtrSource : attributesLtrTranslation;
             painter = null;
         } else {

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -63,6 +63,7 @@ import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -99,6 +100,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
     final DockableScrollPane scrollPane;
 
     private ISegmentPropertiesView viewImpl;
+    private boolean isTargetRtl;
 
     public SegmentPropertiesArea(IMainWindow mw) {
         scrollPane = new DockableScrollPane("SEGMENTPROPERTIES", OStrings.getString("SEGPROP_PANE_TITLE"),
@@ -115,6 +117,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
             @Override
             public void onEntryActivated(SourceTextEntry newEntry) {
                 scrollPane.stopNotifying();
+                isTargetRtl = BiDiUtils.isTargetLangRtl();
                 setProperties(newEntry);
                 doNotify(getKeysToNotify());
             }
@@ -326,7 +329,11 @@ public class SegmentPropertiesArea implements IPaneMenu {
                 setProperty(KEY_ISDUP, ste.getDuplicate());
             }
             if (ste.getSourceTranslation() != null) {
-                setProperty(KEY_TRANSLATION, ste.getSourceTranslation());
+                if (isTargetRtl) {
+                    setProperty(KEY_TRANSLATION, BiDiUtils.addRtlBidiAround(ste.getSourceTranslation()));
+                } else {
+                    setProperty(KEY_TRANSLATION, ste.getSourceTranslation());
+                }
                 if (ste.isSourceTranslationFuzzy()) {
                     setProperty(KEY_TRANSLATIONISFUZZY, true);
                 }

--- a/src/org/omegat/util/BiDiUtils.java
+++ b/src/org/omegat/util/BiDiUtils.java
@@ -30,8 +30,6 @@ package org.omegat.util;
 import java.awt.ComponentOrientation;
 
 import org.omegat.core.Core;
-import org.omegat.gui.editor.Document3;
-import org.omegat.gui.editor.EditorController;
 
 public class BiDiUtils {
 
@@ -179,10 +177,6 @@ public class BiDiUtils {
     }
 
     public static boolean isMixedOrientationProject() {
-        return (BiDiUtils.getOrientationType() == BiDiUtils.ORIENTATION.DIFFER);
-    }
-
-    public static boolean isOrientationAllLtr() {
-        return ((EditorController) Core.getEditor()).getOrientation() == Document3.ORIENTATION.ALL_LTR;
+        return (BiDiUtils.getOrientationType() == ORIENTATION.DIFFER);
     }
 }

--- a/src/org/omegat/util/BiDiUtils.java
+++ b/src/org/omegat/util/BiDiUtils.java
@@ -31,6 +31,9 @@ import java.awt.ComponentOrientation;
 
 import org.omegat.core.Core;
 
+/**
+ * @author Damien Rembert
+ */
 public class BiDiUtils {
 
     public enum ORIENTATION {

--- a/src/org/omegat/util/BiDiUtils.java
+++ b/src/org/omegat/util/BiDiUtils.java
@@ -1,0 +1,188 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2008 Alex Buloichik
+               2012 Didier Briel
+               2015 Aaron Madlon-Kay
+               2023 Damien Rembert
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.util;
+
+import java.awt.ComponentOrientation;
+
+import org.omegat.core.Core;
+import org.omegat.gui.editor.Document3;
+import org.omegat.gui.editor.EditorController;
+
+public class BiDiUtils {
+
+    public enum ORIENTATION {
+        /** All text is left-to-right oriented. */
+        ALL_LTR,
+        /** All text is right-to-left oriented. */
+        ALL_RTL,
+        /**
+         * different texts/segments have different orientation, depending on
+         * language/locale.
+         */
+        DIFFER
+    };
+
+    public static final String BIDI_LRE = "\u202a";
+    public static final String BIDI_RLE = "\u202b";
+    public static final String BIDI_PDF = "\u202c";
+    public static final String BIDI_LRM = "\u200e";
+    public static final String BIDI_RLM = "\u200f";
+    public static final char BIDI_LRM_CHAR = '\u200e';
+    public static final char BIDI_RLM_CHAR = '\u200f';
+
+    public static ORIENTATION getOrientationType() {
+        ORIENTATION orientation;
+
+        if (Core.getProject().isProjectLoaded()) {
+            orientation = getOrientationFromProject();
+        } else if (isLocaleRtl()) {
+            // project not loaded, use locale
+            orientation = ORIENTATION.ALL_RTL;
+        } else {
+            // project not loaded, default to LTR
+            orientation = ORIENTATION.ALL_LTR;
+        }
+        return orientation;
+    }
+
+    /**
+     * Decide what document orientation should be default for source/target
+     * languages.
+     */
+    private static ORIENTATION getOrientationFromProject() {
+        ORIENTATION orientation;
+
+        boolean sourceLangIsRTL = isSourceLangRtl();
+        boolean targetLangIsRTL = isTargetLangRtl();
+
+        if (sourceLangIsRTL) {
+            orientation = ORIENTATION.ALL_RTL;
+        } else {
+            orientation = ORIENTATION.ALL_LTR;
+        }
+        if (sourceLangIsRTL != targetLangIsRTL || sourceLangIsRTL != isLocaleRtl()) {
+            orientation = ORIENTATION.DIFFER;
+        }
+        return orientation;
+    }
+
+    /**
+     * Decide what document orientation should be default for source/target
+     * languages.
+     */
+    public static ComponentOrientation getInitialOrientation() {
+        return getOrientation(null);
+    }
+
+    /**
+     * Decide what document orientation should be default for source/target
+     * languages.
+     */
+    public static ComponentOrientation getOrientation(ORIENTATION orientationType) {
+
+        ComponentOrientation targetOrientation = null;
+
+        if (orientationType == null) {
+            orientationType = getOrientationType();
+        }
+
+        switch (orientationType) {
+        case ALL_LTR:
+            targetOrientation = ComponentOrientation.LEFT_TO_RIGHT;
+            break;
+        case ALL_RTL:
+            targetOrientation = ComponentOrientation.RIGHT_TO_LEFT;
+            break;
+        case DIFFER:
+            if (isTargetLangRtl()) {
+                // using target lang direction gives better result when user
+                // starts editing.
+                targetOrientation = ComponentOrientation.RIGHT_TO_LEFT;
+            } else {
+                targetOrientation = ComponentOrientation.LEFT_TO_RIGHT;
+            }
+        }
+        return targetOrientation;
+    }
+
+    public static String addRtlBidiAround(String string) {
+        return BIDI_RLE + string + BIDI_PDF;
+    }
+
+    public static String addLtrBidiAround(String string) {
+        return BIDI_LRE + string + BIDI_PDF;
+    }
+
+    public static boolean isSourceLangRtl() {
+        return isRtl(getSourceLanguage());
+    }
+
+    public static boolean isTargetLangRtl() {
+        return isRtl(getTargetLanguage());
+    }
+
+    private static String getSourceLanguage() {
+        return Core.getProject().getProjectProperties().getSourceLanguage().getLanguageCode();
+    }
+
+    private static String getTargetLanguage() {
+        return Core.getProject().getProjectProperties().getTargetLanguage().getLanguageCode();
+    }
+
+    /**
+     * Check if locale is Right-To-Left oriented.
+     * 
+     * @return true if locale is Right-To-Left oriented.
+     */
+    public static boolean isLocaleRtl() {
+        String language = Language.getLowerCaseLanguageFromLocale();
+        return isRtl(language);
+    }
+
+    /**
+     * Check if language is Right-To-Left oriented.
+     *
+     * @param language
+     *            ISO-639-2 language code
+     * @return true if language is RTL
+     */
+    public static boolean isRtl(final String language) {
+        return "ar".equalsIgnoreCase(language) || "iw".equalsIgnoreCase(language)
+                || "he".equalsIgnoreCase(language) || "fa".equalsIgnoreCase(language)
+                || "ur".equalsIgnoreCase(language) || "ug".equalsIgnoreCase(language)
+                || "ji".equalsIgnoreCase(language) || "yi".equalsIgnoreCase(language);
+    }
+
+    public static boolean isMixedOrientationProject() {
+        return (BiDiUtils.getOrientationType() == BiDiUtils.ORIENTATION.DIFFER);
+    }
+
+    public static boolean isOrientationAllLtr() {
+        return ((EditorController) Core.getEditor()).getOrientation() == Document3.ORIENTATION.ALL_LTR;
+    }
+}

--- a/src/org/omegat/util/Language.java
+++ b/src/org/omegat/util/Language.java
@@ -763,30 +763,6 @@ public class Language implements Comparable<Object> {
         return isSameCountryLanguage(new Language(target));
     }
 
-    /**
-     * Check if locale is Right-To-Left oriented.
-     * 
-     * @return true if locale is Right-To-Left oriented.
-     */
-    public static boolean localeIsRTL() {
-        String language = Locale.getDefault().getLanguage().toLowerCase(Locale.ENGLISH);
-        return isRTL(language);
-    }
-
-    /**
-     * Check if language is Right-To-Left oriented.
-     *
-     * @param language
-     *            ISO-639-2 language code
-     * @return true if language is RTL
-     */
-    public static boolean isRTL(final String language) {
-        return "ar".equalsIgnoreCase(language) || "iw".equalsIgnoreCase(language)
-                || "he".equalsIgnoreCase(language) || "fa".equalsIgnoreCase(language)
-                || "ur".equalsIgnoreCase(language) || "ug".equalsIgnoreCase(language)
-                || "ji".equalsIgnoreCase(language) || "yi".equalsIgnoreCase(language);
-    }
-
     public static String getLowerCaseLanguageFromLocale() {
         return Locale.getDefault().getLanguage().toLowerCase(Locale.ENGLISH);
     }

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -1,0 +1,442 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2012 Thomas Cordonnier, Aaron Madlon-Kay
+               2013-2014 Aaron Madlon-Kay
+               2014 Alex Buloichik
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.matches;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.matching.NearString;
+import org.omegat.gui.editor.IEditor;
+import org.omegat.gui.editor.IEditorFilter;
+import org.omegat.gui.editor.IEditorSettings;
+import org.omegat.gui.editor.IPopupMenuConstructor;
+import org.omegat.gui.editor.autocompleter.IAutoCompleter;
+import org.omegat.gui.editor.mark.Mark;
+import org.omegat.util.Language;
+import org.omegat.util.TMXProp;
+
+public class MatchesVarExpansionTest {
+
+    final Language LTR_LANGUAGE = new Language("pl");
+    final Language RTL_LANGUAGE = new Language("ar");
+    final Locale LTR_LOCALE = LTR_LANGUAGE.getLocale();
+    final Locale RTL_LOCALE = RTL_LANGUAGE.getLocale();
+    final Locale INITIAL_LOCALE = Locale.getDefault();
+
+    final String VAR_CREATION_ID = "${creationId}";
+    final String VAR_CREATION_DATE = "${creationDate}";
+    final String VAR_INITIAL_CREATION_ID = "${initialCreationId}";
+    final String VAR_INITIAL_CREATION_DATE = "${initialCreationDate}";
+    final String VAR_CHANGED_ID = "${changedId}";
+    final String VAR_CHANGED_DATE = "${changedDate}";
+    final String VAR_FUZZY_FLAG = "${fuzzyFlag}";
+    final String VAR_DIFF = "${diff}";
+    final String VAR_DIFF_REVERSED = "${diffReversed}";
+    final String VAR_SOURCE_LANGUAGE = "${sourceLanguage}";
+    final String VAR_TARGET_LANGUAGE = "${targetLanguage}";
+    final String VAR_SOURCE_TEXT = "${sourceText}";
+    final String VAR_TARGET_TEXT = "${targetText}";
+    final String VAR_PROJECT_SOURCE_LANG = "${projectSourceLang}";
+    final String VAR_PROJECT_SOURCE_LANG_CODE = "${projectSourceLangCode}";
+    final String VAR_PROJECT_TARGET_LANG = "${projectTargetLang}";
+    final String VAR_PROJECT_TARGET_LANG_CODE = "${projectTargetLangCode}";
+    final String VAR_FILE_NAME = "${fileName}";
+    final String VAR_FILE_NAME_ONLY = "${fileNameOnly}";
+    final String VAR_FILE_EXTENSION = "${fileExtension}";
+    final String VAR_FILE_PATH = "${filePath}";
+    final String VAR_FILE_SHORT_PATH = "${fileShortPath}";
+    final String VAR_ID = "${id}";
+    final String VAR_SCORE_BASE = "${score}";
+    final String VAR_SCORE_NOSTEM = "${noStemScore}";
+    final String VAR_SCORE_ADJUSTED = "${adjustedScore}";
+
+    final String DEFAULT_TEMPLATE = VAR_ID + ". " + VAR_FUZZY_FLAG + VAR_SOURCE_TEXT + "\n" + VAR_TARGET_TEXT + "\n"
+            + "<" + VAR_SCORE_BASE + "/" + VAR_SCORE_NOSTEM + "/" + VAR_SCORE_ADJUSTED + "% " + VAR_FILE_PATH + ">";
+
+    final String TEST_TEMPLATE = VAR_ID + ". ... " + VAR_SOURCE_TEXT + "\n" + VAR_TARGET_TEXT
+            + "\n" + "<" + VAR_SCORE_BASE + "/" + VAR_SCORE_NOSTEM + "/" + VAR_SCORE_ADJUSTED + "% "
+            + VAR_FILE_PATH + ">";
+
+    final String BIG_TEMPLATE = VAR_ID + ". " + VAR_PROJECT_SOURCE_LANG + " - " + VAR_FILE_NAME + " "
+            + VAR_SOURCE_LANGUAGE + ": "
+            + VAR_SOURCE_TEXT + "\n" + VAR_TARGET_LANGUAGE + " " + VAR_TARGET_TEXT + "\n"
+            + "<" + VAR_SCORE_BASE + "/" + VAR_SCORE_NOSTEM + "/" + VAR_SCORE_ADJUSTED + "% " + VAR_FILE_PATH
+            + " by " + VAR_INITIAL_CREATION_ID + " >\n" + VAR_PROJECT_TARGET_LANG;
+
+    final String TEST_BIDI_TEMPLATE = VAR_SOURCE_TEXT + " and " + VAR_TARGET_TEXT;
+
+    @Before
+    public void setUp() {
+        TestCoreInitializer.initEditor(editor);
+    }
+
+    @After
+    public void resetInitialLocale() {
+        Locale.setDefault(INITIAL_LOCALE);
+    }
+
+    @Test
+    public void testApplyBiDiReplacers_allRtl() {
+        Locale.setDefault(RTL_LOCALE);
+        setupAllRtlProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(TEST_BIDI_TEMPLATE);
+        String expected = "mock source text and mock target text";
+        String actual = expander.apply(getMockNearString(), 2).text;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testApplyBiDiReplacers_allLtr() {
+        Locale.setDefault(LTR_LOCALE);
+        setupAllLtrProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(TEST_BIDI_TEMPLATE);
+        String expected = "mock source text and mock target text";
+        String actual = expander.apply(getMockNearString(), 2).text;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testApply_allLtr() {
+        Locale.setDefault(LTR_LOCALE);
+        setupAllLtrProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(BIG_TEMPLATE);
+        String expected = "2. pl - mock testing project mock source language: mock source text\nmock target language mock target text\n<20/40/60% mock testing project by mock creator >\npl";
+        String actual = expander.apply(getMockNearString(), 2).text;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testExpandVariables() {
+        Locale.setDefault(LTR_LOCALE);
+        setupAllLtrProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(TEST_TEMPLATE);
+        String expected = "${id}. ... ${sourceText}\nmock target text\n<20/40/60% mock testing project>";
+        String actual = expander.expandVariables(getMockNearString());
+        assertEquals(expected, actual);
+    }
+
+    // Helper methods
+
+    private void setupAllLtrProject() {
+        setupProject(LTR_LANGUAGE, LTR_LANGUAGE);
+    }
+
+    private void setupAllRtlProject() {
+        setupProject(RTL_LANGUAGE, RTL_LANGUAGE);
+    }
+
+    private void setupRtlToLtrProject() {
+        setupProject(RTL_LANGUAGE, LTR_LANGUAGE);
+    }
+
+    private void setupLtrToRtlProject() {
+        setupProject(LTR_LANGUAGE, RTL_LANGUAGE);
+    }
+
+    public NearString getMockNearString() {
+        List<TMXProp> testProps = new ArrayList<>();
+        testProps.add(new TMXProp("sourceLanguage", "mock source language"));
+        testProps.add(new TMXProp("targetLanguage", "mock target language"));
+
+        return new NearString(null, "mock source text", "mock target text", null, false, 20, 40, 60, null,
+                "mock testing project", "mock creator", 20020523, "mock modifier", 20020523, testProps);
+    };
+
+    private void setupProject(Language sourceLanguage, Language targetLanguage) {
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return true;
+            }
+
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return new ProjectProperties() {
+                    @Override
+                    public Language getSourceLanguage() {
+                        return sourceLanguage;
+                    }
+
+                    @Override
+                    public String getTMRoot() {
+                        return "/mock/testing/path";
+                    }
+
+                    @Override
+                    public Language getTargetLanguage() {
+                        return targetLanguage;
+                    }
+                };
+            }
+        });
+    }
+
+    final IEditor editor = new IEditor() {
+
+        @Override
+        public SourceTextEntry getCurrentEntry() {
+            return null;
+        }
+
+        @Override
+        public void windowDeactivated() {
+        }
+
+        @Override
+        public void undo() {
+        }
+
+        @Override
+        public void setFilter(IEditorFilter filter) {
+        }
+
+        @Override
+        public void setAlternateTranslationForCurrentEntry(boolean alternate) {
+        }
+
+        @Override
+        public void requestFocus() {
+        }
+
+        @Override
+        public void replaceEditTextAndMark(String text) {
+        }
+
+        @Override
+        public void replaceEditText(String text) {
+        }
+
+        @Override
+        public void replaceEditTextAndMark(final String text, final String origin) {
+        }
+
+        @Override
+        public void removeFilter() {
+        }
+
+        @Override
+        public void remarkOneMarker(String markerClassName) {
+        }
+
+        @Override
+        public void registerUntranslated() {
+        }
+
+        @Override
+        public void registerPopupMenuConstructors(int priority, IPopupMenuConstructor constructor) {
+        }
+
+        @Override
+        public void registerIdenticalTranslation() {
+        }
+
+        @Override
+        public void registerEmptyTranslation() {
+        }
+
+        @Override
+        public void refreshViewAfterFix(List<Integer> fixedEntries) {
+        }
+
+        @Override
+        public void refreshView(boolean doCommit) {
+        }
+
+        @Override
+        public void redo() {
+        }
+
+        @Override
+        public void prevEntryWithNote() {
+        }
+
+        @Override
+        public void prevEntry() {
+        }
+
+        @Override
+        public void nextXAutoEntry() {
+        }
+
+        @Override
+        public void prevXAutoEntry() {
+        }
+
+        @Override
+        public void nextXEnforcedEntry() {
+        }
+
+        @Override
+        public void prevXEnforcedEntry() {
+        }
+
+        @Override
+        public void nextUntranslatedEntry() {
+        }
+
+        @Override
+        public void nextUniqueEntry() {
+        }
+
+        @Override
+        public void nextTranslatedEntry() {
+        }
+
+        @Override
+        public void nextEntryWithNote() {
+        }
+
+        @Override
+        public void nextEntry() {
+        }
+
+        @Override
+        public void markActiveEntrySource(SourceTextEntry requiredActiveEntry, List<Mark> marks,
+                String markerClassName) {
+        }
+
+        @Override
+        public void insertText(String text) {
+        }
+
+        @Override
+        public void insertTextAndMark(String text) {
+        }
+
+        @Override
+        public void insertTag(String tag) {
+        }
+
+        @Override
+        public void gotoHistoryForward() {
+        }
+
+        @Override
+        public void gotoHistoryBack() {
+        }
+
+        @Override
+        public void gotoFile(int fileIndex) {
+        }
+
+        @Override
+        public void gotoEntryAfterFix(int fixedEntry, String fixedSource) {
+        }
+
+        @Override
+        public void gotoEntry(String srcString, EntryKey key) {
+        }
+
+        @Override
+        public void gotoEntry(int entryNum) {
+        }
+
+        @Override
+        public void gotoEntry(int entryNum, CaretPosition pos) {
+        }
+
+        @Override
+        public IEditorSettings getSettings() {
+            return null;
+        }
+
+        @Override
+        public String getSelectedText() {
+            return null;
+        }
+
+        @Override
+        public void selectSourceText() {
+        }
+
+        @Override
+        public IEditorFilter getFilter() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentTranslation() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentTargetFile() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentFile() {
+            return null;
+        }
+
+        @Override
+        public int getCurrentEntryNumber() {
+            return 0;
+        }
+
+        @Override
+        public IAutoCompleter getAutoCompleter() {
+            return null;
+        }
+
+        @Override
+        public void commitAndLeave() {
+        }
+
+        @Override
+        public void commitAndDeactivate() {
+        }
+
+        @Override
+        public void changeCase(IEditor.CHANGE_CASE_TO newCase) {
+        }
+
+        @Override
+        public void replaceEditText(final String text, final String origin) {
+
+        }
+
+        @Override
+        public void activateEntry() {
+        }
+    };
+
+}

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -36,7 +36,6 @@ import java.util.Locale;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.omegat.core.Core;
 import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.EntryKey;
@@ -50,6 +49,7 @@ import org.omegat.gui.editor.IEditorSettings;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.autocompleter.IAutoCompleter;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.util.BiDiUtils;
 import org.omegat.util.Language;
 import org.omegat.util.TMXProp;
 
@@ -129,6 +129,28 @@ public class MatchesVarExpansionTest {
         setupAllLtrProject();
         MatchesVarExpansion expander = new MatchesVarExpansion(TEST_BIDI_TEMPLATE);
         String expected = "mock source text and mock target text";
+        String actual = expander.apply(getMockNearString(), 2).text;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testApplyBiDiReplacers_rtlToLtr() {
+        Locale.setDefault(RTL_LOCALE);
+        setupRtlToLtrProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(TEST_BIDI_TEMPLATE);
+        String expected = BiDiUtils.BIDI_RLE + "mock source text" + BiDiUtils.BIDI_PDF + " and "
+                + BiDiUtils.BIDI_LRE + "mock target text" + BiDiUtils.BIDI_PDF;
+        String actual = expander.apply(getMockNearString(), 2).text;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testApplyBiDiReplacers_ltrToRtl() {
+        Locale.setDefault(LTR_LOCALE);
+        setupLtrToRtlProject();
+        MatchesVarExpansion expander = new MatchesVarExpansion(TEST_BIDI_TEMPLATE);
+        String expected = BiDiUtils.BIDI_LRE + "mock source text" + BiDiUtils.BIDI_PDF + " and "
+                + BiDiUtils.BIDI_RLE + "mock target text" + BiDiUtils.BIDI_PDF;
         String actual = expander.apply(getMockNearString(), 2).text;
         assertEquals(expected, actual);
     }

--- a/test/src/org/omegat/util/BiDiUtilsTest.java
+++ b/test/src/org/omegat/util/BiDiUtilsTest.java
@@ -1,0 +1,288 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2008 Alex Buloichik
+               2012 Didier Briel
+               2015 Aaron Madlon-Kay
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.awt.ComponentOrientation;
+import java.util.Locale;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+
+public class BiDiUtilsTest {
+    final Language LTR_LANGUAGE = new Language("pl");
+    final Language RTL_LANGUAGE = new Language("ar");
+    final Locale LTR_LOCALE = LTR_LANGUAGE.getLocale();
+    final Locale RTL_LOCALE = RTL_LANGUAGE.getLocale();
+    final Locale INITIAL_LOCALE = Locale.getDefault();
+
+    @After
+    public void resetInitialLocale() {
+        Locale.setDefault(INITIAL_LOCALE);
+    }
+
+    @Test
+    public void testGetOrientationType_noProjectLocaleLtr_allLtr() {
+        Locale.setDefault(LTR_LOCALE);
+        setupProjectNotLoaded();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_LTR, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_noProjectLocaleRtl_allRtl() {
+        Locale.setDefault(RTL_LOCALE);
+        setupProjectNotLoaded();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_RTL, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_allLtrProjectAndRtlLocale_differ() {
+        Locale.setDefault(RTL_LOCALE);
+        setupAllLtrProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_allRtlProjectAndLtrLocale_differ() {
+        Locale.setDefault(Locale.ENGLISH);
+        setupAllRtlProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_allLtrProjectAndLtrLocale_allLtr() {
+        Locale.setDefault(LTR_LOCALE);
+        setupAllLtrProject();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_LTR, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_allRtlProjectAndRtlLocale_allRtl() {
+        Locale.setDefault(RTL_LOCALE);
+        setupAllRtlProject();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_RTL, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_ltrToRtlProjectAndLtrLocale_differ() {
+        Locale.setDefault(LTR_LOCALE);
+        setupLtrToRtlProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_ltrToRtlProjectAndRtlLocale_differ() {
+        Locale.setDefault(RTL_LOCALE);
+        setupLtrToRtlProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_rtlToLtrProjectAndLtrLocale_differ() {
+        Locale.setDefault(LTR_LOCALE);
+        setupRtlToLtrProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetOrientationType_rtlToLtrProjectAndRtlLocale_differ() {
+        Locale.setDefault(RTL_LOCALE);
+        setupRtlToLtrProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+    }
+
+    @Test
+    public void testGetInitialOrientation_notNull() {
+        Locale.setDefault(RTL_LOCALE);
+        setupRtlToLtrProject();
+        assertNotNull(BiDiUtils.getInitialOrientation());
+    }
+
+    @Test
+    public void testGetOrientation_nullParam_notNull() {
+        Locale.setDefault(RTL_LOCALE);
+        setupRtlToLtrProject();
+        assertNotNull(BiDiUtils.getOrientation(null));
+    }
+
+    @Test
+    public void testGetOrientation_allLtrTargetIsLtr_Ltr() {
+        setupAllLtrProject();
+        ComponentOrientation orientation = BiDiUtils.getOrientation(BiDiUtils.ORIENTATION.ALL_LTR);
+        assertEquals(ComponentOrientation.LEFT_TO_RIGHT, orientation);
+    }
+
+    @Test
+    public void testGetOrientation_allRtlTargetIsRtl_Rtl() {
+        setupAllRtlProject();
+        ComponentOrientation orientation = BiDiUtils.getOrientation(BiDiUtils.ORIENTATION.ALL_RTL);
+        assertEquals(ComponentOrientation.RIGHT_TO_LEFT, orientation);
+    }
+
+    @Test
+    public void testAddRtlBidiAround() {
+        String input = "everything";
+        String output = BiDiUtils.addRtlBidiAround(input);
+        assertEquals("\u202beverything\u202c", output);
+    }
+
+    @Test
+    public void testAddLtrBidiAround() {
+        String input = "everything";
+        String output = BiDiUtils.addLtrBidiAround(input);
+        assertEquals("\u202aeverything\u202c", output);
+    }
+
+    @Test
+    public void testIsSourceLangRtl_RtlSource_true() {
+        setupRtlToLtrProject();
+        assertTrue(BiDiUtils.isSourceLangRtl());
+    }
+
+    @Test
+    public void testIsSourceLangRtl_LtrSource_false() {
+        setupLtrToRtlProject();
+        assertFalse(BiDiUtils.isSourceLangRtl());
+    }
+
+    @Test
+    public void testIsTargetLangRtl_RtlTarget_true() {
+        setupLtrToRtlProject();
+        assertTrue(BiDiUtils.isTargetLangRtl());
+    }
+
+    @Test
+    public void testIsTargetLangRtl_LtrTarget_false() {
+        setupRtlToLtrProject();
+        assertFalse(BiDiUtils.isTargetLangRtl());
+    }
+
+    @Test
+    public void testIsLocaleRtl_RtlLocale_true() {
+        Locale.setDefault(RTL_LOCALE);
+        assertTrue(BiDiUtils.isLocaleRtl());
+    }
+
+    @Test
+    public void testIsLocaleRtl_LtrLocale_false() {
+        Locale.setDefault(LTR_LOCALE);
+        assertFalse(BiDiUtils.isLocaleRtl());
+    }
+
+    @Test
+    public void testIsRtl_RtlLocale_true() {
+        assertTrue(BiDiUtils.isRtl(RTL_LANGUAGE.getLanguage()));
+    }
+
+    @Test
+    public void testIsRtl_LtrLocale_false() {
+        assertFalse(BiDiUtils.isRtl(LTR_LANGUAGE.getLanguage()));
+    }
+
+    @Test
+    public void testIsMixedOrientationProject_orientationAllLtr_false() {
+        Locale.setDefault(LTR_LOCALE);
+        setupProjectNotLoaded();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_LTR, BiDiUtils.getOrientationType());
+        assertFalse(BiDiUtils.isMixedOrientationProject());
+    }
+
+    @Test
+    public void testIsMixedOrientationProject_orientationAllRtl_false() {
+        Locale.setDefault(RTL_LOCALE);
+        setupProjectNotLoaded();
+        assertEquals(BiDiUtils.ORIENTATION.ALL_RTL, BiDiUtils.getOrientationType());
+        assertFalse(BiDiUtils.isMixedOrientationProject());
+    }
+
+    @Test
+    public void testIsMixedOrientationProject_orientationDiffer_true() {
+        Locale.setDefault(RTL_LOCALE);
+        setupAllLtrProject();
+        assertEquals(BiDiUtils.ORIENTATION.DIFFER, BiDiUtils.getOrientationType());
+        assertTrue(BiDiUtils.isMixedOrientationProject());
+    }
+
+    // Helper methods
+
+    private void setupAllLtrProject() {
+        setupProject(LTR_LANGUAGE, LTR_LANGUAGE);
+    }
+
+    private void setupAllRtlProject() {
+        setupProject(RTL_LANGUAGE, RTL_LANGUAGE);
+    }
+
+    private void setupRtlToLtrProject() {
+        setupProject(RTL_LANGUAGE, LTR_LANGUAGE);
+    }
+
+    private void setupLtrToRtlProject() {
+        setupProject(LTR_LANGUAGE, RTL_LANGUAGE);
+    }
+
+    private void setupProject(Language sourceLanguage, Language targetLanguage) {
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return true;
+            }
+
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return new ProjectProperties() {
+                    @Override
+                    public Language getSourceLanguage() {
+                        return sourceLanguage;
+                    }
+
+                    @Override
+                    public Language getTargetLanguage() {
+                        return targetLanguage;
+                    }
+                };
+            }
+        });
+    }
+
+    private void setupProjectNotLoaded() {
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return false;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Form #519 to be cleaner commits.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->
-  Incorrect display of RTL segments in the Fuzzy Matches pane
- https://sourceforge.net/p/omegat/bugs/558/

## What does this PR change?

- Introduce BiDiUtils utility class, gathering all BiDi things
- Add test for MatchesVarExpansion and then extend it to support RtL
- refactor Document3.ORIENTATION enum in BiDiUtils.ORIENTATION
- refactor to remove ORIENTATION from return value of internal API
- Set LtR/RtL properly on editor and another panes
- refactor Langauge#isRTL Language#localeIsRTL to move into BiDiUtils
- All commits author @damien-rembert 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
