### PR TITLE
feat: selector credentials per host/repo

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1839,7 +1839,7 @@ PREFS_TITLE_PROXY_LOGIN=Proxy Login
 PROXY_LOGIN_DESCRIPTION=Authenticated proxy credentials:
 LOG_DECODING_ERROR=Error decoding user and password.
 
-LOGIN_USER=User:
+LOGIN_USER=Username:
 LOGIN_PASSWORD=Password:
 
 # PREFERENCES - TAG PROCESSING

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2332,7 +2332,8 @@ TEAM_PASSPHRASE_WRONG=Failed to decrypt for SSH key {0}
 TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
 TEAM_YESNO_ABORT=Cannot get the correct answer. Abort...
 
-CREDENTIALS_PER_HOST=Apply for repositories on the host
+TEAM_CREDENTIALS_PER_HOST=Apply for repositories on the host
+TEAM_CREDENTIALS_PER_HOST_CUI=Apply for repositories on the host(Yes/No):
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2322,7 +2322,7 @@ TEAM_26_to_36_CONVERT_FAILED=Project conversion failed.\n\
   Check whether your repository has correct commits and files.\n\
   You may have forgotten an initial commit.
 TEAM_USERPASS_TITLE=Authentication
-TEAM_USERPASS_FIRST=Enter username/password for {0}
+TEAM_USERPASS_FIRST=Enter your credentials for {0}
 TEAM_USERPASS_WRONG=Incorrect username/password for {0}
 TEAM_USER_FIRST=Enter the username for {0}
 TEAM_PASS_FIRST=Enter the password for {0}
@@ -2332,7 +2332,7 @@ TEAM_PASSPHRASE_WRONG=Failed to decrypt for SSH key {0}
 TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
 TEAM_YESNO_ABORT=Cannot get the correct answer. Abort...
 
-TEAM_CREDENTIALS_PER_HOST=Apply for all repositories on the host {0}
+TEAM_CREDENTIALS_PER_HOST=Apply to all repositories on host {0}
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2330,7 +2330,9 @@ TEAM_PASSPHRASE_FIRST=Enter the passphrase for SSH key {0}
 TEAM_PASS_WRONG=Incorrect password for {0}
 TEAM_PASSPHRASE_WRONG=Failed to decrypt for SSH key {0}
 TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
-TEAM_YESNO_ABORT=Cannot get correct answer. Abort...
+TEAM_YESNO_ABORT=Cannot get the correct answer. Abort...
+
+CREDENTIALS_PER_HOST=Apply for repositories on the host
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2332,7 +2332,7 @@ TEAM_PASSPHRASE_WRONG=Failed to decrypt for SSH key {0}
 TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
 TEAM_YESNO_ABORT=Cannot get the correct answer. Abort...
 
-TEAM_CREDENTIALS_PER_HOST=Apply for all repositories on the host
+TEAM_CREDENTIALS_PER_HOST=Apply for all repositories on the host {0}
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2332,8 +2332,7 @@ TEAM_PASSPHRASE_WRONG=Failed to decrypt for SSH key {0}
 TEAM_YESNO_AGAIN=Got unexpected input. Ask again...
 TEAM_YESNO_ABORT=Cannot get the correct answer. Abort...
 
-TEAM_CREDENTIALS_PER_HOST=Apply for repositories on the host
-TEAM_CREDENTIALS_PER_HOST_CUI=Apply for repositories on the host(Yes/No):
+TEAM_CREDENTIALS_PER_HOST=Apply for all repositories on the host
 
 TEAM_NEW_PROJECT_URL_OR_FILE=<html>Repository URL:</html>
 TEAM_NEW_HEADER=Download Team Project

--- a/src/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/org/omegat/core/team2/gui/UserPassDialog.java
@@ -163,8 +163,6 @@ public class UserPassDialog extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
         mainPanel.add(passwordField, gridBagConstraints);
 
-        org.openide.awt.Mnemonics.setLocalizedText(perHostCheckBox,
-                OStrings.getString("TEAM_CREDENTIALS_PER_HOST")); // NOI18N
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 7;
@@ -243,5 +241,9 @@ public class UserPassDialog extends javax.swing.JDialog {
 
     public void setDescription(String description) {
         descriptionTextArea.setText(description);
+    }
+
+    public void setPerHostCheckBoxText(String text) {
+        org.openide.awt.Mnemonics.setLocalizedText(perHostCheckBox, text);
     }
 }

