### PR TITLE
refactor(filters4): XLIFF1,2 filters and abstract classes

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -177,14 +177,8 @@
               checks="(InnerAssignment|LocalVariableName|ParameterName|MemberName|MissingSwitchDefault|MethodLength)"
               lines="95,292,302,456,520,578,609,767"/>
     <suppress files="MsOfficeFileFilter\.java" checks="(MemberName|OperatorWrap)" lines="49,50,190"/>
-    <suppress files="Xliff1Filter\.java" checks="AvoidNestedBlocks" lines="412"/>
     <suppress files="SdlXliff\.java" checks="MemberName" lines="62,105,106,107"/>
-    <suppress files="AbstractXliffFilter\.java" checks="ConstantName" lines="246"/>
-    <suppress files="Xliff2Filter\.java" checks="RightCurly" lines="146"/>
-    <suppress files="Xliff2Filter\.java" checks="AvoidNestedBlocks" lines="266"/>
-    <suppress files="AbstractXmlFilter\.java" checks="(MissingSwitchDefault|ConstantName)" lines="325,380,464"/>
 
-   
     <!-- missing javadoc: temporary global suppression  -->
     <suppress checks="(DesignForExtension|MagicNumber)"
               files=".*"/>

--- a/src/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -461,7 +461,7 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     protected Map<String, List<XMLEvent>> tagsMap = new TreeMap<>();
 
     protected static final Pattern OMEGAT_TAG = Pattern.compile("<(\\/?)([a-z]\\d+)\\/?>");
-    protected static final XMLEventFactory eFactory = XMLEventFactory.newInstance();
+    protected final XMLEventFactory eFactory = XMLEventFactory.newInstance();
 
     /**
      * Produces xliff content for the translated text. Note: must be called
@@ -535,7 +535,7 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     }
 
     /** Convert <xxx/> to <xxx></xxx> **/
-    protected static List<XMLEvent> toPair(StartElement ev) {
+    protected List<XMLEvent> toPair(StartElement ev) {
         List<XMLEvent> l = new LinkedList<XMLEvent>();
         l.add(ev);
         l.add(eFactory.createEndElement(ev.getName(), null));

--- a/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -242,7 +242,4 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
             tagStack.push("" + prefix + count);
         }
     }
-
-    protected static final javax.xml.stream.XMLEventFactory eFactory = javax.xml.stream.XMLEventFactory
-            .newInstance();
 }

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -409,7 +409,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
                     res.setLength(0);
                     res = saveBuf.pop();
                     break;
-                default: {
+                default:
                     String pop = tagStack.pop();
                     if (pop.equals("mark-protected")) { // isProtectedTag(start
                                                         // element) was true
@@ -427,7 +427,6 @@ public class Xliff1Filter extends AbstractXliffFilter {
                         tagsMap.put("/" + pop, Collections.singletonList(ev));
                         res.append("</").append(pop).append(">");
                     }
-                }
                 }
             }
         }
@@ -628,7 +627,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
      * Builds target from OmegaT to XLIFF format. May be overridden in
      * subclasses
      **/
-    protected List<XMLEvent> restoreTags(String unitId, String path, String src, String tra) {
+    protected List<XMLEvent> restoreTags(String aUnitId, String path, String src, String tra) {
         return restoreTags(tra);
     }
 

--- a/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -143,10 +143,9 @@ public class Xliff2Filter extends AbstractXliffFilter {
         default:
             if (currentBuffer != null) {
                 currentBuffer.add(startElement);
-            }
-            // <target> must be before any other-namespace markup
-            else if (((ignoreScope == null || ignoreScope.startsWith("!")) && (segId != null))
+            } else if (((ignoreScope == null || ignoreScope.startsWith("!")) && (segId != null))
                     && (!startElement.getName().getNamespaceURI().equals(namespace))) {
+                // <target> must be before any other-namespace markup
                 flushTranslations(writer);
             }
         }
@@ -263,12 +262,11 @@ public class Xliff2Filter extends AbstractXliffFilter {
                 case "ec":
                     break; // Should be empty!!!
                 case "pc":
-                default: {
+                default:
                     String pop = tagStack.pop();
                     tagsMap.put("/" + pop, Collections.singletonList(ev));
                     res.append("</").append(pop).append(">");
                     break;
-                }
                 }
             }
         }


### PR DESCRIPTION
There are many code style warnings/errors on StaX filters.
The changes here to resolve the style errors.

These style errors has been introduced when accepting filters, all checkstyle errors are treated as warning, and author and reviewer does not aware of it.

## Pull request type

- refactor

## What does this PR change?

- Unnecessary static for `eFactory` field
- Unnecessary silent override of `eFactory`
- Unnecessary nested blocks
- Bad style of commenting in `if-elseif` syntax
- Unnecessary static for `toPair` method
- Use `try-resource` in `AbstractZipFilter`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
