### PR TITLE
[BUGS#1194] fix: allow empty custom tag

### DIFF
--- a/src/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
+++ b/src/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
@@ -113,8 +113,14 @@ public class TagProcessingOptionsController extends BasePreferencesController {
         panel.javaPatternCheckBox.setSelected(Preferences.isPreference(Preferences.CHECK_JAVA_PATTERN_TAGS));
         panel.cbCountingProtectedText.setSelected(
                 StatisticsSettings.isCountingProtectedText() || StatisticsSettings.isCountingCustomTags());
-        panel.customPatternRegExpTF.setText(Preferences.getPreferenceDefault(Preferences.CHECK_CUSTOM_PATTERN, 
-                PatternConsts.CHECK_CUSTOM_PATTERN_DEFAULT));
+        String customTag = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
+        if (PatternConsts.EMPTY_MARK.equals(customTag)) {
+            panel.customPatternRegExpTF.setText("");
+        } else if (customTag.isEmpty()) {
+            panel.customPatternRegExpTF.setText(PatternConsts.CHECK_CUSTOM_PATTERN_DEFAULT);
+        } else {
+            panel.customPatternRegExpTF.setText(customTag);
+        }
         panel.removePatternRegExpTF.setText(Preferences.getPreference(Preferences.CHECK_REMOVE_PATTERN));
         panel.looseTagOrderCheckBox.setSelected(Preferences.isPreference(Preferences.LOOSE_TAG_ORDERING));
         panel.cbTagsValidRequired.setSelected(Preferences.isPreference(Preferences.TAGS_VALID_REQUIRED));
@@ -164,7 +170,12 @@ public class TagProcessingOptionsController extends BasePreferencesController {
         Preferences.setPreference(Preferences.CHECK_SIMPLE_PRINTF_TAGS, panel.simpleCheckRadio.isSelected());
         Preferences.setPreference(Preferences.CHECK_ALL_PRINTF_TAGS, panel.fullCheckRadio.isSelected());
         Preferences.setPreference(Preferences.CHECK_JAVA_PATTERN_TAGS, panel.javaPatternCheckBox.isSelected());
-        Preferences.setPreference(Preferences.CHECK_CUSTOM_PATTERN, panel.customPatternRegExpTF.getText());
+        String customTagRegEx = panel.customPatternRegExpTF.getText();
+        if ("".equals(customTagRegEx)) {
+            Preferences.setPreference(Preferences.CHECK_CUSTOM_PATTERN, PatternConsts.EMPTY_MARK);
+        } else {
+            Preferences.setPreference(Preferences.CHECK_CUSTOM_PATTERN, customTagRegEx);
+        }
         Preferences.setPreference(Preferences.CHECK_REMOVE_PATTERN, panel.removePatternRegExpTF.getText());
         Preferences.setPreference(Preferences.LOOSE_TAG_ORDERING, panel.looseTagOrderCheckBox.isSelected());
         Preferences.setPreference(Preferences.TAGS_VALID_REQUIRED, panel.cbTagsValidRequired.isSelected());

--- a/src/org/omegat/util/PatternConsts.java
+++ b/src/org/omegat/util/PatternConsts.java
@@ -53,6 +53,7 @@ public final class PatternConsts {
 
     /** Tag Validation Option: check user defined tags according to regexp.*/
     public static final String CHECK_CUSTOM_PATTERN_DEFAULT = "\\d+";
+    public static final String EMPTY_MARK = "__EMPTY__";
 
     /**
      * Compiled pattern to extract the encoding from XML file, if any. Found
@@ -256,9 +257,13 @@ public final class PatternConsts {
                 regexp += "|" + RE_SIMPLE_JAVA_MESSAGEFORMAT_PATTERN_VARS;
             }
             // assume: customRegExp has already been validated.
-            String customRegExp = Preferences.getPreferenceDefault(Preferences.CHECK_CUSTOM_PATTERN, CHECK_CUSTOM_PATTERN_DEFAULT);
-            if (!"".equalsIgnoreCase(customRegExp)) {
-                regexp += "|" + customRegExp;
+            String customRegExp = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
+            if (!"__EMPTY__".equals(customRegExp)) {
+                if (customRegExp.isEmpty()) {
+                    regexp += "|" + CHECK_CUSTOM_PATTERN_DEFAULT;
+                } else {
+                    regexp += "|" + customRegExp;
+                }
             }
             placeholders = Pattern.compile(regexp);
         }


### PR DESCRIPTION
Fix the bug OmegaT does not allow disable tag regex "\\d+"

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

Bugs: https://sourceforge.net/p/omegat/bugs/1194

## What does this PR change?

- Add special configuration value `"__EMPTY__"` to express ""
- When remove tag value in preference, OmegaT store it as `"__EMPTY__"`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
