### PR TITLE
[BUGS#1204] fix: dependencies `lucene-gosen:5.5.1:ipadic`  based on `Lucene/Solr-5.5.5` and `LanguageTool-6.1`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ sourceSets {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 configurations {
@@ -215,7 +216,7 @@ dependencies {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
             exclude module: 'lucene-gosen-ipadic'
         }
-        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.0.0:ipadic'
+        runtimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneVersion}-SNAPSHOT"
 
         // Lucene for tokenizers
         implementation "org.apache.lucene:lucene-core:${luceneVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,8 @@ sourceSets {
 
 repositories {
     mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
+    mavenLocal()
+    // maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 configurations {
@@ -155,6 +156,7 @@ ext {
     providedLibsDir = file('lib/provided')
     languageToolVersion = '6.1'
     luceneVersion = '5.5.5'
+    luceneGosenVersion = '5.5.5-SNAPSHOT'
     jgitVersion = '6.6.0.202305301015-r'
 }
 
@@ -216,7 +218,7 @@ dependencies {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
             exclude module: 'lucene-gosen-ipadic'
         }
-        runtimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneVersion}-SNAPSHOT"
+        runtimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneGosenVersion}"
 
         // Lucene for tokenizers
         implementation "org.apache.lucene:lucene-core:${luceneVersion}"
@@ -306,6 +308,11 @@ dependencies {
     ['be', 'en', 'fr'].each {
         testImplementation "org.languagetool:language-${it}:${languageToolVersion}"
     }
+    testImplementation("org.languagetool:language-ja:${languageToolVersion}") {
+        // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
+        exclude module: 'lucene-gosen-ipadic'
+    }
+    testRuntimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneGosenVersion}"
     testRuntimeOnly "org.languagetool:language-pl:${languageToolVersion}"
     testRuntimeOnly "org.slf4j:slf4j-jdk14:1.7.32"
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,20 @@ allprojects {
             removeUnusedImports()
         }
     }
+
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
+    }
+}
+
+subprojects {
+    // All subproject dpenends on main project.
+    dependencies {
+        compileOnly(project.rootProject)
+        testImplementation(testFixtures(project.rootProject))
+    }
 }
 
 sourceSets {
@@ -137,12 +151,6 @@ sourceSets {
             srcDir 'test-integration/src'
         }
     }
