### PR TITLE
[RFE#1690] Have "Commit Target Files" also commit statistics file

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------
  OmegaT 6.1.0
 ----------------------------------------------------------------------
-  14 Enhancement
+  15 Enhancement
   21 Bug fixes
 ----------------------------------------------------------------------
 6.1.0 vs 6.0.0
@@ -22,6 +22,9 @@
 
   - Generate JSON format stastics file when save
   https://sourceforge.net/p/omegat/feature-requests/1695/
+
+  - Generate and compile TXT and JSON file when committing target files
+  https://sourceforge.net/p/omegat/feature-requests/1690/
 
   - Build System: update gradle verison to 7.5.1
   https://sourceforge.net/p/omegat/feature-requests/1691/

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -722,6 +722,7 @@ public class RealProject implements IProject {
             stat.updateStatisticsInfo(hotStat);
             String fn = config.getProjectInternal() + OConsts.STATS_FILENAME;
             Statistics.writeStat(fn, stat.getTextData());
+            Statistics.writeStat(fn.replace(".txt",".json"), stat.getJsonData());
             // commit translations and statistics
             try {
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_TARGET_START");
@@ -735,6 +736,7 @@ public class RealProject implements IProject {
                 path.setRelativeOrAbsolute(fn);
                 fn = path.getUnderRoot();
                 remoteRepositoryProvider.copyFilesFromProjectToRepos(fn,null);
+                remoteRepositoryProvider.copyFilesFromProjectToRepos(fn.replace(".txt",".json"),null);
                 remoteRepositoryProvider.commitFiles(fn, "Statistics");
                 Core.getMainWindow().showStatusMessageRB("TF_COMMIT_TARGET_DONE");
             } catch (Exception e) {


### PR DESCRIPTION
When we call "commit target files", whenever from console or UI, the TXT and JSON statistics files are re-generated and if you are in a team project, the JSON is also sent to the repository

For explanation about the reason:
https://sourceforge.net/p/omegat/mailman/message/37780726/

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

https://sourceforge.net/p/omegat/feature-requests/1690/
