### PR TITLE
[BUGS#1193] fix: allow custom tag empty

### DIFF
--- a/src/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
+++ b/src/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
@@ -113,8 +113,11 @@ public class TagProcessingOptionsController extends BasePreferencesController {
         panel.javaPatternCheckBox.setSelected(Preferences.isPreference(Preferences.CHECK_JAVA_PATTERN_TAGS));
         panel.cbCountingProtectedText.setSelected(
                 StatisticsSettings.isCountingProtectedText() || StatisticsSettings.isCountingCustomTags());
-        panel.customPatternRegExpTF.setText(Preferences.getPreferenceDefault(Preferences.CHECK_CUSTOM_PATTERN, 
-                PatternConsts.CHECK_CUSTOM_PATTERN_DEFAULT));
+        if (Preferences.existsPreference(Preferences.CHECK_CUSTOM_PATTERN)) {
+            panel.customPatternRegExpTF.setText(Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN));
+        } else {
+            panel.customPatternRegExpTF.setText(PatternConsts.CHECK_CUSTOM_PATTERN_DEFAULT);
+        }
         panel.removePatternRegExpTF.setText(Preferences.getPreference(Preferences.CHECK_REMOVE_PATTERN));
         panel.looseTagOrderCheckBox.setSelected(Preferences.isPreference(Preferences.LOOSE_TAG_ORDERING));
         panel.cbTagsValidRequired.setSelected(Preferences.isPreference(Preferences.TAGS_VALID_REQUIRED));

--- a/src/org/omegat/util/PatternConsts.java
+++ b/src/org/omegat/util/PatternConsts.java
@@ -255,11 +255,18 @@ public final class PatternConsts {
             if ("true".equalsIgnoreCase(Preferences.getPreference(Preferences.CHECK_JAVA_PATTERN_TAGS))) {
                 regexp += "|" + RE_SIMPLE_JAVA_MESSAGEFORMAT_PATTERN_VARS;
             }
-            // assume: customRegExp has already been validated.
-            String customRegExp = Preferences.getPreferenceDefault(Preferences.CHECK_CUSTOM_PATTERN, CHECK_CUSTOM_PATTERN_DEFAULT);
+            String customRegExp;
+            if (Preferences.existsPreference(Preferences.CHECK_CUSTOM_PATTERN)) {
+                customRegExp = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
+            } else {
+                // assume default
+                customRegExp = CHECK_CUSTOM_PATTERN_DEFAULT;
+            }
             if (!"".equalsIgnoreCase(customRegExp)) {
+                // assume: customRegExp has already been validated.
                 regexp += "|" + customRegExp;
             }
+
             placeholders = Pattern.compile(regexp);
         }
         return placeholders;
@@ -291,7 +298,7 @@ public final class PatternConsts {
 
     public static Pattern getCustomTagPattern() {
         if (customTags == null) {
-            String customTagsRegex = Preferences.getPreferenceDefault(Preferences.CHECK_CUSTOM_PATTERN, CHECK_CUSTOM_PATTERN_DEFAULT);
+            String customTagsRegex = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
             if (!"".equalsIgnoreCase(customTagsRegex)) {
                 customTags = Pattern.compile(customTagsRegex);
             }


### PR DESCRIPTION


## Pull request type

- Bug fix -> [bug]


## Which ticket is resolved?


- Regular expression for custom tags
- https://sourceforge.net/p/omegat/bugs/1193/

## What does this PR change?

- Allow empty custom tag pattern
- When not exists a configuration key of custom tag pattern, assume default from PatternsConsts.DEFAULT_CHECK_CUSTOM_PATERN

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
