### PR TITLE
[BUGS#1228] chore: workaround innosetup docker permission issue

### DIFF
--- a/ci/iscc
+++ b/ci/iscc
@@ -14,8 +14,28 @@ bindpaths() {
 
 if type nerdctl &> /dev/null ; then
     CMD=nerdctl
+    IMAGE=amake/innosetup:innosetup6-buster
 elif type docker &> /dev/null ; then
     CMD=docker
+
+    # workaround for build failure on CI env.
+    # see https://sourceforge.net/p/omegat/bugs/1228/
+    PUID=`id -u`
+    PGID=`id -g`
+    IMAGE=omegatorg/innosetup:innosetup6
+    cat << __EOF__ | docker build -t $IMAGE - || true
+FROM docker.io/amake/innosetup:innosetup6-buster
+USER root
+RUN usermod -u $PUID -o xclient && groupmod -g $PGID -o xusers
+RUN chown -R $PUID:$PGID /home/xclient /work
+USER xclient
+ENV HOME /home/xclient
+ENV WINEPREFIX /home/xclient/.wine
+ENV WINEARCH win32
+WORKDIR /work
+ENTRYPOINT ["iscc"]
+__EOF__
+
 else
   echo Please install docker or nerdctl!
   exit 2
@@ -26,5 +46,5 @@ exec $CMD run -i --rm  \
    -u `id -u`:`id -g` \
    -v "$PWD":/work \
    $(bindpaths "$@") \
-   amake/innosetup:innosetup6-buster \
+   $IMAGE \
    $(relpaths "$@")


### PR DESCRIPTION
Fix CI failure for weekly release

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]


## Which ticket is resolved?

- CI: weekly release failed with permission error inside docker image
- https://sourceforge.net/p/omegat/bugs/1228/



## What does this PR change?

- Update uid/gid in docker image as same as host when launch `ci/iscc`
- Only docker environment supported, no change in containerd/nerdctl (TBD)
- Intend to fix the CI issue with docker on Ubuntu 22.04 hosted by Microsoft
## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
