### PR TITLE
docs: Expand on machine translation explanation (6.0)

### DIFF
--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -31,8 +31,8 @@
 		  </listitem>
 		</itemizedlist>
 
-		<para>Allows you to activate or deactivate the available machine
-		translation engines.</para>
+        <para>Allows you to activate or deactivate enabled and properly configured
+          machine translation engines.</para>
 
         <para>If several translation engines are selected, you can also use
         <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo> to switch

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -913,9 +913,10 @@ Folder = <token>Dossier</token></programlisting>
     <title id="panes.machinetranslation.title"><guilabel>Machine
     Translations</guilabel></title>
 
-    <para>This pane, when opened, shows the suggestions
-    for the current segment produced by each enabled translation
-    engine . When suggestions from more than one engine are available,</para>
+    <para>If you have enabled and configured at least one machine translation
+      engine this pane shows the suggestions for the current segment produced
+      by the available engines. When suggestions from more than one translation
+      engine are available,</para>
 	
     <itemizedlist>
       <listitem>

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -85,8 +85,8 @@
         fetch translations</option></term>
 
 				<listitem>
-					<para>Enable this option to fetch machine translations from the providers
-						you have enabled and configured automatically. If you leave this option
+					<para>Enable this option to automatically fetch machine translations from
+						the providers you have enabled and configured. If you leave this option
 						disabled, machine translations are only fetched when you use <link
 						linkend="menus.edit" endterm="menus.edit.title"/>
 						<link linkend="menus.edit.replace.with.mt"

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -84,14 +84,16 @@
 			id="dialogs.preferences.mt.automatically.fetch.translations.title"><option>Automatically
         fetch translations</option></term>
 
-        <listitem>
-          <para>If you disable this option, machine translations will only be
-          fetched when you use <link linkend="menus.edit"
-          endterm="menus.edit.title"/><link linkend="menus.edit.replace.with.mt"
-          endterm="menus.edit.replace.with.mt.title"/> in the current
-          segment. You will then have to press that combination again to insert
-          the suggestion.</para>
-        </listitem>
+				<listitem>
+					<para>Enable this option to fetch machine translations from the providers
+						you have enabled and configured automatically. If you leave this option
+						disabled, machine translations are only fetched when you use <link
+						linkend="menus.edit" endterm="menus.edit.title"/>
+						<link linkend="menus.edit.replace.with.mt"
+						endterm="menus.edit.replace.with.mt.title"/> in the current
+						segment. You then have to press that combination again to insert
+						the suggestion.</para>
+				</listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.untranslated.segments.only">


### PR DESCRIPTION
Here's the PR covering the backport to 6.0

Which ticket is resolved?

Machine translation activation
https://sourceforge.net/p/omegat/documentation/413/
What does this PR change?

Expand and clarify the explanations concerning machine translation in the manual.