### PR TITLE
filter/latex: add reproducible of bugs#743

### DIFF
--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -10,6 +10,7 @@
                2011 Didier Briel
                2014 Adiel Mittmann
                2017 Didier Briel
+               2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -56,6 +57,7 @@ import org.omegat.util.OStrings;
  * @author Arno Peters
  * @author Didier Briel
  * @author Adiel Mittmann
+ * @author Hiroshi Miura
  */
 public class LatexFilter extends AbstractFilter {
 
@@ -141,7 +143,7 @@ public class LatexFilter extends AbstractFilter {
             String s;
             StringBuilder comment = new StringBuilder();
 
-            LinkedList<String> commands = new LinkedList<>();
+            List<String> commands = new LinkedList<>();
 
             /*
               Possible states: N: beginning of a new line M: middle S: skipping
@@ -317,7 +319,7 @@ public class LatexFilter extends AbstractFilter {
         oneArgParText.add("\\section");
     }
 
-    private String replaceOneArgNoText(LinkedList<String[]> substituted, LinkedList<String> commands,
+    private String replaceOneArgNoText(LinkedList<String[]> substituted, List<String> commands,
             String par) {
         int counter = 0;
 
@@ -332,7 +334,7 @@ public class LatexFilter extends AbstractFilter {
                 Pattern p = Pattern.compile(find);
                 Matcher m = p.matcher(par);
                 while (m.find()) {
-                    String replace = "<n" + String.valueOf(counter) + ">";
+                    String replace = "<n" + counter + ">";
                     String[] subst = {reHarden(m.group(0)), reHarden(replace)};
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
@@ -346,7 +348,7 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private String replaceOneArgInlineText(LinkedList<String[]> substituted, LinkedList<String> commands,
+    private String replaceOneArgInlineText(LinkedList<String[]> substituted, List<String> commands,
             String par) {
         int counter = 0;
 
@@ -380,7 +382,7 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private String replaceOneArgParText(LinkedList<String[]> substituted, LinkedList<String> commands,
+    private String replaceOneArgParText(LinkedList<String[]> substituted, List<String> commands,
             String par) {
         int counter = 0;
 
@@ -412,7 +414,7 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private String replaceUnknownCommand(LinkedList<String[]> substituted, LinkedList<String> commands,
+    private String replaceUnknownCommand(LinkedList<String[]> substituted, List<String> commands,
             String par) {
         int counter = 0;
 
@@ -457,7 +459,7 @@ public class LatexFilter extends AbstractFilter {
         return re;
     }
 
-    private String processParagraph(LinkedList<String> commands, String par) {
+    private String processParagraph(List<String> commands, String par) {
         LinkedList<String[]> substituted = new LinkedList<>();
 
         par = substituteUnicode(par);

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -275,14 +275,11 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private final List<String> parSeparator = new LinkedList<>();
     private final List<String> oneArgNoText = new LinkedList<>();
     private final List<String> oneArgInlineText = new LinkedList<>();
     private final List<String> oneArgParText = new LinkedList<>();
 
     private void init() {
-        parSeparator.add("\\item");
-
         oneArgNoText.add("\\begin");
         oneArgNoText.add("\\end");
         oneArgNoText.add("\\cite");
@@ -299,6 +296,7 @@ public class LatexFilter extends AbstractFilter {
         oneArgNoText.add("\\includegraphics");
         oneArgNoText.add("\\documentclass");
         oneArgNoText.add("\\usepackage");
+        oneArgNoText.add("\\documentstyle");
 
         oneArgInlineText.add("\\emph");
         oneArgInlineText.add("\\textbf");
@@ -383,7 +381,7 @@ public class LatexFilter extends AbstractFilter {
     }
 
     private String replaceOneArgParText(LinkedList<String[]> substituted, List<String> commands,
-            String par) {
+                                        String par) {
         int counter = 0;
 
         for (String command : commands) {

--- a/test/data/filters/Latex/file-latex-comments.tex
+++ b/test/data/filters/Latex/file-latex-comments.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\begin{document}
+\title{LaTeX Comment example}
+
+\section {Comment}
+
+This is a text % First comment
+with inline % Second comment
+comments.
+
+\end{document}

--- a/test/data/filters/Latex/file-latex-items.tex
+++ b/test/data/filters/Latex/file-latex-items.tex
@@ -1,4 +1,4 @@
-\documentclass{article}
+\documentstyle[11pt]{article}
 \begin{document}
 \title{LaTeX Itemize example}
 

--- a/test/data/filters/Latex/file-latex-items.tex
+++ b/test/data/filters/Latex/file-latex-items.tex
@@ -5,10 +5,15 @@
 \section {Itemize}
 
 \begin{itemize}
+
 \item INTERRUTTORE GENERALE ON/OFF (I/0)
+
 \item SPIA PRESENZA TENSIONE
+
 \item SPIA PREALLARME
+
 \item PULPITO/PANNELLO DI COMANDO
+
 \end{itemize}
 
 \end{document}

--- a/test/data/filters/Latex/file-latex-items.tex
+++ b/test/data/filters/Latex/file-latex-items.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\begin{document}
+\title{LaTeX Itemize example}
+
+\section {Itemize}
+
+\begin{itemize}
+\item INTERRUTTORE GENERALE ON/OFF (I/0)
+\item SPIA PRESENZA TENSIONE
+\item SPIA PREALLARME
+\item PULPITO/PANNELLO DI COMANDO
+\end{itemize}
+
+\end{document}

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2011 Alex Buloichik
+               2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -40,5 +41,20 @@ public class LatexFilterTest extends TestFilterBase {
         checkMulti("[11pt]{article}", null, null, "", "LaTeX Typesetting By Example", null);
         checkMulti("LaTeX Typesetting By Example", null, null, "[11pt]{article}",
                 "Phil Farrell<br0> Stanford University School of Earth Sciences", null);
+    }
+
+    @Test
+    public void testLoadItemize() throws Exception {
+        String f = "test/data/filters/Latex/file-latex-items.tex";
+        IProject.FileInfo fi = loadSourceFiles(new LatexFilter(), f);
+
+        checkMultiStart(fi, f);
+        checkMulti("LaTeX Itemize example", null, null, "", "Itemize", null);
+        checkMulti("Itemize", null, null, "LaTeX Itemize example", "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
+        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "LaTeX Itemize example", "SPIA PRESENZA TENSIONE", null);
+        checkMulti("SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)", "", null);
+        checkMulti("SPIA PREALLARME", null, null, "SPIA PRESENZA TENSIONE", "PULPITO/PANNELLO DI COMANDO", null);
+        checkMulti("PULPITO/PANNELLO DI COMANDO", null, null, "SPIA PREALLARME", "", null);
+        checkMultiEnd();
     }
 }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -50,10 +50,14 @@ public class LatexFilterTest extends TestFilterBase {
 
         checkMultiStart(fi, f);
         checkMulti("LaTeX Itemize example", null, null, "", "Itemize", null);
-        checkMulti("Itemize", null, null, "LaTeX Itemize example", "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
-        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "LaTeX Itemize example", "SPIA PRESENZA TENSIONE", null);
-        checkMulti("SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)", "", null);
-        checkMulti("SPIA PREALLARME", null, null, "SPIA PRESENZA TENSIONE", "PULPITO/PANNELLO DI COMANDO", null);
+        checkMulti("Itemize", null, null, "LaTeX Itemize example",
+                "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
+        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize",
+                "SPIA PRESENZA TENSIONE", null);
+        checkMulti("SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
+                "SPIA PREALLARME", null);
+        checkMulti("SPIA PREALLARME", null, null, "SPIA PRESENZA TENSIONE",
+                "PULPITO/PANNELLO DI COMANDO", null);
         checkMulti("PULPITO/PANNELLO DI COMANDO", null, null, "SPIA PREALLARME", "", null);
         checkMultiEnd();
     }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -61,4 +61,17 @@ public class LatexFilterTest extends TestFilterBase {
         checkMulti("PULPITO/PANNELLO DI COMANDO", null, null, "SPIA PREALLARME", "", null);
         checkMultiEnd();
     }
+
+    @Test
+    public void testLoadComments() throws Exception {
+        String f = "test/data/filters/Latex/file-latex-comments.tex";
+        IProject.FileInfo fi = loadSourceFiles(new LatexFilter(), f);
+
+        checkMultiStart(fi, f);
+        checkMulti("LaTeX Comment example", null, null, "", "Comment", null);
+        checkMulti("Comment", null, null, "LaTeX Comment example",
+                "This is a text with inline comments.", null);
+        checkMulti("This is a text with inline comments.", null, null, "Comment", "", null);
+        checkMultiEnd();
+    }
 }


### PR DESCRIPTION
Refactor filter/latex based on proposal of BUGS#743 and its case reporoducibles.

## Pull request type


- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- The LaTeX filter should use \item as a delimiter
- https://sourceforge.net/p/omegat/bugs/743/



## What does this PR change?

- refactoring filter/latex code
- Add reproducible as unit test
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
