### PR TITLE
feat: glossary: encode URL in glossary comment and linkify percent escaped URLs with human readable link text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,7 @@ dependencies {
     } else {
         implementation(libs.commons.io)
         implementation(libs.commons.lang3)
+        implementation(libs.commons.validator)
         api(libs.slf4j.api)
         implementation(libs.slf4j.format.jdk14)
         runtimeOnly(libs.slf4j.jdk14)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lang3 = "3.11"
 io = "2.11.0"
 codec = "1.13"
 text = "1.9"
+commons_validator = "1.7"
 unbescape = "1.1.6.RELEASE"
 xerces = "2.12.2"
 jstyleparser = "4.1.3"
@@ -80,6 +81,7 @@ commons-io = {group = "commons-io", name = "commons-io", version.ref = "io"}
 commons-lang3 = {group = "org.apache.commons", name = "commons-lang3", version.ref = "lang3"}
 commons-codec = {group = "commons-codec", name = "commons-codec", version.ref = "codec"}
 commons-text = {group = "org.apache.commons", name = "commons-text", version.ref = "text"}
+commons-validator = {group = "commons-validator", name = "commons-validator", version.ref = "commons_validator"}
 unbescape = {group = "org.unbescape", name = "unbescape", version.ref = "unbescape"}
 xerces-impl = {group = "xerces", name = "xercesImpl", version.ref = "xerces"}
 jstyleparser = {group = "tokyo.northside", name = "jstyleparser", version.ref = "jstyleparser"}

--- a/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
@@ -55,12 +55,7 @@ public class DefaultGlossaryRenderer implements IGlossaryRenderer {
         StringBuilder commentsBuf = new StringBuilder();
         for (int i = 0, commentIndex = 0; i < targets.length; i++) {
             if (i > 0 && targets[i].equals(targets[i - 1])) {
-                if (!comments[i].equals("")) {
-                    commentsBuf.append("\n");
-                    commentsBuf.append(commentIndex);
-                    commentsBuf.append(". ");
-                    commentsBuf.append(comments[i]);
-                }
+                appendCommentsBuf(commentsBuf, commentIndex, comments[i]);
                 continue;
             }
             SimpleAttributeSet attrs = new SimpleAttributeSet(TARGET_ATTRIBUTES);
@@ -74,15 +69,18 @@ public class DefaultGlossaryRenderer implements IGlossaryRenderer {
             trg.append(bracketEntry(targets[i]), attrs);
 
             commentIndex++;
-            if (!comments[i].equals("")) {
-                commentsBuf.append("\n");
-                commentsBuf.append(commentIndex);
-                commentsBuf.append(". ");
-                commentsBuf.append(comments[i]);
-            }
+            appendCommentsBuf(commentsBuf, commentIndex, comments[i]);
         }
-
         trg.append(commentsBuf.toString(), NOTES_ATTRIBUTES);
+    }
+
+    private void appendCommentsBuf(StringBuilder commentsBuf, int commentIndex, String comment) {
+        if (!comment.isEmpty()) {
+            commentsBuf.append("\n");
+            commentsBuf.append(commentIndex);
+            commentsBuf.append(". ");
+            commentsBuf.append(comment);
+        }
     }
 
     /**

--- a/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
@@ -84,9 +84,9 @@ public class DefaultGlossaryRenderer implements IGlossaryRenderer {
     }
 
     /**
-     * If a combined glossary entry contains ',', it needs to be bracketed by quotes, to prevent confusion
-     * when entries are combined. However, if the entry contains ';' or '"', it will automatically be
-     * bracketed by quotes.
+     * If a combined glossary entry contains ',', it needs to be bracketed by
+     * quotes, to prevent confusion when entries are combined. However, if the
+     * entry contains ';' or '"', it will automatically be bracketed by quotes.
      *
      * @param entry
      *            A glossary text entry

--- a/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
@@ -70,7 +70,7 @@ public class DictionaryGlossaryRenderer implements IGlossaryRenderer {
                     trg.append(", ", null);
                 }
             }
-            if (!comments[i].equals("")) {
+            if (!comments[i].isEmpty()) {
                 trg.startIndent(NOTES_ATTRIBUTES);
                 trg.append("- " + comments[i], NOTES_ATTRIBUTES);
                 hasComments = true;

--- a/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
@@ -79,9 +79,9 @@ public class DictionaryGlossaryRenderer implements IGlossaryRenderer {
     }
 
     /**
-     * If a combined glossary entry contains ',', it needs to be bracketed by quotes, to prevent confusion
-     * when entries are combined. However, if the entry contains ';' or '"', it will automatically be
-     * bracketed by quotes.
+     * If a combined glossary entry contains ',', it needs to be bracketed by
+     * quotes, to prevent confusion when entries are combined. However, if the
+     * entry contains ';' or '"', it will automatically be bracketed by quotes.
      *
      * @param entry
      *            A glossary text entry

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -105,8 +105,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     private static final String EXPLANATION = OStrings.getString("GUI_GLOSSARYWINDOW_explanation");
 
     /**
-     * Currently processed entry. Used to detect if user moved into new entry. In this case, new find should
-     * be started.
+     * Currently processed entry. Used to detect if user moved into new entry.
+     * In this case, new find should be started.
      */
     protected StringEntry processedEntry;
 
@@ -142,14 +142,17 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
                 public boolean canAcceptDrop() {
                     return Core.getProject().isProjectLoaded();
                 }
+
                 @Override
                 public String getOverlayMessage() {
                     return OStrings.getString("DND_ADD_GLOSSARY_FILE");
                 }
+
                 @Override
                 public String getImportDestination() {
                     return Core.getProject().getProjectProperties().getGlossaryRoot();
                 }
+
                 @Override
                 public boolean acceptFile(File pathname) {
                     String name = pathname.getName().toLowerCase(Locale.ENGLISH);
@@ -157,6 +160,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
                             || name.endsWith(OConsts.EXT_TSV_DEF) || name.endsWith(OConsts.EXT_TSV_TXT)
                             || name.endsWith(OConsts.EXT_TSV_TSV) || name.endsWith(OConsts.EXT_TSV_UTF8);
                 }
+
                 @Override
                 public Component getComponentToOverlay() {
                     return scrollPane;
@@ -204,8 +208,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     }
 
     /**
-     * Sets the list of glossary entries to show in the pane. Each element of the list should be an instance
-     * of {@link GlossaryEntry}.
+     * Sets the list of glossary entries to show in the pane. Each element of
+     * the list should be an instance of {@link GlossaryEntry}.
      */
     @Override
     protected void setFoundResult(SourceTextEntry en, List<GlossaryEntry> entries) {
@@ -223,7 +227,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
 
         nowEntries = entries;
 
-        // If the TransTips is enabled then underline all the matched glossary entries
+        // If the TransTips is enabled then underline all the matched glossary
+        // entries
         if (Core.getEditor().getSettings().isMarkGlossaryMatches()) {
             Core.getEditor().remarkOneMarker(TransTipsMarker.class.getName());
         }
@@ -298,7 +303,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         });
         item = popup.add(OStrings.getString("GUI_GLOSSARYWINDOW_addentry"));
         item.setEnabled(projectLoaded);
-        item.addActionListener(e -> showCreateGlossaryEntryDialog(Core.getMainWindow().getApplicationFrame()));
+        item.addActionListener(
+                e -> showCreateGlossaryEntryDialog(Core.getMainWindow().getApplicationFrame()));
     }
 
     @Override