--- a/src/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/org/omegat/core/team2/gui/UserPassDialog.java
@@ -162,7 +162,7 @@ public class UserPassDialog extends javax.swing.JDialog {
         mainPanel.add(passwordField, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(perHostCheckBox,
-                OStrings.getString("CREDENTIALS_PER_HOST")); // NOI18N
+                OStrings.getString("TEAM_CREDENTIALS_PER_HOST")); // NOI18N
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 7;

--- a/src/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/org/omegat/core/team2/gui/UserPassDialog.java
@@ -27,7 +27,20 @@
 
 package org.omegat.core.team2.gui;
 
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
 
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.StaticUIUtils;
@@ -52,14 +65,13 @@ public class UserPassDialog extends javax.swing.JDialog {
         StaticUIUtils.setEscapeClosable(this);
 
         initComponents();
-
         getRootPane().setDefaultButton(okButton);
 
         invalidate();
         pack();
         setLocationRelativeTo(parent);
 
-        userText.requestFocusInWindow();
+        usernameField.requestFocusInWindow();
     }
 
     /** @return the return status of this dialog - one of RET_OK or RET_CANCEL */
@@ -71,110 +83,123 @@ public class UserPassDialog extends javax.swing.JDialog {
      * This method is called from within the constructor to initialize the form.
      */
     private void initComponents() {
-        java.awt.GridBagConstraints gridBagConstraints;
+        GridBagConstraints gridBagConstraints;
 
-        jPanel3 = new javax.swing.JPanel();
-        descriptionTextArea = new javax.swing.JTextArea();
-        jPanel2 = new javax.swing.JPanel();
-        userLabel = new JLabel();
-        userText = new javax.swing.JTextField();
-        passwordLabel = new JLabel();
-        passwordField = new javax.swing.JPasswordField();
-        jPanel4 = new javax.swing.JPanel();
-        jPanel1 = new javax.swing.JPanel();
-        okButton = new javax.swing.JButton();
-        cancelButton = new javax.swing.JButton();
+        JPanel northPanel = new JPanel();
+        JPanel mainPanel = new JPanel();
+        JPanel buttonPanel = new JPanel();
+        JPanel southPanel = new JPanel();
+        descriptionTextArea = new JTextArea();
+        JLabel usernameLabel = new JLabel();
+        usernameField = new JTextField();
+        JLabel passwordLabel = new JLabel();
+        passwordField = new JPasswordField();
+        perHostCheckBox = new JCheckBox();
+        okButton = new JButton();
+        JButton cancelButton = new JButton();
 
         setTitle(OStrings.getString("TEAM_USERPASS_TITLE")); // NOI18N
-        setMinimumSize(new java.awt.Dimension(450, 200));
-        addWindowListener(new java.awt.event.WindowAdapter() {
-            public void windowClosing(java.awt.event.WindowEvent evt) {
+        setMinimumSize(new Dimension(450, 200));
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent evt) {
                 formWindowClosing(evt);
             }
         });
 
-        jPanel3.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        jPanel3.setLayout(new java.awt.BorderLayout());
+        northPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        northPanel.setLayout(new BorderLayout());
 
         descriptionTextArea.setEditable(false);
         descriptionTextArea.setFont(new JLabel().getFont());
         descriptionTextArea.setLineWrap(true);
         descriptionTextArea.setWrapStyleWord(true);
         descriptionTextArea.setOpaque(false);
-        jPanel3.add(descriptionTextArea, java.awt.BorderLayout.CENTER);
+        northPanel.add(descriptionTextArea, BorderLayout.CENTER);
 
-        getContentPane().add(jPanel3, java.awt.BorderLayout.NORTH);
+        getContentPane().add(northPanel, BorderLayout.NORTH);
 
-        jPanel2.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 10, 10, 10));
-        jPanel2.setLayout(new java.awt.GridBagLayout());
+        mainPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 10, 10, 10));
+        mainPanel.setLayout(new java.awt.GridBagLayout());
 
