### PR TITLE
fix(integ-test): load repository plugins

### DIFF
--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -253,6 +253,15 @@ public final class PluginUtils {
     }
 
     /**
+     * Load plugin for test.
+     * WARN: don't use for general purpose.
+     */
+    public static void loadPluginFromProperties(Properties props) throws ClassNotFoundException {
+        ClassLoader pluginsClassLoader = PluginUtils.class.getClassLoader();
+        loadFromProperties(props, pluginsClassLoader);
+    }
+
+    /**
      * This method create a list of plugins to load. It tries to onky take the
      * most recent version of plugins. To differenciate between different
      * versions, the plugins must have the same name, have the same number of

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -230,7 +230,7 @@ public final class PluginUtils {
                         }
                     }
                 } else {
-                    // load from plugins property list
+                    // load from `Plugins.properties` file
                     Properties props = new Properties();
                     try (FileInputStream fis = new FileInputStream(PLUGINS_LIST_FILE)) {
                         props.load(fis);
@@ -254,7 +254,13 @@ public final class PluginUtils {
 
     /**
      * Load plugin for test.
-     * WARN: don't use for general purpose.
+     * <p>
+     * WARN: don't use it for general purpose.
+     * 
+     * @param props
+     *            properties that have "plugin=(classes...)"
+     * @throws ClassNotFoundException
+     *             when specified plugin is not found.
      */
     public static void loadPluginFromProperties(Properties props) throws ClassNotFoundException {
         ClassLoader pluginsClassLoader = PluginUtils.class.getClassLoader();
@@ -262,12 +268,12 @@ public final class PluginUtils {
     }
 
     /**
-     * This method create a list of plugins to load. It tries to onky take the
-     * most recent version of plugins. To differenciate between different
+     * This method creates a list of plugins to load. It tries to only take the
+     * most recent version of plugins. To differentiate between different
      * versions, the plugins must have the same name, have the same number of
      * version components (we can't compare <code>x.y.z</code> with
-     * <code>y.z</code>). Also the qualifier (ie. anything after the "-" in the
-     * version number) is discarded for the comparison.
+     * <code>y.z</code>). Also, the qualifier (i.e., anything after the "-" in
+     * the version number) is discarded for the comparison.
      *
      * @param pluginsDirs
      *            List of directories where plugins can be loaded
@@ -364,6 +370,7 @@ public final class PluginUtils {
 
     /**
      * Reterun registered plugin classes for spellchecker category.
+     * 
      * @return list of classes.
      */
     public static List<Class<?>> getSpellCheckClasses() {

--- a/test-integration/plugins.properties
+++ b/test-integration/plugins.properties
@@ -1,0 +1,4 @@
+plugin=org.omegat.core.team2.impl.FileRepository \
+    org.omegat.core.team2.impl.HTTPRemoteRepository \
+    org.omegat.core.team2.impl.GITRemoteRepository2 \
+    org.omegat.core.team2.impl.SVNRemoteRepository2

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -26,7 +26,10 @@
 package org.omegat.core.data;
 
 import java.io.File;
+import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,6 +68,7 @@ import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.team2.impl.GITRemoteRepository2;
 import org.omegat.core.team2.impl.SVNAuthenticationManager;
+import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;
 import org.omegat.util.ProjectFileStorage;
 import org.omegat.util.TMXWriter2;
@@ -119,6 +124,7 @@ public final class TestTeamIntegration {
     private TestTeamIntegration() {
     }
 
+    public static final String PLUGINS_LIST_FILE = "test-integration/plugins.properties";
     private static final Pattern URL_PATTERN = Pattern
             .compile("(http(s)?|svn(\\+ssh)?)" + "://(?<username>.+?)(:(?<password>.+?))?@.+");
 
@@ -145,6 +151,11 @@ public final class TestTeamIntegration {
         if (repository == null) {
             System.err.println("Property omegat.test.repo is mandatory.");
             System.exit(1);
+        }
+        Properties props = new Properties();
+        try (InputStream fis = Files.newInputStream(Paths.get(PLUGINS_LIST_FILE))) {
+            props.load(fis);
+            PluginUtils.loadPluginFromProperties(props);
         }
         REPO.add(repository);
         String altRepo = System.getProperty("omegat.test.repo.alt", null);


### PR DESCRIPTION

Now repository connectors are in-source plugin, so we need to load these plugins explicitly in integration test.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

## What does this PR change?

- Add PluginUtils.loadPluginFromProperties for test purpose
- Add `test-integration/plugins.properties` that lists plugins required for the test.
- Update TestTeamIntegration class to load plugins before start.

## Other information

related #604
