### PR TITLE
[RFE#1726] refactor: filters: create(Reader|Writer), get(Input|Output)Encoding overrides

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -155,13 +155,12 @@
     <suppress checks="MissingSwitchDefault" files="(OneFilter|Filters)TableModel\.java"/>
 
     <!-- filters -->
-    <suppress checks="(InnerAssignment|TypeName)" files="MozillaLangFilter\.java" lines="67,161"/>
     <suppress checks="LocalVariableName" files="MozillaFTLFilter\.java" lines="118"/>
     <suppress checks="InnerAssignment" files="RcFilter\.java" lines="176,180,184"/>
     <suppress checks="MethodLength" files="FilterVisitor\.java" lines="450"/>
-    <suppress checks="MethodLength" files="PoFilter\.java" lines="408"/>
+    <suppress checks="MethodLength" files="PoFilter\.java" lines="380"/>
     <suppress checks="(TypeName|MissingSwitchDefault)" files="srtFilter\.java" lines="55,102"/>
-    <suppress files="ResourceBundleFilter\.java" checks="(InnerAssignment|EmptyBlock)" lines="216,347"/>
+    <suppress files="ResourceBundleFilter\.java" checks="(InnerAssignment|EmptyBlock)" lines="168,308"/>
     <suppress checks="TypeName" files="XLIFFOptions\.java" lines="67"/>
     <suppress files="XHTMLDialect\.java" checks="InnerAssignment" lines="131,132"/>
     <suppress files="CamtasiaWindowsDialect\.java" checks="MethodLength" lines="45"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,10 @@ antlr = "4.13.1"
 hamcrest = "2.2"
 nekohtml = "1.9.22"
 htmlunit = "3.4.0"
-lang3 = "3.11"
-io = "2.11.0"
-codec = "1.13"
-text = "1.9"
+commons_lang3 = "3.11"
+commons_io = "2.15.0"
+commons_codec = "1.13"
+commons_text = "1.9"
 unbescape = "1.1.6.RELEASE"
 xerces = "2.12.2"
 jstyleparser = "4.1.3"
@@ -76,10 +76,10 @@ antlr4 = {group = "org.antlr", name = "antlr4", version.ref = "antlr"}
 hamcrest = {group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest"}
 nekohtml = {group = "net.sourceforge.nekohtml", name = "nekohtml", version.ref = "nekohtml"}
 neko-htmlunit = {group = "org.htmlunit", name = "neko-htmlunit", version.ref = "htmlunit"}
-commons-io = {group = "commons-io", name = "commons-io", version.ref = "io"}
-commons-lang3 = {group = "org.apache.commons", name = "commons-lang3", version.ref = "lang3"}
-commons-codec = {group = "commons-codec", name = "commons-codec", version.ref = "codec"}
-commons-text = {group = "org.apache.commons", name = "commons-text", version.ref = "text"}
+commons-io = {group = "commons-io", name = "commons-io", version.ref = "commons_io"}
+commons-lang3 = {group = "org.apache.commons", name = "commons-lang3", version.ref = "commons_lang3"}
+commons-codec = {group = "commons-codec", name = "commons-codec", version.ref = "commons_codec"}
+commons-text = {group = "org.apache.commons", name = "commons-text", version.ref = "commons_text"}
 unbescape = {group = "org.unbescape", name = "unbescape", version.ref = "unbescape"}
 xerces-impl = {group = "xerces", name = "xercesImpl", version.ref = "xerces"}
 jstyleparser = {group = "tokyo.northside", name = "jstyleparser", version.ref = "jstyleparser"}

--- a/src/org/omegat/filters2/AbstractFilter.java
+++ b/src/org/omegat/filters2/AbstractFilter.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
@@ -315,7 +316,7 @@ public abstract class AbstractFilter implements IFilter {
      *            The source file.
      * @param inEncoding
      *            Encoding of the input file, if the filter supports it.
-     *            Otherwise null.
+     *            Otherwise, null.
      * @return The reader for the source file
      * @throws UnsupportedEncodingException
      *             Thrown if JVM doesn't support the specified inEncoding
@@ -333,7 +334,7 @@ public abstract class AbstractFilter implements IFilter {
         if (bomLastParsedFile != null) {
             charset = bomLastParsedFile.getCharsetName();
         } else {
-            charset = Objects.requireNonNullElseGet(inEncoding, () -> Charset.defaultCharset().name());
+            charset = Objects.requireNonNullElseGet(inEncoding, () -> StandardCharsets.UTF_8.name());
         }
         return new BufferedReader(new InputStreamReader(bomInputStream, charset));
     }
@@ -363,7 +364,7 @@ public abstract class AbstractFilter implements IFilter {
         } else if (outEncoding != null) {
             charset = Charset.forName(outEncoding);
         } else {
-            charset = Charset.defaultCharset();
+            charset = StandardCharsets.UTF_8;
         }
         return Files.newBufferedWriter(outFile.toPath(), charset);
     }

--- a/src/org/omegat/filters2/AbstractFilter.java
+++ b/src/org/omegat/filters2/AbstractFilter.java
@@ -195,7 +195,7 @@ public abstract class AbstractFilter implements IFilter {
      * True means that OmegaT should handle all the encoding mess.
      * <p>
      * Return false to state that your filter doesn't need encoding management
-     * provided by OmegaT, because it either autodetects the encoding based on
+     * provided by OmegaT, because it either autodetect the encoding based on
      * file contents (like HTML filter does) or the encoding is fixed (like in
      * OpenOffice files).
      *
@@ -224,9 +224,9 @@ public abstract class AbstractFilter implements IFilter {
      * file and encoding {@link #isFileSupported(File, Map, FilterContext))}.
      * You should override only one of the two.
      * <p>
-     * By default returns true, because this method should be overriden only by
-     * filters that differentiate input files not by extensions, but by file's
-     * content.
+     * By default, returns true, because this method should be overridden only
+     * by filters that differentiate input files not by extensions, but by
+     * file's content.
      * <p>
      * For example, DocBook files have .xml extension, as possibly many other
      * XML files, so the filter should check a DTD of the document.
@@ -288,7 +288,7 @@ public abstract class AbstractFilter implements IFilter {
     }
 
     /**
-     * OmegaT calls this to see whether the filter has any options. By default
+     * OmegaT calls this to see whether the filter has any options. By default,
      * returns false, so filter authors should override this to tell OmegaT core
      * that this filter has options.
      *
@@ -345,7 +345,7 @@ public abstract class AbstractFilter implements IFilter {
      *            The target file
      * @param outEncoding
      *            Encoding of the target file, if the filter supports it.
-     *            Otherwise null.
+     *            Otherwise, null.
      * @return The writer for the target file
      * @throws UnsupportedEncodingException
      *             Thrown if JVM doesn't support the specified outEncoding
@@ -458,10 +458,10 @@ public abstract class AbstractFilter implements IFilter {
      * ({@link #isSourceEncodingVariable()}), try to detect it. The result may
      * be null.
      * 
-     * @param fc
-     * @param inFile
-     * @return
-     * @throws IOException
+     * @param fc FilterContext to use.
+     * @param inFile target file to determine encoding.
+     * @return encoding name.
+     * @throws IOException when I/O error occurred.
      */
     protected String getInputEncoding(FilterContext fc, File inFile) throws IOException {
         String encoding = fc.getInEncoding();
@@ -481,8 +481,8 @@ public abstract class AbstractFilter implements IFilter {
      * </ul>
      * The result may be null.
      * 
-     * @param fc
-     * @return
+     * @param fc Filter Context to use.
+     * @return Encoding to write.
      */
     protected String getOutputEncoding(FilterContext fc) {
         String encoding = fc.getOutEncoding();
@@ -498,6 +498,9 @@ public abstract class AbstractFilter implements IFilter {
         return encoding;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public final void parseFile(File inFile, Map<String, String> config, FilterContext fc,
             IParseCallback callback) throws Exception {
@@ -518,6 +521,9 @@ public abstract class AbstractFilter implements IFilter {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public final void alignFile(File inFile, File outFile, Map<String, String> config, FilterContext fc,
             IAlignCallback callback) throws Exception {
@@ -533,9 +539,9 @@ public abstract class AbstractFilter implements IFilter {
 
     /**
      * Align source file against translated file. If this function is not
-     * overridden, then alignment in console mode will not be available for this
-     * filter.
-     *
+     * overridden, then alignment in console mode will not be available for
+     * this filter.
+     * <p>
      * Implementations should call entryAlignCallback.addTranslation with source
      * and target text, and with source file path.
      *
@@ -557,7 +563,7 @@ public abstract class AbstractFilter implements IFilter {
      * Align source file against translated file. If this function is not
      * overridden, then alignment in console mode will not be available for this
      * filter.
-     *
+     * <p>
      * Implementations should call entryAlignCallback.addTranslation
      *
      * @param sourceFile
@@ -582,6 +588,9 @@ public abstract class AbstractFilter implements IFilter {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public final void translateFile(File inFile, File outFile, Map<String, String> config, FilterContext fc,
             ITranslateCallback callback) throws Exception {
@@ -659,6 +668,9 @@ public abstract class AbstractFilter implements IFilter {
         this.entryTranslateCallback = translateCallback;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getInEncodingLastParsedFile() {
         return inEncodingLastParsedFile;

--- a/src/org/omegat/filters2/html2/HTMLFilter2.java
+++ b/src/org/omegat/filters2/html2/HTMLFilter2.java
@@ -32,7 +32,6 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -41,7 +40,9 @@ import java.util.regex.PatternSyntaxException;
 
 import org.htmlparser.Parser;
 import org.htmlparser.util.ParserException;
+
 import org.omegat.filters2.AbstractFilter;
+import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.TranslationException;
 import org.omegat.util.Log;
@@ -93,6 +94,17 @@ public class HTMLFilter2 extends AbstractFilter {
         return true;
     }
 
+    @Override
+    protected String getInputEncoding(FilterContext filterContext, File infile) throws IOException {
+        String encoding = filterContext.getInEncoding();
+        if (encoding == null && isSourceEncodingVariable()) {
+            try (HTMLReader hreader = new HTMLReader(infile.getAbsolutePath(), null)) {
+                encoding = hreader.getEncoding();
+            }
+        }
+        return encoding;
+    }
+
     /**
      * Customized version of creating input reader for HTML files, aware of
      * encoding by using <code>EncodingAwareReader</code> class.
@@ -100,8 +112,7 @@ public class HTMLFilter2 extends AbstractFilter {
      * @see HTMLReader
      */
     @Override
-    public BufferedReader createReader(File infile, String encoding)
-            throws UnsupportedEncodingException, IOException {
+    public BufferedReader createReader(File infile, String encoding) throws IOException {
         HTMLReader hreader = new HTMLReader(infile.getAbsolutePath(), encoding);
         sourceEncoding = hreader.getEncoding();
         return new BufferedReader(hreader);
@@ -114,8 +125,7 @@ public class HTMLFilter2 extends AbstractFilter {
      * @see HTMLWriter
      */
     @Override
-    public BufferedWriter createWriter(File outfile, String encoding)
-            throws UnsupportedEncodingException, IOException {
+    public BufferedWriter createWriter(File outfile, String encoding) throws IOException {
         HTMLWriter hwriter;
         HTMLOptions options = new HTMLOptions(processOptions);
         if (encoding == null) {

--- a/src/org/omegat/filters2/html2/HTMLFilter2.java
+++ b/src/org/omegat/filters2/html2/HTMLFilter2.java
@@ -32,6 +32,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class HTMLFilter2 extends AbstractFilter {
     protected String getInputEncoding(FilterContext filterContext, File infile) throws IOException {
         String encoding = filterContext.getInEncoding();
         if (encoding == null && isSourceEncodingVariable()) {
-            try (HTMLReader hreader = new HTMLReader(infile.getAbsolutePath(), null)) {
+            try (HTMLReader hreader = new HTMLReader(infile.getAbsolutePath(), StandardCharsets.UTF_8.name())) {
                 encoding = hreader.getEncoding();
             }
         }

--- a/src/org/omegat/filters2/html2/HTMLReader.java
+++ b/src/org/omegat/filters2/html2/HTMLReader.java
@@ -52,9 +52,9 @@ import org.omegat.util.PatternConsts;
  * @author Maxym Mykhalchuk
  * @author Didier Briel
  */
-public class HTMLReader extends Reader {
+public class HTMLReader extends Reader implements AutoCloseable {
     /** Inner reader */
-    private BufferedReader reader;
+    private final BufferedReader reader;
 
     /**
      * Creates a new instance of HTMLReader. If encoding cannot be detected,

--- a/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -29,12 +29,7 @@ import java.awt.Window;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,24 +87,23 @@ public class MoodlePHPFilter extends AbstractFilter {
     }
 
     @Override
-    protected BufferedReader createReader(File inFile, String inEncoding)
-            throws UnsupportedEncodingException, IOException {
-        return new BufferedReader(new InputStreamReader(new FileInputStream(inFile), StandardCharsets.UTF_8));
+    protected String getInputEncoding(FilterContext fc, File infile) {
+        return StandardCharsets.UTF_8.name();
     }
 
     @Override
-    protected BufferedWriter createWriter(File outFile, String outEncoding)
-            throws UnsupportedEncodingException, IOException {
-        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8));
+    protected String getOutputEncoding(FilterContext fc) {
+        return StandardCharsets.UTF_8.name();
     }
 
     @Override
-    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc) throws IOException,
-            TranslationException {
+    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc)
+            throws IOException, TranslationException {
 
         String removeStringsUntranslatedStr = processOptions.get(OPTION_REMOVE_STRINGS_UNTRANSLATED);
         // If the value is null the default is false
-        if ((removeStringsUntranslatedStr != null) && (removeStringsUntranslatedStr.equalsIgnoreCase("true"))) {
+        if ((removeStringsUntranslatedStr != null)
+                && (removeStringsUntranslatedStr.equalsIgnoreCase("true"))) {
             removeStringsUntranslated = true;
         } else {
             removeStringsUntranslated = false;
@@ -168,7 +162,7 @@ public class MoodlePHPFilter extends AbstractFilter {
 
     @Override
     protected void alignFile(BufferedReader sourceFile, BufferedReader translatedFile, FilterContext fc,
-                             String sourceFilePath) throws Exception {
+            String sourceFilePath) throws Exception {
         Map<String, String> source = new HashMap<>();
         Map<String, String> translated = new HashMap<>();
 
@@ -179,7 +173,8 @@ public class MoodlePHPFilter extends AbstractFilter {
         for (Map.Entry<String, String> en : source.entrySet()) {
             String tr = translated.get(en.getKey());
             if (!StringUtil.isEmpty(tr)) {
-                entryAlignCallback.addTranslation(en.getKey(), en.getValue(), tr, false, sourceFilePath, this);
+                entryAlignCallback.addTranslation(en.getKey(), en.getValue(), tr, false, sourceFilePath,
+                        this);
             }
         }
     }

--- a/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -33,7 +33,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -51,13 +50,14 @@ import org.omegat.util.StringUtil;
 /**
  * Filter for support Mozilla DTD files.
  * <p>
- * Option to remove untranslated segments in the target files by Enrique Estevez (Code adapted from the file:
- * PoFilter.java)
+ * Option to remove untranslated segments in the target files by Enrique Estevez
+ * (Code adapted from the file: PoFilter.java)
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Didier Briel
  * @author Enrique Estevez (keko.gl@gmail.com)
- * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa380599(v=vs.85).aspx">Format
+ * @see <a href=
+ *      "https://msdn.microsoft.com/en-us/library/windows/desktop/aa380599(v=vs.85).aspx">Format
  *      description</a>
  */
 public class MozillaDTDFilter extends AbstractFilter {
@@ -95,18 +95,18 @@ public class MozillaDTDFilter extends AbstractFilter {
     }
 
     @Override
-    protected BufferedReader createReader(File inFile, String inEncoding) throws IOException {
-        return Files.newBufferedReader(inFile.toPath(), StandardCharsets.UTF_8);
+    protected String getInputEncoding(FilterContext fc, File infile) {
+        return StandardCharsets.UTF_8.name();
     }
 
     @Override
-    protected BufferedWriter createWriter(File outFile, String outEncoding) throws IOException {
-        return Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8);
+    protected String getOutputEncoding(FilterContext fc) {
+        return StandardCharsets.UTF_8.name();
     }
 
     @Override
-    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc) throws IOException,
-            TranslationException {
+    protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc)
+            throws IOException, TranslationException {
 
         String removeStringsUntranslatedStr = processOptions.get(OPTION_REMOVE_STRINGS_UNTRANSLATED);
         // If the value is null the default is false
@@ -137,13 +137,15 @@ public class MozillaDTDFilter extends AbstractFilter {
                 foundQuotes = false;
                 processBlock(block.toString(), outFile);
                 block.setLength(0);
-            } else if ((c == '>' && isInBlock && previousChar == '-')) { // This was a comment
+            } else if ((c == '>' && isInBlock && previousChar == '-')) {
+                // This was a comment
                 isInBlock = false;
                 foundQuotes = false;
                 outFile.write(block.toString());
                 block.setLength(0);
             }
-            if (!Character.isWhitespace(c)) { // In the regexp, there could be whitespace between " and >
+            // In the regexp, there could be whitespace between " and >
+            if (!Character.isWhitespace(c)) {
                 previousChar = c;
             }
         }

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -205,7 +205,7 @@ public class MozillaLangFilter extends AbstractFilter {
     }
 
     protected void flushTranslation(FilterContext fc) throws IOException {
-        if (out != null) {
+        if (entryTranslateCallback != null) {
             String tr;
             tr = entryTranslateCallback.getTranslation(null, source.toString(), null);
             if (tr == null) {

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -28,12 +28,8 @@ package org.omegat.filters2.mozlang;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -79,35 +75,30 @@ public class MozillaLangFilter extends AbstractFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[]
-            { new Instance("*.lang") };
+        return new Instance[] { new Instance("*.lang") };
     }
 
     /**
-     * Creating an input stream to read the source .lang file.
+     * Return input encoding.
      * <p>
-     * NOTE: Mozilla lang files use always UTF-8 encoding without BOM.
+     * NOTE: Mozilla lang files use always UTF-8 encoding.
      */
     @Override
-    public BufferedReader createReader(File infile, String encoding) throws UnsupportedEncodingException,
-            IOException {
-        return new BufferedReader(new InputStreamReader(new FileInputStream(infile), StandardCharsets.UTF_8));
+    protected String getInputEncoding(FilterContext fc, File inFile) {
+        return StandardCharsets.UTF_8.name();
     }
 
     /**
-     * Creating an output stream to save a localized .lang file.
-     * <p>
-     * NOTE: Mozilla lang files use always UTF-8 encoding without BOM.
-     * <p>
+     * Return output encoding.
+     * 
+     * @param fc
+     *            Filter context. NOTE: Mozilla lang files use always UTF-8
+     *            encoding.
+     * @return "UTF-8"
      */
     @Override
-    public BufferedWriter createWriter(File outfile, String encoding) throws UnsupportedEncodingException,
-            IOException {
-        if (outfile == null) {
-            return null;
-        }
-        // lang file use UTF8 encoding
-        return Files.newBufferedWriter(outfile.toPath(), StandardCharsets.UTF_8);
+    protected String getOutputEncoding(FilterContext fc) {
+        return StandardCharsets.UTF_8.name();
     }
 
     @Override
@@ -126,17 +117,6 @@ public class MozillaLangFilter extends AbstractFilter {
     }
 
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc) throws IOException,
-            TranslationException {
-
-        inEncodingLastParsedFile = fc.getInEncoding();
-        try (BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
-             BufferedWriter writer = createWriter(outFile, fc.getOutEncoding())) {
-            processFile(reader, writer, fc);
-        }
-    }
-
-    @Override
     protected void processFile(BufferedReader inFile, BufferedWriter outFile, FilterContext fc)
             throws IOException, TranslationException {
         source = new StringBuilder();
@@ -150,7 +130,8 @@ public class MozillaLangFilter extends AbstractFilter {
         String s;
         while ((s = inFile.readLine()) != null) {
 
-            // We trim trailing spaces, otherwise the regexps could fail, thus making some segments
+            // We trim trailing spaces, otherwise the regexps could fail, thus
+            // making some segments
             // invisible to OmegaT
             s = s.trim();
 
@@ -197,7 +178,8 @@ public class MozillaLangFilter extends AbstractFilter {
             t = target.toString();
         }
         if (localizationNote.length() > 0) {
-            c += "\n" + OStrings.getString("LANGFILTER_LOCALIZATION_NOTE") + "\n" + localizationNote.toString();
+            c += "\n" + OStrings.getString("LANGFILTER_LOCALIZATION_NOTE") + "\n"
+                    + localizationNote.toString();
         }
         if (c.length() == 0) {
             c = null;
@@ -213,9 +195,10 @@ public class MozillaLangFilter extends AbstractFilter {
      */
     protected void align(String source, String translation, String comments) {
         if (entryParseCallback != null) {
-            List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(source, PatternConsts.PRINTF_VARS,
-                    null);
-            entryParseCallback.addEntry(null, source, translation, false, comments, null, this, protectedParts);
+            List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(source,
+                    PatternConsts.PRINTF_VARS, null);
+            entryParseCallback.addEntry(null, source, translation, false, comments, null, this,
+                    protectedParts);
         } else if (entryAlignCallback != null) {
             entryAlignCallback.addTranslation(null, source, translation, false, null, this);
         }

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -131,15 +131,15 @@ public class MozillaLangFilter extends AbstractFilter {
         while ((s = inFile.readLine()) != null) {
 
             // We trim trailing spaces, otherwise the regexps could fail, thus
-            // making some segments
-            // invisible to OmegaT
+            // making some segments invisible to OmegaT
             s = s.trim();
 
             Matcher m;
 
             switch (state) {
             case WAIT_SOURCE:
-                if ((m = PATTERN_SOURCE.matcher(s)).matches()) {
+                m = PATTERN_SOURCE.matcher(s);
+                if (m.matches()) {
                     source.append(m.group(1));
                     state = READ_STATE.WAIT_TARGET;
                 }
@@ -172,7 +172,7 @@ public class MozillaLangFilter extends AbstractFilter {
         String s = source.toString();
         String c = "";
         String t;
-        if (s.equals(target.toString())) {
+        if (s.contentEquals(target)) {
             t = null;
         } else {
             t = target.toString();
@@ -181,7 +181,7 @@ public class MozillaLangFilter extends AbstractFilter {
             c += "\n" + OStrings.getString("LANGFILTER_LOCALIZATION_NOTE") + "\n"
                     + localizationNote.toString();
         }
-        if (c.length() == 0) {
+        if (c.isEmpty()) {
             c = null;
         }
         align(s, t, c);
@@ -210,7 +210,7 @@ public class MozillaLangFilter extends AbstractFilter {
             tr = entryTranslateCallback.getTranslation(null, source.toString(), null);
             if (tr == null) {
                 tr = source.toString();
-            } else if (tr.equals(source.toString())) {
+            } else if (tr.contentEquals(source)) {
                 tr += " {ok}";
             }
             eol(tr);

--- a/src/org/omegat/filters2/po/PoFilter.java
+++ b/src/org/omegat/filters2/po/PoFilter.java
@@ -36,10 +36,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,9 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.io.input.BOMInputStream;
 
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SegmentProperties;
@@ -67,7 +61,8 @@ import org.omegat.util.TagUtil;
 /**
  * Filter to support po files (in various encodings).
  *
- * Format described on https://www.gnu.org/software/hello/manual/gettext/PO-Files.html
+ * Format described on
+ * https://www.gnu.org/software/hello/manual/gettext/PO-Files.html
  *
  * Filter is not thread-safe !
  *
@@ -91,7 +86,7 @@ public class PoFilter extends AbstractFilter {
 
     private static class PluralInfo {
         public int plurals;
-        public String  expression;
+        public String expression;
 
         PluralInfo(int nrOfPlurals, String pluralExpression) {
             plurals = nrOfPlurals;
@@ -103,29 +98,36 @@ public class PoFilter extends AbstractFilter {
     private static final Map<String, PluralInfo> PLURAL_INFOS;
     static {
         HashMap<String, PluralInfo> info = new HashMap<String, PluralInfo>();
-        // list taken from http://translate.sourceforge.net/wiki/l10n/pluralforms d.d. 14-09-2012
-        // See also http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
+        // list taken from
+        // http://translate.sourceforge.net/wiki/l10n/pluralforms d.d.
+        // 14-09-2012
+        // See also
+        // http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
         info.put("ach", new PluralInfo(2, "(n > 1)"));
         info.put("af", new PluralInfo(2, "(n != 1)"));
         info.put("ak", new PluralInfo(2, "(n > 1)"));
         info.put("am", new PluralInfo(2, "(n > 1)"));
         info.put("an", new PluralInfo(2, "(n != 1)"));
-        info.put("ar", new PluralInfo(6, " n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5"));
+        info.put("ar", new PluralInfo(6,
+                " n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5"));
         info.put("arn", new PluralInfo(2, "(n > 1)"));
         info.put("ast", new PluralInfo(2, "(n != 1)"));
         info.put("ay", new PluralInfo(1, "0"));
         info.put("az", new PluralInfo(2, "(n != 1) "));
-        info.put("be", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("be", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("bg", new PluralInfo(2, "(n != 1)"));
         info.put("bn", new PluralInfo(2, "(n != 1)"));
         info.put("bo", new PluralInfo(1, "0"));
         info.put("br", new PluralInfo(2, "(n > 1)"));
         info.put("brx", new PluralInfo(2, "(n != 1)"));
-        info.put("bs", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2) "));
+        info.put("bs", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2) "));
         info.put("ca", new PluralInfo(2, "(n != 1)"));
         info.put("cgg", new PluralInfo(1, "0"));
         info.put("cs", new PluralInfo(3, "(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2"));
-        info.put("csb", new PluralInfo(3, "n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2"));
+        info.put("csb",
+                new PluralInfo(3, "n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2"));
         info.put("cy", new PluralInfo(4, " (n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3"));
         info.put("da", new PluralInfo(2, "(n != 1)"));
         info.put("de", new PluralInfo(2, "(n != 1)"));
@@ -146,7 +148,8 @@ public class PoFilter extends AbstractFilter {
         info.put("fur", new PluralInfo(2, "(n != 1)"));
         info.put("fy", new PluralInfo(2, "(n != 1)"));
         info.put("ga", new PluralInfo(5, "n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4"));
-        info.put("gd", new PluralInfo(4, "(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3"));
+        info.put("gd",
+                new PluralInfo(4, "(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3"));
         info.put("gl", new PluralInfo(2, "(n != 1)"));
         info.put("gu", new PluralInfo(2, "(n != 1)"));
         info.put("gun", new PluralInfo(2, "(n > 1)"));
@@ -155,7 +158,8 @@ public class PoFilter extends AbstractFilter {
         info.put("hi", new PluralInfo(2, "(n != 1)"));
         info.put("hne", new PluralInfo(2, "(n != 1)"));
         info.put("hy", new PluralInfo(2, "(n != 1)"));
-        info.put("hr", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("hr", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("hu", new PluralInfo(2, "(n != 1)"));
         info.put("ia", new PluralInfo(2, "(n != 1)"));
         info.put("id", new PluralInfo(1, "0"));
@@ -175,7 +179,8 @@ public class PoFilter extends AbstractFilter {
         info.put("lb", new PluralInfo(2, "(n != 1)"));
         info.put("ln", new PluralInfo(2, "n>1"));
         info.put("lo", new PluralInfo(1, "0"));
-        info.put("lt", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 or n%100>=20) ? 1 : 2)"));
+        info.put("lt",
+                new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 or n%100>=20) ? 1 : 2)"));
         info.put("lv", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)"));
         info.put("mai", new PluralInfo(2, "(n != 1)"));
         info.put("mfe", new PluralInfo(2, "(n > 1)"));
@@ -188,7 +193,8 @@ public class PoFilter extends AbstractFilter {
         info.put("mnk", new PluralInfo(3, "(n==0 ? 0 : n==1 ? 1 : 2"));
         info.put("mr", new PluralInfo(2, "(n != 1)"));
         info.put("ms", new PluralInfo(1, "0"));
-        info.put("mt", new PluralInfo(4, "(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3)"));
+        info.put("mt", new PluralInfo(4,
+                "(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3)"));
         info.put("my", new PluralInfo(1, "0"));
         info.put("nah", new PluralInfo(2, "(n != 1)"));
         info.put("nap", new PluralInfo(2, "(n != 1)"));
@@ -204,12 +210,14 @@ public class PoFilter extends AbstractFilter {
         info.put("ps", new PluralInfo(2, "(n != 1)"));
         info.put("pa", new PluralInfo(2, "(n != 1)"));
         info.put("pap", new PluralInfo(2, "(n != 1)"));
-        info.put("pl", new PluralInfo(3, "(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("pl",
+                new PluralInfo(3, "(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("pms", new PluralInfo(2, "(n != 1)"));
         info.put("pt", new PluralInfo(2, "(n != 1)"));
         info.put("rm", new PluralInfo(2, "(n!=1)"));
         info.put("ro", new PluralInfo(3, "(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2)"));
-        info.put("ru", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("ru", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("rw", new PluralInfo(2, "(n != 1)"));
         info.put("sah", new PluralInfo(1, "0"));
         info.put("sat", new PluralInfo(2, "(n != 1)"));
@@ -221,7 +229,8 @@ public class PoFilter extends AbstractFilter {
         info.put("so", new PluralInfo(2, "n != 1"));
         info.put("son", new PluralInfo(2, "(n != 1)"));
         info.put("sq", new PluralInfo(2, "(n != 1)"));
-        info.put("sr", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("sr", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("su", new PluralInfo(1, "0"));
         info.put("sw", new PluralInfo(2, "(n != 1)"));
         info.put("sv", new PluralInfo(2, "(n != 1)"));
@@ -234,7 +243,8 @@ public class PoFilter extends AbstractFilter {
         info.put("tr", new PluralInfo(2, "(n>1)"));
         info.put("tt", new PluralInfo(1, "0"));
         info.put("ug", new PluralInfo(1, "0"));
-        info.put("uk", new PluralInfo(3, "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
+        info.put("uk", new PluralInfo(3,
+                "(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)"));
         info.put("ur", new PluralInfo(2, "(n != 1)"));
         info.put("uz", new PluralInfo(2, "(n > 1)"));
         info.put("vi", new PluralInfo(1, "0"));
@@ -259,7 +269,8 @@ public class PoFilter extends AbstractFilter {
      */
     private boolean skipHeader = false;
     /**
-     * If true, wrong but widely used format support, where msgid contains ID, msgstr contains original text.
+     * If true, wrong but widely used format support, where msgid contains ID,
+     * msgstr contains original text.
      */
     private boolean formatMonolingual = false;
 
@@ -282,8 +293,8 @@ public class PoFilter extends AbstractFilter {
     protected static final Pattern MSG_STR = Pattern.compile("msgstr(\\[([0-9]+)\\])?\\s+\"(.*)\"");
     protected static final Pattern MSG_CTX = Pattern.compile("msgctxt\\s+\"(.*)\"");
     protected static final Pattern MSG_OTHER = Pattern.compile("\"(.*)\"");
-    protected static final Pattern PLURAL_FORMS = Pattern.compile("Plural-Forms: *nplurals= *([0-9]+) *; *plural",
-            Pattern.CASE_INSENSITIVE);
+    protected static final Pattern PLURAL_FORMS = Pattern
+            .compile("Plural-Forms: *nplurals= *([0-9]+) *; *plural", Pattern.CASE_INSENSITIVE);
     protected static final Pattern MSG_FUZZY = Pattern.compile("#\\|\\s\"(.*)\"");
 
     enum MODE {
@@ -306,49 +317,9 @@ public class PoFilter extends AbstractFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[]
-        { new Instance("*.po", StandardCharsets.UTF_8.name(), StandardCharsets.UTF_8.name()),
+        return new Instance[] {
+                new Instance("*.po", StandardCharsets.UTF_8.name(), StandardCharsets.UTF_8.name()),
                 new Instance("*.pot", StandardCharsets.UTF_8.name(), StandardCharsets.UTF_8.name()) };
-    }
-
-    /**
-     * return BufferdReader for PoFile reading.
-     * @param inFile
-     *            The source file.
-     * @param inEncoding
-     *            Encoding of the input file, if the filter supports it. Otherwise null.
-     * @return
-     * @throws IOException
-     */
-    @Override
-    protected BufferedReader createReader(File inFile, String inEncoding) throws IOException {
-        BOMInputStream bomInputStream = new BOMInputStream(Files.newInputStream(inFile.toPath()),
-                ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE);
-        ByteOrderMark bom = bomInputStream.getBOM();
-        String charset;
-        if (bom != null) {
-            charset = bom.getCharsetName();
-        } else if (inEncoding == null) {
-            charset = Charset.defaultCharset().name();
-        } else {
-            charset = inEncoding;
-        }
-        return new BufferedReader(new InputStreamReader(bomInputStream, charset));
-    }
-
-    @Override
-    protected BufferedWriter createWriter(File outFile, String outEncoding)
-            throws IOException {
-        if (outFile == null) {
-            return null;
-        }
-        Charset charset;
-        if (outEncoding != null) {
-            charset = Charset.forName(outEncoding);
-        } else {
-            charset = Charset.defaultCharset();
-        }
-        return Files.newBufferedWriter(outFile.toPath(), charset);
     }
 
     @Override
@@ -367,8 +338,8 @@ public class PoFilter extends AbstractFilter {
     }
 
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc) throws IOException,
-            TranslationException {
+    public void processFile(File inFile, File outFile, FilterContext fc)
+            throws IOException, TranslationException {
 
         String allowBlankStr = processOptions.get(OPTION_ALLOW_BLANK);
         allowBlank = allowBlankStr == null || allowBlankStr.equalsIgnoreCase("true");
@@ -388,13 +359,14 @@ public class PoFilter extends AbstractFilter {
 
         inEncodingLastParsedFile = fc.getInEncoding();
         try (BufferedReader reader = createReader(inFile, inEncodingLastParsedFile);
-             BufferedWriter writer = createWriter(outFile, fc.getOutEncoding())) {
+                BufferedWriter writer = createWriter(outFile, fc.getOutEncoding())) {
             processFile(reader, writer, fc);
         }
     }
 
     @Override
-    protected void alignFile(BufferedReader sourceFile, BufferedReader translatedFile, FilterContext fc) throws Exception {
+    protected void alignFile(BufferedReader sourceFile, BufferedReader translatedFile, FilterContext fc)
+            throws Exception {
         this.out = null;
         processPoFile(translatedFile, fc);
     }
@@ -416,7 +388,8 @@ public class PoFilter extends AbstractFilter {
         sources = new StringBuilder[2];
         sources[0] = new StringBuilder();
         sources[1] = new StringBuilder();
-        // can be overridden when header has been read and the number of plurals is different.
+        // can be overridden when header has been read and the number of plurals
+        // is different.
         targets = new StringBuilder[2];
         targets[0] = new StringBuilder();
         targets[1] = new StringBuilder();
@@ -430,7 +403,8 @@ public class PoFilter extends AbstractFilter {
         String s;
         while ((s = in.readLine()) != null) {
 
-            // We trim trailing spaces, otherwise the regexps could fail, thus making some segments
+            // We trim trailing spaces, otherwise the regexps could fail, thus
+            // making some segments
             // invisible to OmegaT
             s = s.trim();
 
@@ -449,7 +423,8 @@ public class PoFilter extends AbstractFilter {
             }
 
             /*
-             * Removing the fuzzy markers, as it has no meanings after being processed by omegat
+             * Removing the fuzzy markers, as it has no meanings after being
+             * processed by omegat
              */
             if (COMMENT_FUZZY.matcher(s).matches()) {
                 currentPlural = 0;
@@ -468,9 +443,11 @@ public class PoFilter extends AbstractFilter {
                 currentPlural = 0;
                 flushTranslation(currentMode, fc);
                 /*
-                 * Read the no-wrap comment, indicating that the creator of the po-file did not want long
-                 * messages to be wrapped on multiple lines. See 5.6.2 no-wrap of http://docs.oasis-open
-                 * .org/xliff/v1.2/xliff-profile-po/xliff -profile-po-1.2-cd02.html for an example.
+                 * Read the no-wrap comment, indicating that the creator of the
+                 * po-file did not want long messages to be wrapped on multiple
+                 * lines. See 5.6.2 no-wrap of
+                 * http://docs.oasis-open.org/xliff/v1.2/xliff-profile-po/xliff-profile-po-1.2-cd02.html
+                 * for an example.
                  */
                 nowrap = true;
                 eol(s);
@@ -483,8 +460,9 @@ public class PoFilter extends AbstractFilter {
                 String text = mId.group(2);
                 if (mId.group(1) == null) {
                     // non-plural ID ('msg_id')
-                    // we can start a new translation. Flush current translation.
-                    // This has not happened when no empty lines are in between 'segments'.
+                    // we can start a new translation. Flush current
+                    // translation. This has not happened when no empty
+                    // lines are in between 'segments'.
                     if (sources[0].length() > 0) {
                         flushTranslation(currentMode, fc);
                     }
@@ -505,8 +483,10 @@ public class PoFilter extends AbstractFilter {
 
                 // Hack to be able to translate empty segments
                 // If the source segment is empty and there is a reference then
-                // it copies the reference of the segment and the localization note into the source segment
-                if (allowEditingBlankSegment && sources[0].length() == 0 && references.length() > 0 && headerProcessed) {
+                // it copies the reference of the segment and the localization
+                // note into the source segment
+                if (allowEditingBlankSegment && sources[0].length() == 0 && references.length() > 0
+                        && headerProcessed) {
                     String aux = references + extractedComments.toString();
                     sources[0].append(aux);
                 }
@@ -651,8 +631,8 @@ public class PoFilter extends AbstractFilter {
      * @param translation
      * @param comments
      * @param pathSuffix
-     *            suffix for path to distinguish plural forms. It will be empty for first one, and [1],[2],...
-     *            for next
+     *            suffix for path to distinguish plural forms. It will be empty
+     *            for first one, and [1],[2],... for next
      */
     protected void parseOrAlign(String source, String translation, String comments, String pathSuffix) {
         if (translation.isEmpty()) {
@@ -668,15 +648,17 @@ public class PoFilter extends AbstractFilter {
                 List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(source,
                         PatternConsts.PRINTF_VARS, null);
                 if (fuzzyTrue) { // We add a reference entry
-                    String[] props = { SegmentProperties.COMMENT, comments, SegmentProperties.REFERENCE, "true" };
-                    entryParseCallback.addEntryWithProperties(null, sourceFuzzyTrue.toString(), translation, false,
-                            props, path + pathSuffix, this, null);
+                    String[] props = { SegmentProperties.COMMENT, comments, SegmentProperties.REFERENCE,
+                            "true" };
+                    entryParseCallback.addEntryWithProperties(null, sourceFuzzyTrue.toString(), translation,
+                            false, props, path + pathSuffix, this, null);
                     fuzzyTrue = false;
-                    fuzzy = false;    // Do not load false fuzzy when there is a real one
+                    // Do not load false fuzzy when there is a real one
+                    fuzzy = false;
                     translation = null;
                 }
-                entryParseCallback.addEntry(null, source, translation, fuzzy, comments, path + pathSuffix, this,
-                        protectedParts);
+                entryParseCallback.addEntry(null, source, translation, fuzzy, comments, path + pathSuffix,
+                        this, protectedParts);
             }
         } else if (entryAlignCallback != null) {
             entryAlignCallback.addTranslation(null, source, translation, fuzzy, path + pathSuffix, this);
@@ -701,7 +683,8 @@ public class PoFilter extends AbstractFilter {
             } else {
                 // header
 
-                // check existing plural statement. If it contains the number of plurals, then use it!
+                // check existing plural statement. If it contains the number of
+                // plurals, then use it!
                 StringBuilder targets0 = targets[0];
                 String header = targets[0].toString();
                 Matcher pluralMatcher = PLURAL_FORMS.matcher(header);
@@ -709,7 +692,7 @@ public class PoFilter extends AbstractFilter {
                     String nrOfPluralsString = header.substring(pluralMatcher.start(1), pluralMatcher.end(1));
                     plurals = Integer.parseInt(nrOfPluralsString);
                 } else {
-                    //else use predefined number of plurals, if it exists
+                    // else use predefined number of plurals, if it exists
                     Language targetLang = fc.getTargetLang();
                     String lang = targetLang.getLanguageCode().toLowerCase(Locale.ENGLISH);
                     PluralInfo pluralInfo = PLURAL_INFOS.get(lang);
@@ -717,7 +700,7 @@ public class PoFilter extends AbstractFilter {
                         plurals = pluralInfo.plurals;
                     }
                 }
-                //update the number of targets according to new plural number
+                // update the number of targets according to new plural number
                 targets = new StringBuilder[plurals];
                 targets[0] = targets0;
                 for (int i = 1; i < plurals; i++) {
@@ -751,10 +734,11 @@ public class PoFilter extends AbstractFilter {
             } else {
                 // plurals
                 if (out != null) {
-                    out.write("msgstr[0] " + getTranslation(null, sources[0], allowBlank, false, fc, 0) + "\n");
+                    out.write(
+                            "msgstr[0] " + getTranslation(null, sources[0], allowBlank, false, fc, 0) + "\n");
                     for (int i = 1; i < plurals; i++) {
-                        out.write("msgstr[" + i + "] " + getTranslation(null, sources[1], allowBlank, false, fc, i)
-                                + "\n");
+                        out.write("msgstr[" + i + "] "
+                                + getTranslation(null, sources[1], allowBlank, false, fc, i) + "\n");
                     }
                 } else {
                     parseOrAlign(0);
@@ -784,15 +768,19 @@ public class PoFilter extends AbstractFilter {
 
     /**
      * Private processEntry to do pre- and postprocessing.<br>
-     * The given entry is interpreted to a string (e.g. escaped quotes are unescaped, '\n' is translated into newline
-     * character, '\t' into tab character.) then translated and then returned as a PO-string-notation (e.g. double
-     * quotes escaped, newline characters represented as '\n' and surrounded by double quotes, possibly split up over
-     * multiple lines)<Br>
-     * Long translations are not split up over multiple lines as some PO editors do, but when there are newline
-     * characters in a translation, it is split up at the newline markers.<Br>
-     * If the nowrap parameter is true, a translation that exists of multiple lines starts with an empty string-line to
-     * left-align all lines. [With nowrap set to true, long lines are also never wrapped (except for at newline
-     * characters), but that was already not done without nowrap.] [ 1869069 ] Escape support for PO
+     * The given entry is interpreted to a string (e.g. escaped quotes are
+     * unescaped, '\n' is translated into newline character, '\t' into tab
+     * character.) then translated and then returned as a PO-string-notation
+     * (e.g. double quotes escaped, newline characters represented as '\n' and
+     * surrounded by double quotes, possibly split up over multiple lines)<Br>
+     * Long translations are not split up over multiple lines as some PO editors
+     * do, but when there are newline characters in a translation, it is split
+     * up at the newline markers.<Br>
+     * If the nowrap parameter is true, a translation that exists of multiple
+     * lines starts with an empty string-line to left-align all lines. [With
+     * nowrap set to true, long lines are also never wrapped (except for at
+     * newline characters), but that was already not done without nowrap.] [
+     * 1869069 ] Escape support for PO
      *
      * @param en
      *            The entire source text
@@ -803,13 +791,14 @@ public class PoFilter extends AbstractFilter {
      * @param fc
      *            The FilterContext, for targetLanguage
      * @param plural
-     *            if the source text is a plural, which plural number / variant are we on? 0 = no plural, 1.. are the
-     *            plurals for the given target language.
-     * @return The translated entry, within double quotes on each line (thus ready to be printed to target file
-     *         immediately)
+     *            if the source text is a plural, which plural number / variant
+     *            are we on? 0 = no plural, 1.. are the plurals for the given
+     *            target language.
+     * @return The translated entry, within double quotes on each line (thus
+     *         ready to be printed to target file immediately)
      **/
-    private String getTranslation(String id, StringBuilder en, boolean allowNull, boolean isHeader, FilterContext fc,
-            int plural) {
+    private String getTranslation(String id, StringBuilder en, boolean allowNull, boolean isHeader,
+            FilterContext fc, int plural) {
         String entry = unescape(en.toString());
 
         String pathSuffix;
@@ -830,7 +819,8 @@ public class PoFilter extends AbstractFilter {
             translation = entryTranslateCallback.getTranslation(id, entry, path + pathSuffix);
         }
 
-        if (translation == null && !allowNull) { // We write the source in translation
+        if (translation == null && !allowNull) { // We write the source in
+                                                 // translation
             translation = entry;
         }
 
@@ -843,8 +833,11 @@ public class PoFilter extends AbstractFilter {
 
     /**
      * Replaces Plural-Forms: nplurals=INTEGER; plural=EXPRESSION; when selected
-     * @param header The header text that contains the Plural-forms line.
-     * @return Header with the correct plural forms line according to target language.
+     * 
+     * @param header
+     *            The header text that contains the Plural-forms line.
+     * @return Header with the correct plural forms line according to target
+     *         language.
      */
     private String autoFillInPluralStatement(String header, FilterContext fc) {
         if (autoFillInPluralStatement) {
@@ -853,7 +846,8 @@ public class PoFilter extends AbstractFilter {
             PluralInfo pluralInfo = PLURAL_INFOS.get(lang);
             if (pluralInfo != null) {
                 return header.replaceAll("Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;",
-                        "Plural-Forms: nplurals=" + pluralInfo.plurals + "; plural=" + pluralInfo.expression + ";");
+                        "Plural-Forms: nplurals=" + pluralInfo.plurals + "; plural=" + pluralInfo.expression
+                                + ";");
             }
         }
         return header;
@@ -899,13 +893,17 @@ public class PoFilter extends AbstractFilter {
         translation = translation.replace("\"", "\\\"");
 
         /*
-         * Normally, long lines are wrapped at 'output page width', which defaults to ?76?, and always at
-         * newlines. IF the no-wrap indicator is present, long lines should not be wrapped, except on newline
-         * characters, in which case the first line should be empty, so that the different lines are aligned
-         * the same. OmegaT < 2.0 has never wrapped any line, and it is quite useless when the po-file is not
-         * edited with a plain-text-editor. But it is simple to wrap at least at newline characters (which is
-         * necessary for the translation of the po-header anyway) We can also honor the no-wrap instruction at
-         * least by letting the first line of a multi-line translation not be on the same line as 'msgstr'.
+         * Normally, long lines are wrapped at 'output page width', which
+         * defaults to ?76?, and always at newlines. IF the no-wrap indicator is
+         * present, long lines should not be wrapped, except on newline
+         * characters, in which case the first line should be empty, so that the
+         * different lines are aligned the same. OmegaT < 2.0 has never wrapped
+         * any line, and it is quite useless when the po-file is not edited with
+         * a plain-text-editor. But it is simple to wrap at least at newline
+         * characters (which is necessary for the translation of the po-header
+         * anyway) We can also honor the no-wrap instruction at least by letting
+         * the first line of a multi-line translation not be on the same line as
+         * 'msgstr'.
          */
         // Interprets newline chars. 'blah<br>blah' becomes
         // 'blah\n"<br>"blah'

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -211,6 +211,15 @@ public class ResourceBundleFilter extends AbstractFilter {
         return result.toString();
     }
 
+    private int skipWhiteSpace(String line) {
+        int index = 0;
+        int cp = line.codePointAt(index);
+        while (Character.isWhitespace(cp)) {
+            index += 1;
+        }
+        return index;
+    }
+
     private enum EscapeMode {
         KEY, VALUE, COMMENT
     }

--- a/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -34,14 +34,10 @@ package org.omegat.filters2.text.bundles;
 import java.awt.Window;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,50 +140,6 @@ public class ResourceBundleFilter extends AbstractFilter {
     public Instance[] getDefaultInstances() {
         return new Instance[] { new Instance("*.properties", DEFAULT_SOURCE_ENCODING, DEFAULT_TARGET_ENCODING,
                 TFP_NAMEONLY + "_" + TFP_TARGET_LOCALE + "." + TFP_EXTENSION) };
-    }
-
-    /**
-     * Creates a reader of an input file.
-     * <p>
-     * Override because of keep buggy behavior in OmegaT 5.7.1 or before. It set
-     * default encoding US-ASCII but Java standard InputStreamReader class
-     * wrongly accept non-ASCII characters as-is.
-     * </p>
-     *
-     * @param inFile
-     *            The source file.
-     * @param inEncoding
-     *            Encoding of the input file, if the filter supports it.
-     *            Otherwise null.
-     * @return The reader for the source file
-     * @throws IOException
-     *             If any I/O Error occurs upon reader creation
-     */
-    @Override
-    public BufferedReader createReader(File inFile, String inEncoding) throws IOException {
-        Charset charset;
-        if (inEncoding != null) {
-            charset = Charset.forName(inEncoding);
-        } else {
-            charset = Charset.defaultCharset();
-        }
-        return new BufferedReader(new InputStreamReader(Files.newInputStream(inFile.toPath()), charset));
-    }
-
-    /**
-     * Creating an output stream to save a localized resource bundle.
-     * <p>
-     * NOTE: the name of localized resource bundle is different from the name of
-     * original one. e.g. "Bundle.properties" -&gt; Russian =
-     * "Bundle_ru.properties"
-     */
-    @Override
-    public BufferedWriter createWriter(File outfile, String encoding) throws IOException {
-        if (encoding != null) {
-            targetEncoding = encoding;
-        }
-        Charset charset = Charset.forName(targetEncoding);
-        return new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(outfile.toPath()), charset));
     }
 
     @Override

--- a/src/org/omegat/util/MagicComment.java
+++ b/src/org/omegat/util/MagicComment.java
@@ -65,14 +65,14 @@ public class MagicComment {
     /**
      * Extract the first line of the file and parse with {@code #parse(String)}
      *
-     * @param file
-     * @return
-     * @throws IOException
+     * @param file target file.
+     * @return Map with magic comment database.
+     * @throws IOException when I/O error happened.
      */
     public static Map<String, String> parse(File file) throws IOException {
         String line;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                BOMInputStream.builder().setFile(file).setCharset(StandardCharsets.US_ASCII).get()))) {
+                BOMInputStream.builder().setFile(file).get(), StandardCharsets.US_ASCII))) {
             line = reader.readLine();
         }
         if (line != null && line.startsWith("#")) {

--- a/src/org/omegat/util/MagicComment.java
+++ b/src/org/omegat/util/MagicComment.java
@@ -26,7 +26,6 @@ package org.omegat.util;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -60,7 +59,8 @@ public class MagicComment {
      *  key and value: ? string w/ alphabet, number, underscore, hyphen ? ;
      * </pre>
      */
-    private static final Pattern MAGIC_COMMENT_PATTERN = Pattern.compile("(?<key>[\\w-]+)\\s*:\\s*(?<value>[\\w-]+)(?:\\s*;)?");
+    private static final Pattern MAGIC_COMMENT_PATTERN = Pattern
+            .compile("(?<key>[\\w-]+)\\s*:\\s*(?<value>[\\w-]+)(?:\\s*;)?");
 
     /**
      * Extract the first line of the file and parse with {@code #parse(String)}
@@ -69,10 +69,10 @@ public class MagicComment {
      * @return
      * @throws IOException
      */
-    public static Map<String, String> parse(File file) throws IOException  {
+    public static Map<String, String> parse(File file) throws IOException {
         String line;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                new BOMInputStream(new FileInputStream(file)), StandardCharsets.US_ASCII))) {
+                BOMInputStream.builder().setFile(file).setCharset(StandardCharsets.US_ASCII).get()))) {
             line = reader.readLine();
         }
         if (line != null && line.startsWith("#")) {
@@ -85,11 +85,13 @@ public class MagicComment {
     /**
      * Parse magic comment
      *
-     * @param str input string.
+     * @param str
+     *            input string.
      * @return Key-Value map of String.
      */
     public static Map<String, String> parse(final String str) {
-        if (str == null || str.length() < 11) {  // minimum = "-*- a:b -*-".length()
+        // minimum = "-*- a:b -*-".length()
+        if (str == null || str.length() < 11) {
             return Collections.emptyMap();
         }
         int startMarker = str.indexOf("-*- ");

--- a/src/org/omegat/util/TMXReader2.java
+++ b/src/org/omegat/util/TMXReader2.java
@@ -108,7 +108,7 @@ public class TMXReader2 {
      * Detects charset of XML file.
      */
     public static String detectCharset(File file) throws IOException {
-        try (XmlStreamReader rd = new XmlStreamReader(file)) {
+        try (XmlStreamReader rd = XmlStreamReader.builder().setFile(file).get()) {
             return rd.getEncoding();
         }
     }

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -681,6 +681,6 @@ public abstract class TestCore {
 
     @After
     public final void tearDownCore() throws Exception {
-        FileUtils.deleteDirectory(configDir);
+        FileUtils.forceDeleteOnExit(configDir);
     }
 }

--- a/test/src/org/omegat/filters/HTMLFilter2Test.java
+++ b/test/src/org/omegat/filters/HTMLFilter2Test.java
@@ -120,6 +120,8 @@ public class HTMLFilter2Test extends TestFilterBase {
         checkMulti("This is second line.", null, null, "This is first line.", "", null);
         checkMultiEnd();
 
+        assertEquals("UTF-8", filter.getInEncodingLastParsedFile());
+
         f = "test/data/filters/html/file-HTMLFilter2-SMP.html";
         fi = loadSourceFiles(filter, f);
 


### PR DESCRIPTION
Improvement, refactor and style change for AbstractFilter class.

Some filter override `processFile(File, File, fc)`  to enforce encoding, but I prefer to implement `getInputEncoding` and `getOutputEncoding` methods.



## Pull request type


- Other (describe below)
Refactoring

## Which ticket is resolved?

- #1726 AbstractFilter should handle BOM when create reader
- https://sourceforge.net/p/omegat/feature-requests/1726/

## What does this PR change?

- Bump commons-io@2.15.0
    - Modify MagicComment and TMXReader2 classes 
- Use BOMInputStream class where hand-crafted detectors in AbstractFilter class
    - Change fallback default charsets to `StandardCharsets.UTF_8`  rather than `Charset.defaultCharset()`
- Prefer override get(Input|Output)Encoding method instead of create(Reader|Writer)
    - MozillaDTDFilter
    - MozillaLangFilter
    - ResourceBundleFilter
    - MoodlePHPFilter
    - PoFilter 
- Apply spotless
- Fix missing javadoc for AbstractFilter class
 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