@@ -379,11 +385,12 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
                 if (dialog.getReturnStatus() == CreateGlossaryEntry.RET_OK) {
                     String src = StringUtil.normalizeUnicode(dialog.getSourceText().getText()).trim();
                     String loc = StringUtil.normalizeUnicode(dialog.getTargetText().getText()).trim();
-                    String com = HttpConnectionUtils.encodeHttpURLs(StringUtil.normalizeUnicode(
-                            dialog.getCommentText().getText()).trim());
+                    String com = HttpConnectionUtils.encodeHttpURLs(
+                            StringUtil.normalizeUnicode(dialog.getCommentText().getText()).trim());
                     if (!StringUtil.isEmpty(src) && !StringUtil.isEmpty(loc)) {
                         try {
-                            GlossaryReaderTSV.append(out, new GlossaryEntry(src, loc, com, true, out.getPath()));
+                            GlossaryReaderTSV.append(out,
+                                    new GlossaryEntry(src, loc, com, true, out.getPath()));
                         } catch (Exception ex) {
                             Log.log(ex);
                         }
@@ -404,7 +411,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         openFile.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                Core.getMainWindow().getMainMenu().invokeAction("projectAccessWritableGlossaryMenuItem", e.getModifiers());
+                Core.getMainWindow().getMainMenu().invokeAction("projectAccessWritableGlossaryMenuItem",
+                        e.getModifiers());
             }
         });
         openFile.setEnabled(false);
