### PR TITLE
[BUGS#1219] fix: tweak Woodstox parser behavior

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -89,6 +89,9 @@
 
   Bug fixes:
 
+  - OmegaT does not handle line breaks correctly on Windows
+  https://sourceforge.net/p/omegat/bugs/1219/
+
   - OmegaT 6.1 with JRE does not work out of the box on Windows
   https://sourceforge.net/p/omegat/bugs/1218/
 

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -28,6 +28,8 @@
  **************************************************************************/
 package org.omegat.util;
 
+import static com.ctc.wstx.api.WstxOutputProperties.P_OUTPUT_ESCAPE_CR;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -104,6 +106,7 @@ public class TMXWriter2 implements AutoCloseable {
         this.levelTwo = levelTwo;
         this.forceValidTMX = forceValidTMX;
         factory = XMLOutputFactory.newInstance();
+        factory.setProperty(P_OUTPUT_ESCAPE_CR, false);
 
         out = new BufferedOutputStream(Files.newOutputStream(file.toPath()));
         xml = factory.createXMLStreamWriter(out, StandardCharsets.UTF_8.name());

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -29,6 +29,7 @@
 package org.omegat.util;
 
 import static com.ctc.wstx.api.WstxOutputProperties.P_OUTPUT_ESCAPE_CR;
+import static org.codehaus.stax2.XMLOutputFactory2.P_AUTOMATIC_EMPTY_ELEMENTS;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -107,6 +108,7 @@ public class TMXWriter2 implements AutoCloseable {
         this.forceValidTMX = forceValidTMX;
         factory = XMLOutputFactory.newInstance();
         factory.setProperty(P_OUTPUT_ESCAPE_CR, false);
+        factory.setProperty(P_AUTOMATIC_EMPTY_ELEMENTS, true);
 
         out = new BufferedOutputStream(Files.newOutputStream(file.toPath()));
         xml = factory.createXMLStreamWriter(out, StandardCharsets.UTF_8.name());

--- a/test/src/org/omegat/util/TMXWriterTest.java
+++ b/test/src/org/omegat/util/TMXWriterTest.java
@@ -160,7 +160,6 @@ public class TMXWriterTest extends TestFilterBase {
 
     @Test
     public void testEOLwrite() throws Exception {
-        org.junit.Assume.assumeFalse(Platform.isWindows); // FIXME
         String eol = TMXWriter2.lineSeparator;
         TMXWriter2 wr = new TMXWriter2(outFile, new Language("en-US"), new Language("be-BY"), false, true,
                 false);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type


Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Unit tests failed on Windows
  - https://sourceforge.net/p/omegat/bugs/1223/
 
- OmegaT does not handle line breaks correctly on Windows
     - https://sourceforge.net/p/omegat/bugs/1219/


## What does this PR change?

- Set Woodstox property
    -  not to normalize `/r` in TMXWriter2.  Default is "do normalize"
    - produce self-contained empty tags
    
## Other information

