### PR TITLE
[BUGS#1164] Fix properly reloading TMX after team synchronization

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1039,16 +1039,18 @@ public class RealProject implements IProject {
                         }
 
                         @Override
-                        public void rebaseAndSave(File out) throws Exception {
+                        public void rebaseAndSave(File tempOut) throws Exception {
+                            // rebase-merge and immediately save to
+                            // the temporary TMX
                             mergeTMX(baseTMX, headTMX, commitDetails);
+                            projectTMX.exportTMX(config, tempOut, false, false, true);
+                        }
 
+                        @Override
+                        public void reload(File file) throws Exception {
                             ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
-                                    config.isSentenceSegmentingEnabled(),
-                                    new File(config.getProjectInternalDir(), OConsts.STATUS_EXTENSION), null);
+                                    config.isSentenceSegmentingEnabled(), file, null);
                             projectTMX.replaceContent(newTMX);
-
-                            projectTMX.exportTMX(config, out, false, false, true);
-
                         }
 
                         @Override
@@ -1109,6 +1111,10 @@ public class RealProject implements IProject {
                                 for (GlossaryEntry ge : headGlossaryEntries) {
                                     GlossaryReaderTSV.append(out, ge);
                                 }
+                            }
+
+                            @Override
+                            public void reload(final File file) {
                             }
 
                             @Override

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1042,7 +1042,13 @@ public class RealProject implements IProject {
                         public void rebaseAndSave(File out) throws Exception {
                             mergeTMX(baseTMX, headTMX, commitDetails);
 
+                            ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
+                                    config.isSentenceSegmentingEnabled(),
+                                    new File(config.getProjectInternalDir(), OConsts.STATUS_EXTENSION), null);
+                            projectTMX.replaceContent(newTMX);
+
                             projectTMX.exportTMX(config, out, false, false, true);
+
                         }
 
                         @Override
@@ -1055,13 +1061,6 @@ public class RealProject implements IProject {
                             return TMXReader2.detectCharset(file);
                         }
                     });
-            if (projectTMX != null) {
-                // it can be not loaded yet
-                ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
-                        config.isSentenceSegmentingEnabled(),
-                        new File(config.getProjectInternalDir(), OConsts.STATUS_EXTENSION), null);
-                projectTMX.replaceContent(newTMX);
-            }
         }
 
         if (processGlossary) {

--- a/src/org/omegat/core/team2/RebaseAndCommit.java
+++ b/src/org/omegat/core/team2/RebaseAndCommit.java
@@ -214,6 +214,7 @@ public final class RebaseAndCommit {
                 // file was committed good
                 provider.getTeamSettings().set(VERSION_PREFIX + path, newVersion);
             }
+            rebaser.reload(headRepoFile);
         }
     }
 
@@ -264,6 +265,11 @@ public final class RebaseAndCommit {
          * user, i.e. can work up to some minutes.
          */
         void rebaseAndSave(File out) throws Exception;
+
+        /**
+         * Reload projectTMX from resulted TMX.
+         */
+        void reload(File file) throws Exception;
 
         /**
          * Construct commit message.


### PR DESCRIPTION
PR #645 , that try to resolve BUGS#1164,  breaks team feature so integration test become failure.
So it is revertd in PR #643 .

## Pull request type


Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Translation memories are not correctly reloaded after team synchronization
- https://sourceforge.net/p/omegat/bugs/1164

## What does this PR change?

- Extend `RebaseAndCommit.IRebase` interface to have `reload` method
- `RebaseAndCommit#rebaseAndCommit` properly call `reload` with target file when it is ready to load 
- Improve integration-test container configuration

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
