### PR TITLE
chore(test-integ): update build.gradle/compose.yml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1288,6 +1288,10 @@ test {
 
 task testIntegration(type: JavaExec) {
     description = 'Run integration tests. Pass repo URL as -Domegat.test.repo=<repo>'
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
     group = 'omegat workflow'
     mainClass = 'org.omegat.core.data.TestTeamIntegration'
     classpath = sourceSets.testIntegration.runtimeClasspath

--- a/compose.yml
+++ b/compose.yml
@@ -12,7 +12,12 @@ services:
       - "10080:80"
       - "10443:443"
   client:
-    build: test-integration/docker/client
+    build:
+      context: test-integration/docker/client
+      args:
+        JAVA: 17
+        JDKVER: jdk_17.0.8.1.0+1
+        GRADLE: 8.3
     depends_on:
       - server
     volumes:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Bump Docker JDK to jdk-17.0.8.1.0+1
- Running test-integ on Java 17

## Other information

Now we bundles Adoptium OpenJDK JRE 17 for weekly release distribution.
It is better to test team integrations with JDK17.
