### PR TITLE
chore(gradle): use lucene-gosen-6 for langaugetool-ja

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,13 +211,9 @@ dependencies {
         }
         // Explicitly specify guava dependency for `jre` version rather than `-android`
         implementation 'com.google.guava:guava:31.0.1-jre'
-        runtimeOnly("org.languagetool:language-all:${languageToolVersion}") {
-            // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen'
-        }
-        // alternative use of v5.0.0
-        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0'
-        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0:ipadic'
+        runtimeOnly("org.languagetool:language-all:${languageToolVersion}")
+        // see discussion on https://sourceforge.net/p/omegat/bugs/814/
+        // about a dependency issue on language-ja
 
         // Lucene for tokenizers
         implementation "org.apache.lucene:lucene-core:${luceneVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -213,8 +213,10 @@ dependencies {
         implementation 'com.google.guava:guava:31.0.1-jre'
         runtimeOnly("org.languagetool:language-all:${languageToolVersion}") {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen-ipadic'
+            exclude module: 'lucene-gosen'
         }
+        // alternative use of v5.0.0
+        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0'
         runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0:ipadic'
 
         // Lucene for tokenizers


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- LanguageTool6  lucene-gosen-ipadic from omegat project  is incompatible
    *  https://sourceforge.net/p/omegat/bugs/1204/

- LanguageTool lucene-gosen-ipadic is incompatible with Lucene 5
   * https://sourceforge.net/p/omegat/bugs/814/

## What does this PR change?

- Revert workaround for bugs#814

## Other information

Error message:

```
47837: Erreur: java.lang.NoSuchMethodError: 'net.java.sen.StringTagger net.java.sen.SenFactory.getStringTagger(java.lang.String, boolean)'
47837: Erreur: 	at org.languagetool.tokenizers.ja.JapaneseWordTokenizer.<init>(JapaneseWordTokenizer.java:34)
47837: Erreur: 	at org.languagetool.language.Japanese.createDefaultWordTokenizer(Japanese.java:76)
47837: Erreur: 	at org.languagetool.Language.getWordTokenizer(Language.java:452)
47837: Erreur: 	at org.languagetool.JLanguageTool.getRawAnalyzedSentence(JLanguageTool.java:1567)
47837: Erreur: 	at org.languagetool.JLanguageTool.getAnalyzedSentence(JLanguageTool.java:1536)
47837: Erreur: 	at org.languagetool.tools.Tools.checkBitext(Tools.java:67)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolNativeBridge.getRuleMatches(LanguageToolNativeBridge.java:117)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolNativeBridge.getCheckResultsImpl(LanguageToolNativeBridge.java:101)
47837: Erreur: 	at org.omegat.languagetools.BaseLanguageToolBridge.getCheckResults(BaseLanguageToolBridge.java:59)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolWrapper$LanguageToolMarker.getMarksForEntry(LanguageToolWrapper.java:143)
47837: Erreur: 	at org.omegat.gui.editor.mark.CalcMarkersThread.run(CalcMarkersThread.java:116)
47837: Erreur: java.lang.NoSuchMethodError: 'net.java.sen.StringTagger net.java.sen.SenFactory.getStringTagger(java.lang.String, boolean)'
47837: Erreur: 	at org.languagetool.tokenizers.ja.JapaneseWordTokenizer.<init>(JapaneseWordTokenizer.java:34)
47837: Erreur: 	at org.languagetool.language.Japanese.createDefaultWordTokenizer(Japanese.java:76)
47837: Erreur: 	at org.languagetool.Language.getWordTokenizer(Language.java:452)
47837: Erreur: 	at org.languagetool.JLanguageTool.getRawAnalyzedSentence(JLanguageTool.java:1567)
47837: Erreur: 	at org.languagetool.JLanguageTool.getAnalyzedSentence(JLanguageTool.java:1536)
47837: Erreur: 	at org.languagetool.tools.Tools.checkBitext(Tools.java:67)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolNativeBridge.getRuleMatches(LanguageToolNativeBridge.java:117)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolNativeBridge.getCheckResultsImpl(LanguageToolNativeBridge.java:101)
47837: Erreur: 	at org.omegat.languagetools.BaseLanguageToolBridge.getCheckResults(BaseLanguageToolBridge.java:59)
47837: Erreur: 	at org.omegat.languagetools.LanguageToolWrapper$LanguageToolMarker.getMarksForEntry(LanguageToolWrapper.java:143)
47837: Erreur: 	at org.omegat.gui.editor.MarkerController.reprocessImmediately(MarkerController.java:212)
47837: Erreur: 	at org.omegat.gui.editor.EditorController.activateEntry(EditorController.java:838)
47837: Erreur: 	at org.omegat.gui.editor.EditorController.gotoEntry(EditorController.java:1559)
47837: Erreur: 	at org.omegat.gui.editor.EditorController.gotoEntry(EditorController.java:1511)
47837: Erreur: 	at org.omegat.gui.editor.EditorController.lambda$updateState$7(EditorController.java:465)
47837: Erreur: 	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
47837: Erreur: 	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
47837: Erreur: 	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
47837: Erreur: 	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
47837: Erreur: 	at java.base/java.security.AccessController.doPrivileged(Native Method)
47837: Erreur: 	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
47837: Erreur: 	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
47837: Erreur: 	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
47837: Erreur: java.lang.NoSuchMethodError: 'net.java.sen.StringTagger net.java.sen.SenFactory.getStringTagger(java.lang.String, boolean)'

```