@@ -414,7 +422,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         }
         menu.add(openFile);
         menu.addSeparator();
-        final JMenuItem notify = new JCheckBoxMenuItem(OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_NOTIFICATIONS"));
+        final JMenuItem notify = new JCheckBoxMenuItem(
+                OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_NOTIFICATIONS"));
         notify.setSelected(Preferences.isPreference(Preferences.NOTIFY_GLOSSARY_HITS));
         notify.addActionListener(new ActionListener() {
             @Override
@@ -424,12 +433,12 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         });
         menu.add(notify);
         menu.addSeparator();
-        final JMenuItem sortOrderLocLength = new JCheckBoxMenuItem(OStrings.getString(
-                "GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_LENGTH"));
-        sortOrderLocLength.setSelected(Preferences.isPreferenceDefault(
-                Preferences.GLOSSARY_SORT_BY_LENGTH, false));
-        sortOrderLocLength.addActionListener(actionEvent -> Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH,
-                sortOrderLocLength.isSelected()));
+        final JMenuItem sortOrderLocLength = new JCheckBoxMenuItem(
+                OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_LENGTH"));
+        sortOrderLocLength
+                .setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_LENGTH, false));
+        sortOrderLocLength.addActionListener(actionEvent -> Preferences
+                .setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH, sortOrderLocLength.isSelected()));
         menu.add(sortOrderLocLength);
     }
 }

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -73,6 +73,7 @@ import org.omegat.gui.editor.EditorUtils;
 import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
