### PR TITLE
[RFE#1713] feat(filter/bundle): make "don't translate NOI18N comment" feature optional

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1433,7 +1433,7 @@ RB_FILTER_REMOVE_STRINGS_UNTRANSLATED=&Remove untranslated strings in the target
 RB_FILTER_NOT_CONVERT_UNICODE_CHARACTERS=Keep Unico&de literals (\\uXXXX)
 RB_FILTER_SUPPORT_JAVA8_ENCODING=Force Unicode literals compatibility with Java 8
 RB_FILTER_EXCEPTION=The Java Resource Bundles filter encountered an error:
-RB_FILTER_SUPPORT_NOI18N_COMMENT=Don't translate property when NOI18N comment given
+RB_FILTER_SUPPORT_NOI18N_COMMENT=Do not translate property if it has a NOI18N comment
 
 # RcFilter.java
 RCFILTER_FILTER_NAME=Windows Resources

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1433,6 +1433,8 @@ RB_FILTER_REMOVE_STRINGS_UNTRANSLATED=&Remove untranslated strings in the target
 RB_FILTER_NOT_CONVERT_UNICODE_CHARACTERS=Keep Unico&de literals (\\uXXXX)
 RB_FILTER_SUPPORT_JAVA8_ENCODING=Force Unicode literals compatibility with Java 8
 RB_FILTER_EXCEPTION=The Java Resource Bundles filter encountered an error:
+RB_FILTER_SUPPORT_NOI18N_COMMENT=Don't translate property when NOI18N comment given
+
 # RcFilter.java
 RCFILTER_FILTER_NAME=Windows Resources
 

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -9,6 +9,7 @@
                2013-2014 Enrique Estevez, Didier Briel
                2015 Aaron Madlon-Kay, Enrique Estevez
                2016 Aaron Madlon-Kay
+               2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -69,6 +70,7 @@ import org.omegat.util.TagUtil;
  * @author Enrique Estevez (keko.gl@gmail.com)
  * @author Didier Briel
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  *
  *         Option to remove untranslated segments in the target files Code
  *         adapted from the file: MozillaDTDFilter.java Support for encoding
@@ -89,14 +91,13 @@ public class ResourceBundleFilter extends AbstractFilter {
     /**
      * Key=value pairs with a preceding comment containing this string are not
      * translated, and are output verbatim.
-     * <p>
-     * TODO: Make this optional
      */
     public static final String DO_NOT_TRANSLATE_COMMENT = "NOI18N";
 
     public static final String OPTION_REMOVE_STRINGS_UNTRANSLATED = "unremoveStringsUntranslated";
     public static final String OPTION_DONT_UNESCAPE_U_LITERALS = "dontUnescapeULiterals";
     public static final String OPTION_FORCE_JAVA8_LITERALS_ESCAPE = "forceJava8LiteralsEscape";
+    public static final String OPTION_DONT_TRANSLATE_COMMENT = "dontTargetCommentValue";
     public static final String DEFAULT_SOURCE_ENCODING = StandardCharsets.UTF_8.name();
     public static final String DEFAULT_TARGET_ENCODING = StandardCharsets.UTF_8.name();
 
@@ -104,11 +105,6 @@ public class ResourceBundleFilter extends AbstractFilter {
 
     private String targetEncoding = DEFAULT_TARGET_ENCODING;
     private Boolean forceTargetEscape = true;
-
-    /**
-     * If true, will remove non-translated segments in the target files
-     */
-    private boolean removeStringsUntranslated = false;
 
     /**
      * If true, will not convert characters into \\uXXXX notation
@@ -374,12 +370,14 @@ public class ResourceBundleFilter extends AbstractFilter {
     @Override
     public void processFile(BufferedReader reader, BufferedWriter outfile, FilterContext fc)
             throws IOException, TranslationException {
-        // Parameter in the options of filter to customize the target file
-        removeStringsUntranslated = processOptions != null
+        // Parameter in the options of filter to customize the target file.
+
+        // If true, will remove non-translated segments in the target files.
+        boolean removeStringsUntranslated = processOptions != null
                 && "true".equalsIgnoreCase(processOptions.get(OPTION_REMOVE_STRINGS_UNTRANSLATED));
 
         // Parameter in the options of filter to customize the behavior of the
-        // filter
+        // filter.
         dontUnescapeULiterals = processOptions != null
                 && "true".equalsIgnoreCase(processOptions.get(OPTION_DONT_UNESCAPE_U_LITERALS));
 
@@ -387,6 +385,9 @@ public class ResourceBundleFilter extends AbstractFilter {
             forceTargetEscape = !"false"
                     .equalsIgnoreCase(processOptions.get(OPTION_FORCE_JAVA8_LITERALS_ESCAPE));
         }
+
+        boolean dontTranslateComment = processOptions != null
+                && !"false".equalsIgnoreCase(processOptions.get(OPTION_DONT_TRANSLATE_COMMENT));
 
         String raw;
         boolean noi18n = false;
@@ -475,7 +476,7 @@ public class ResourceBundleFilter extends AbstractFilter {
                         value = "";
                     }
 
-                    if (noi18n) {
+                    if (noi18n && dontTranslateComment) {
                         // if we don't need to internationalize
                         outfile.write(toAscii(key, EscapeMode.KEY));
                         outfile.write(equals);

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -206,7 +206,7 @@ public class ResourceBundleFilter extends AbstractFilter {
      * or non-key-value-breaking equals).
      * <ul>
      */
-    protected String normalizeInputLine(String line) throws IOException, TranslationException {
+    protected String normalizeInputLine(String line) throws TranslationException {
 
         // Whitespace at the beginning of lines is ignored
         boolean strippingWhitespace = true;
@@ -303,18 +303,15 @@ public class ResourceBundleFilter extends AbstractFilter {
                     && charsetEncoder.canEncode(text.substring(i, i + Character.charCount(cp)))) {
                 result.appendCodePoint(cp);
             } else {
-                for (char c : Character.toChars(cp)) {
-                    String code = Integer.toString(c, 16);
-                    while (code.codePointCount(0, code.length()) < 4) {
-                        code = '0' + code;
-                    }
-                    result.append("\\u").append(code);
+                char[] chars = Character.toChars(cp); // optimized for speed
+                for (int j = 0, charsLength = chars.length; j < charsLength; j++) {
+                    String code = Integer.toString(chars[j], 16).toUpperCase();
+                    result.append("\\u").append("0".repeat(Math.max(0, 4 - code.codePointCount(0, code.length()))))
+                            .append(code);
                 }
             }
         }
-
         return result.toString();
-
     }
 
     private static boolean containsUEscapeAt(String text, int offset) {

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.form
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.form
@@ -45,6 +45,7 @@
             </Property>
           </Properties>
           <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
             <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
           </AuxValues>
           <Constraints>
@@ -59,6 +60,9 @@
               <ResourceString bundle="org/omegat/Bundle.properties" key="RB_FILTER_NOT_CONVERT_UNICODE_CHARACTERS" replaceFormat="java.util.ResourceBundle.getBundle(&quot;{bundleNameSlashes}&quot;).getString(&quot;{key}&quot;)"/>
             </Property>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="0" gridY="2" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
@@ -71,9 +75,27 @@
               <ResourceString bundle="org/omegat/Bundle.properties" key="RB_FILTER_SUPPORT_JAVA8_ENCODING" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
             </Property>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+              <GridBagConstraints gridX="0" gridY="0" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="supportNOI18NCommentCB">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="RB_FILTER_SUPPORT_NOI18N_COMMENT" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="3" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
@@ -57,7 +57,7 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
     public ResourceBundleOptionsDialog(Window parent, Map<String, String> options) {
         super(parent);
         setModal(true);
-        this.options = new TreeMap<String, String>(options);
+        this.options = new TreeMap<>(options);
         initComponents();
 
         String removeStringsUntranslated = options.get(ResourceBundleFilter.OPTION_REMOVE_STRINGS_UNTRANSLATED);
@@ -68,6 +68,9 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
 
         String supportJava8Encoding = options.get(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE);
         supportJava8EncodingCB.setSelected(!"false".equals(supportJava8Encoding));
+
+        String supportNOI18NComment = options.get(ResourceBundleFilter.OPTION_DONT_TRANSLATE_COMMENT);
+        supportNOI18NCommentCB.setSelected(!"false".equals(supportNOI18NComment));
 
         StaticUIUtils.setEscapeAction(this, new AbstractAction() {
             @Override
@@ -101,6 +104,7 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         removeStringsUntranslatedCB = new javax.swing.JCheckBox();
         dontUnescapeULiteralsCB = new javax.swing.JCheckBox();
         supportJava8EncodingCB = new javax.swing.JCheckBox();
+        supportNOI18NCommentCB = new javax.swing.JCheckBox();
         buttonPanel = new javax.swing.JPanel();
         okButton = new javax.swing.JButton();
         cancelButton = new javax.swing.JButton();
@@ -139,7 +143,19 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         jPanel1.add(supportJava8EncodingCB, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(supportNOI18NCommentCB, OStrings.getString("RB_FILTER_SUPPORT_NOI18N_COMMENT")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        jPanel1.add(supportNOI18NCommentCB, gridBagConstraints);
 
         getContentPane().add(jPanel1, java.awt.BorderLayout.CENTER);
 
@@ -174,6 +190,7 @@ private void okButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
         options.put(ResourceBundleFilter.OPTION_REMOVE_STRINGS_UNTRANSLATED, Boolean.toString(removeStringsUntranslatedCB.isSelected()));
         options.put(ResourceBundleFilter.OPTION_DONT_UNESCAPE_U_LITERALS, Boolean.toString(dontUnescapeULiteralsCB.isSelected()));
         options.put(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE, Boolean.toString(supportJava8EncodingCB.isSelected()));
+        options.put(ResourceBundleFilter.OPTION_DONT_TRANSLATE_COMMENT, Boolean.toString(supportNOI18NCommentCB.isSelected()));
         doClose(RET_OK);
 }//GEN-LAST:event_okButtonActionPerformed
 
@@ -190,11 +207,12 @@ private void cancelButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel buttonPanel;
     private javax.swing.JButton cancelButton;
-    private javax.swing.JCheckBox dontUnescapeULiteralsCB;
+    javax.swing.JCheckBox dontUnescapeULiteralsCB;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JButton okButton;
-    private javax.swing.JCheckBox removeStringsUntranslatedCB;
-    private javax.swing.JCheckBox supportJava8EncodingCB;
+    javax.swing.JCheckBox removeStringsUntranslatedCB;
+    javax.swing.JCheckBox supportJava8EncodingCB;
+    javax.swing.JCheckBox supportNOI18NCommentCB;
     // End of variables declaration//GEN-END:variables
 
     private int returnStatus = RET_CANCEL;


### PR DESCRIPTION
Implement "TODO" commented feature of resource bundle filter.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- #1713 ResourceBundle filter: "Don't translate NOI18N comment" feature optional
- https://sourceforge.net/p/omegat/feature-requests/1713/

## What does this PR change?

- make "don't translate NOI18N comment" feature optional
- improve unicode escape
    - output standard Capital hex for escape
    - improve string manipulation performance

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
