### PR TITLE
chore: add spotbugsReport task in Gradle and run it on CI

### DIFF
--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -16,6 +16,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
+    - name: create annotation
+      run: echo "::add-matcher::${{ github.workspace }}/ci/github/problem-matcher.json"
     - name: run spotbugs
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -1,0 +1,22 @@
+name: Run SpotBugs
+
+on:
+  push:
+    branches:
+      - master
+      - releases/*
+  pull_request:
+
+jobs:
+  spotbugs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+    - name: run spotbugs
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: --continue -PenvIsCi spotbugsMain spotbugsTest

--- a/build.gradle
+++ b/build.gradle
@@ -89,14 +89,12 @@ allprojects {
 
     tasks.register('spotbugsMainReport') {
         doLast {
-            def reportFile = file("${projectDir}/build/reports/spotbugs/main.text")
+            def reportFile = file("build/reports/spotbugs/main.txt")
             if (reportFile.exists()) {
                 println()
                 reportFile.readLines().forEach {
                     println(it)
                 }
-            } else {
-                didWork = false
             }
         }
         group = 'verification'
@@ -104,14 +102,12 @@ allprojects {
 
     tasks.register('spotbugsTestReport') {
         doLast {
-            def reportFile = file("${projectDir}/build/reports/spotbugs/test.text")
+            def reportFile = file("build/reports/spotbugs/test.txt")
             if (reportFile.exists()) {
                 println()
                 reportFile.readLines().forEach {
                     println(it)
                 }
-            } else {
-                didWork = false
             }
         }
         group = 'verification'

--- a/build.gradle
+++ b/build.gradle
@@ -87,11 +87,58 @@ allprojects {
         reportLevel = 'high'
     }
 
-    tasks.findAll { it.name =~ /^spotbugs.*/ }.each {
-        it.reports {
-            xml.required = envIsCi
+    tasks.register('spotbugsMainReport') {
+        doLast {
+            def reportFile = file("${projectDir}/build/reports/spotbugs/main.text")
+            if (reportFile.exists()) {
+                println()
+                reportFile.readLines().forEach {
+                    println(it)
+                }
+            } else {
+                didWork = false
+            }
+        }
+        group = 'verification'
+    }
+
+    tasks.register('spotbugsTestReport') {
+        doLast {
+            def reportFile = file("${projectDir}/build/reports/spotbugs/test.text")
+            if (reportFile.exists()) {
+                println()
+                reportFile.readLines().forEach {
+                    println(it)
+                }
+            } else {
+                didWork = false
+            }
+        }
+        group = 'verification'
+    }
+
+    spotbugsMain {
+        if (envIsCi) {
+            extraArgs = ['-longBugCodes']
+            jvmArgs = ['-Duser.language=en']
+        }
+        reports {
+            text.required = envIsCi
             html.required = !envIsCi
         }
+        finalizedBy(spotbugsMainReport)
+    }
+
+    spotbugsTest {
+        if (envIsCi) {
+            extraArgs = ['-longBugCodes']
+            jvmArgs = ['-Duser.language=en']
+        }
+        reports {
+            text.required = envIsCi
+            html.required = !envIsCi
+        }
+        finalizedBy(spotbugsTestReport)
     }
 
     checkstyle {

--- a/ci/github/problem-matcher.json
+++ b/ci/github/problem-matcher.json
@@ -1,0 +1,39 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "spotbugs",
+      "pattern": [
+        {
+          "regexp": "^.*((?:H|M|L)\\s+(?:[A-Z])\\s+(?:[A-Z0-9_]+\\s+)?(?:[A-Za-z0-9]+)):\\s+(.*)\\s+(?:a|A)t\\s+([A-Za-z0-9_]+\\.java):\\[line(s)? (\\d+(?:-\\d+))\\]$",
+          "file": 3,
+          "line": 4,
+          "message": 2,
+          "code": 1
+        }
+      ]
+    },
+    {
+      "owner": "spotbugs-OBL",
+      "pattern": [
+        {
+          "regexp": "^.*(M X (?:[A-Z0-9_]+\\s+)?(?:[A-Za-z0-9]+)):\\s+((?:.*)\\s+(?:a|A)t\\s+([A-Za-z0-9_]+\\.java):\\[line (\\d+)\\] is not discharged)$",
+          "file": 3,
+          "line": 4,
+          "message": 2,
+          "code": 1
+        }
+      ]
+    },
+    {
+      "owner": "spotbugs-no-line-number",
+      "pattern": [
+        {
+          "regexp": "^.*((?:H|M|L)\\s+(?:[A-Z])\\s+(?:[A-Z0-9_]+\\s+)?(?:[A-Za-z0-9]+)):\\s+(.*)\\s+In\\s+([A-Za-z0-9_]+\\.java)$",
+          "file": 3,
+          "message": 2,
+          "code": 1
+        }
+      ]
+    }
+  ]
+}

--- a/languagetools/build.gradle
+++ b/languagetools/build.gradle
@@ -82,4 +82,8 @@ plugins.forEach { args ->
         group = 'languagetool'
     }
     jar.dependsOn "${name}Jar"
+    def capitalName = name.capitalize()
+    tasks.getByName("spotbugs${capitalName}") {
+        group = 'other'
+    }
 }


### PR DESCRIPTION
Show spotbugs errors on console on CI

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

- Add sportbugsReport task in Gradle
- Run sportbugsReport task on CI
- Annnotate Spotbugs warning/error in Github Actions using `problem-matcher.json`

## Other information

The feature is discussed at
https://github.com/spotbugs/spotbugs-gradle-plugin/issues/172#issuecomment-555901305