-        userLabel.setLabelFor(userText);
-        org.openide.awt.Mnemonics.setLocalizedText(userLabel, OStrings.getString("LOGIN_USER")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        usernameLabel.setLabelFor(usernameField);
+        org.openide.awt.Mnemonics.setLocalizedText(usernameLabel, OStrings.getString("LOGIN_USER")); // NOI18N
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 5;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);
-        jPanel2.add(userLabel, gridBagConstraints);
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        mainPanel.add(usernameLabel, gridBagConstraints);
+
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 5;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 50;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
-        jPanel2.add(userText, gridBagConstraints);
+        mainPanel.add(usernameField, gridBagConstraints);
 
         passwordLabel.setLabelFor(passwordField);
         org.openide.awt.Mnemonics.setLocalizedText(passwordLabel, OStrings.getString("LOGIN_PASSWORD")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 6;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);
-        jPanel2.add(passwordLabel, gridBagConstraints);
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        mainPanel.add(passwordLabel, gridBagConstraints);
+
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 6;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 50;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(4, 4, 4, 4);
-        jPanel2.add(passwordField, gridBagConstraints);
+        mainPanel.add(passwordField, gridBagConstraints);
 
-        getContentPane().add(jPanel2, java.awt.BorderLayout.CENTER);
+        org.openide.awt.Mnemonics.setLocalizedText(perHostCheckBox,
+                OStrings.getString("CREDENTIALS_PER_HOST")); // NOI18N
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 7;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);
+        mainPanel.add(perHostCheckBox, gridBagConstraints);
 
-        jPanel4.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        jPanel4.setLayout(new java.awt.BorderLayout());
+        getContentPane().add(mainPanel, BorderLayout.CENTER);
+
+        southPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        southPanel.setLayout(new BorderLayout());
 
         org.openide.awt.Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK")); // NOI18N
         okButton.addActionListener(this::okButtonActionPerformed);
-        jPanel1.add(okButton);
+        buttonPanel.add(okButton);
 
         org.openide.awt.Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL")); // NOI18N
         cancelButton.addActionListener(this::cancelButtonActionPerformed);
-        jPanel1.add(cancelButton);
+        buttonPanel.add(cancelButton);
 
-        jPanel4.add(jPanel1, java.awt.BorderLayout.EAST);
+        southPanel.add(buttonPanel, BorderLayout.EAST);
 
-        getContentPane().add(jPanel4, java.awt.BorderLayout.SOUTH);
+        getContentPane().add(southPanel, BorderLayout.SOUTH);
 
         pack();
     }
 
-    private void okButtonActionPerformed(java.awt.event.ActionEvent evt) {
+    private void okButtonActionPerformed(ActionEvent evt) {
         doClose(RET_OK);
     }
 
-    private void cancelButtonActionPerformed(java.awt.event.ActionEvent evt) {
+    private void cancelButtonActionPerformed(ActionEvent evt) {
         doClose(RET_CANCEL);
     }
 
-    private void formWindowClosing(java.awt.event.WindowEvent evt) {
+    private void formWindowClosing(WindowEvent evt) {
         doClose(RET_CANCEL);
     }
 
@@ -184,34 +209,36 @@ public class UserPassDialog extends javax.swing.JDialog {
         dispose();
     }
 
-    private javax.swing.JButton cancelButton;
-    public javax.swing.JTextArea descriptionTextArea;
-    private javax.swing.JPanel jPanel1;
-    private javax.swing.JPanel jPanel2;
-    private javax.swing.JPanel jPanel3;
-    private javax.swing.JPanel jPanel4;
-    private javax.swing.JButton okButton;
-    private javax.swing.JPasswordField passwordField;
-    private JLabel passwordLabel;
-    private JLabel userLabel;
-    private javax.swing.JTextField userText;
+    private JButton okButton;
+    private JTextArea descriptionTextArea;
+    private JTextField usernameField;
+    private JPasswordField passwordField;
+    private javax.swing.JCheckBox perHostCheckBox;
 
     private int returnStatus = RET_CANCEL;
 
     public void setUsername(String txt) {
-        userText.setText(txt);
+        usernameField.setText(txt);
     }
 
     public void enableUsernameField(boolean enabled) {
-        userText.setEditable(enabled);
-        userText.setEnabled(enabled);
+        usernameField.setEditable(enabled);
+        usernameField.setEnabled(enabled);
     }
 
     public String getUsername() {
-        return userText.getText();
+        return usernameField.getText();
     }
 
     public String getPassword() {
         return new String(passwordField.getPassword());
+    }
+
+    public boolean isPerHost() {
+        return perHostCheckBox.isSelected();
+    }
+
+    public void setDescription(String description) {
+        descriptionTextArea.setText(description);
     }
 }

--- a/src/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/org/omegat/core/team2/gui/UserPassDialog.java
@@ -74,7 +74,9 @@ public class UserPassDialog extends javax.swing.JDialog {
         usernameField.requestFocusInWindow();
     }
 
-    /** @return the return status of this dialog - one of RET_OK or RET_CANCEL */
+    /**
+     * @return the return status of this dialog - one of RET_OK or RET_CANCEL
+     */
     public int getReturnStatus() {
         return returnStatus;
     }

--- a/src/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/org/omegat/core/team2/gui/UserPassDialog.java
@@ -126,7 +126,7 @@ public class UserPassDialog extends javax.swing.JDialog {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 5;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);
         mainPanel.add(usernameLabel, gridBagConstraints);
@@ -146,7 +146,7 @@ public class UserPassDialog extends javax.swing.JDialog {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 6;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);
         mainPanel.add(passwordLabel, gridBagConstraints);
@@ -166,6 +166,7 @@ public class UserPassDialog extends javax.swing.JDialog {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(4, 16, 4, 4);

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -389,6 +389,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
             if (userPassDialog.getReturnStatus() == UserPassDialog.RET_OK) {
                 credentials.username = userPassDialog.getUsername();
                 credentials.password = userPassDialog.getPassword();
+                credentials.perHost = userPassDialog.isPerHost();
                 return credentials;
             }
         }
@@ -412,6 +413,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
             }
             char[] pass = console.readPassword(OStrings.getString("TEAM_PASS_FIRST", uri.getHumanishName()));
             credentials.password = Arrays.toString(pass);
+            String yesNo = console.readLine(OStrings.getString("TEAM_CREDENTIALS_PER_HOST_CUI"));
+            credentials.perHost = "yes".equalsIgnoreCase(yesNo) || "y".equalsIgnoreCase(yesNo);
             return credentials;
         }
         Log.log("No console found.");

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -47,13 +47,12 @@ import org.eclipse.jgit.transport.URIish;
 
 import org.omegat.core.Core;
 import org.omegat.core.KnownException;
