### PR TITLE
[BUGS#459] fix: check URL before doWikiGet

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -287,6 +287,7 @@ TF_MENU_WIKI_IMPORT=Add MediaWiki Pa&ge...
 TF_WIKI_IMPORT_TITLE=Add MediaWiki Page
 TF_WIKI_IMPORT_PROMPT=URL
 TF_WIKI_IMPORT_URL_ERROR=Provided URL is invalid.
+TF_WIKI_IMPORT_URL_ERROR_TITLE=URL Error
 TF_WIKI_IMPORT_FAILED=Failed to download page
 MAIN_ERROR_File_Import_Failed=Failed to copy files
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -286,6 +286,7 @@ TF_FILE_IMPORT_TITLE=Add Files to Source Folder...
 TF_MENU_WIKI_IMPORT=Add MediaWiki Pa&ge...
 TF_WIKI_IMPORT_TITLE=Add MediaWiki Page
 TF_WIKI_IMPORT_PROMPT=URL
+TF_WIKI_IMPORT_URL_ERROR=Provided URL is invalid.
 TF_WIKI_IMPORT_FAILED=Failed to download page
 MAIN_ERROR_File_Import_Failed=Failed to copy files
 

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -1307,6 +1307,11 @@ public final class ProjectUICommands {
             return;
         }
         try {
+            if (!HttpConnectionUtils.checkUrl(remoteUrl)) {
+                JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
+                        OStrings.getString("TF_WIKI_IMPORT_URL_ERROR"));
+                return;
+            }
             WikiGet.doWikiGet(remoteUrl, projectsource);
             projectReload();
         } catch (Exception ex) {

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -1308,8 +1308,9 @@ public final class ProjectUICommands {
         }
         try {
             if (!HttpConnectionUtils.checkUrl(remoteUrl)) {
-                JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
-                        OStrings.getString("TF_WIKI_IMPORT_URL_ERROR"));
+                JOptionPane.showMessageDialog(Core.getMainWindow().getApplicationFrame(),
+                        OStrings.getString("TF_WIKI_IMPORT_URL_ERROR"),
+                        OStrings.getString("TF_WIKI_IMPORT_URL_ERROR_TITLE"), JOptionPane.WARNING_MESSAGE);
                 return;
             }
             WikiGet.doWikiGet(remoteUrl, projectsource);

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -75,18 +75,17 @@ public final class HttpConnectionUtils {
     // From https://gist.github.com/dperini/729294
     // and https://github.com/JetBrains/intellij-community
     // See lib/licenses/Licenses.txt
-    private static final String REGEX_URL = "(?:https?|ftp)://"  // protocol
-            + "(?:\\S+(?::\\S*)?@)?(?:(?!"  // user:pass (optional)
+    private static final String REGEX_URL = "(?:https?|ftp)://" // protocol
+            + "(?:\\S+(?::\\S*)?@)?(?:(?!" // user:pass (optional)
             + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
             + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
             + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
             // IP addresses
-            + "|"
-            + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
+            + "|" + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
             + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
-            + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)"  // domain host
-            + "(?::\\d{2,5})?"  // port (optional)
-            + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?";  // resources
+            + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)" // domain host
+            + "(?::\\d{2,5})?" // port (optional)
+            + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?"; // resources
 
     /**
      * Regular Expression for https and ftp URL validation.
@@ -96,8 +95,8 @@ public final class HttpConnectionUtils {
     /**
      * Regular Expression for file URL validation.
      */
