### PR TITLE
[6.0] fix: google2 MT to ignore model property

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,13 +2,16 @@
  OmegaT 6.0.1
 ----------------------------------------------------------------------
   0 Enhancement
-  1 Bug fixes
+  3 Bug fixes
 ----------------------------------------------------------------------
 
   Bug fixes:
 
-  - Dictionary displays apostrophe as html entitty code
-  https://sourceforge.net/p/omegat/bugs/1181
+  - Google2 MT connector failed to parse response
+  https://sourceforge.net/p/omegat/bugs/1206/
+
+  - Dictionary displays apostrophe as html entity code
+  https://sourceforge.net/p/omegat/bugs/1181/
 
   - Content of notes elements are not displayed correctly with Xliff filter
   https://sourceforge.net/p/omegat/bugs/1192/

--- a/src/org/omegat/core/machinetranslators/Google2Translate.java
+++ b/src/org/omegat/core/machinetranslators/Google2Translate.java
@@ -37,6 +37,7 @@ import java.util.TreeMap;
 
 import javax.swing.JCheckBox;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.omegat.gui.exttrans.MTConfigDialog;
@@ -277,6 +278,7 @@ public class Google2Translate extends BaseCachedTranslate {
     /**
      * Data schema class.
      */
+    @JsonIgnoreProperties({"model"})
     public static final class Translation {
         private String translatedText;
         private String detectedSourceLanguage;


### PR DESCRIPTION
Google translate v2 api may return a model field.
OmegaT google2 MT connector ignore it for quick fix.


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Google2 MT connector failed to parse response
  * https://sourceforge.net/p/omegat/bugs/1206/

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Backport #711
- Ignore "model" property in response json.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