-}
-
-repositories {
-    mavenCentral()
-    mavenLocal()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ sourceSets {
 repositories {
     mavenCentral()
     mavenLocal()
-    // maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ allprojects {
     repositories {
         mavenCentral()
         mavenLocal()
+        // Sonatype OSSRH snapshots
         maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
     }
 }
@@ -164,7 +165,7 @@ ext {
     providedLibsDir = file('lib/provided')
     languageToolVersion = '6.1'
     luceneVersion = '5.5.5'
-    luceneGosenVersion = '5.5.5-SNAPSHOT'
+    luceneGosenVersion = '5.5.1'
     jgitVersion = '6.6.0.202305301015-r'
 }
 
@@ -224,9 +225,9 @@ dependencies {
         implementation 'com.google.guava:guava:31.0.1-jre'
         runtimeOnly("org.languagetool:language-all:${languageToolVersion}") {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen-ipadic'
+            exclude module: 'lucene-gosen'
         }
-        runtimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneGosenVersion}"
+        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.5.1:ipadic'
 
         // Lucene for tokenizers
         implementation "org.apache.lucene:lucene-core:${luceneVersion}"
@@ -318,9 +319,9 @@ dependencies {
     }
     testImplementation("org.languagetool:language-ja:${languageToolVersion}") {
         // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-        exclude module: 'lucene-gosen-ipadic'
+        exclude module: 'lucene-gosen'
     }
-    testRuntimeOnly "org.omegat.lucene:lucene-gosen-ipadic:${luceneGosenVersion}"
+    testRuntimeOnly "org.omegat.lucene:lucene-gosen:${luceneGosenVersion}:ipadic"
     testRuntimeOnly "org.languagetool:language-pl:${languageToolVersion}"
     testRuntimeOnly "org.slf4j:slf4j-jdk14:1.7.32"
 

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -6,27 +6,18 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -6,27 +6,18 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/deepl/build.gradle
+++ b/machinetranslators/deepl/build.gradle
@@ -8,10 +8,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
-    compileOnly(project.rootProject)
     // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
         compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')

--- a/machinetranslators/deepl/build.gradle
+++ b/machinetranslators/deepl/build.gradle
@@ -6,26 +6,18 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -6,27 +6,18 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -6,14 +6,7 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
         compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
     } else {
@@ -22,11 +15,9 @@ dependencies {
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -6,27 +6,19 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
 
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -6,27 +6,18 @@ plugins {
     id 'java-library'
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
     } else {
         compileOnly 'commons-io:commons-io:2.11.0'
         compileOnly 'org.apache.commons:commons-text:1.9'
         // JSON parser
         compileOnly "com.fasterxml.jackson.core:jackson-core:2.13.4"
         compileOnly "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
+        testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
+        testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     }
-    // Test dependencies
-    testImplementation(testFixtures(project.rootProject))
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.13.4"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
 }
 
 jar {

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -61,6 +61,9 @@
 
   Bug fixes:
 
+  - Incompatible among LanguageTool@6 and lucene-gosen@5 from omegat-org
+  https://sourceforge.net/p/omegat/bugs/1204/
+
   - Content of notes elements are not displayed correctly with Xliff filter
   https://sourceforge.net/p/omegat/bugs/1192/
 

--- a/test/src/org/omegat/languagetools/LuceneGosenCompatibilityTest.java
+++ b/test/src/org/omegat/languagetools/LuceneGosenCompatibilityTest.java
@@ -1,0 +1,64 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.omegat.languagetools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import net.java.sen.SenFactory;
+import net.java.sen.StringTagger;
+
+import org.junit.Test;
+
+import org.languagetool.JLanguageTool;
+import org.languagetool.language.Japanese;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.patterns.PatternRule;
+
+public class LuceneGosenCompatibilityTest {
+
+    /**
+     * Regression test for bugs#1204.
+     * https://sourceforge.net/p/omegat/bugs/1204/
+     */
+    @Test
+    public void testLuceneGosenGetStringTagger6() {
+        StringTagger stringTagger = SenFactory.getStringTagger(null, false);
+        assertNotNull(stringTagger);
+    }
+
+    @Test
+    public void testJapanese() throws Exception {
+        JLanguageTool lt = new JLanguageTool(new Japanese());
+        List<RuleMatch> matches = lt.check("そんじゃそこらのやつらとは違う");
+        assertEquals(1, matches.size());
+        assertTrue(matches.get(0).getRule() instanceof PatternRule);
+        assertEquals("SONJASOKORA", matches.get(0).getSpecificRuleId());
+    }
+}

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -16,16 +16,9 @@ sourceSets {
     }
 }
 
-repositories {
-    mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-}
-
 dependencies {
-    compileOnly(project.rootProject)
-    // Libs are provided in the "source" distribution only
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/*.jar')
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/tipoftheday-*.jar', '**/jackson*.jar'])
     } else {
         // runtime dependencies should be in main project
         compileOnly "tokyo.northside:tipoftheday:0.4.1"

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -18,6 +18,7 @@ sourceSets {
 
 repositories {
     mavenCentral()
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {


### PR DESCRIPTION
languagetool-ja uses (potentially) incompatible  lucene-gosen-ipadic@6.2.1 against lucene-5.5.5
OmegaT forked and published lucene-gosen-ipadic@5.0.0 but languagetool-ja uses incompatible method.

OmegaT project update lucene-gosen to compile with lucene 5.5.5 and add work around for languagetool-ja@6.1 change, and publish to maven central.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- LanguageTool6 lucene-gosen-ipadic from omegat project is incompatible
    - https://sourceforge.net/p/omegat/bugs/1204/ 

## What does this PR change?

- fork, modify and publish `org.omegat.lucene:lucene-gosen:5.5.1:ipadic` from https://github.com/omegat-org/lucene-gosen
- add unit tests for regression check and compatibility check

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
