### PR TITLE
chore: annotate spotbugs errors on github PR

### DIFF
--- a/.github/workflows/checkstyle-annotate.yml
+++ b/.github/workflows/checkstyle-annotate.yml
@@ -15,4 +15,4 @@ jobs:
     - name: run checkstyle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: checkstyleMain checkstyleTest
+        arguments: -PenvIsCi checkstyleMain checkstyleTest

--- a/.github/workflows/checkstyle-annotate.yml
+++ b/.github/workflows/checkstyle-annotate.yml
@@ -1,6 +1,6 @@
 name: Run checkstyle
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   checkstyle:

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -19,4 +19,4 @@ jobs:
       name: annotate spotbugs warnings/errors
       if: ${{ failure() || success() }}
       with:
-        path: '**/build/spotbugs/*.xml'
+        path: '**/build/reports/spotbugs/*.xml'

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -1,0 +1,22 @@
+name: Run checkstyle
+
+on: pull_request
+
+jobs:
+  checkstyle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+    - name: run spotbugs
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: spotbugsMain spotbugsTest
+    - uses: jwgmeligmeyling/spotbugs-github-action@master
+      name: annotate spotbugs warnings/errors
+      if: ${{ failure() || success() }}
+      with:
+        path: '**/build/spotbugs/*.xml'

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -14,7 +14,7 @@ jobs:
     - name: run spotbugs
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: spotbugsMain spotbugsTest
+        arguments: -PenvIsCi spotbugsMain spotbugsTest
     - uses: jwgmeligmeyling/spotbugs-github-action@master
       name: annotate spotbugs warnings/errors
       if: ${{ failure() || success() }}

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -1,6 +1,6 @@
 name: Run checkstyle
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   checkstyle:

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -1,9 +1,9 @@
-name: Run checkstyle
+name: Run SpotBugs
 
 on: [push, pull_request]
 
 jobs:
-  checkstyle:
+  spotbugs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,10 +57,9 @@ stages:
 
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
-  dependsOn: Check
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
-  - job: Check
+  - job: Check for weekly
     displayName: Test and Check
     pool:
       vmImage: 'ubuntu-22.04'
@@ -87,7 +86,7 @@ stages:
 - stage: Release
   condition: and(succeeded(), eq(variables.isRelease, true))
   jobs:
-  - job: Check
+  - job: Check for release
     displayName: Test and Check
     pool:
       vmImage: 'ubuntu-22.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,38 +42,30 @@ stages:
 - stage: Test
   condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
   jobs:
-  - job: GitHubCI
-    displayName: Test on Java 11
+  - job: TestOnJava11
+    displayName: on Java 11
     pool:
       vmImage: 'ubuntu-22.04'
     steps:
       - template: ci/azure-pipelines/test_steps.yml
-
-- stage: TestOnJava17
-  condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
-  jobs:
-    - job: GitHubCI
-      displayName: Test on Java 17
-      pool:
-        vmImage: 'ubuntu-22.04'
-      steps:
-        - template: ci/azure-pipelines/test_java17_steps.yml
-
-- stage: Check
-  condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true))
-  jobs:
-    - job: GitHubCI
-      displayName: Test and Check
-      pool:
-        vmImage: 'ubuntu-22.04'
-      steps:
-        - template: ci/azure-pipelines/check_steps.yml
+  - job: TestOnJava17
+    displayName: on Java 17
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+      - template: ci/azure-pipelines/test_java17_steps.yml
 
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
   dependsOn: Check
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
+  - job: Check
+    displayName: Test and Check
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+      - template: ci/azure-pipelines/check_steps.yml
   - job: WeeklyBuild
     displayName: Build for master weekly
     pool:
@@ -93,9 +85,14 @@ stages:
 
   # Release steps will run on the main and/or release branch with tags.
 - stage: Release
-  dependsOn: Check
   condition: and(succeeded(), eq(variables.isRelease, true))
   jobs:
+  - job: Check
+    displayName: Test and Check
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+      - template: ci/azure-pipelines/check_steps.yml
   - job: ReleaseBuild
     pool:
       vmImage: 'ubuntu-22.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
 - stage: Weekly
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
-  - job: Check for weekly
+  - job: CheckForWeekly
     displayName: Test and Check
     pool:
       vmImage: 'ubuntu-22.04'
