### PR TITLE
[BUGS#1206] fix: google2 MT to ignore model property

### DIFF
--- a/machinetranslators/google/src/main/java/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/machinetranslators/google/src/main/java/org/omegat/core/machinetranslators/Google2Translate.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 
 import javax.swing.JCheckBox;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.omegat.core.Core;
@@ -309,6 +310,7 @@ public class Google2Translate extends BaseCachedTranslate {
     /**
      * Data schema class.
      */
+    @JsonIgnoreProperties({"model"})
     public static final class Translation {
         private String translatedText;
         private String detectedSourceLanguage;

--- a/machinetranslators/google/src/main/java/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/machinetranslators/google/src/main/java/org/omegat/core/machinetranslators/Google2Translate.java
@@ -36,7 +36,6 @@ import java.util.TreeMap;
 
 import javax.swing.JCheckBox;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.omegat.core.Core;
@@ -310,10 +309,10 @@ public class Google2Translate extends BaseCachedTranslate {
     /**
      * Data schema class.
      */
-    @JsonIgnoreProperties({"model"})
     public static final class Translation {
         private String translatedText;
         private String detectedSourceLanguage;
+        private String model;
 
         public String getTranslatedText() {
             return translatedText;
@@ -331,10 +330,21 @@ public class Google2Translate extends BaseCachedTranslate {
             this.detectedSourceLanguage = detectedSourceLanguage;
         }
 
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(final String model) {
+            this.model = model;
+        }
+
         @Override
         public String toString() {
-            return "Translation{translatedText='" + translatedText + "', detectedSourceLanguage='"
-                    + detectedSourceLanguage + "'}";
+            return "Translation{" +
+                    "translatedText='" + translatedText + '\'' +
+                    ", detectedSourceLanguage='" + detectedSourceLanguage + '\'' +
+                    ", model='" + model + '\'' +
+                    '}';
         }
     }
 }

--- a/machinetranslators/google/src/test/java/org/omegat/core/machinetranslators/Google2TranslateTest.java
+++ b/machinetranslators/google/src/test/java/org/omegat/core/machinetranslators/Google2TranslateTest.java
@@ -52,11 +52,29 @@ public class Google2TranslateTest extends TestCore {
             + "  }\n"
             + "}";
 
+    private static final String JSON2 = "{\n"
+            + "  \"data\": {\n"
+            + "     \"translations\": [{\n"
+            + "        \"translatedText\": \"Hallo Welt\",\n"
+            + "        \"detectedSourceLanguage\": \"en\",\n"
+            + "        \"model\": \"projects/PROJECT_NUMBER/locations/LOCATION/models/123\"\n"
+            + "     }]\n"
+            + "   }\n"
+            + "}";
+
     @Test
     public void testGetJsonResults() throws MachineTranslateError {
         Preferences.setPreference(Preferences.ALLOW_GOOGLE2_TRANSLATE, true);
         Google2Translate google2Translate = new Google2Translate();
         String translation = google2Translate.getJsonResults(json);
+        assertEquals("Hallo Welt", translation);
+    }
+
+    @Test
+    public void testGetJson2Results() throws MachineTranslateError {
+        Preferences.setPreference(Preferences.ALLOW_GOOGLE2_TRANSLATE, true);
+        Google2Translate google2Translate = new Google2Translate();
+        String translation = google2Translate.getJsonResults(JSON2);
         assertEquals("Hallo Welt", translation);
     }
 

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -61,6 +61,9 @@
 
   Bug fixes:
 
+  - Google2 Translate MT connector failed to parse response
+  https://sourceforge.net/p/omegat/bugs/1206/
+
   - Integration test(docker) failure with 503
   https://sourceforge.net/p/omegat/bugs/1199/
 


### PR DESCRIPTION
Google translate v2 api may return response with a model field. OmegaT google2 MT connector has a definition that miss the model field.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Google2 Translate MT connector failed to parse response
    - https://sourceforge.net/p/omegat/bugs/1206/

Dev ML post
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/f5c71c67-4cef-0044-735d-f469240aaa8e%40marcprior.de/#msg37874311

## What does this PR change?

- define field "model" in parser

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
