### PR TITLE
[BUGS#1146] ui: TagProcessingOptionsPanel to TextArea

### DIFF
--- a/src/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.form
+++ b/src/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.form
@@ -21,10 +21,11 @@
     <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,87,0,0,2,73"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-86,0,0,2,73"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
@@ -43,7 +44,6 @@
         </Property>
         <Property name="wrapStyleWord" type="boolean" value="true"/>
         <Property name="alignmentX" type="float" value="0.0"/>
-        <Property name="dragEnabled" type="boolean" value="false"/>
         <Property name="focusable" type="boolean" value="false"/>
         <Property name="opaque" type="boolean" value="false"/>
       </Properties>
@@ -299,19 +299,6 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JTextField" name="customPatternRegExpTF">
-          <Properties>
-            <Property name="alignmentX" type="float" value="0.0"/>
-          </Properties>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
-              <BorderConstraints direction="Center"/>
-            </Constraint>
-          </Constraints>
-        </Component>
         <Component class="javax.swing.JTextArea" name="customPatternWarningTextArea">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
@@ -335,6 +322,29 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+          <AuxValues>
+            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+          </AuxValues>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="Center"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <SubComponents>
+            <Component class="javax.swing.JTextArea" name="customPatternRegExpTF">
+              <Properties>
+                <Property name="columns" type="int" value="20"/>
+                <Property name="rows" type="int" value="5"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
     <Component class="javax.swing.Box$Filler" name="filler8">
@@ -372,19 +382,6 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JTextField" name="removePatternRegExpTF">
-          <Properties>
-            <Property name="alignmentX" type="float" value="0.0"/>
-          </Properties>
-          <AuxValues>
-            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
-              <BorderConstraints direction="Center"/>
-            </Constraint>
-          </Constraints>
-        </Component>
         <Component class="javax.swing.JTextArea" name="removePatternWarningTextArea">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
@@ -408,6 +405,29 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Container class="javax.swing.JScrollPane" name="jScrollPane2">
+          <AuxValues>
+            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+          </AuxValues>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="Center"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+          <SubComponents>
+            <Component class="javax.swing.JTextArea" name="removePatternRegExpTF">
+              <Properties>
+                <Property name="columns" type="int" value="20"/>
+                <Property name="rows" type="int" value="5"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.java
+++ b/src/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.java
@@ -74,13 +74,15 @@ public class TagProcessingOptionsPanel extends JPanel {
         filler9 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 10));
         jPanel2 = new javax.swing.JPanel();
         jLabelCustomPattern = new javax.swing.JLabel();
-        customPatternRegExpTF = new javax.swing.JTextField();
         customPatternWarningTextArea = new javax.swing.JTextArea();
+        jScrollPane1 = new javax.swing.JScrollPane();
+        customPatternRegExpTF = new javax.swing.JTextArea();
         filler8 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 10));
         jPanel1 = new javax.swing.JPanel();
         jLabelRemovePattern = new javax.swing.JLabel();
-        removePatternRegExpTF = new javax.swing.JTextField();
         removePatternWarningTextArea = new javax.swing.JTextArea();
+        jScrollPane2 = new javax.swing.JScrollPane();
+        removePatternRegExpTF = new javax.swing.JTextArea();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
         setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.PAGE_AXIS));
