### PR TITLE
feat: team: shallow clone team project

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -8,6 +8,9 @@
 
   Implemented requests:
 
+  - Download team project with a shallow history
+  https://sourceforge.net/p/omegat/feature-requests/1720/
+
   - ResourceBundle Filter: default not to escape Unicode character
   https://sourceforge.net/p/omegat/feature-requests/1716/
 

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -106,7 +106,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
 
     // allow override timeout.
     protected static final int TIMEOUT = 30; // seconds
-    protected static int CLONE_DEPTH = 1; // clone depth
+    protected static final int CLONE_DEPTH = 1; // clone depth
 
     String repositoryURL;
     String branch;

--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -106,6 +106,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
 
     // allow override timeout.
     protected static final int TIMEOUT = 30; // seconds
+    protected static int CLONE_DEPTH = 1; // clone depth
 
     String repositoryURL;
     String branch;
@@ -189,6 +190,7 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
                 c.setURI(repositoryURL);
                 c.setDirectory(localDirectory);
                 c.setTimeout(TIMEOUT);
+                c.setDepth(CLONE_DEPTH);
                 try {
                     c.call();
                 } catch (InvalidRemoteException e) {


### PR DESCRIPTION
When user clone team project at first, OmegaT clone with `--depth 1`  to be a shallow clone to reduce disk usage.
Implement RFE#1720

## Pull request type
- Feature enhancement -> [enhancement]

## Which ticket is resolved?


- Download team project with shallow history
- https://sourceforge.net/p/omegat/feature-requests/1720/


## What does this PR change?

- set CloneCommand object configure  `setDepth(1)`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