-import org.omegat.core.team2.TeamSettings;
 import org.omegat.core.team2.gui.PassphraseDialog;
 import org.omegat.core.team2.gui.UserPassDialog;
+import org.omegat.core.team2.impl.TeamUtils.Credentials;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
-import org.omegat.util.StringUtil;
 
 /**
  * Git repository credentials provider. One credential provider created for all
@@ -83,9 +82,6 @@ import org.omegat.util.StringUtil;
 
 public class GITCredentialsProvider extends CredentialsProvider {
 
-    private static final String KEY_USERNAME_SUFFIX = "username";
-    private static final String KEY_PASSWORD_SUFFIX = "password";
-    private static final String KEY_FINGERPRINT_SUFFIX = "fingerprint";
     private static final Pattern[] fingerPrintRegex = new Pattern[] {
             Pattern.compile("The authenticity of host '" + /* host */ ".*" + "' can't be established\\.\\n" +
             /* key_type */ "(RSA|DSA|ECDSA|EDDSA)" + " key fingerprint is " +
@@ -144,57 +140,11 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private Credentials loadCredentials(URIish uri) {
-        Credentials credentials = new Credentials();
-        // we use "schema://server:port" or "/path/to/.ssh/id_rsa"
-        // and backward compatible "schema://server:port/path"
-        // check following order
-        String url = uri.toString();
-        credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
-        credentials.password = TeamUtils.decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
-        if (credentials.password == null) {
-            if (uri.getScheme() == null) {
-                url = uri.getPath();
-            } else {
-                url = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort();
-            }
-            credentials.username = TeamSettings.get(url + "!" + KEY_USERNAME_SUFFIX);
-            credentials.password = TeamUtils
-                    .decodePassword(TeamSettings.get(url + "!" + KEY_PASSWORD_SUFFIX));
-        }
-        return credentials;
+        return TeamUtils.loadCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(), uri.getPort());
     }
 
     private void saveCredentials(URIish uri, Credentials credentials) {
-        String url;
-        if (uri.getScheme() == null) {
-            url = uri.getPath();
-        } else if (uri.getScheme() != null && uri.getHost() != null) {
-            url = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort();
-        } else {
-            url = uri.getRawPath();
-        }
-        try {
-            if (!StringUtil.isEmpty(credentials.username)) {
-                TeamSettings.set(url + "!" + KEY_USERNAME_SUFFIX, credentials.username);
-            }
-            TeamSettings.set(url + "!" + KEY_PASSWORD_SUFFIX, TeamUtils.encodePassword(credentials.password));
-        } catch (Exception e) {
-            Log.logErrorRB(e, "TEAM_ERROR_SAVE_CREDENTIALS");
-        }
-    }
-
-    private String loadFingerprint(URIish uri) {
-        String url = uri.toString();
-        return TeamSettings.get(url + "!" + KEY_FINGERPRINT_SUFFIX);
-    }
-
-    private void saveFingerprint(URIish uri, String fingerprint) {
-        String url = uri.toString();
-        try {
-            TeamSettings.set(url + "!" + KEY_FINGERPRINT_SUFFIX, fingerprint);
-        } catch (Exception e) {
-            Core.getMainWindow().displayErrorRB(e, "TEAM_ERROR_SAVE_CREDENTIALS", null, "TF_ERROR");
-        }
+        TeamUtils.saveCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(), uri.getPort(), credentials);
     }
 
     /**
@@ -268,7 +218,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 // RSA key fingerprint is
                 // e2:d3:84:d5:86:e7:68:69:a0:aa:a6:ad:a3:a0:ab:a2.
                 // Are you sure you want to continue connecting?
-                String storedFingerprint = loadFingerprint(uri);
+                String storedFingerprint = TeamUtils.loadFingerprint(uri.toString());
                 // exhausted messages to promptText and reset sb
                 String promptText = sb.append(item.getPromptText()).toString();
                 sb = new StringBuilder();
@@ -340,7 +290,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 JOptionPane.WARNING_MESSAGE);
         if (choice == JOptionPane.YES_OPTION) {
             ((CredentialItem.YesNoType) item).setValue(true);
-            saveFingerprint(uri, promptedFingerprint);
+            TeamUtils.saveFingerprint(uri.toString(), promptedFingerprint);
         } else {
             ((CredentialItem.YesNoType) item).setValue(false);
         }
@@ -356,7 +306,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
                     String answer = console.readLine("([y]es or [n]o): ");
                     if (answer.equalsIgnoreCase("y") || answer.equalsIgnoreCase("yes")) {
                         ((CredentialItem.YesNoType) item).setValue(true);
-                        saveFingerprint(uri, promptedFingerprint);
+                        TeamUtils.saveFingerprint(uri.toString(), promptedFingerprint);
                         succeeded = true;
                         break;
                     } else if (answer.equalsIgnoreCase("n") || answer.equalsIgnoreCase("no")) {
@@ -425,7 +375,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
         } else {
             UserPassDialog userPassDialog = new UserPassDialog(mw.getApplicationFrame());
             userPassDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
-            userPassDialog.descriptionTextArea.setText(OStrings.getString(
+            userPassDialog.setDescription(OStrings.getString(
                     credentials.username == null ? "TEAM_USERPASS_FIRST" : "TEAM_USERPASS_WRONG",
                     uri.getHumanishName()));
             if (uri.getUser() != null && !"".equals(uri.getUser())) {
@@ -469,7 +419,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private Credentials askCredentials(URIish uri, Credentials credentials, boolean passwordOnly,
-            String msg) {
+                                                 String msg) {
         Credentials result;
         if (isGUI()) {
             result = askCredentialsGUI(uri, credentials, passwordOnly, msg);
@@ -504,6 +454,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
         Credentials credentials = loadCredentials(uri);
         credentials.username = null;
         credentials.password = null;
+        credentials.perHost = false;
         saveCredentials(uri, credentials);
     }
 
@@ -538,11 +489,4 @@ public class GITCredentialsProvider extends CredentialsProvider {
         return false;
     }
 
-    /**
-     * POJO to hold credentials.
-     */
-    public static class Credentials {
-        public String username = null;
-        public String password = null;
-    }
 }

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -355,6 +355,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
             userPassDialog.setDescription(OStrings.getString(
                     credentials.username == null ? "TEAM_USERPASS_FIRST" : "TEAM_USERPASS_WRONG",
                     uri.getHumanishName()));
