### PR TITLE
[BUGS#1185] Saving does not register pre-translation in new projects

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,7 +2,7 @@
  OmegaT 6.1.0
 ----------------------------------------------------------------------
   22 Enhancement
-  30 Bug fixes
+  31 Bug fixes
 ----------------------------------------------------------------------
 6.1.0 vs 6.0.0
 
@@ -165,6 +165,10 @@
 
   - First session message in log not localised
   https://sourceforge.net/p/omegat/bugs/272/
+
+  - If project memory is updated during load via tm/auto or tm/enforce, set project as modified
+    so that save also updates project_save.tmx
+  https://sourceforge.net/p/omegat/bugs/1185/
 
 ----------------------------------------------------------------------
  OmegaT 6.0.0 (2023-06-19)

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -190,6 +190,24 @@ public class ImportFromAutoTMX {
 
     private void setTranslation(SourceTextEntry entry, ITMXEntry trans, boolean defaultTranslation,
             TMXEntry.ExternalLinked externalLinked) {
+        if (!didAnyChange) { // check if this call really changes anything
+            TMXEntry oldEntry = defaultTranslation ? project.projectTMX.defaults.get(entry.getSrcText())
+                : project.projectTMX.alternatives.get(entry.getKey());
+            if (oldEntry == null) {
+                if (trans.isTranslated()) {
+                    didAnyChange = true;
+                }                
+            } else if (oldEntry.isTranslated()) {
+                if (! oldEntry.getTranslationText().equals(trans.getTranslationText())) {
+                    didAnyChange = true;
+                }
+            } else {
+                if (trans.isTranslated()) {
+                    didAnyChange = true;
+                }
+            }
+        }
+        
         TMXEntry newTrEntry;
 
         if ((!trans.isTranslated()) && (!trans.hasNote())) {
@@ -199,6 +217,5 @@ public class ImportFromAutoTMX {
             newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
-        didAnyChange = true;
     }
 }

--- a/src/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/org/omegat/core/data/ImportFromAutoTMX.java
@@ -48,6 +48,8 @@ public class ImportFromAutoTMX {
      * processes.
      */
     Map<String, List<SourceTextEntry>> existEntries = new HashMap<String, List<SourceTextEntry>>();
+    // initially false, this variable becomes true if process() did almost one change
+    boolean didAnyChange = false;
 
     public ImportFromAutoTMX(RealProject project, List<SourceTextEntry> allProjectEntries) {
         this.project = project;
@@ -197,5 +199,6 @@ public class ImportFromAutoTMX {
             newTrEntry = new TMXEntry(trans, defaultTranslation, externalLinked);
         }
         project.projectTMX.setTranslation(entry, newTrEntry, defaultTranslation);
+        didAnyChange = true;
     }
 }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -416,7 +416,7 @@ public class RealProject implements IProject {
             // Project Loaded...
             Core.getMainWindow().showStatusMessageRB(null);
 
-            setProjectModified(false);
+            setProjectModified(importHandler.didAnyChange);
         } catch (OutOfMemoryError oome) {
             // Fix for bug 1571944 @author Henry Pijffers
             // (henry.pijffers@saxnot.com)


### PR DESCRIPTION
Actually if you create a project containing something in tm/auto, the segments are auto-populated but when you click on SAVE OmegaT does consider the project as non-modified and saves nothing, despite the fact that importing segments against empty file is a modification.

## Pull request type

Bug fix -> [bug]

## Which ticket is resolved?

https://sourceforge.net/p/omegat/bugs/1185/
https://sourceforge.net/p/omegat/bugs/1200/

## What does this PR change?

Beginning of tm/auto import a new boolean didAnyChange is false. If any segmennt has been imported it is set to true
At the end of the process, if didAnyChange = true then project.isModified = true

