### PR TITLE
[bug #1219] OmegaT does not handle line breaks correctly on Windows

### DIFF
--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -62,7 +62,7 @@ import org.omegat.core.data.ITMXEntry;
  * @author Aaron Madlon-Kay
  */
 public class TMXWriter2 implements AutoCloseable {
-    static String lineSeparator = System.lineSeparator();
+    static String lineSeparator = "\n";
 
     public static final String PROP_ID = "id";
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- #1219 OmegaT does not handle line breaks correctly on Windows
  * [https://sourceforge.net/p/omegat/bugs/1219/](https://sourceforge.net/p/omegat/bugs/1219/)
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Changes line separator from operating system dependent `System.lineSeparator()` to `"\n"`, since TMXWriter2 and TMXReader2 can not handle `"\r"` within Windows-style line break (`"\r\n"`) correctly.
- 
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
