### PR TITLE
[BUGS#743] fix: filters/latex enhance itemize parse to split paragraphs

### DIFF
--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -83,7 +83,8 @@ public class LatexFilter extends AbstractFilter {
     }
 
     @Override
-    public void processFile(BufferedReader in, BufferedWriter out, org.omegat.filters2.FilterContext fc) throws IOException {
+    public void processFile(BufferedReader in, BufferedWriter out, org.omegat.filters2.FilterContext fc)
+            throws IOException {
         // BOM (byte order mark) bugfix
         in.mark(1);
         int ch = in.read();
@@ -146,8 +147,8 @@ public class LatexFilter extends AbstractFilter {
             List<String> commands = new LinkedList<>();
 
             /*
-              Possible states: N: beginning of a new line M: middle S: skipping
-              blanks
+             * Possible states: N: beginning of a new line M: middle S: skipping
+             * blanks
              */
             String state;
             while ((s = lpin.readLine()) != null) {
@@ -320,8 +321,7 @@ public class LatexFilter extends AbstractFilter {
         parBreakCommand.add("\\item");
     }
 
-    private String replaceOneArgNoText(LinkedList<String[]> substituted, List<String> commands,
-            String par) {
+    private String replaceOneArgNoText(LinkedList<String[]> substituted, List<String> commands, String par) {
         int counter = 0;
 
         for (String command : commands) {
@@ -330,13 +330,14 @@ public class LatexFilter extends AbstractFilter {
             if (oneArgNoText.contains(command)) {
                 // opt [] arg
                 // opt () arg
-                String find = (String.format("\\%s\\*?(\\[[^\\]]*\\]|\\([^\\)]*\\))?\\s*\\{[^\\}]*+\\}", command));
+                String find = (String.format("\\%s\\*?(\\[[^\\]]*\\]|\\([^\\)]*\\))?\\s*\\{[^\\}]*+\\}",
+                        command));
 
                 Pattern p = Pattern.compile(find);
                 Matcher m = p.matcher(par);
                 while (m.find()) {
                     String replace = "<n" + counter + ">";
-                    String[] subst = {reHarden(m.group(0)), reHarden(replace)};
+                    String[] subst = { reHarden(m.group(0)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;
@@ -365,10 +366,10 @@ public class LatexFilter extends AbstractFilter {
                     String preReplace = "<i" + counter + ">";
                     String postReplace = "</i" + counter + ">";
 
-                    String[] s1 = {reHarden(m.group(1)), reHarden(preReplace)};
+                    String[] s1 = { reHarden(m.group(1)), reHarden(preReplace) };
                     substituted.addFirst(s1);
 
-                    String[] s2 = {reHarden("}"), reHarden(postReplace)};
+                    String[] s2 = { reHarden("}"), reHarden(postReplace) };
                     substituted.addFirst(s2);
 
                     String replace = (preReplace + "$2" + postReplace);
@@ -383,8 +384,7 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private String replaceOneArgParText(LinkedList<String[]> substituted, List<String> commands,
-                                        String par) {
+    private String replaceOneArgParText(LinkedList<String[]> substituted, List<String> commands, String par) {
         int counter = 0;
 
         for (String command : commands) {
@@ -401,7 +401,7 @@ public class LatexFilter extends AbstractFilter {
                     if (m.group(2) != null) {
                         content = processParagraph(commands, m.group(2));
                     }
-                    String[] subst = {reHarden(m.group(1) + "{" + content + "}"), reHarden(replace)};
+                    String[] subst = { reHarden(m.group(1) + "{" + content + "}"), reHarden(replace) };
 
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
@@ -420,7 +420,8 @@ public class LatexFilter extends AbstractFilter {
         int counter = 0;
 
         for (String command : commands) {
-            if (command.equals("\\\\") || command.equals("\\{") || command.equals("\\[") || command.equals("\\|")) {
+            if (command.equals("\\\\") || command.equals("\\{") || command.equals("\\[")
+                    || command.equals("\\|")) {
                 // continue;
                 command = String.format("\\%s", command);
             }
@@ -433,7 +434,7 @@ public class LatexFilter extends AbstractFilter {
                 Matcher m = p.matcher(par);
                 while (m.find()) {
                     String replace = "<u" + counter + ">";
-                    String[] subst = {reHarden(m.group(0)), reHarden(replace)};
+                    String[] subst = { reHarden(m.group(0)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;
@@ -442,7 +443,7 @@ public class LatexFilter extends AbstractFilter {
 
                 par = sb.toString();
             } catch (java.util.regex.PatternSyntaxException e) {
-                //TODO: understand the exceptions
+                // TODO: understand the exceptions
                 Log.log("LaTeX PatternSyntaxException: " + e.getMessage());
                 Log.log(command);
             }
@@ -496,7 +497,8 @@ public class LatexFilter extends AbstractFilter {
         return par;
     }
 
-    private String replaceParBreakCommand(LinkedList<String[]> substituted, List<String> commands, String par) {
+    private String replaceParBreakCommand(LinkedList<String[]> substituted, List<String> commands,
+            String par) {
         int counter = 0;
         String tmp = par;
 
@@ -511,8 +513,8 @@ public class LatexFilter extends AbstractFilter {
                 int lastStart = 0;
                 while (m.find()) {
                     String replace = "<r" + counter + ">";
-                    String content = processParagraph(commands, tmp.substring(m.start(1), m.start(4) -1));
-                    String[] subst = {reHarden(content + "\n" + m.group(4)), reHarden(replace)};
+                    String content = processParagraph(commands, tmp.substring(m.start(1), m.start(4) - 1));
+                    String[] subst = { reHarden(content + "\n" + m.group(4)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -228,12 +228,11 @@ public class LatexFilter extends AbstractFilter {
 
                 /* at the end of the line */
                 if (state.equals("N")) {
-                    String endOfLine = lineBreak;
                     /* \par */
                     if (par.length() > 0) {
                         out.write(processParagraph(commands, par.toString()));
-                        out.write(endOfLine);
-                        out.write(endOfLine);
+                        out.write(lineBreak);
+                        out.write(lineBreak);
                         par.setLength(0);
                     }
                     // System.out.println(commands);
@@ -241,7 +240,7 @@ public class LatexFilter extends AbstractFilter {
                     if (comment.length() > 0) { // If there is a comment, write
                                                 // it
                         out.write(comment.toString());
-                        out.write(endOfLine);
+                        out.write(lineBreak);
                         comment.setLength(0);
                     }
                 } else if (state.equals("M")) {
@@ -319,9 +318,15 @@ public class LatexFilter extends AbstractFilter {
         oneArgParText.add("\\title");
         oneArgParText.add("\\Chapter");
         oneArgParText.add("\\chapter");
+        oneArgParText.add("\\section*");
         oneArgParText.add("\\section");
 
         parBreakCommand.add("\\item");
+        parBreakCommand.add("\\newcommand");
+        parBreakCommand.add("\\renewcommand");
+        parBreakCommand.add("\\maketitle");
+        parBreakCommand.add("\\maketitle");
+        parBreakCommand.add("\\addcontentsline");
     }
 
     private String replaceOneArgNoText(LinkedList<String[]> substituted, List<String> commands, String par) {
@@ -340,7 +345,7 @@ public class LatexFilter extends AbstractFilter {
                 Matcher m = p.matcher(par);
                 while (m.find()) {
                     String replace = "<n" + counter + ">";
-                    String[] subst = { reHarden(m.group(0)), reHarden(replace) };
+                    String[] subst = { reHarden(lineBreak + m.group(0)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;
@@ -404,7 +409,7 @@ public class LatexFilter extends AbstractFilter {
                     if (m.group(2) != null) {
                         content = processParagraph(commands, m.group(2));
                     }
-                    String[] subst = { reHarden(m.group(1) + "{" + content + "}"), reHarden(replace) };
+                    String[] subst = { reHarden(lineBreak + m.group(1) + "{" + content + "}"), reHarden(replace) };
 
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
@@ -509,15 +514,15 @@ public class LatexFilter extends AbstractFilter {
             StringBuilder sb = new StringBuilder();
 
             if (parBreakCommand.contains(command)) {
-                String find = String.format("(\\%s)\\s(.*)(\\s+)(\\%s)", command, command);
+                String find = String.format(".*(\\%s)", command, command);
 
                 Pattern p = Pattern.compile(find);
                 Matcher m = p.matcher(tmp);
                 int lastStart = 0;
                 while (m.find()) {
                     String replace = "<r" + counter + ">";
-                    String content = processParagraph(commands, tmp.substring(m.start(1), m.start(4) - 1));
-                    String[] subst = { reHarden(content + lineBreak + m.group(4)), reHarden(replace) };
+                    String content = processParagraph(commands, tmp.substring(0, m.start(1)));
+                    String[] subst = { reHarden(content + lineBreak + m.group(1)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -130,6 +130,8 @@ public class LatexFilter extends AbstractFilter {
         return 12;
     }
 
+    private String lineBreak;
+
     /**
      * Processes a LaTeX document.
      *
@@ -152,6 +154,7 @@ public class LatexFilter extends AbstractFilter {
              */
             String state;
             while ((s = lpin.readLine()) != null) {
+                lineBreak = lpin.getLinebreak();
                 // String[] c = s.split(""); In Java 8, that line gave a first
                 // empty element, so it was replaced with the
                 // following lines, and idx below was started at 0 instead of 1
@@ -225,7 +228,7 @@ public class LatexFilter extends AbstractFilter {
 
                 /* at the end of the line */
                 if (state.equals("N")) {
-                    String endOfLine = lpin.getLinebreak();
+                    String endOfLine = lineBreak;
                     /* \par */
                     if (par.length() > 0) {
                         out.write(processParagraph(commands, par.toString()));
@@ -514,7 +517,7 @@ public class LatexFilter extends AbstractFilter {
                 while (m.find()) {
                     String replace = "<r" + counter + ">";
                     String content = processParagraph(commands, tmp.substring(m.start(1), m.start(4) - 1));
-                    String[] subst = { reHarden(content + "\n" + m.group(4)), reHarden(replace) };
+                    String[] subst = { reHarden(content + lineBreak + m.group(4)), reHarden(replace) };
                     substituted.addFirst(subst);
                     m.appendReplacement(sb, replace);
                     counter++;

--- a/test/data/filters/Latex/file-latex-comments.tex
+++ b/test/data/filters/Latex/file-latex-comments.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\begin{document}
+\title{LaTeX Comment example}
+
+\section {Comment}
+
+This is a text % First comment
+with inline % Second comment
+comments.
+
+\end{document}

--- a/test/data/filters/Latex/file-latex-items-exp.tex
+++ b/test/data/filters/Latex/file-latex-items-exp.tex
@@ -1,0 +1,10 @@
+\documentclass{article} \begin{document} \title{LaTeX Itemize example} 
+
+\section {Itemize} 
+
+\begin{itemize} \item INTERRUTTORE GENERALE ON/OFF (I/0)
+\item SPIA PRESENZA TENSIONE
+\item SPIA PREALLARME
+\item PULPITO/PANNELLO DI COMANDO \end{itemize} 
+
+\end{document} 

--- a/test/data/filters/Latex/file-latex-items-exp.tex
+++ b/test/data/filters/Latex/file-latex-items-exp.tex
@@ -1,10 +1,18 @@
-\documentclass{article} \begin{document} \title{LaTeX Itemize example} 
+
+\documentclass{article} 
+\begin{document} 
+\title{LaTeX Itemize example} 
+
 
 \section {Itemize} 
 
-\begin{itemize} \item INTERRUTTORE GENERALE ON/OFF (I/0)
-\item SPIA PRESENZA TENSIONE
-\item SPIA PREALLARME
-\item PULPITO/PANNELLO DI COMANDO \end{itemize} 
+
+\begin{itemize} 
+\item INTERRUTTORE GENERALE ON/OFF (I/0) 
+\item SPIA PRESENZA TENSIONE 
+\item SPIA PREALLARME 
+\item PULPITO/PANNELLO DI COMANDO 
+\end{itemize} 
+
 
 \end{document} 

--- a/test/data/filters/Latex/file-latex-items.tex
+++ b/test/data/filters/Latex/file-latex-items.tex
@@ -5,15 +5,10 @@
 \section {Itemize}
 
 \begin{itemize}
-
 \item INTERRUTTORE GENERALE ON/OFF (I/0)
-
 \item SPIA PRESENZA TENSIONE
-
 \item SPIA PREALLARME
-
 \item PULPITO/PANNELLO DI COMANDO
-
 \end{itemize}
 
 \end{document}

--- a/test/data/filters/Latex/file-latex-items.tex
+++ b/test/data/filters/Latex/file-latex-items.tex
@@ -1,0 +1,19 @@
+\documentclass{article}
+\begin{document}
+\title{LaTeX Itemize example}
+
+\section {Itemize}
+
+\begin{itemize}
+
+\item INTERRUTTORE GENERALE ON/OFF (I/0)
+
+\item SPIA PRESENZA TENSIONE
+
+\item SPIA PREALLARME
+
+\item PULPITO/PANNELLO DI COMANDO
+
+\end{itemize}
+
+\end{document}

--- a/test/data/filters/Latex/test-article-exp.tex
+++ b/test/data/filters/Latex/test-article-exp.tex
@@ -1,0 +1,257 @@
+% arara: pdflatex
+% arara: bibtex
+% arara: pdflatex
+% arara: pdflatex
+
+\documentclass{article} 
+
+
+\usepackage{lipsum} 
+\usepackage{amsmath} 
+\usepackage{pifont} 
+\usepackage{textcase} 
+\usepackage[cbgreek]{bpchem} 
+\usepackage{mhchem} 
+\usepackage{siunitx} 
+\usepackage{textcomp} 
+\usepackage{graphicx} 
+\usepackage{tipa} 
+\usepackage{mfirstuc-english} 
+\usepackage[colorlinks]{hyperref} 
+
+
+\title{Sample Article} 
+\author{Nicola Talbot\thanks{Some attribution}} 
+
+
+\newcommand*{\pfrac}[2]{\frac{\partial#1}{\partial#2}} 
+\newcommand*{\dpfrac}[3]{\frac{\partial^2#1}{\partial#2\partial#3}} 
+
+
+\renewcommand*{\vec}[1]{\boldsymbol{#1}} \newtoks\mytoks \mytoks={token register contents} 
+
+\long\def\longfoo#1{Foo 
+
+#1 
+
+bar} 
+
+
+\begin{document} 
+\maketitle
+
+\tableofcontents
+
+
+\begin{abstract} \lipsum[1] 
+\end{abstract} 
+
+Token register contents: \the\mytoks. \longfoo{test}.\marginpar{A marginal note.} 
+
+
+\section*{An Unnumbered Section} 
+\addcontentsline{toc}{section}{An Unnumbered Section} 
+
+Chars: \symbol{98}, \texttt{\char98}, \texttt{\char`b}, \texttt{\char'142}, \texttt{\char"62}, \texttt{\char`\b}, \texttt{\char`\\ foo}. 
+
+Normal Text. \rotatebox{45}{Rotated Text} \scalebox{2}{Scaled Text} 
+
+\lipsum[4-5] 
+
+Subscript\textsubscript{subscript} and Superscript\textsuperscript{superscript}. 
+
+From the bpchem manual: \BPChem{C\_2H\_5OH} or \BPChem{SO\_4\^{2-}}. 
+
+\bpalpha \bpbeta \bpDelta\HNMR \CNMR \cis \trans \hapto{1234} 
+
+From the siunitx manual: \si{\kilo\gram\metre\per\square\second}. 
+
+\si{kg.m.s^{-2}} 
+
+cubic metre per kilogram: \si{\cubic\metre\per\kilogram}. 
+
+\si{m^{3}.kg^{-1}} 
+
+per cubic metre: \si{\per\cubic\metre} 
+
+square metre: \si{\square\metre} 
+
+metre squared: \si{\metre\squared} 
+
+metre cubed: \si{\metre\cubed}. 
+
+From the mhchem manual: 
+
+\ce{CO2 + C -> 2 CO} 
+
+\ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-} 
+
+\ce{Y^99+} 
+
+\ce{Fe^{II}Fe^{III}204} 
+
+\ce{1/2H2O} 
+
+\ce{\mu-Cl} 
+
+\ce{$n$H2O} 
+
+\ce{{(+)}_589{-}[Co(en)3]Cl3} 
+
+textcomp: \texttwosuperior\ \texteuro 
+
+
+\section{Introduction} 
+\label{sec:intro} 
+
+This is an example section. An unnumbered equation: \[ f(\vec{a}; x) = \sum_{i=1}^n a_i x^i \] 
+
+In-line maths: $y = \text{some text} - \pi$. 
+
+A numbered equation: 
+\begin{equation} y = m x + c 
+\label{eq:mx+c} 
+\end{equation} 
+
+Another numbered equation: 
+\begin{equation}
+\label{eq:dp} \dpfrac{L}{\eta_j}{w_k} = \dpfrac{L}{w_k}{\eta_j} = \sum_{i=1}^n \pfrac{g(z_i)}{z_i} \phi_k(\vec{x}_i)\pfrac{z_i}{\eta_j} + (\hat{y}_i - y_i)\pfrac{\phi_k(\vec{x}_i)}{\eta_j} 
+\end{equation} 
+
+Oh, no! It's an \texttt{eqnarray}: 
+\begin{eqnarray} f(x) &=& ax^2 +b
+\label{eq:f}\\ f'(x) &=& 2ax
+\label{eq:df} 
+\end{eqnarray} and an \texttt{eqnarray*}: 
+\begin{eqnarray*} \mathcal{I} &= &\int_0^\infty f(x)\,dx\\ g(x) &= &\prod_i h_i(x) 
+\end{eqnarray*} 
+
+Some \textbf{bold text}, \textit{italic text}, \textsf{sans-serif text}, \textsc{small caps}. Here's a footnote.
+\footnote{Here's the footnote text.} 
+
+
+\section{Case-Changing} 
+\label{sec:casechange} 
+
+\TeX\ case-change: \uppercase{upper \lowercase{LOWER} MiXeD $\alpha \neq a$.} \LaTeX\ case-change: \MakeUppercase{abc\ae\ \protect\( a = b \protect\) and $\alpha \neq a$}. 
+
+{abc\ae\ \protect\( a = b \protect\) and $\alpha \neq a$} 
+
+\texttt{textcase.sty} case-change: \MakeTextUppercase{abc\ae\ \( a = b \) and $\alpha \neq a$ \NoCaseChange{No Case-Change}}. 
+
+
+\newcommand{\foo}{fooa} 
+\newcommand{\FOO}{foob} Upper: \uppercase{\foo}. Lower: \lowercase{\FOO}. TC: Upper: \MakeTextUppercase{\foo}. Lower: \MakeTextLowercase{\FOO}. 
+
+\makefirstuc{first letter upper}. \makefirstuc{\textbf{first} letter upper}. \capitalisewords{the book of words}. \capitalisewords{the book of the silliest words}. \capitalisewords{the \emph{book} of words}. \capitalisewords{\textbf{the \emph{book} of words}}. \capitalisefmtwords{\textbf{the \emph{book} of words}}. \makefirstuc{\MFUskippunc{`}first letter upper'}. \capitalisewords{the book of words\MFUwordbreak{\slash}phrases}. 
+
+
+\section{Another Section} 
+
+Some cross-references: section~
+\ref{sec:intro}, equation~
+\ref{eq:mx+c} and some citations~
+\cite{article-full,incollection-full} and~
+\cite[some text]{inproceedings-full}. 
+
+Some more references: equations~
+\ref{eq:f} and~
+\ref{eq:df}. 
+
+\lipsum[2-3] 
+
+\subsection{A Subsection} 
+
+\lipsum[6-7] 
+
+
+\section*{Another Unnumbered Section} 
+\addcontentsline{toc}{section}{Another Unnumbered Section} 
+
+Some symbols: \ding{67}, \ding{118}, \ding{161}. \$1,000 not to be confused with the math mode shift \verb|$|. 
+
+\lipsum[8-9] 
+
+
+\section{Floats} 
+\label{sec:floats} 
+
+Table~
+\ref{tab:sample} isn't very interesting. Figure~
+\ref{fig:sample} uses an image provided with the \texttt{mwe} package. 
+
+
+\begin{table}[htbp] \caption{A Sample Table} 
+\label{tab:sample} \centering
+
+
+\begin{tabular}{clrl} Centred Column &Left Aligned &Right Aligned &Left Aligned\\ One &Two &Three &Four\\ A &B &C &D\\ \multicolumn{2}{|c|}{Centre Span} &R &L 
+\end{tabular} 
+\end{table} 
+
+
+\begin{figure}[htbp] \centering
+
+
+\includegraphics{example-image} \caption{An Example Image} 
+\label{fig:sample} 
+\end{figure} 
+
+
+\section{IPA}
+\label{sec:ipa} \textipa{@"A\AA \char 197} \AA \char 197 \textschwa
+
+
+\section{Loops} 
+
+\newcount\myctr \loop
+
+\advance\myctr by 1\relax \the\myctr. \ifnum\myctr<10 \repeat
+
+\makeatletter
+
+\@for\tmp:=Foo,Bar,Baz\do{\tmp. } 
+
+\def\tmplist{Foo,Bar,Baz} \@for\tmp:=\tmplist\do{\tmp. } \makeatother
+
+
+\section{If-Case} 
+
+\myctr=3\relax In or: \ifcase\myctr One \or Two \or
+
+%%
+Three \or
+
+%
+Four \else
+
+%
+Other \fi
+
+%
+In else: \ifcase\myctr One \or Two \else
+
+%%
+Other \fi
+
+%
+No else: \ifcase\myctr One \or Two \fi
+
+%%
+
+\section{Counters} 
+
+\newcounter{mycounter} Counter value: \themycounter. 
+
+Add 10. \addtocounter{mycounter}{10} Counter value: \themycounter. Roman: \Roman{mycounter}; lowercase: \roman{mycounter}. Alph: \Alph{mycounter}; lowercase: \alph{mycounter}. 
+
+Number=10? \ifnum\value{mycounter}=10 true\else false\fi 
+
+Subtract 6. \addtocounter{mycounter}{-6} New value: \arabic{mycounter}. Fn: \fnsymbol{mycounter}. 
+
+Number=10? \ifnum\value{mycounter}=10 true\else false\fi 
+
+\bibliographystyle{plain} \bibliography{xampl} 
+
+
+\end{document} 

--- a/test/data/filters/Latex/test-article.tex
+++ b/test/data/filters/Latex/test-article.tex
@@ -1,0 +1,300 @@
+% arara: pdflatex
+% arara: bibtex
+% arara: pdflatex
+% arara: pdflatex
+\documentclass{article}
+
+\usepackage{lipsum}
+\usepackage{amsmath}
+\usepackage{pifont}
+\usepackage{textcase}
+\usepackage[cbgreek]{bpchem}
+\usepackage{mhchem}
+\usepackage{siunitx}
+\usepackage{textcomp}
+\usepackage{graphicx}
+\usepackage{tipa}
+\usepackage{mfirstuc-english}
+\usepackage[colorlinks]{hyperref}
+
+\title{Sample Article}
+\author{Nicola Talbot\thanks{Some attribution}}
+
+\newcommand*{\pfrac}[2]{\frac{\partial#1}{\partial#2}}
+\newcommand*{\dpfrac}[3]{\frac{\partial^2#1}{\partial#2\partial#3}}
+
+\renewcommand*{\vec}[1]{\boldsymbol{#1}}
+\newtoks\mytoks
+\mytoks={token register contents}
+
+\long\def\longfoo#1{Foo
+
+#1
+
+bar}
+
+\begin{document}
+\maketitle
+
+\tableofcontents
+
+\begin{abstract}
+\lipsum[1]
+\end{abstract}
+
+Token register contents: \the\mytoks.
+\longfoo{test}.\marginpar{A marginal note.}
+
+\section*{An Unnumbered Section}
+\addcontentsline{toc}{section}{An Unnumbered Section}
+
+Chars: \symbol{98}, \texttt{\char98}, \texttt{\char`b}, \texttt{\char'142},
+\texttt{\char"62}, \texttt{\char`\b}, \texttt{\char`\\ foo}.
+
+Normal Text.
+\rotatebox{45}{Rotated Text}
+\scalebox{2}{Scaled Text}
+
+\lipsum[4-5]
+
+Subscript\textsubscript{subscript} and
+Superscript\textsuperscript{superscript}.
+
+From the bpchem manual:
+\BPChem{C\_2H\_5OH} or \BPChem{SO\_4\^{2-}}.
+
+\bpalpha \bpbeta \bpDelta
+\HNMR \CNMR \cis \trans \hapto{1234}
+
+From the siunitx manual:
+\si{\kilo\gram\metre\per\square\second}.
+
+\si{kg.m.s^{-2}}
+
+cubic metre per kilogram:
+\si{\cubic\metre\per\kilogram}.
+
+\si{m^{3}.kg^{-1}}
+
+per cubic metre: \si{\per\cubic\metre}
+
+square metre: \si{\square\metre}
+
+metre squared: \si{\metre\squared}
+
+metre cubed: \si{\metre\cubed}.
+
+From the mhchem manual:
+
+\ce{CO2 + C -> 2 CO}
+
+\ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-}
+
+\ce{Y^99+}
+
+\ce{Fe^{II}Fe^{III}204}
+
+\ce{1/2H2O}
+
+\ce{\mu-Cl}
+
+\ce{$n$H2O}
+
+\ce{{(+)}_589{-}[Co(en)3]Cl3}
+
+textcomp: \texttwosuperior\ \texteuro
+
+\section{Introduction}
+\label{sec:intro}
+
+This is an example section. An unnumbered equation:
+\[
+  f(\vec{a}; x) = \sum_{i=1}^n a_i x^i
+\]
+
+In-line maths: $y = \text{some text} - \pi$.
+
+A numbered equation:
+\begin{equation}
+y = m x + c
+\label{eq:mx+c}
+\end{equation}
+
+Another numbered equation:
+\begin{equation}\label{eq:dp}
+ \dpfrac{L}{\eta_j}{w_k}
+ = \dpfrac{L}{w_k}{\eta_j}
+ = \sum_{i=1}^n \pfrac{g(z_i)}{z_i}
+   \phi_k(\vec{x}_i)\pfrac{z_i}{\eta_j}
+ + (\hat{y}_i - y_i)\pfrac{\phi_k(\vec{x}_i)}{\eta_j}
+\end{equation}
+
+Oh, no! It's an \texttt{eqnarray}:
+\begin{eqnarray}
+f(x) &=& ax^2 +b\label{eq:f}\\
+f'(x) &=& 2ax\label{eq:df}
+\end{eqnarray}
+and an \texttt{eqnarray*}:
+\begin{eqnarray*}
+\mathcal{I} & = & \int_0^\infty f(x)\,dx\\
+g(x) & = & \prod_i h_i(x)
+\end{eqnarray*}
+
+Some \textbf{bold text}, \textit{italic text}, 
+\textsf{sans-serif text}, \textsc{small caps}.
+Here's a footnote.\footnote{Here's the footnote text.}
+
+\section{Case-Changing}
+\label{sec:casechange}
+
+\TeX\ case-change: \uppercase{upper \lowercase{LOWER} MiXeD $\alpha \neq a$.}
+\LaTeX\ case-change: \MakeUppercase{abc\ae\ \protect\( a = b
+\protect\) and $\alpha \neq a$}.
+
+{abc\ae\ \protect\( a = b
+\protect\) and $\alpha \neq a$}
+
+\texttt{textcase.sty} case-change: \MakeTextUppercase{abc\ae\ \( a = b \) and 
+$\alpha \neq a$ \NoCaseChange{No Case-Change}}.
+
+\newcommand{\foo}{fooa}
+\newcommand{\FOO}{foob}
+Upper: \uppercase{\foo}. Lower: \lowercase{\FOO}.
+TC: Upper: \MakeTextUppercase{\foo}. Lower:
+\MakeTextLowercase{\FOO}.
+
+\makefirstuc{first letter upper}.
+\makefirstuc{\textbf{first} letter upper}.
+\capitalisewords{the book of words}.
+\capitalisewords{the book of the silliest words}.
+\capitalisewords{the \emph{book} of words}.
+\capitalisewords{\textbf{the \emph{book} of words}}.
+\capitalisefmtwords{\textbf{the \emph{book} of words}}.
+\makefirstuc{\MFUskippunc{`}first letter upper'}.
+\capitalisewords{the book of words\MFUwordbreak{\slash}phrases}.
+
+\section{Another Section}
+
+Some cross-references: section~\ref{sec:intro},
+equation~\ref{eq:mx+c} and some
+citations~\cite{article-full,incollection-full}
+and~\cite[some text]{inproceedings-full}.
+
+Some more references: equations~\ref{eq:f} and~\ref{eq:df}.
+
+\lipsum[2-3]
+
+\subsection{A Subsection}
+
+\lipsum[6-7]
+
+\section*{Another Unnumbered Section}
+\addcontentsline{toc}{section}{Another Unnumbered Section}
+
+Some symbols: \ding{67}, \ding{118}, \ding{161}. \$1,000 not to be
+confused with the math mode shift \verb|$|.
+
+\lipsum[8-9]
+
+\section{Floats}
+\label{sec:floats}
+
+Table~\ref{tab:sample} isn't very interesting.
+Figure~\ref{fig:sample} uses an image provided with the 
+\texttt{mwe} package.
+
+\begin{table}[htbp]
+\caption{A Sample Table}
+\label{tab:sample}
+\centering
+\begin{tabular}{clrl}
+Centred Column & Left Aligned & Right Aligned & Left Aligned\\
+One & Two & Three & Four\\
+A & B & C & D\\
+\multicolumn{2}{|c|}{Centre Span} & R & L
+\end{tabular}
+\end{table}
+
+\begin{figure}[htbp]
+\centering
+ \includegraphics{example-image}
+ \caption{An Example Image}
+ \label{fig:sample}
+\end{figure}
+
+\section{IPA}\label{sec:ipa}
+\textipa{@"A\AA \char 197} \AA \char 197
+\textschwa
+
+\section{Loops}
+
+\newcount\myctr
+\loop
+ \advance\myctr by 1\relax
+ \the\myctr.
+\ifnum\myctr<10
+\repeat
+
+\makeatletter
+\@for\tmp:=Foo,Bar,Baz\do{\tmp. }
+
+\def\tmplist{Foo,Bar,Baz}
+\@for\tmp:=\tmplist\do{\tmp. }
+\makeatother
+
+\section{If-Case}
+
+\myctr=3\relax
+In or:
+\ifcase\myctr
+ One%
+ \or 
+ Two%
+ \or
+ Three%
+ \or
+ Four%
+ \else
+ Other%
+\fi
+
+In else:
+\ifcase\myctr
+ One%
+ \or 
+ Two%
+ \else
+ Other%
+\fi
+
+No else:
+\ifcase\myctr
+ One%
+ \or 
+ Two%
+\fi
+
+\section{Counters}
+
+\newcounter{mycounter}
+Counter value: \themycounter.
+
+Add 10.
+\addtocounter{mycounter}{10}
+Counter value: \themycounter.
+Roman: \Roman{mycounter}; lowercase: \roman{mycounter}.
+Alph: \Alph{mycounter}; lowercase: \alph{mycounter}.
+
+Number=10? \ifnum\value{mycounter}=10 true\else false\fi
+
+Subtract 6.
+\addtocounter{mycounter}{-6}
+New value: \arabic{mycounter}.
+Fn: \fnsymbol{mycounter}.
+
+Number=10? \ifnum\value{mycounter}=10 true\else false\fi
+
+\bibliographystyle{plain}
+\bibliography{xampl}
+
+\end{document}

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.latex.LatexFilter;
 
+import java.io.File;
+
 public class LatexFilterTest extends TestFilterBase {
 
     @Test
@@ -38,8 +40,7 @@ public class LatexFilterTest extends TestFilterBase {
         IProject.FileInfo fi = loadSourceFiles(new LatexFilter(), f);
 
         checkMultiStart(fi, f);
-        checkMulti("[11pt]{article}", null, null, "", "LaTeX Typesetting By Example", null);
-        checkMulti("LaTeX Typesetting By Example", null, null, "[11pt]{article}",
+        checkMulti("LaTeX Typesetting By Example", null, null, "",
                 "Phil Farrell<br0> Stanford University School of Earth Sciences", null);
     }
 
@@ -53,12 +54,33 @@ public class LatexFilterTest extends TestFilterBase {
         checkMulti("Itemize", null, null, "LaTeX Itemize example",
                 "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
         checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize",
-                "SPIA PRESENZA TENSIONE", null);
-        checkMulti("SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
-                "SPIA PREALLARME", null);
-        checkMulti("SPIA PREALLARME", null, null, "SPIA PRESENZA TENSIONE",
-                "PULPITO/PANNELLO DI COMANDO", null);
-        checkMulti("PULPITO/PANNELLO DI COMANDO", null, null, "SPIA PREALLARME", "", null);
+                "<r0> SPIA PRESENZA TENSIONE", null);
+        checkMulti("<r0> SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
+                "<r0> SPIA PREALLARME", null);
+        checkMulti("<r0> SPIA PREALLARME", null, null, "<r0> SPIA PRESENZA TENSIONE",
+                "<r0> PULPITO/PANNELLO DI COMANDO", null);
+        checkMulti("<r0> PULPITO/PANNELLO DI COMANDO", null, null, "<r0> SPIA PREALLARME", "", null);
+        checkMultiEnd();
+    }
+
+
+    @Test
+    public void testParseItemize() throws Exception {
+        translate(new LatexFilter(), "test/data/filters/Latex/file-latex-items.tex");
+        compareBinary(new File("test/data/filters/Latex/file-latex-items-exp.tex"), outFile);
+    }
+
+
+    @Test
+    public void testLoadComments() throws Exception {
+        String f = "test/data/filters/Latex/file-latex-comments.tex";
+        IProject.FileInfo fi = loadSourceFiles(new LatexFilter(), f);
+
+        checkMultiStart(fi, f);
+        checkMulti("LaTeX Comment example", null, null, "", "Comment", null);
+        checkMulti("Comment", null, null, "LaTeX Comment example",
+                "This is a text with inline comments.", null);
+        checkMulti("This is a text with inline comments.", null, null, "Comment", "", null);
         checkMultiEnd();
     }
 }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -51,10 +51,10 @@ public class LatexFilterTest extends TestFilterBase {
 
         checkMultiStart(fi, f);
         checkMulti("LaTeX Itemize example", null, null, "", "Itemize", null);
-        checkMulti("Itemize", null, null, "LaTeX Itemize example",
-                "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
-        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize",
-                "<r0> SPIA PRESENZA TENSIONE", null);
+        checkMulti("Itemize", null, null, "LaTeX Itemize example", "INTERRUTTORE GENERALE ON/OFF (I/0)",
+                null);
+        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize", "<r0> SPIA PRESENZA TENSIONE",
+                null);
         checkMulti("<r0> SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
                 "<r0> SPIA PREALLARME", null);
         checkMulti("<r0> SPIA PREALLARME", null, null, "<r0> SPIA PRESENZA TENSIONE",
@@ -63,13 +63,11 @@ public class LatexFilterTest extends TestFilterBase {
         checkMultiEnd();
     }
 
-
     @Test
     public void testParseItemize() throws Exception {
         translate(new LatexFilter(), "test/data/filters/Latex/file-latex-items.tex");
         compareBinary(new File("test/data/filters/Latex/file-latex-items-exp.tex"), outFile);
     }
-
 
     @Test
     public void testLoadComments() throws Exception {
@@ -78,8 +76,8 @@ public class LatexFilterTest extends TestFilterBase {
 
         checkMultiStart(fi, f);
         checkMulti("LaTeX Comment example", null, null, "", "Comment", null);
-        checkMulti("Comment", null, null, "LaTeX Comment example",
-                "This is a text with inline comments.", null);
+        checkMulti("Comment", null, null, "LaTeX Comment example", "This is a text with inline comments.",
+                null);
         checkMulti("This is a text with inline comments.", null, null, "Comment", "", null);
         checkMultiEnd();
     }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -51,11 +51,11 @@ public class LatexFilterTest extends TestFilterBase {
 
         checkMultiStart(fi, f);
         checkMulti("LaTeX Itemize example", null, null, "", "Itemize", null);
-        checkMulti("Itemize", null, null, "LaTeX Itemize example", "INTERRUTTORE GENERALE ON/OFF (I/0)",
+        checkMulti("Itemize", null, null, "LaTeX Itemize example", "<r0> INTERRUTTORE GENERALE ON/OFF (I/0)",
                 null);
-        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize", "<r0> SPIA PRESENZA TENSIONE",
+        checkMulti("<r0> INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize", "<r0> SPIA PRESENZA TENSIONE",
                 null);
-        checkMulti("<r0> SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
+        checkMulti("<r0> SPIA PRESENZA TENSIONE", null, null, "<r0> INTERRUTTORE GENERALE ON/OFF (I/0)",
                 "<r0> SPIA PREALLARME", null);
         checkMulti("<r0> SPIA PREALLARME", null, null, "<r0> SPIA PRESENZA TENSIONE",
                 "<r0> PULPITO/PANNELLO DI COMANDO", null);
@@ -80,5 +80,11 @@ public class LatexFilterTest extends TestFilterBase {
                 null);
         checkMulti("This is a text with inline comments.", null, null, "Comment", "", null);
         checkMultiEnd();
+    }
+
+    @Test
+    public void testArticle() throws Exception {
+        translate(new LatexFilter(), "test/data/filters/Latex/test-article.tex");
+        compareBinary(new File("test/data/filters/Latex/test-article-exp.tex"), outFile);
     }
 }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2011 Alex Buloichik
+               2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -40,5 +41,24 @@ public class LatexFilterTest extends TestFilterBase {
         checkMulti("[11pt]{article}", null, null, "", "LaTeX Typesetting By Example", null);
         checkMulti("LaTeX Typesetting By Example", null, null, "[11pt]{article}",
                 "Phil Farrell<br0> Stanford University School of Earth Sciences", null);
+    }
+
+    @Test
+    public void testLoadItemize() throws Exception {
+        String f = "test/data/filters/Latex/file-latex-items.tex";
+        IProject.FileInfo fi = loadSourceFiles(new LatexFilter(), f);
+
+        checkMultiStart(fi, f);
+        checkMulti("LaTeX Itemize example", null, null, "", "Itemize", null);
+        checkMulti("Itemize", null, null, "LaTeX Itemize example",
+                "INTERRUTTORE GENERALE ON/OFF (I/0)", null);
+        checkMulti("INTERRUTTORE GENERALE ON/OFF (I/0)", null, null, "Itemize",
+                "SPIA PRESENZA TENSIONE", null);
+        checkMulti("SPIA PRESENZA TENSIONE", null, null, "INTERRUTTORE GENERALE ON/OFF (I/0)",
+                "SPIA PREALLARME", null);
+        checkMulti("SPIA PREALLARME", null, null, "SPIA PRESENZA TENSIONE",
+                "PULPITO/PANNELLO DI COMANDO", null);
+        checkMulti("PULPITO/PANNELLO DI COMANDO", null, null, "SPIA PREALLARME", "", null);
+        checkMultiEnd();
     }
 }


### PR DESCRIPTION
Split paragraph when `\item` command accept in latex file.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- The LaTeX filter should use \item as a delimiter
- https://sourceforge.net/p/omegat/bugs/743/

## What does this PR change?

- Refactoring latex filter.
- define `parBreakCommand` list
- split and translate itemized clauses

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
