### PR TITLE
chore(integ-test): support nerdctl and custom logging.propeties

### DIFF
--- a/docs_devel/docs/34.IntegrationTest.md
+++ b/docs_devel/docs/34.IntegrationTest.md
@@ -191,9 +191,8 @@ you can easily operate it.
 For example,
 
 ```console
-env DURATION=2400 TYPE=SVN nerdctl compose up
-nerdctl compose logs
-nerdctl compose down 
+env DURATION=2400 TYPE=SVN sudo nerdctl compose up
+sudo nerdctl compose down 
 ```
 
 ### How to run with podman
@@ -206,8 +205,7 @@ See [Using Podman and Docker Compose](https://www.redhat.com/sysadmin/podman-doc
 ## runner shell script
 
 For your convenience, we have a runner script `test-integration/runner.sh`.
-The script automatically detect docker compose and nerdctl and
-use properly.
+The script automatically detect `docker-compose` or `nerdctl` for run.
 
 you can run it like
 

--- a/docs_devel/docs/34.IntegrationTest.md
+++ b/docs_devel/docs/34.IntegrationTest.md
@@ -35,7 +35,9 @@ git config gc.autodetach false
 git config receive.autogc false
 ```
 
-## Test with Docker and Docker Compose
+## Integration Test with container tools
+
+### Docker
 
 Docker and docker compose are popular to prepare a pragmatic test environment.
 You can find docker configurations `Dockerfile` in `test-integration/docker/`
@@ -57,7 +59,20 @@ The Server has FOUR individual contents.
 
 Repositories are independent among each other.
 
-### How to run
+### containerd, runc, buildkit and nerdctl
+
+There are alternative toolsets to support container operations.
+[Open Container Initiative](https://opencontainers.org/) creates open standard
+around container format and runtimes.
+
+OCI runtime spec v1.1 defines the behavior and the configuration interface of
+low-level container runtime such as runc. These container runtimes are called
+from high-level container runtimes such as containerd.
+
+[nerdctl](https://github.com/containerd/nerdctl) is a docker compatible CLI for
+containerd that also support `compose` subcommand.
+
+### How to run with docker-compose
 
 WARNING: You should operate all commands from project root directory.
 
@@ -113,7 +128,7 @@ When using `--abort-on-container-exit` option, server container will become
 a dirty status that abort server processes, which cause error when next run.
 It is recommended to use `docker-compose down` to remove aborted container.
 
-### check logs
+### check logs with compose
 
 You can check the execution log with docker-compose command after execution.
 
@@ -167,15 +182,38 @@ env DURATION=2400 TYPE=GIT docker-compose up
 env DURATION=2400 TYPE=SVN docker-compose up
 ```
 
-### runner shell script
+### How to run with nerdctl
+
+We currently support `rootful` mode of containerd only.
+Because `nerdctl` support similar syntax with Docker,
+you can easily operate it.
+
+For example,
+
+```console
+env DURATION=2400 TYPE=SVN nerdctl compose up
+nerdctl compose logs
+nerdctl compose down 
+```
+
+### How to run with podman
+
+Podman V3.0 support docker-compose through REST API.
+Please check Redhat manuals to enable REST API.
+See [Using Podman and Docker Compose](https://www.redhat.com/sysadmin/podman-docker-compose)
+
+
+## runner shell script
 
 For your convenience, we have a runner script `test-integration/runner.sh`.
+The script automatically detect docker compose and nerdctl and
+use properly.
+
 you can run it like
 
 ```console
 test-integration/runner.sh GIT 1200
 ```
-
 
 ## Manual execution
 

--- a/src/org/omegat/util/Log.java
+++ b/src/org/omegat/util/Log.java
@@ -60,13 +60,28 @@ public final class Log {
         LOGGER = Logger.getLogger("global");
 
         boolean loaded = false;
-        File usersLogSettings = new File(StaticUtils.getConfigDir(), "logger.properties");
-        if (usersLogSettings.isFile() && usersLogSettings.canRead()) {
+
+        String customLogConfig = System.getProperty("java.util.logging.config.file");
+        if (customLogConfig != null) {
+            File customLogSettings = new File(customLogConfig);
+            if (customLogSettings.isFile() && customLogSettings.canRead()) {
+                // try to load logger settings from custom file
+                try (InputStream in = new FileInputStream(customLogSettings)) {
+                    init(in);
+                    loaded = true;
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        if (!loaded) {
             // try to load logger settings from user home dir
-            try (InputStream in = new FileInputStream(usersLogSettings)) {
-                init(in);
-                loaded = true;
-            } catch (Exception e) {
+            File usersLogSettings = new File(StaticUtils.getConfigDir(), "logger.properties");
+            if (usersLogSettings.isFile() && usersLogSettings.canRead()) {
+                try (InputStream in = new FileInputStream(usersLogSettings)) {
+                    init(in);
+                    loaded = true;
+                } catch (Exception ignored) {
+                }
             }
         }
         if (!loaded) {

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -26,13 +26,13 @@
 
 FROM debian:bullseye-slim
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git openjdk-11-jdk inotify-tools \
-    curl subversion unzip
-RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh \
-    && touch /home/omegat/.ssh/known_hosts && chmod 600 /home/omegat/.ssh/known_hosts
-COPY ssh_config /home/omegat/.ssh/config
+    curl subversion unzip rsync
+RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh
+RUN chown -R omegat.omegat /home/omegat
+COPY --chown=omegat ssh_config /home/omegat/.ssh/config
+COPY --chown=omegat gitconfig /home/omegat/.gitconfig
 COPY entrypoint.sh /usr/local/bin/
-RUN chown -R omegat /home/omegat && chmod 755 /usr/local/bin/entrypoint.sh && chmod 700 /home/omegat/.ssh \
-    && chmod 600 /home/omegat/.ssh/config
+RUN chmod 755 /usr/local/bin/entrypoint.sh && chmod 700 /home/omegat/.ssh && chmod 600 /home/omegat/.ssh/config
 RUN (cd /opt && curl -LO https://services.gradle.org/distributions/gradle-7.5.1-bin.zip  \
     && unzip -q gradle-7.5.1-bin.zip && rm -f gradle-7.5.1-bin.zip)
 

--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -27,7 +27,6 @@
 [ -f /keys/id_rsa ] || inotifywait -e attrib /keys
 
 cp /keys/id_rsa /home/omegat/.ssh/id_rsa
-chown omegat.omegat /home/omegat/.ssh/id_rsa
 chmod 600 /home/omegat/.ssh/id_rsa
 
 if [[ "${TYPE}" == "SVN" ]]; then
@@ -36,18 +35,13 @@ if [[ "${TYPE}" == "SVN" ]]; then
 elif [[ "${TYPE}" == "GIT" ]]; then
   export REPO=git@server:omegat-test.git
   export REPO2=https://git:gitpass@server/omegat-test.git
-  git config --global user.name example
-  git config --global user.email git@example.com
-  git config --global http.sslVerify false
 fi
 
 ssh-keyscan -H server > /home/omegat/.ssh/known_hosts
 
-cd /code
-umask a+w
-/opt/gradle-7.5.1/bin/gradle testIntegration -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
-       -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README
-result=$?
-chmod -R a+w .gradle || true
-find * -name build -type d -exec chmod -R a+w {} \; || true
-exit $result
+rsync -av --exclude=.git --exclude=build --exclude=docs --exclude=doc_src --exclude=docs_devel /code /home/omegat
+cd /home/omegat/code
+/opt/gradle-7.5.1/bin/gradle testIntegration \
+   -Djava.util.logging.config.file=test-integration/logger.properties \
+   -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
+   -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/client/gitconfig
+++ b/test-integration/docker/client/gitconfig
@@ -1,0 +1,5 @@
+[user]
+        email = git@example.com
+        name = example user
+[http]
+        sslVerify = false

--- a/test-integration/logger.properties
+++ b/test-integration/logger.properties
@@ -1,0 +1,37 @@
+handlers = java.util.logging.ConsoleHandler, org.omegat.util.logging.OmegaTFileHandler
+    
+# Set the default logging level for the root logger
+.level = INFO
+org.omegat.level = ALL
+    
+# Set the default logging level
+java.util.logging.ConsoleHandler.level = ALL
+org.omegat.util.logging.OmegaTFileHandler.level = ALL
+
+org.omegat.util.logging.OmegaTLogFormatter.mask=$mark: $level: $text $key
+#org.omegat.util.logging.OmegaTLogFormatter.mask=$time: $threadName [$level] $key $text
+
+#org.omegat.util.logging.OmegaTLogFormatter.timeFormat=HH:mm:ss,SSSS
+
+java.util.logging.ConsoleHandler.formatter = org.omegat.util.logging.OmegaTLogFormatter
+
+org.omegat.util.logging.OmegaTFileHandler.formatter = org.omegat.util.logging.OmegaTLogFormatter
+org.omegat.util.logging.OmegaTFileHandler.size=1048576
+org.omegat.util.logging.OmegaTFileHandler.count=10
+
+# Suppress debug logs
+org.omegat.core.data.level = INFO
+org.omegat.core.threads.level = FINE
+org.omegat.core.team2.level = FINE
+org.omegat.core.team2.impl.level = FINE
+org.omegat.gui.editor.history.level = INFO
+org.omegat.gui.matches.level = INFO
+org.omegat.util.gui.level = INFO
+org.omegat.util.level = INFO
+
+# Suppress warning from depndency jStyleParser
+cz.vutbr.web.level = SEVERE
+org.fit.net.level = SEVERE
+
+# We can enable specific logging level for some classes 
+#org.omegat.core.data.SaveThread.level = FINEST

--- a/test-integration/runner.sh
+++ b/test-integration/runner.sh
@@ -35,6 +35,18 @@ SHELL_PATH=`dirname "$0"`
 cd $SHELL_PATH && cd ..
 
 EXIT_CODE=0
-env DURATION=$2 TYPE=$1 docker-compose -f docker-compose.yml up --abort-on-container-exit --exit-code-from client || EXIT_CODE=$?
-docker-compose -f docker-compose.yml down
+if type docker &> /dev/null ; then
+  env DURATION=$2 TYPE=$1 docker-compose -f docker-compose.yml up --abort-on-container-exit --exit-code-from client || EXIT_CODE=$?
+  docker-compose -f docker-compose.yml down
+elif type nerdctl &> /dev/null ; then
+  env DURATION=$2 TYPE=$1 nerdctl compose -f docker-compose.yml up
+  EXIT_CODE=$?
+  nerdctl compose -f docker-compose.yml down
+elif type podman &> /dev/null ; then
+  echo You need to install podman-compose or docker-compose
+  EXIT_CODE=2
+else
+  echo Please install docker-compose or nerdctl!
+  EXIT_CODE=2
+fi
 exit ${EXIT_CODE}

--- a/test-integration/runner.sh
+++ b/test-integration/runner.sh
@@ -39,9 +39,9 @@ if type docker &> /dev/null ; then
   env DURATION=$2 TYPE=$1 docker-compose -f docker-compose.yml up --abort-on-container-exit --exit-code-from client || EXIT_CODE=$?
   docker-compose -f docker-compose.yml down
 elif type nerdctl &> /dev/null ; then
-  env DURATION=$2 TYPE=$1 nerdctl compose -f docker-compose.yml up
+  sudo DURATION=$2 TYPE=$1 nerdctl compose -f docker-compose.yml up
   EXIT_CODE=$?
-  nerdctl compose -f docker-compose.yml down
+  sudo nerdctl compose -f docker-compose.yml down
 elif type podman &> /dev/null ; then
   echo You need to install podman-compose or docker-compose
   EXIT_CODE=2


### PR DESCRIPTION
We have multiple container handle commands  popular for users.
This change support nerdctl and podman which are alternative to docker.
These tools are built upon OCI standard specification. 

The PR also add a support of custom logging configuration with System property. 

## Pull request type

- Build and release changes -> [build/release]
Support netctl and podman for integration-test

## Which ticket is resolved?

## What does this PR change?

- Support custom logging.properties by system property.
- Improve client docker image, by coping source code using rsync, that solves permission problem
- Imporve runner.sh helper to support nerdctl and podman through docker-compose

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