@@ -86,7 +86,7 @@ stages:
 - stage: Release
   condition: and(succeeded(), eq(variables.isRelease, true))
   jobs:
-  - job: Check for release
+  - job: CheckForRelease
     displayName: Test and Check
     pool:
       vmImage: 'ubuntu-22.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,17 +43,27 @@ stages:
   condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
   jobs:
   - job: GitHubCI
-    displayName: CI Test
+    displayName: Test on Java 11
     pool:
       vmImage: 'ubuntu-22.04'
     steps:
       - template: ci/azure-pipelines/test_steps.yml
 
+- stage: TestOnJava17
+  condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
+  jobs:
+    - job: GitHubCI
+      displayName: Test on Java 17
+      pool:
+        vmImage: 'ubuntu-22.04'
+      steps:
+        - template: ci/azure-pipelines/test_java17_steps.yml
+
 - stage: Check
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true))
   jobs:
     - job: GitHubCI
-      displayName: CI Check
+      displayName: Test and Check
       pool:
         vmImage: 'ubuntu-22.04'
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,18 +39,29 @@ variables:
   GRADLE_USER_HOME: '$(Pipeline.Workspace)/.gradle'
 
 stages:
-- stage: Check
-  condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')))
+- stage: Test
+  condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
   jobs:
   - job: GitHubCI
-    displayName: CI Check for master, releases/* and Pull-Requests
+    displayName: CI Test
     pool:
       vmImage: 'ubuntu-22.04'
     steps:
-      - template: ci/azure-pipelines/check_steps.yml
+      - template: ci/azure-pipelines/test_steps.yml
+
+- stage: Check
+  condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true))
+  jobs:
+    - job: GitHubCI
+      displayName: CI Check
+      pool:
+        vmImage: 'ubuntu-22.04'
+      steps:
+        - template: ci/azure-pipelines/check_steps.yml
 
   # Weekly release steps will be triggerred after integration-test succeeded.
 - stage: Weekly
+  dependsOn: Check
   condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - job: WeeklyBuild

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -8,9 +8,5 @@ steps:
       umask a+w
       mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test testOnJava17
-    displayName: 'Run Gradle clean and Gradle check'
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results build/reports/**/*.xml'
-    inputs:
-      testResultsFiles: 'build/reports/**/*.xml'
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean check
+    displayName: 'Run Gradle clean and check'

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -9,4 +9,4 @@ steps:
       mkdir -p build
       chmod -R a+w doc_src
       $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean check
-    displayName: 'Run Gradle clean and check'
+    displayName: 'Run Gradle check'

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -8,7 +8,7 @@ steps:
       umask a+w
       mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean check testOnJava17
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test testOnJava17
     displayName: 'Run Gradle clean and Gradle check'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results build/reports/**/*.xml'

--- a/ci/azure-pipelines/test_java17_steps.yml
+++ b/ci/azure-pipelines/test_java17_steps.yml
@@ -8,8 +8,8 @@ steps:
       umask a+w
       mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test
-    displayName: 'Run Gradle clean, test and test on Java17'
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean testOnJava17
+    displayName: 'Run Gradle test on Java17'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results build/reports/**/*.xml'
     inputs:

--- a/ci/azure-pipelines/test_steps.yml
+++ b/ci/azure-pipelines/test_steps.yml
@@ -1,0 +1,16 @@
+steps:
+  - task: Cache@2
+    displayName: 'Cache Gradle'
+    inputs:
+      key: 'gradle | $(Agent.OS) | $(Build.SourcesDirectory)/build.gradle'
+      path: '$(GRADLE_USER_HOME)'
+  - script: |
+      umask a+w
+      mkdir -p build
+      chmod -R a+w doc_src
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test testOnJava17
+    displayName: 'Run Gradle clean, test and test on Java17'
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results build/reports/**/*.xml'
+    inputs:
+      testResultsFiles: 'build/reports/**/*.xml'


### PR DESCRIPTION
It is not easy to see spotbugs error on azure pipelines CI log because there are so many warnings on checkstyles.
This PR resolves a pain point by running spotbugs on github actions and put annotations on PR file diffs.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Other (describe below)
CI enhancement

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->


## What does this PR change?

- Refactoring azure pipelines flows
- Add spotbugs actions on Github

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
