### PR TITLE
feat(filter/bundle): change default not to do a Unicode escape (java 9-21 standard)

### DIFF
--- a/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -384,7 +384,7 @@ public class ResourceBundleFilter extends AbstractFilter {
                 && "true".equalsIgnoreCase(processOptions.get(OPTION_DONT_UNESCAPE_U_LITERALS));
 
         if (processOptions != null) {
-            forceTargetEscape = !"false"
+            forceTargetEscape = "true"
                     .equalsIgnoreCase(processOptions.get(OPTION_FORCE_JAVA8_LITERALS_ESCAPE));
         }
 

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
@@ -67,7 +67,7 @@ public class ResourceBundleOptionsDialog extends javax.swing.JDialog {
         dontUnescapeULiteralsCB.setSelected("true".equalsIgnoreCase(notConvertCharacters));
 
         String supportJava8Encoding = options.get(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE);
-        supportJava8EncodingCB.setSelected(!"false".equals(supportJava8Encoding));
+        supportJava8EncodingCB.setSelected("true".equals(supportJava8Encoding));
 
         StaticUIUtils.setEscapeAction(this, new AbstractAction() {
             @Override

--- a/test/src/org/omegat/filters/ResourceBundleFilterTest.java
+++ b/test/src/org/omegat/filters/ResourceBundleFilterTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
@@ -50,8 +51,10 @@ public class ResourceBundleFilterTest extends TestFilterBase {
 
     @Test
     public void testTranslate() throws Exception {
+        Map<String, String> options = new TreeMap<>();
+        options.put(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE, "true");
         translateText(new ResourceBundleFilter(),
-                "test/data/filters/resourceBundle/file-ResourceBundleFilter.properties");
+                "test/data/filters/resourceBundle/file-ResourceBundleFilter.properties", options);
     }
 
     @Test


### PR DESCRIPTION
- not to force escape Unicode
- Java 9 and later change the default of resource bundle charset to UTF-8, so there is no need to escape it now. 

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- #1716 ResourceBundle Filter: default not to escape Unicode character
- https://sourceforge.net/p/omegat/feature-requests/1716/


## What does this PR change?

- Change option default

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
