### PR TITLE
[RFE#1682] fix: Support Java 17 runtime and ensure CI test on Java17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1102,7 +1102,7 @@ task spotlessChangedApply {
 }
 
 jacoco {
-    toolVersion="0.8.6"
+    toolVersion="0.8.10"
 }
 
 tasks.jacocoTestReport {
@@ -1250,6 +1250,7 @@ task runOnJava17(type: JavaExec) {
     description = 'Launch app on Java 17'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
     }
     mainClass = application.mainClass
     classpath = sourceSets.main.runtimeClasspath
@@ -1279,6 +1280,7 @@ task testOnJava17(type: Test) {
     description = 'Run test cases on Java 17'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
     }
     if (project.hasProperty('headless')) {
         systemProperty 'java.awt.headless', 'true'

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -8,7 +8,7 @@ steps:
       umask a+w
       mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean check
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean check testOnJava17
     displayName: 'Run Gradle clean and Gradle check'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results build/reports/**/*.xml'

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -148,6 +148,10 @@ public final class Main {
         // https://sourceforge.net/p/omegat/bugs/812/
         System.setProperty("jna.encoding", Charset.defaultCharset().name());
 
+        // Workaround for Java 17 or later support of JAXB.
+        // See https://sourceforge.net/p/omegat/feature-requests/1682/#12c5
+        System.setProperty("com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize", "true");
+
         PARAMS.putAll(CLIParameters.parseArgs(args));
 
         String projectDir = PARAMS.get(CLIParameters.PROJECT_DIR);

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTBXTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTBXTest.java
@@ -42,6 +42,10 @@ import org.omegat.util.Language;
 public class GlossaryReaderTBXTest extends TestCore {
     @Test
     public void testRead() throws Exception {
+        // Workaround for Java 17 or later support of JAXB.
+        // See https://sourceforge.net/p/omegat/feature-requests/1682/#12c5
+        System.setProperty("com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize", "true");
+
         Core.setProject(new NotLoadedProject() {
             public ProjectProperties getProjectProperties() {
                 try {


### PR DESCRIPTION
Ensure pass unit tests with Java 17

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]

## Which ticket is resolved?

Feature requests: 

- #1682 Ensure that OmegaT functions properly under Java 17
  * https://sourceforge.net/p/omegat/feature-requests/1682/


## What does this PR change?

- Add task testOnJava17 in CI
- bump jacoco@0.8.10,  Java 18,19 are supported in jacoco@0.8.9
- removal of an unused property in the resource bundle: STARTUP_JAXB_LINKAGE_ERROR

## Other information


