### PR TITLE
chore(ci): publish webManual in snapshot folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,30 @@ variables:
   GRADLE_USER_HOME: '$(Pipeline.Workspace)/.gradle'
 
 stages:
+- stage: DocCI
+  pool:
+    vmImage: 'ubuntu-22.04'
+  jobs:
+  - job: preCheck
+    steps:
+    - bash: |
+        files=$(git diff-tree --no-commit-id --name-only -r HEAD)
+        for file in $files; do
+          if [[ $file =~ ^doc_src.* ]]; then
+            echo "##vso[task.setvariable variable=changeDoc;isoutput=true]True"
+          fi
+        done
+      name: checkChangeDoc
+  - job: DocCIJob
+    dependsOn: preCheck
+    condition: and(eq(dependencies.preCheck.outputs['checkChangeDoc.changeDoc'], 'True'), ne(variables.isRelease, true))
+    displayName: build and publish manual snapshot version
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+      - template: ci/azure-pipelines/build_doc_steps.yml
+      - template: ci/azure-pipelines/publish_manual_snapshot.yml
+
 - stage: Test
   condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
   jobs:

--- a/ci/azure-pipelines/build_doc_steps.yml
+++ b/ci/azure-pipelines/build_doc_steps.yml
@@ -1,0 +1,12 @@
+steps:
+  - task: Cache@2
+    displayName: 'Cache Gradle'
+    inputs:
+      key: 'gradle | $(Agent.OS) | $(Build.SourcesDirectory)/build.gradle'
+      path: '$(GRADLE_USER_HOME)'
+  - script: |
+      umask a+w
+      mkdir -p build
+      chmod -R a+w doc_src
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean webManual
+    displayName: 'Run Gradle clean and Gradle webManual'

--- a/ci/azure-pipelines/publish_manual_snapshot.yml
+++ b/ci/azure-pipelines/publish_manual_snapshot.yml
@@ -1,0 +1,16 @@
+parameters:
+  - name: omegatVersion
+    default: ''
+
+steps:
+  - task: Bash@3
+    displayName: 📂 SCP upload to sourceforge file management
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Push manuals to sourceforge project web"
+        srcdir=$(system.defaultworkingdirectory)/build/docs/manual/
+        dest=$(SOURCEFORGE_FILE_USER)@frs.sourceforge.net
+        destdir=/home/project-web/omegat/htdocs/manual-snapshot/
+        echo "mkdir $destdir" | SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e sftp -v $dest || true
+        SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e scp -v -oStrictHostKeyChecking=no $srcdir/* $dest:$destdir


### PR DESCRIPTION
Publish snapshot version of manual  when writers update files under `doc_src`.
the manual will be appeared in https://omegat.sourceforge.io/manual-snapshot/

## Pull request type

- Documentation -> [documentation]
- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Define CI task to build manual HTMLs and publish at web site.
- Spin out PR from #705 that have a same change
- When #705 merged, document writer have a difficulty to check resulted manuals. The DocCI will help writers to check resulted HTML manuals on web browser without running build job.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
