### PR TITLE
chore: Update documentation fuzzy match navigation.

### DIFF
--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -340,12 +340,14 @@
 		<itemizedlist>
 		  <listitem>
 			<para><guimenuitem>Select Previous Match</guimenuitem>
-			<keycombo><keycap>C</keycap><keycap>↑</keycap></keycombo></para>
+			<keycombo><keycap>C</keycap><keycap>↑</keycap></keycombo>
+			(<keycombo><keycap>A</keycap><keycap>↑</keycap></keycombo> on mac OS)</para>
 		  </listitem>
 
 		  <listitem>
 			<para><guimenuitem>Select Next Match</guimenuitem>
-			<keycombo><keycap>C</keycap><keycap>↓</keycap></keycombo></para>
+			<keycombo><keycap>C</keycap><keycap>↓</keycap></keycombo>
+			(<keycombo><keycap>A</keycap><keycap>↓</keycap></keycombo> on macOS)</para>
 		  </listitem>
 
 		  <listitem>

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -340,12 +340,12 @@
 		<itemizedlist>
 		  <listitem>
 			<para><guimenuitem>Select Previous Match</guimenuitem>
-			<keycombo><keycap>A</keycap><keycap>↑</keycap></keycombo></para>
+			<keycombo><keycap>C</keycap><keycap>↑</keycap></keycombo></para>
 		  </listitem>
 
 		  <listitem>
 			<para><guimenuitem>Select Next Match</guimenuitem>
-			<keycombo><keycap>A</keycap><keycap>↓</keycap></keycombo></para>
+			<keycombo><keycap>C</keycap><keycap>↓</keycap></keycombo></para>
 		  </listitem>
 
 		  <listitem>

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -731,7 +731,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     highest match percentage) is automatically selected. You can press
     <keycombo><keycap>C</keycap><keycap>2, 3, 4, or 5</keycap>
     </keycombo> to select a specific match, or cycle through the available matches with
-    <keycombo><keycap>C</keycap><keycap>up or down arrow</keycap></keycombo>. Alternatively, you can use
+    <keycombo><keycap>C</keycap><keycap>↑ or ↓</keycap></keycombo>. Alternatively, you can use
     <link linkend="menus.edit" endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
     endterm="menus.edit.select.match.title"/> to select a different match.</para>
 

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -731,9 +731,11 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     highest match percentage) is automatically selected. You can press
     <keycombo><keycap>C</keycap><keycap>2, 3, 4, or 5</keycap>
     </keycombo> to select a specific match, or cycle through the available matches with
-    <keycombo><keycap>C</keycap><keycap>↑ or ↓</keycap></keycombo>. Alternatively, you can use
-    <link linkend="menus.edit" endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
-    endterm="menus.edit.select.match.title"/> to select a different match.</para>
+    <keycombo><keycap>C</keycap><keycap>↑ or ↓</keycap></keycombo>
+    (<keycombo><keycap>A</keycap><keycap>↑ or ↓</keycap></keycombo> on macOS).
+    Alternatively, you can use <link linkend="menus.edit" endterm="menus.edit.title"/>
+    <link linkend="menus.edit.select.match" endterm="menus.edit.select.match.title"/>
+    to select a different match.</para>
 
 	<example id="the.first.match">
 	  <title id="the.first.match.title">An empty segment and its first two matches</title>

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -731,7 +731,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     highest match percentage) is automatically selected. You can press
     <keycombo><keycap>C</keycap><keycap>2, 3, 4, or 5</keycap>
     </keycombo> to select a specific match, or cycle through the available matches with
-    <keycombo><keycap>C</keycap>up or down arrow</keycombo>. Alternatively, you can use
+    <keycombo><keycap>C</keycap><keycap>up or down arrow</keycap></keycombo>. Alternatively, you can use
     <link linkend="menus.edit" endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
     endterm="menus.edit.select.match.title"/> to select a different match.</para>
 

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -730,10 +730,10 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     <para>When you enter a segment, the first fuzzy match (the one with the
     highest match percentage) is automatically selected. You can press
     <keycombo><keycap>C</keycap><keycap>2, 3, 4, or 5</keycap>
-    </keycombo>, or use <link linkend="menus.edit"
-    endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
-    endterm="menus.edit.select.match.title"/>, to select
-    a different match .</para>
+    </keycombo> to select a specific match, or cycle through the available matches with
+    <keycombo><keycap>C</keycap>up or down arrow</keycombo>. Alternatively, you can use
+    <link linkend="menus.edit" endterm="menus.edit.title"/><link linkend="menus.edit.select.match"
+    endterm="menus.edit.select.match.title"/> to select a different match.</para>
 
 	<example id="the.first.match">
 	  <title id="the.first.match.title">An empty segment and its first two matches</title>


### PR DESCRIPTION
- Add information on navigating between available fuzzy matches using the CTRL+up or down arrow keys.

- Fix the shortcut in the Edit menu description.