-    public static final Pattern FILE_URL_PATTERN = Pattern.compile(
-            "\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
+    public static final Pattern FILE_URL_PATTERN = Pattern
+            .compile("\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
 
     /**
      * Don't instantiate util class.
@@ -461,7 +460,9 @@ public final class HttpConnectionUtils {
 
     /**
      * Validate URL string.
-     * @param remoteUrl URL candidate string.
+     * 
+     * @param remoteUrl
+     *            URL candidate string.
      * @return true when valid, otherwise false.
      */
     public static boolean checkUrl(String remoteUrl) {

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -44,6 +44,8 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 
@@ -68,6 +70,34 @@ public final class HttpConnectionUtils {
      * default timeout
      */
     private static final int TIMEOUT_MS = 10_000;
+
+    // Regular Expression for URL validation
+    // From https://gist.github.com/dperini/729294
+    // and https://github.com/JetBrains/intellij-community
+    // See lib/licenses/Licenses.txt
+    private static final String REGEX_URL = "(?:https?|ftp)://"  // protocol
+            + "(?:\\S+(?::\\S*)?@)?(?:(?!"  // user:pass (optional)
+            + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
+            + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
+            + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
+            // IP addresses
+            + "|"
+            + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
+            + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
+            + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)"  // domain host
+            + "(?::\\d{2,5})?"  // port (optional)
+            + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?";  // resources
+
+    /**
+     * Regular Expression for https and ftp URL validation.
+     */
+    public static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Regular Expression for file URL validation.
+     */
+    public static final Pattern FILE_URL_PATTERN = Pattern.compile(
+            "\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
 
     /**
      * Don't instantiate util class.
@@ -427,6 +457,19 @@ public final class HttpConnectionUtils {
         try (InputStream in = conn.getInputStream()) {
             return IOUtils.toString(in, charset);
         }
+    }
+
+    /**
+     * Validate URL string.
+     * @param remoteUrl URL candidate string.
+     * @return true when valid, otherwise false.
+     */
+    public static boolean checkUrl(String remoteUrl) {
+        if (remoteUrl.isEmpty()) {
+            return false;
+        }
+        Matcher m = URL_PATTERN.matcher(remoteUrl);
+        return m.matches();
     }
 
     /**

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -400,7 +400,7 @@ public final class ProjectFileStorage {
         @Override
         public void serialize(final Map<QName, String> value, final JsonGenerator gen,
                 final SerializerProvider provider) throws IOException {
-            if (value.size() > 0) {
+            if (!value.isEmpty()) {
                 gen.writeStartObject();
                 for (Map.Entry<QName, String> item : value.entrySet()) {
                     if (item.getValue() == null) {

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -162,10 +162,10 @@ public final class JTextPaneLinkifier {
         AttributeInserterDocumentFilter(StyledDocument doc, boolean extended) {
             this.doc = doc;
             if (extended) {
-                urlPatterns = new Pattern[]{HttpConnectionUtils.URL_PATTERN,
-                        HttpConnectionUtils.FILE_URL_PATTERN};
+                urlPatterns = new Pattern[] { HttpConnectionUtils.URL_PATTERN,
+                        HttpConnectionUtils.FILE_URL_PATTERN };
             } else {
-                urlPatterns = new Pattern[]{HttpConnectionUtils.URL_PATTERN};
+                urlPatterns = new Pattern[] { HttpConnectionUtils.URL_PATTERN };
             }
             timer = new Timer(REFRESH_DELAY, e -> refreshPane());
             timer.setRepeats(false);
@@ -186,7 +186,8 @@ public final class JTextPaneLinkifier {
         @Override
         public void remove(FilterBypass fb, int offset, int length) throws BadLocationException {
             boolean refresh = true;
-            final AttributeSet attr = ((StyledDocument) fb.getDocument()).getCharacterElement(offset).getAttributes();
+            final AttributeSet attr = ((StyledDocument) fb.getDocument()).getCharacterElement(offset)
+                    .getAttributes();
             if (attr != null && attr.isDefined(StyleConstants.ComposedTextAttribute)) {
                 refresh = false;
             }

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -46,6 +46,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+import org.omegat.util.HttpConnectionUtils;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
@@ -143,25 +144,6 @@ public final class JTextPaneLinkifier {
 
         private static final int REFRESH_DELAY = 200;
 
-        // Regular Expression for URL validation
-        // From https://gist.github.com/dperini/729294
-        // and https://github.com/JetBrains/intellij-community
-        // See lib/licenses/Licenses.txt
-        private static final String REGEX_URL = "(?:https?|ftp)://"  // protocol
-                + "(?:\\S+(?::\\S*)?@)?(?:(?!"  // user:pass (optional)
-                + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
-                + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
-                + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
-                // IP addresses
-                + "|"
-                + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
-                + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
-                + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)"  // domain host
-                + "(?::\\d{2,5})?"  // port (optional)
-                + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?";  // resources
-        private static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
-        private static final Pattern FILE_URL_PATTERN = Pattern.compile(
-                "\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
         private static final AttributeSet DEFAULT_ATTRIBUTES = new SimpleAttributeSet();
         private static final AttributeSet LINK_ATTRIBUTES;
 
@@ -180,9 +162,10 @@ public final class JTextPaneLinkifier {
         AttributeInserterDocumentFilter(StyledDocument doc, boolean extended) {
             this.doc = doc;
             if (extended) {
-                urlPatterns = new Pattern[]{URL_PATTERN, FILE_URL_PATTERN};
+                urlPatterns = new Pattern[]{HttpConnectionUtils.URL_PATTERN,
+                        HttpConnectionUtils.FILE_URL_PATTERN};
             } else {
-                urlPatterns = new Pattern[]{URL_PATTERN};
+                urlPatterns = new Pattern[]{HttpConnectionUtils.URL_PATTERN};
             }
             timer = new Timer(REFRESH_DELAY, e -> refreshPane());
             timer.setRepeats(false);


### PR DESCRIPTION
- Resolved BUGS#459 Print Exception with Invalid URL in "Import From MediaWiki..

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]


## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

 
- Print Exception with Invalid URL in "Import From MediaWiki..
- https://sourceforge.net/p/omegat/bugs/459/


## What does this PR change?

- Extend HttpConnectionUtils to have checkUrl method
- Refactor JTextPaneLinkifier to move URL_PATTERN to HttpConnectionUtils class



## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
