### PR TITLE
[BUGS#1164] fix: break project translation when rebase and commit

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1040,10 +1040,11 @@ public class RealProject implements IProject {
 
                         @Override
                         public void rebaseAndSave(File tempOut) throws Exception {
-                            // rebase-merge and immediately save to
-                            // the temporary TMX
-                            mergeTMX(baseTMX, headTMX, commitDetails);
-                            projectTMX.exportTMX(config, tempOut, false, false, true);
+                            // Rebase-merge and immediately save mergedTMX
+                            // to tempOut.
+                            // It shall not save it as the projectTMX here.
+                            ProjectTMX mergedTMX = mergeTMX(baseTMX, headTMX, commitDetails);
+                            mergedTMX.exportTMX(config, tempOut, false, false, true);
                         }
 
                         @Override
@@ -1143,7 +1144,8 @@ public class RealProject implements IProject {
      *
      * File 2: headTMX (theirs)
      */
-    protected void mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
+    protected ProjectTMX mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
+        ProjectTMX mergedTMX;
         StmProperties props = new StmProperties().setLanguageResource(OStrings.getResourceBundle())
                 .setParentWindow(Core.getMainWindow().getApplicationFrame())
                 // More than this number of conflicts will trigger List View by
@@ -1151,14 +1153,14 @@ public class RealProject implements IProject {
                 .setListViewThreshold(5);
         String srcLang = config.getSourceLanguage().getLanguage();
         String trgLang = config.getTargetLanguage().getLanguage();
-        ProjectTMX mergedTMX = SuperTmxMerge.merge(
+        mergedTMX = SuperTmxMerge.merge(
                 new SyncTMX(baseTMX, OStrings.getString("TMX_MERGE_BASE"), srcLang, trgLang),
                 new SyncTMX(projectTMX, OStrings.getString("TMX_MERGE_MINE"), srcLang, trgLang),
                 new SyncTMX(headTMX, OStrings.getString("TMX_MERGE_THEIRS"), srcLang, trgLang), props);
-        projectTMX.replaceContent(mergedTMX);
         Log.logDebug(LOGGER, "Merge report: {0}", props.getReport());
         commitDetails.append('\n');
         commitDetails.append(props.getReport().toString());
+        return mergedTMX;
     }
 
     /**

--- a/src/org/omegat/core/team2/RebaseAndCommit.java
+++ b/src/org/omegat/core/team2/RebaseAndCommit.java
@@ -222,6 +222,9 @@ public final class RebaseAndCommit {
                 provider.getTeamSettings().set(VERSION_PREFIX + path, newVersion);
             }
             rebaser.reload(headRepoFile);
+        } else {
+            // no changes so just load.
+            rebaser.reload(headRepoFile);
         }
     }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -617,7 +617,7 @@ public final class TestTeamIntegrationChild {
         ProjectTMX headTMX;
 
         @Override
-        protected void mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
+        protected ProjectTMX mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
             Log.log("Base:   " + baseTMX);
             Log.log("Mine:   " + projectTMX);
             Log.log("Theirs: " + headTMX);
@@ -666,20 +666,18 @@ public final class TestTeamIntegrationChild {
                     });
             String srcLang = config.getSourceLanguage().getLanguage();
             String trgLang = config.getTargetLanguage().getLanguage();
-            synchronized (projectTMX) {
-                ProjectTMX mergedTMX = SuperTmxMerge.merge(
-                        new SyncTMX(baseTMX, OStrings.getString("TMX_MERGE_BASE"), srcLang, trgLang),
-                        new SyncTMX(projectTMX, OStrings.getString("TMX_MERGE_MINE"), srcLang, trgLang),
-                        new SyncTMX(headTMX, OStrings.getString("TMX_MERGE_THEIRS"), srcLang, trgLang), props);
-                Log.log("Merged: " + mergedTMX);
-                if (!checkMergeInput(baseTMX, mergedTMX)) {
-                    Log.log("'Merged' TM is not a valid derivative of 'Base' TM");
-                    System.exit(1);
-                }
-                projectTMX.replaceContent(mergedTMX);
+            ProjectTMX mergedTMX = SuperTmxMerge.merge(
+                    new SyncTMX(baseTMX, OStrings.getString("TMX_MERGE_BASE"), srcLang, trgLang),
+                    new SyncTMX(projectTMX, OStrings.getString("TMX_MERGE_MINE"), srcLang, trgLang),
+                    new SyncTMX(headTMX, OStrings.getString("TMX_MERGE_THEIRS"), srcLang, trgLang), props);
+            Log.log("Merged: " + mergedTMX);
+            if (!checkMergeInput(baseTMX, mergedTMX)) {
+                Log.log("'Merged' TM is not a valid derivative of 'Base' TM");
+                System.exit(1);
             }
             commitDetails.append('\n');
             commitDetails.append(props.getReport().toString());
+            return mergedTMX;
         }
 
         /**


### PR DESCRIPTION
When saving a team project and another member have updated translations and OmegaT run rebaseAndCommit, enforce TM become removed from the result.

The change here to change that when merge TMX from remote and local, we save it into file, but DON'T replace it in projectTMX. We reload the file when necessary, in RebaseAndCommit.IRebase#reload.

It changes RealProject#mergeTMX to return merged TMX and the caller should handle the tmx.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  Translation memories are not correctly reloaded after team synchronization
- https://sourceforge.net/p/omegat/bugs/1164/


## What does this PR change?

- `RealProject#mergeTMX` to return merged TMX and the caller should handle the tmx.
- `RealProject#mergeTMX` does not replace `projectTMX` with `mergedTMX`
-

## Other information

- Passed integration test in 10 min.
- When running OmegaT with team project with enforce entry, the log is as follows;




```
82416: 情報: リベース開始 (TEAM_REBASE_START)
82416: FINE: Rebase and commit 'omegat/project_save.tmx' ★1
82416: FINE: GIT switchToVersion 1748bc85557c0497761fa5d178d21a50ec992b60  
82416: FINE: local file 'omegat/project_save.tmx' was changed 
82416: 情報: TMX ファイル /home/miurahr/Projects/Translation/omegat-test/.repositories/https_github.com_miurahr_omegat_test.git//omegat/project_save.tmx を読み込み中です (TMXR_INFO_READING_FILE)
82416: 情報: 作成者：OmegaT (TMXR_INFO_CREATION_TOOL)
82416: 情報: バージョン：6.1.0_0_1feedf5b4 (TMXR_INFO_CREATION_TOOL_VERSION)
82416: 情報: 分節化の方法：sentence (TMXR_INFO_SEG_TYPE)
82416: 情報: 原文言語：en-US (TMXR_INFO_SOURCE_LANG)
82416: 情報: TMX ファイルの読み込みが完了しました (TMXR_INFO_READING_COMPLETE)
82416: FINE: GIT switchToVersion origin/main  
82416: FINE: remote file 'omegat/project_save.tmx' wasn't changed 
82416: FINE: only local changes - just use local file 'omegat/project_save.tmx' ★2
82416: 情報: Git 'addForCommit' 実行開始 (GIT_START)
82416: 情報: Git 'addForCommit' 実行成功 (GIT_FINISH)
82416: 情報: Git 'upload' 実行開始 (GIT_START)
82416: FINE: GIT committed into new version 57aca5d28192d01f6d13ad2ee6a2e8a606b7a54c  
82416: 情報: Git 'upload' 実行成功 (GIT_FINISH)★3
82416: 情報: TMX ファイル /home/miurahr/Projects/Translation/omegat-test/.repositories/https_github.com_miurahr_omegat_test.git//omegat/project_save.tmx を読み込み中です (TMXR_INFO_READING_FILE)
82416: 情報: 作成者：OmegaT (TMXR_INFO_CREATION_TOOL)
82416: 情報: バージョン：6.1.0_0_eb2a8d0b3 (TMXR_INFO_CREATION_TOOL_VERSION)
82416: 情報: 分節化の方法：sentence (TMXR_INFO_SEG_TYPE)
82416: 情報: 原文言語：en-US (TMXR_INFO_SOURCE_LANG)
82416: 情報: TMX ファイルの読み込みが完了しました (TMXR_INFO_READING_COMPLETE) ★4
82416: FINE: Rebase and commit 'glossary/glossary.txt' 
82416: FINE: GIT switchToVersion 1748bc85557c0497761fa5d178d21a50ec992b60  
82416: FINE: local file 'glossary/glossary.txt' wasn't changed 
82416: FINE: GIT switchToVersion origin/main  
82416: FINE: remote file 'glossary/glossary.txt' was changed 
82416: FINE: only remote changes - get remote 'glossary/glossary.txt' 
82416: 情報: リベース終了 (TEAM_REBASE_END)
82416: FINE: Enable autosave 
82416: 情報: プロジェクト保存の終了 (LOG_DATAENGINE_SAVE_END)
```

- ★1  Start of `RebaseAndCommit#rebaseAndCommit` line 91
- ★2 if block of `RebaseAndCommit#rebaseAndCommit` where checking local and remote changes, it report only local file is changed. 

Line 165
```java
        if (fileChangedLocally && fileChangedRemotely) {
            // rebase need only in case file was changed locally AND remotely
            Log.logDebug(LOGGER, "rebase and save '" + path + "'");
            needBackup = true;
            rebaser.rebaseAndSave(tempOut);
        } else if (fileChangedLocally && !fileChangedRemotely) {
            // only local changes - just use local file
            Log.logDebug(LOGGER, "only local changes - just use local file '" + path + "'"); // ★2
        } else if (!fileChangedLocally && fileChangedRemotely) {
```

- ★3  upload the merged `project_save.tmx` into team repository.
- ★4  called new added method `IRebase#reload` which load new  `project_save.tmx`  into memory.
    This is added in PR #730.

`RebaseAndCommit#rebaseAndCommit`  line 209

```java
            // new file already saved - need to commit
            String comment = rebaser.getCommentForCommit();
            provider.copyFilesFromProjectToRepos(path, rebaser.getFileCharset(localFile));
            String newVersion = provider.commitFileAfterVersion(path, comment, headVersion, null); // ★3 
            if (newVersion != null) {
                // file was committed good
                provider.getTeamSettings().set(VERSION_PREFIX + path, newVersion);
            }
            rebaser.reload(headRepoFile); // ★4
```