### PR TITLE
chore(ci/azure pipelines): fix  integration test script for weekly release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,18 +65,26 @@ stages:
       vmImage: 'ubuntu-22.04'
     steps:
       - template: ci/azure-pipelines/check_steps.yml
+  - job: IntegrationTestForWeekly
+    displayName: Integration Test
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+      - template: ci/azure-pipelines/integ_test_steps.yml
+        parameters:
+          testType: 'GIT'
+          duration: 600
   - job: WeeklyBuild
     displayName: Build for master weekly
+    dependsOn:
+      - CheckForWeekly
+      - IntegrationTestForWeekly
     pool:
       vmImage: 'ubuntu-22.04'
     steps:
       - script: |
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
-      - template: ci/azure-pipelines/integ_test_steps.yml
-        parameters:
-          testType: 'GIT'
-          duration: 600
       - template: ci/azure-pipelines/build_steps.yml
       - template: ci/azure-pipelines/publish_weekly.yml
         parameters:

--- a/ci/azure-pipelines/integ_test_steps.yml
+++ b/ci/azure-pipelines/integ_test_steps.yml
@@ -14,28 +14,12 @@ steps:
       echo "Run ${{ parameters.testType }} integration test"
   - task: DockerCompose@0
     inputs:
-      action: Build services
+      action: Run a Docker Compose command
       containerregistrytype: Container Registry
       dockerComposeFile: compose.yml
-    displayName: 'build container image'
-  - task: DockerCompose@0
-    inputs:
-      action: Run a specific service
-      containerregistrytype: Container Registry
-      dockerComposeFile: compose.yml
+      dockerComposeCommand: up
       buildImages: true
-      serviceName: server
-      detached: true
-    displayName: 'Run team server'
-  - task: DockerCompose@0
-    inputs:
-      action: Run a specific service
-      containerregistrytype: Container Registry
-      dockerComposeFile: compose.yml
-      buildImages: true
-      serviceName: client
       abortOnContainerExit: true
-      detached: false
     env:
       DURATION: ${{ parameters.duration }}
       TYPE: ${{ parameters.testType }}


### PR DESCRIPTION
Integration test which run before weekly release become failure.
This change fix the issue.

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

- Weekly release job depends on check and integration-test
- Update integration-test yaml template to run correctly

## Other information

Manual run check works fine (canceled by hand)