@@ -91,7 +93,6 @@ public class TagProcessingOptionsPanel extends JPanel {
         descriptionTextArea.setText(OStrings.getString("GUI_TAGVALIDATION_DESCRIPTION")); // NOI18N
         descriptionTextArea.setWrapStyleWord(true);
         descriptionTextArea.setAlignmentX(0.0F);
-        descriptionTextArea.setDragEnabled(false);
         descriptionTextArea.setFocusable(false);
         descriptionTextArea.setOpaque(false);
         add(descriptionTextArea);
@@ -152,9 +153,6 @@ public class TagProcessingOptionsPanel extends JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(jLabelCustomPattern, OStrings.getString("TV_OPTION_CUSTOMPATTERN")); // NOI18N
         jPanel2.add(jLabelCustomPattern, java.awt.BorderLayout.NORTH);
 
-        customPatternRegExpTF.setAlignmentX(0.0F);
-        jPanel2.add(customPatternRegExpTF, java.awt.BorderLayout.CENTER);
-
         customPatternWarningTextArea.setEditable(false);
         customPatternWarningTextArea.setFont(jLabelCustomPattern.getFont());
         customPatternWarningTextArea.setForeground(java.awt.Color.red);
@@ -163,6 +161,12 @@ public class TagProcessingOptionsPanel extends JPanel {
         customPatternWarningTextArea.setAlignmentX(0.0F);
         customPatternWarningTextArea.setOpaque(false);
         jPanel2.add(customPatternWarningTextArea, java.awt.BorderLayout.SOUTH);
+
+        customPatternRegExpTF.setColumns(20);
+        customPatternRegExpTF.setRows(5);
+        jScrollPane1.setViewportView(customPatternRegExpTF);
+
+        jPanel2.add(jScrollPane1, java.awt.BorderLayout.CENTER);
 
         add(jPanel2);
         add(filler8);
@@ -173,9 +177,6 @@ public class TagProcessingOptionsPanel extends JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(jLabelRemovePattern, OStrings.getString("TV_OPTION_REMOVEPATTERN")); // NOI18N
         jPanel1.add(jLabelRemovePattern, java.awt.BorderLayout.NORTH);
 
-        removePatternRegExpTF.setAlignmentX(0.0F);
-        jPanel1.add(removePatternRegExpTF, java.awt.BorderLayout.CENTER);
-
         removePatternWarningTextArea.setEditable(false);
         removePatternWarningTextArea.setFont(jLabelCustomPattern.getFont());
         removePatternWarningTextArea.setForeground(java.awt.Color.red);
@@ -185,13 +186,19 @@ public class TagProcessingOptionsPanel extends JPanel {
         removePatternWarningTextArea.setOpaque(false);
         jPanel1.add(removePatternWarningTextArea, java.awt.BorderLayout.SOUTH);
 
+        removePatternRegExpTF.setColumns(20);
+        removePatternRegExpTF.setRows(5);
+        jScrollPane2.setViewportView(removePatternRegExpTF);
+
+        jPanel1.add(jScrollPane2, java.awt.BorderLayout.CENTER);
+
         add(jPanel1);
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     javax.swing.JCheckBox cbCountingProtectedText;
     javax.swing.JCheckBox cbTagsValidRequired;
-    javax.swing.JTextField customPatternRegExpTF;
+    javax.swing.JTextArea customPatternRegExpTF;
     javax.swing.JTextArea customPatternWarningTextArea;
     private javax.swing.JTextArea descriptionTextArea;
     private javax.swing.Box.Filler filler1;
@@ -209,12 +216,14 @@ public class TagProcessingOptionsPanel extends JPanel {
     private javax.swing.JPanel jPanel2;
     private javax.swing.JPanel jPanel3;
     private javax.swing.JPanel jPanel4;
+    private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JScrollPane jScrollPane2;
     javax.swing.JCheckBox javaPatternCheckBox;
     javax.swing.JCheckBox looseTagOrderCheckBox;
     private javax.swing.JTextArea looseTagOrderWarningTextArea;
     javax.swing.JRadioButton noCheckRadio;
     javax.swing.ButtonGroup ourButtonGroup;
-    javax.swing.JTextField removePatternRegExpTF;
+    javax.swing.JTextArea removePatternRegExpTF;
     javax.swing.JTextArea removePatternWarningTextArea;
     javax.swing.JRadioButton simpleCheckRadio;
     // End of variables declaration//GEN-END:variables


### PR DESCRIPTION
There are two text field in TagProcessingOptionsPanel. This change these to textarea.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/


Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->
 
- #1146 Custom tag field does not resize based on contents
- Bugs: https://sourceforge.net/p/omegat/bugs/1146/

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
