### PR TITLE
docs_devel: update Integration-test procedure

### DIFF
--- a/docs_devel/docs/34.IntegrationTest.md
+++ b/docs_devel/docs/34.IntegrationTest.md
@@ -73,16 +73,27 @@ then you can run with default settings
 docker-compose -f docker-compose.yml up
 ```
 
-You can stop integration test processes by pressing Ctrl-C key.
+You can stop integration test processes by pressing Ctrl-C key or command.
+
+```console
+docker-compose -f docker-compose.yml down
+```
+
+We can omit `-f` option because a default script filename is `docker-compose.yml`
+
+```console
+docker-compose up
+docker-compose down
+```
 
 The Default duration of execution is 4200 second (= 40 min.)
 When you want to specify duration, you can set environment variable
 and give the docker-compose option to stop servers after test finished.
 
 ```console
-env DURATION=600 \
-  docker-compose -f docker-compose.yml up \
-    --abort-on-container-exit
+env DURATION=600 docker-compose -f docker-compose.yml up \
+    --abort-on-container-exit 
+docker-compose down
 ```
 
 This case specifies duration as 10 min. and will exit all three containers when 
@@ -98,15 +109,23 @@ env DURATION=600 \
     --abort-on-container-exit --exit-code-from client
 ```
 
+When using `--abort-on-container-exit` option, server container will become
+a dirty status that abort server processes, which cause error when next run.
+It is recommended to use `docker-compose down` to remove aborted container.
+
 ### check logs
 
-You can check the execution log with docker-compose command.
+You can check the execution log with docker-compose command after execution.
 
 ```console
-docker-compose -f docker-compose.yml logs client
+docker-compose logs client
 ```
 
-When you want to monitor log, you can add `-f` option.
+When you want to monitor log, you can add `-f` option for `logs` command.
+
+```console
+docker-compose logs -f client
+```
 
 ### Stop test setup
 
@@ -116,7 +135,7 @@ You can also stop test setup and remove image from another shell.
 docker-compose -f docker-compose.yml stop
 ```
 
-This stops container execution and you can see logs afterword.
+This stops container execution, and you can see logs afterword.
 This is as same as enter Ctrl-C key in executed shell.
 
 ### Cleanup resources
@@ -132,34 +151,31 @@ This cleans up container resources.
 
 ### repository type
 
-When "TYPE" environment variable is set to "GIT", it tests ssh+git configuration
+When "TYPE" environment variable is set to "GIT", it tests https and ssh+git protocols
 with a mapping configuration with http repository for source data. 
 
-When set it to "SVN", it tests with "http://svn-server/svn/trunk/repo.svn" setup
-with a mapping configuration with http repository for source data.
-
-When set it to "SSH", it tests with "svn+ssh://svn-server/svn/repo.svn" setup
+When set it to "SVN", it tests with https and ssh+svn protocols
 with a mapping configuration with http repository for source data.
 
 When "TYPE" is not set or other than above, it tests with "GIT" configuration as default. 
 
 ```console
-env DURATION=2400 TYPE=GIT \
-  docker-compose -f docker-compose.yml up \
-    --abort-on-container-exit --exit-code-from client
+env DURATION=2400 TYPE=GIT docker-compose up
 ```
 
 ```console
-env DURATION=2400 TYPE=SVN \
-  docker-compose -f docker-compose.yml up \
-    --abort-on-container-exit --exit-code-from client
+env DURATION=2400 TYPE=SVN docker-compose up
 ```
 
+### runner shell script
+
+For your convenience, we have a runner script `test-integration/runner.sh`.
+you can run it like
+
 ```console
-env DURATION=2400 TYPE=SSH \
-  docker-compose -f docker-compose.yml up \
-    --abort-on-container-exit --exit-code-from client
+test-integration/runner.sh GIT 1200
 ```
+
 
 ## Manual execution
 

--- a/test-integration/runner.sh
+++ b/test-integration/runner.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+#  OmegaT - Computer Assisted Translation (CAT) tool
+#           with fuzzy matching, translation memory, keyword search,
+#           glossaries, and translation leveraging into updated projects.
+#
+#  Copyright (C) 2023 Hiroshi Miura
+#                Home page: https://www.omegat.org/
+#                Support center: https://omegat.org/support
+#
+#  This file is part of OmegaT.
+#
+#  OmegaT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  OmegaT is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+if [ "$#" -ne 2 ]; then
+  echo "Illegal number of arguments. Please run with arguments" >&2
+  echo "$0 (GIT|SVN) DURATION " >&2
+  exit 2
+fi
+
+# should run on the project root directory
+SHELL_PATH=`dirname "$0"`
+cd $SHELL_PATH && cd ..
+
+EXIT_CODE=0
+env DURATION=$2 TYPE=$1 docker-compose -f docker-compose.yml up --abort-on-container-exit --exit-code-from client || EXIT_CODE=$?
+docker-compose -f docker-compose.yml down
+exit ${EXIT_CODE}


### PR DESCRIPTION
Integration test sometimes become failed with server error.
It is because a test procedure is not good to clean up after test.

A proposal here change a developer manual to do clean it after the test done.
Also I add a helper script to help developer to do it with one liner.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Documentation -> [documentation]

## Which ticket is resolved?


- Integration test(docker) failure with 503
   * https://sourceforge.net/p/omegat/bugs/1199/
   

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
