### PR TITLE
chore: fix: change iscc container

### DIFF
--- a/ci/iscc
+++ b/ci/iscc
@@ -26,5 +26,5 @@ exec $CMD run -i --rm  \
    -u `id -u`:`id -g` \
    -v "$PWD":/work \
    $(bindpaths "$@") \
-   amake/innosetup:innosetup6 \
+   amake/innosetup:64bit-buster \
    $(relpaths "$@")


### PR DESCRIPTION
ci/iscc helper command depends on amake/innosetup docker image. now project github.com/amake/innosetup-docker changes image tags

- amake/innosetup:latest is Debian Buster, InnoSetup 6, 32bit
- amake/innosetup:innosetup6 is Debian Buster, InnoSetup 6, 32bit
- amake/innosetup:innosetup6-buster is Debian Buster, InnoSetup 6, 32bit
- amake/innosetup:innosetup6-bookworm is Debian Bookworm, InnoSetup 6, 32bit
- amake/innosetup:64bit is Debian Buster, InnoSetup 6, 64bit
- amake/innosetup:64bit-buster is Debian Buster, InnoSetup 6, 64bit
- amake/innosetup:64bit-bookworm is Debian Bookworm, InnoSetup 6, 64bit

We use
`amake/innosetup:64bit-buster is Debian Buster, InnoSetup 6, 64bit` for our purpose.

## Pull request type

<!-- Please try to limit your pull request to one type; submit 

- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
