### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for the OmegaT project
+
+/src/org/omegat/Bundle.properties    @kazephil
+/src/org/omegat/Bundle_*.properties  @kosivantsov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Code owners for the OmegaT project
 
-/src/org/omegat/Bundle.properties    @kazephil
-/src/org/omegat/Bundle_*.properties  @kosivantsov
+/src/org/omegat/Bundle*.properties    @kazephil @brandelune @kosivantsov


### PR DESCRIPTION
@Kazephil is responsible for the English UI strings, and @kosivantsov for the translations (but that should be handled in the https://github.com/OmegaT-L10N/ repos)

Maybe we can add @brandelune for the `docs/`?

close #696
