### PR TITLE
[BUGS#1223] fix: MozillaFTLFilter:  preserve line-break on windows

### DIFF
--- a/src/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
+++ b/src/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
@@ -228,6 +228,9 @@ public class MozillaFTLFilter extends AbstractFilter {
                 if (trans == null) {
                     trans = value;
                     translatedSegment = false;
+                } else {
+                    // align to original linebreak chars when it has
+                    trans = trans.replaceAll("\n", lbpr.getLinebreak());
                 }
                 // Non-translated segments are written based on the
                 // filter options

--- a/src/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
+++ b/src/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
@@ -114,7 +114,7 @@ public class MozillaFTLFilter extends AbstractFilter {
         String comments = null;
         int identation = 1;
         String key = null;
-        String k = null;
+        StringBuilder k = null;
         String key_attr = "";
         String value = null;
         boolean multiline = false;
@@ -177,17 +177,17 @@ public class MozillaFTLFilter extends AbstractFilter {
                 if (identation == 1) {
                     identation = ide;
                 } else {
-                    identation = (identation < ide ? identation : ide);
+                    identation = Math.min(identation, ide);
                 }
                 // writing out everything before = (and = itself)
             } else {
                 // outfile.write(str.substring(0, afterEqualsPos));
                 if (k == null) {
-                    k = "";
+                    k = new StringBuilder();
                 } else {
-                    k += "\n";
+                    k.append(lbpr.getLinebreak());
                 }
-                k += str.substring(0, afterEqualsPos);
+                k.append(str, 0, afterEqualsPos);
                 v = str.substring(afterEqualsPos);
             }
             if (value == null) {
@@ -235,7 +235,7 @@ public class MozillaFTLFilter extends AbstractFilter {
                 // Non-translated segments are written based on the
                 // filter options
                 if (translatedSegment || !removeStringsUntranslated) {
-                    outfile.write(k);
+                    outfile.write(k.toString());
                     outfile.write(trans);
                     outfile.write(lbpr.getLinebreak());
                 }

--- a/test/src/org/omegat/filters/MozillaFTLFilterTest.java
+++ b/test/src/org/omegat/filters/MozillaFTLFilterTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.text.mozftl.MozillaFTLFilter;
-import org.omegat.util.Platform;
 
 public class MozillaFTLFilterTest extends TestFilterBase {
     @Test
@@ -39,7 +38,6 @@ public class MozillaFTLFilterTest extends TestFilterBase {
 
     @Test
     public void testTranslate() throws Exception {
-        org.junit.Assume.assumeFalse(Platform.isWindows);
         translateText(new MozillaFTLFilter(), "test/data/filters/MozillaFTL/MozillaFTLFilter.ftl");
     }
 


### PR DESCRIPTION
MozillaFTLFilter sometimes insert "\n" even it uses `LineBreakPreservingReader`, so it breaks translation output.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Unit tests failed on Windows
- https://sourceforge.net/p/omegat/bugs/1223/

## What does this PR change?

- replace `write("\n")` with `write(lbpr.getLineBreak())`
- refactor `str1 += str2` with `StringBuider` 
- When translation has a line break, covert  `trans.replaceAll("\n", lbpr.getLinebreak())`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