+            userPassDialog.setPerHostCheckBoxText(OStrings.getString("TEAM_CREDENTIALS_PER_HOST",
+                    uri.getHost()));
             if (uri.getUser() != null && !"".equals(uri.getUser())) {
                 userPassDialog.setUsername(uri.getUser());
                 userPassDialog.enableUsernameField(false);
@@ -390,7 +392,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
             }
             char[] pass = console.readPassword(OStrings.getString("TEAM_PASS_FIRST", uri.getHumanishName()));
             credentials.password = Arrays.toString(pass);
-            credentials.perHost = TeamUtils.askYesNoCui(OStrings.getString("TEAM_CREDENTIALS_PER_HOST"), false);
+            credentials.perHost = TeamUtils.askYesNoCui(OStrings.getString("TEAM_CREDENTIALS_PER_HOST",
+                    uri.getHost()), false);
             return credentials;
         }
         Log.log("No console found.");

--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -140,11 +140,13 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private Credentials loadCredentials(URIish uri) {
-        return TeamUtils.loadCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(), uri.getPort());
+        return TeamUtils.loadCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(),
+                uri.getPort());
     }
 
     private void saveCredentials(URIish uri, Credentials credentials) {
-        TeamUtils.saveCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(), uri.getPort(), credentials);
+        TeamUtils.saveCredentials(uri.toString(), uri.getScheme(), uri.getHost(), uri.getPath(),
+                uri.getPort(), credentials);
     }
 
     /**
@@ -224,9 +226,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 sb = new StringBuilder();
                 String promptedFingerprint = extractFingerprint(promptText);
                 if (promptedFingerprint == null) {
-                    throw new UnsupportedCredentialItem(uri,
-                            String.format("Unknown pattern to ask acceptance of host key fingerprint \n%s",
-                                    promptText));
+                    throw new UnsupportedCredentialItem(uri, String.format(
+                            "Unknown pattern to ask acceptance of host key fingerprint \n%s", promptText));
                 }
                 if (predefinedFingerprint != null) {
                     ((CredentialItem.YesNoType) item)
@@ -422,7 +423,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private Credentials askCredentials(URIish uri, Credentials credentials, boolean passwordOnly,
-                                                 String msg) {
+            String msg) {
         Credentials result;
         if (isGUI()) {
             result = askCredentialsGUI(uri, credentials, passwordOnly, msg);

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -151,8 +151,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
             credentials.username = console.readLine(message);
         }
         credentials.password = new String(console.readPassword(message));
-        String yesNo = console.readLine(OStrings.getString("TEAM_CREDENTIALS_PER_HOST_CUI"));
-        credentials.perHost = "yes".equalsIgnoreCase(yesNo) || "y".equalsIgnoreCase(yesNo);
+        credentials.perHost = TeamUtils.askYesNoCui(OStrings.getString("TEAM_CREDENTIALS_PER_HOST"), false);
         saveCredentials(url, credentials);
         return getAuthenticatorInstance(kind, url, credentials);
     }

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -25,8 +25,6 @@
 
 package org.omegat.core.team2.impl;
 
-import static org.omegat.core.team2.impl.TeamUtils.*;
-
 import java.io.Console;
 
 import javax.net.ssl.TrustManager;
@@ -50,6 +48,7 @@ import org.omegat.core.Core;
 import org.omegat.core.KnownException;
 import org.omegat.core.team2.ProjectTeamSettings;
 import org.omegat.core.team2.gui.UserPassDialog;
+import org.omegat.core.team2.impl.TeamUtils.Credentials;
 import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
@@ -277,7 +276,8 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
     }
 
     private void saveCredentials(SVNURL url, Credentials credentials) {
-        TeamUtils.saveCredentials(url.toString(), url.getProtocol(), url.getHost(), url.getPath(), url.getPort(), credentials);
+        TeamUtils.saveCredentials(url.toString(), url.getProtocol(), url.getHost(), url.getPath(),
+                url.getPort(), credentials);
     }
 
 }

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -126,6 +126,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         if (userPassDialog.getReturnStatus() != UserPassDialog.RET_OK) {
             return null;
         }
+        userPassDialog.setPerHostCheckBoxText(OStrings.getString("TEAM_CREDENTIALS_PER_HOST", url.getHost()));
         Credentials credentials = new Credentials();
         credentials.username = userPassDialog.getUsername();
         credentials.password = userPassDialog.getPassword();
@@ -151,7 +152,8 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
             credentials.username = console.readLine(message);
         }
         credentials.password = new String(console.readPassword(message));
-        credentials.perHost = TeamUtils.askYesNoCui(OStrings.getString("TEAM_CREDENTIALS_PER_HOST"), false);
+        credentials.perHost = TeamUtils.askYesNoCui(OStrings.getString("TEAM_CREDENTIALS_PER_HOST", url.getHost()),
+                false);
         saveCredentials(url, credentials);
         return getAuthenticatorInstance(kind, url, credentials);
     }

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -130,6 +130,7 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         Credentials credentials = new Credentials();
         credentials.username = userPassDialog.getUsername();
         credentials.password = userPassDialog.getPassword();
+        credentials.perHost = userPassDialog.isPerHost();
         saveCredentials(url, credentials);
         return getAuthenticatorInstance(kind, url, credentials);
     }
@@ -151,6 +152,8 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
             credentials.username = console.readLine(message);
         }
         credentials.password = new String(console.readPassword(message));
+        String yesNo = console.readLine(OStrings.getString("TEAM_CREDENTIALS_PER_HOST_CUI"));
+        credentials.perHost = "yes".equalsIgnoreCase(yesNo) || "y".equalsIgnoreCase(yesNo);
         saveCredentials(url, credentials);
         return getAuthenticatorInstance(kind, url, credentials);
     }

--- a/src/org/omegat/core/team2/impl/TeamUtils.java
+++ b/src/org/omegat/core/team2/impl/TeamUtils.java
@@ -75,7 +75,7 @@ public final class TeamUtils {
         if (scheme == null) {
             url = path;
             credentials.perHost = false;
-        } else if (port != -1){
+        } else if (port != -1) {
             url = scheme + "://" + host + ":" + port;
             credentials.perHost = true;
         } else {
@@ -95,7 +95,7 @@ public final class TeamUtils {
         } else if (credentials.perHost && host != null) {
             key = scheme + "://" + host + (port != -1 ? ":" + port : "");
         } else {
-            key = url; // uri.getRawPath();
+            key = url;
         }
         try {
             if (!StringUtil.isEmpty(credentials.username)) {

--- a/src/org/omegat/core/team2/impl/TeamUtils.java
+++ b/src/org/omegat/core/team2/impl/TeamUtils.java
@@ -88,7 +88,7 @@ public final class TeamUtils {
     }
 
     public static void saveCredentials(String url, String scheme, String host, String path, int port,
-                                       Credentials credentials) {
+            Credentials credentials) {
         String key;
         if (scheme == null) {
             key = path;

--- a/src/org/omegat/core/team2/impl/TeamUtils.java
+++ b/src/org/omegat/core/team2/impl/TeamUtils.java
@@ -25,12 +25,15 @@
 
 package org.omegat.core.team2.impl;
 
+import java.io.Console;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import org.omegat.core.Core;
 import org.omegat.core.team2.TeamSettings;
 import org.omegat.util.Log;
+import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 
 /**
@@ -56,6 +59,36 @@ public final class TeamUtils {
     static final String KEY_PASSWORD_SUFFIX = "password";
 
     static final String KEY_FINGERPRINT_SUFFIX = "fingerprint";
+
+    private static final int MAX_RETRY = 5;
+
+    public static boolean askYesNoCui(String promptText, boolean def) {
+        boolean result = def;
+        Console console = System.console();
+        if (console != null) {
+            try (PrintWriter printWriter = console.writer()) {
+                boolean succeeded = false;
+                for (int i = 0; i < MAX_RETRY; i++) {
+                    printWriter.print(promptText);
+                    String answer = console.readLine("([y]es or [n]o): ");
+                    if (answer.equalsIgnoreCase("y") || answer.equalsIgnoreCase("yes")) {
+                        result = true;
+                        break;
+                    } else if (answer.equalsIgnoreCase("n") || answer.equalsIgnoreCase("no")) {
+                        result = false;
+                        succeeded = true;
+                        break;
+                    }
+                    printWriter.println(OStrings.getString("TEAM_YESNO_AGAIN"));
+                }
+                if (!succeeded) {
+                    // no answer is got
+                    printWriter.println(OStrings.getString("TEAM_YESNO_ABORT"));
+                }
+            }
+        }
+        return result;
+    }
 
     public static Credentials loadCredentials(String url, String scheme, String host, String path, int port) {
         Credentials credentials = new Credentials();


### PR DESCRIPTION
- Add checkbox in user/pass dialog to ask credentials for per-host or per-repository

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- RFE#1719  Give a selection of perHost/PerRespo credentials treatment
- https://sourceforge.net/p/omegat/feature-requests/1719/



## What does this PR change?

- Refactor save/loadCredentials methods
- When per-repo selected
   - Store "scheme://host(:port)/path" as a key

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