+import org.omegat.util.HttpConnectionUtils;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
@@ -378,7 +379,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
                 if (dialog.getReturnStatus() == CreateGlossaryEntry.RET_OK) {
                     String src = StringUtil.normalizeUnicode(dialog.getSourceText().getText()).trim();
                     String loc = StringUtil.normalizeUnicode(dialog.getTargetText().getText()).trim();
-                    String com = StringUtil.normalizeUnicode(dialog.getCommentText().getText()).trim();
+                    String com = HttpConnectionUtils.encodeHttpURLs(StringUtil.normalizeUnicode(
+                            dialog.getCommentText().getText()).trim());
                     if (!StringUtil.isEmpty(src) && !StringUtil.isEmpty(loc)) {
                         try {
                             GlossaryReaderTSV.append(out, new GlossaryEntry(src, loc, com, true, out.getPath()));

--- a/src/org/omegat/gui/glossary/IGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/IGlossaryRenderer.java
@@ -40,12 +40,12 @@ import org.omegat.util.gui.Styles;
 public interface IGlossaryRenderer {
     AttributeSet NO_ATTRIBUTES = Styles.createAttributeSet(null, null, false, null);
     AttributeSet PRIORITY_ATTRIBUTES = Styles.createAttributeSet(null, null, true, null);
-    AttributeSet SOURCE_ATTRIBUTES = Styles.createAttributeSet(
-            Styles.EditorColor.COLOR_GLOSSARY_SOURCE.getColor(), null, null, null);
-    AttributeSet TARGET_ATTRIBUTES = Styles.createAttributeSet(
-            Styles.EditorColor.COLOR_GLOSSARY_TARGET.getColor(), null, null, null);
-    AttributeSet NOTES_ATTRIBUTES = Styles.createAttributeSet(
-            Styles.EditorColor.COLOR_GLOSSARY_NOTE.getColor(), null, null, null);
+    AttributeSet SOURCE_ATTRIBUTES = Styles
+            .createAttributeSet(Styles.EditorColor.COLOR_GLOSSARY_SOURCE.getColor(), null, null, null);
+    AttributeSet TARGET_ATTRIBUTES = Styles
+            .createAttributeSet(Styles.EditorColor.COLOR_GLOSSARY_TARGET.getColor(), null, null, null);
+    AttributeSet NOTES_ATTRIBUTES = Styles
+            .createAttributeSet(Styles.EditorColor.COLOR_GLOSSARY_NOTE.getColor(), null, null, null);
 
     interface IRenderTarget<T> {
         void append(String str);
@@ -111,8 +111,8 @@ public interface IGlossaryRenderer {
                 }
                 Color attrColor = StyleConstants.getForeground(attr);
                 if (attrColor != Color.black) {
-                    String colorString = String.format("%02x%02x%02x",
-                            attrColor.getRed(), attrColor.getGreen(), attrColor.getBlue());
+                    String colorString = String.format("%02x%02x%02x", attrColor.getRed(),
+                            attrColor.getGreen(), attrColor.getBlue());
                     buf.append("<font color=#").append(colorString).append(">");
                 }
             }
@@ -148,7 +148,10 @@ public interface IGlossaryRenderer {
     /** Name to be displayed in the drop box. Can be language-dependent **/
     String getName();
 
-    /** String to be stored in config file. Must be language-independent, and unique **/
+    /**
+     * String to be stored in config file. Must be language-independent, and
+     * unique
+     **/
     String getId();
 
     // --------------- Rendering methods -----------------

--- a/src/org/omegat/gui/glossary/IGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/IGlossaryRenderer.java
@@ -34,6 +34,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.StyledDocument;
 import javax.swing.text.StyleConstants;
 
+import org.omegat.util.HttpConnectionUtils;
 import org.omegat.util.gui.Styles;
 
 public interface IGlossaryRenderer {
@@ -112,10 +113,11 @@ public interface IGlossaryRenderer {
                 if (attrColor != Color.black) {
                     String colorString = String.format("%02x%02x%02x",
                             attrColor.getRed(), attrColor.getGreen(), attrColor.getBlue());
-                    buf.append("<font color=#" + colorString + ">");
+                    buf.append("<font color=#").append(colorString).append(">");
                 }
             }
-            buf.append(str);
+            String doc = HttpConnectionUtils.decodeHttpURLs(str);
+            buf.append(doc);
             if (attr != null) {
                 Color attrColor = StyleConstants.getForeground(attr);
                 if (attrColor != Color.black) {

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -96,8 +96,8 @@ public final class HttpConnectionUtils {
     /**
      * Regular Expression for https and ftp URL validation.
      * <p>
-     * You are recommended to use commons-validator instead of hand-crafted here.
-     * We leave it as is for keeping compatibility.
+     * You are recommended to use commons-validator instead of hand-crafted
+     * here. We leave it as is for keeping compatibility.
      */
     public static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
 

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -229,7 +229,8 @@ public final class JTextPaneLinkifier {
                     final Matcher matcher = pattern.matcher(text);
                     while (matcher.find()) {
                         final int offset = matcher.start() + shift;
-                        if (doc.getCharacterElement(offset).getAttributes().containsAttributes(LINK_ATTRIBUTES)) {
+                        if (doc.getCharacterElement(offset).getAttributes()
+                                .containsAttributes(LINK_ATTRIBUTES)) {
                             continue;
                         }
                         final int targetLength = matcher.end() - matcher.start();
@@ -239,7 +240,8 @@ public final class JTextPaneLinkifier {
                                 // Transform into clickable and readable text
                                 String decoded = codec.decode(uri);
                                 if (decoded.length() == uri.length()) {
-                                    SimpleAttributeSet atts = new SimpleAttributeSet(doc.getCharacterElement(offset).getAttributes());
+                                    SimpleAttributeSet atts = new SimpleAttributeSet(
+                                            doc.getCharacterElement(offset).getAttributes());
                                     setLinkAttribute(atts, new URI(uri));
                                     doc.setCharacterAttributes(offset, targetLength, atts, true);
                                 } else {
@@ -249,7 +251,7 @@ public final class JTextPaneLinkifier {
                                     setLinkAttribute(atts, new URI(uri));
                                     doc.insertString(offset, decoded, atts);
                                 }
-                            } catch (DecoderException | URISyntaxException  ex) {
+                            } catch (DecoderException | URISyntaxException ex) {
                                 Log.logWarningRB("TPL_ERROR_URL", matcher.group());
                             }
                         }

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -46,7 +46,10 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
-import org.omegat.util.HttpConnectionUtils;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.net.URLCodec;
+import org.apache.commons.validator.routines.UrlValidator;
+
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
@@ -144,13 +147,13 @@ public final class JTextPaneLinkifier {
 
         private static final int REFRESH_DELAY = 200;
 
-        private static final AttributeSet DEFAULT_ATTRIBUTES = new SimpleAttributeSet();
         private static final AttributeSet LINK_ATTRIBUTES;
 
         static {
             MutableAttributeSet tmp = new SimpleAttributeSet();
             StyleConstants.setUnderline(tmp, true);
             StyleConstants.setForeground(tmp, Styles.EditorColor.COLOR_HYPERLINK.getColor());
+            StyleConstants.setBackground(tmp, Styles.EditorColor.COLOR_BACKGROUND.getColor());
             LINK_ATTRIBUTES = tmp;
         }
 
@@ -161,11 +164,14 @@ public final class JTextPaneLinkifier {
         // as default constructor
         AttributeInserterDocumentFilter(StyledDocument doc, boolean extended) {
             this.doc = doc;
+            Pattern urlPattern = Pattern.compile("\\bhttps?://\\S+\\b", Pattern.CASE_INSENSITIVE);
             if (extended) {
-                urlPatterns = new Pattern[] { HttpConnectionUtils.URL_PATTERN,
-                        HttpConnectionUtils.FILE_URL_PATTERN };
+                Pattern filePattern = Pattern.compile(
+                        "\\\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]\\b",
+                        Pattern.CASE_INSENSITIVE);
+                urlPatterns = new Pattern[] { urlPattern, filePattern };
             } else {
-                urlPatterns = new Pattern[] { HttpConnectionUtils.URL_PATTERN };
+                urlPatterns = new Pattern[] { urlPattern };
             }
             timer = new Timer(REFRESH_DELAY, e -> refreshPane());
             timer.setRepeats(false);
@@ -210,32 +216,42 @@ public final class JTextPaneLinkifier {
         }
 
         private void refreshPane() {
-            final int docLength = doc.getLength();
-            if (docLength == 0) {
+            if (doc.getLength() == 0) {
                 return;
             }
             try {
-                // clear attributes
-                for (int i = 0; i < docLength; ++i) {
-                    if (doc.getCharacterElement(i).getAttributes().containsAttributes(LINK_ATTRIBUTES)) {
-                        doc.setCharacterAttributes(i, 1, DEFAULT_ATTRIBUTES, true);
-                    }
-                }
-
                 // URL detection
+                URLCodec codec = new URLCodec("UTF-8");
+                UrlValidator urlValidator = new UrlValidator();
                 for (Pattern pattern : urlPatterns) {
-                    final String text = doc.getText(0, docLength);
+                    int shift = 0;
+                    final String text = doc.getText(0, doc.getLength());
                     final Matcher matcher = pattern.matcher(text);
                     while (matcher.find()) {
-                        final int offset = matcher.start();
-                        final int targetLength = matcher.end() - offset;
-
-                        try {
-                            // Transform into clickable text
-                            AttributeSet atts = makeAttributes(offset, new URI(matcher.group()));
-                            doc.setCharacterAttributes(offset, targetLength, atts, true);
-                        } catch (URISyntaxException ex) {
-                            Log.logWarningRB("TPL_ERROR_URL", matcher.group());
+                        final int offset = matcher.start() + shift;
+                        if (doc.getCharacterElement(offset).getAttributes().containsAttributes(LINK_ATTRIBUTES)) {
+                            continue;
+                        }
+                        final int targetLength = matcher.end() - matcher.start();
+                        final String uri = matcher.group();
+                        if (urlValidator.isValid(uri)) {
+                            try {
+                                // Transform into clickable and readable text
+                                String decoded = codec.decode(uri);
+                                if (decoded.length() == uri.length()) {
+                                    SimpleAttributeSet atts = new SimpleAttributeSet(doc.getCharacterElement(offset).getAttributes());
+                                    setLinkAttribute(atts, new URI(uri));
+                                    doc.setCharacterAttributes(offset, targetLength, atts, true);
+                                } else {
+                                    shift += decoded.length() - targetLength;
+                                    doc.remove(offset, targetLength);
+                                    SimpleAttributeSet atts = new SimpleAttributeSet();
+                                    setLinkAttribute(atts, new URI(uri));
+                                    doc.insertString(offset, decoded, atts);
+                                }
+                            } catch (DecoderException | URISyntaxException  ex) {
+                                Log.logWarningRB("TPL_ERROR_URL", matcher.group());
+                            }
                         }
                     }
                 }
@@ -245,22 +261,17 @@ public final class JTextPaneLinkifier {
             }
         }
 
-        private AttributeSet makeAttributes(final int offset, final URI target) {
-            SimpleAttributeSet atts = new SimpleAttributeSet(doc.getCharacterElement(offset).getAttributes());
+        private void setLinkAttribute(SimpleAttributeSet atts, URI target) {
             atts.addAttributes(LINK_ATTRIBUTES);
-            atts.addAttribute(ATTR_LINK, new IAttributeAction() {
-                @Override
-                public void execute() {
-                    try {
-                        DesktopWrapper.browse(target);
-                    } catch (Exception e) {
-                        JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
-                                OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
-                        Log.log(e);
-                    }
+            atts.addAttribute(ATTR_LINK, (IAttributeAction) () -> {
+                try {
+                    DesktopWrapper.browse(target);
+                } catch (Exception e) {
+                    JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
+                            OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
+                    Log.log(e);
                 }
             });
-            return atts;
         }
     }
 }

--- a/test/data/glossaries/test.tab
+++ b/test/data/glossaries/test.tab
@@ -1,2 +1,3 @@
 kde	koo moo
 question	qqqqq
+地球システム	System Terre	https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -38,8 +38,7 @@ import org.omegat.core.TestCore;
 public class GlossaryReaderTSVTest extends TestCore {
     @Test
     public void testRead() throws Exception {
-        List<GlossaryEntry> g = GlossaryReaderTSV.read(new File(
-                "test/data/glossaries/test.tab"), false);
+        List<GlossaryEntry> g = GlossaryReaderTSV.read(new File("test/data/glossaries/test.tab"), false);
         assertEquals(3, g.size());
         assertEquals("kde", g.get(0).getSrcText());
         assertEquals("koo moo", g.get(0).getLocText());
@@ -47,10 +46,10 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals("qqqqq", g.get(1).getLocText());
         assertEquals("地球システム", g.get(2).getSrcText());
         assertEquals("System Terre", g.get(2).getLocText());
-        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre", g.get(2).getCommentText());
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
+                g.get(2).getCommentText());
 
-        g = GlossaryReaderTSV.read(new File(
-                "test/data/glossaries/testUTF16LE.txt"), false);
+        g = GlossaryReaderTSV.read(new File("test/data/glossaries/testUTF16LE.txt"), false);
         assertEquals(2, g.size());
         assertEquals(g.get(0).getSrcText(), "UTF");
         assertEquals(g.get(0).getLocText(), "Unicode Transformation Format");

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -40,11 +40,14 @@ public class GlossaryReaderTSVTest extends TestCore {
     public void testRead() throws Exception {
         List<GlossaryEntry> g = GlossaryReaderTSV.read(new File(
                 "test/data/glossaries/test.tab"), false);
-        assertEquals(2, g.size());
-        assertEquals(g.get(0).getSrcText(), "kde");
-        assertEquals(g.get(0).getLocText(), "koo moo");
-        assertEquals(g.get(1).getSrcText(), "question");
-        assertEquals(g.get(1).getLocText(), "qqqqq");
+        assertEquals(3, g.size());
+        assertEquals("kde", g.get(0).getSrcText());
+        assertEquals("koo moo", g.get(0).getLocText());
+        assertEquals("question", g.get(1).getSrcText());
+        assertEquals("qqqqq", g.get(1).getLocText());
+        assertEquals("地球システム", g.get(2).getSrcText());
+        assertEquals("System Terre", g.get(2).getLocText());
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre", g.get(2).getCommentText());
 
         g = GlossaryReaderTSV.read(new File(
                 "test/data/glossaries/testUTF16LE.txt"), false);
@@ -55,10 +58,5 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals(g.get(1).getSrcText(), "LE");
         assertEquals(g.get(1).getLocText(), "Little Endian");
         assertEquals(g.get(1).getCommentText(), "Comment #2");
-    }
-
-    @Test
-    public void testCharset() throws Exception {
-        // TODO
     }
 }

--- a/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -57,7 +57,8 @@ public class GlossaryTextAreaTest extends TestCore {
     @Before
     public final void setUp() {
         // TestCore#setUpCore initialize Preferences with temporary configDir
-        Preferences.setPreference(Preferences.GLOSSARY_LAYOUT, DefaultGlossaryRenderer.class.getCanonicalName());
+        Preferences.setPreference(Preferences.GLOSSARY_LAYOUT,
+                DefaultGlossaryRenderer.class.getCanonicalName());
         Preferences.setPreference(Preferences.MARK_GLOSSARY_MATCHES, false);
         UIManager.put("OmegaT.hyperlink", Color.BLUE);
     }

--- a/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -31,10 +31,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.text.DefaultStyledDocument;
 import javax.swing.text.StyledDocument;
 
@@ -57,6 +59,7 @@ public class GlossaryTextAreaTest extends TestCore {
         // TestCore#setUpCore initialize Preferences with temporary configDir
         Preferences.setPreference(Preferences.GLOSSARY_LAYOUT, DefaultGlossaryRenderer.class.getCanonicalName());
         Preferences.setPreference(Preferences.MARK_GLOSSARY_MATCHES, false);
+        UIManager.put("OmegaT.hyperlink", Color.BLUE);
     }
 
     /**
@@ -68,17 +71,33 @@ public class GlossaryTextAreaTest extends TestCore {
         entries.add(new GlossaryEntry("source1", "translation1", "", false, null));
         entries.add(new GlossaryEntry("source2", "translation2", "comment2", false, null));
         final GlossaryTextArea gta = new GlossaryTextArea(Core.getMainWindow());
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                gta.setFoundResult(null, entries);
-            }
-        });
+        SwingUtilities.invokeAndWait(() -> gta.setFoundResult(null, entries));
         // Make sure representations of both entries are rendered
         DefaultGlossaryRenderer renderer = new DefaultGlossaryRenderer();
         StyledDocument doc = new DefaultStyledDocument();
         renderer.render(entries.get(0), doc);
         renderer.render(entries.get(1), doc);
         String expected = doc.getText(0, doc.getLength());
+        assertEquals(expected, gta.getText());
+    }
+
+    @Test
+    public void testSetGlossaryEntriesWithLink() throws Exception {
+        final List<GlossaryEntry> entries = new ArrayList<>();
+        entries.add(new GlossaryEntry("source1", "translation1", "", false, null));
+        entries.add(new GlossaryEntry("source2", "translation2", "comment2", false, null));
+        entries.add(new GlossaryEntry("source3", "translation3",
+                "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre", false, null));
+        final GlossaryTextArea gta = new GlossaryTextArea(Core.getMainWindow());
+        SwingUtilities.invokeAndWait(() -> gta.setFoundResult(null, entries));
+        // Make sure representations of both entries are rendered
+        DefaultGlossaryRenderer renderer = new DefaultGlossaryRenderer();
+        StyledDocument doc = new DefaultStyledDocument();
+        renderer.render(entries.get(0), doc);
+        renderer.render(entries.get(1), doc);
+        renderer.render(entries.get(2), doc);
+        Thread.sleep(300);
+        String expected = doc.getText(0, doc.getLength()).replaceAll("%C3%A8", "è");
         assertEquals(expected, gta.getText());
     }
 

--- a/test/src/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/test/src/org/omegat/util/HttpConnectionUtilsTest.java
@@ -34,12 +34,14 @@ public class HttpConnectionUtilsTest {
     @Test
     public void testDecodeURLs() {
         String str = "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
-        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_système_Terre", HttpConnectionUtils.decodeHttpURLs(str));
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
     }
+
     @Test
     public void testDecodeURLsInText() {
         String str = "1. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
-        assertEquals( "1. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+        assertEquals("1. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
                 HttpConnectionUtils.decodeHttpURLs(str));
     }
 
@@ -47,8 +49,10 @@ public class HttpConnectionUtilsTest {
     public void testDecodeURLsMultipleLines() {
         String str = "1. https://google.com/\n2. bar\n"
                 + "3. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
-        assertEquals("1. https://google.com/\n2. bar\n"
-                + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre", HttpConnectionUtils.decodeHttpURLs(str));
+        assertEquals(
+                "1. https://google.com/\n2. bar\n"
+                        + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
     }
 
     @Test
@@ -56,10 +60,10 @@ public class HttpConnectionUtilsTest {
         String base = "https://fr.wikipedia.org/";
         String path = "wiki/Science_du_système_Terre";
         String query = "?query=search&lang=en";
-        assertEquals( "https://fr.wikipedia.org/", HttpConnectionUtils.encodeHttpURLs(base));
-        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
+        assertEquals("https://fr.wikipedia.org/", HttpConnectionUtils.encodeHttpURLs(base));
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
                 HttpConnectionUtils.encodeHttpURLs(base + path));
-        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre?query=search&lang=en",
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre?query=search&lang=en",
                 HttpConnectionUtils.encodeHttpURLs(base + path + query));
     }
 }

--- a/test/src/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/test/src/org/omegat/util/HttpConnectionUtilsTest.java
@@ -51,4 +51,15 @@ public class HttpConnectionUtilsTest {
                 + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre", HttpConnectionUtils.decodeHttpURLs(str));
     }
 
+    @Test
+    public void testEncodeURLs() {
+        String base = "https://fr.wikipedia.org/";
+        String path = "wiki/Science_du_système_Terre";
+        String query = "?query=search&lang=en";
+        assertEquals( "https://fr.wikipedia.org/", HttpConnectionUtils.encodeHttpURLs(base));
+        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
+                HttpConnectionUtils.encodeHttpURLs(base + path));
+        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre?query=search&lang=en",
+                HttpConnectionUtils.encodeHttpURLs(base + path + query));
+    }
 }

--- a/test/src/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/test/src/org/omegat/util/HttpConnectionUtilsTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HttpConnectionUtilsTest {
+
+    @Test
+    public void testDecodeURLs() {
+        String str = "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals( "https://fr.wikipedia.org/wiki/Science_du_système_Terre", HttpConnectionUtils.decodeHttpURLs(str));
+    }
+    @Test
+    public void testDecodeURLsInText() {
+        String str = "1. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals( "1. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
+    }
+
+    @Test
+    public void testDecodeURLsMultipleLines() {
+        String str = "1. https://google.com/\n2. bar\n"
+                + "3. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals("1. https://google.com/\n2. bar\n"
+                + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre", HttpConnectionUtils.decodeHttpURLs(str));
+    }
+
+}


### PR DESCRIPTION
When showing glossary which contains URL in comment, OmegaT decode percent-encoded URL into human readable URL. 

When OmegaT accept URL which contains non-ascii characters, OmegaT encode URL into percent-encoded one, and write to writable glossary TSV file.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- https://sourceforge.net/p/omegat/bugs/1229

## What does this PR change?

- Show percent escaped URL as a decoded path with Unicode characters
- Introduce HttpsConnectionUtils#decodeHttpsURLs utility method
- Add commons-validator dependency to validate URLs
- Enhance HttpConnectionUtils#checkUrl utility to use commons-validator to validate URL.
- Enhance IGlossaryRenderer.HtmlTarget#append to decode percent-encoded URLs
- Update test cases
- Document writer should suggest users to put URL with encoded form in glossary file.
- Encode URL when adding glossary term with comment that contains URL

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
