### PR TITLE
feat: StaX filter produce self-contained empty element

### DIFF
--- a/src/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -24,38 +24,40 @@
  **************************************************************************/
 package org.omegat.filters4.xml;
 
+import static org.codehaus.stax2.XMLOutputFactory2.P_AUTOMATIC_EMPTY_ELEMENTS;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.LinkedList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLEventWriter;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.events.StartElement;
-import javax.xml.stream.events.Characters;
-import javax.xml.stream.events.EndElement;
-import javax.xml.stream.events.XMLEvent;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
 import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.Comment;
-import javax.xml.stream.events.ProcessingInstruction;
+import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.EntityReference;
 import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.ProcessingInstruction;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
 
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.filters2.AbstractFilter;
@@ -95,6 +97,7 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     public AbstractXmlFilter() {
         iFactory = XMLInputFactory.newInstance();
         oFactory = XMLOutputFactory.newInstance();
+        oFactory.setProperty(P_AUTOMATIC_EMPTY_ELEMENTS, true);
     }
 
     @Override


### PR DESCRIPTION
Set Woodstox property to allow self-contained empty element in StaX filters

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?


## What does this PR change?


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
