### PR TITLE
BUG#1213 - Ensure file order consistency between platforms

### DIFF
--- a/src/org/omegat/util/DirectoryMonitor.java
+++ b/src/org/omegat/util/DirectoryMonitor.java
@@ -143,10 +143,8 @@ public class DirectoryMonitor extends Thread {
         }
 
         // find new files
-        List<File> foundFiles = FileUtil.findFiles(dir, pathname -> true);
-        
-        // ensure file order consistency between platforms
-        foundFiles.sort((f1, f2) -> f1.toString().toLowerCase().compareTo(f2.toString().toLowerCase()));
+        List<File> foundFiles = FileUtil.findFiles(dir, pathname -> true, 
+                (f1, f2) -> f1.toString().toLowerCase().compareTo(f2.toString().toLowerCase()));
 
         for (File f : foundFiles) {
             if (stopped) {

--- a/src/org/omegat/util/DirectoryMonitor.java
+++ b/src/org/omegat/util/DirectoryMonitor.java
@@ -144,6 +144,10 @@ public class DirectoryMonitor extends Thread {
 
         // find new files
         List<File> foundFiles = FileUtil.findFiles(dir, pathname -> true);
+        
+        // ensure file order consistency between platforms
+        foundFiles.sort((f1, f2) -> f1.toString().toLowerCase().compareTo(f2.toString().toLowerCase()));
+
         for (File f : foundFiles) {
             if (stopped) {
                 return;

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -248,9 +248,16 @@ public final class FileUtil {
      * @return list of filtered found files
      */
     public static List<File> findFiles(final File dir, final FileFilter filter) {
-        final List<File> result = new ArrayList<File>();
-        Set<String> knownDirs = new HashSet<String>();
+        return findFiles(dir, filter, null);
+    }
+
+    public static List<File> findFiles(final File dir, final FileFilter filter, final Comparator<File> comp) {
+        final List<File> result = new ArrayList<>();
+        Set<String> knownDirs = new HashSet<>();
         findFiles(dir, filter, result, knownDirs);
+        if (comp != null) {
+            result.sort(comp);
+        }
         return result;
     }
 
@@ -686,4 +693,5 @@ public final class FileUtil {
             return c;
         }
     }
+
 }


### PR DESCRIPTION
## Which ticket is resolved?

- Selection of match for pre-translation varies through different OS's
  * https://sourceforge.net/p/omegat/bugs/1213/

## What does this PR change?

- When TMX are loaded, the order is determined by `java.io.File.listFiles()` which can return files in a directory in a different order depending on the underlying OS. This fix sort the resulting files by name, case-insensitive.