### PR TITLE
chore: update JRE to 17.0.9.9+1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -893,6 +893,7 @@ tasks.register('gatherJpkgJars', Copy) {
 
 // prepare docs contents
 tasks.register('gatherJpkgReleaseDocs', Copy) {
+    dependsOn genDocIndex
     def dest = layout.buildDirectory.file('jpackage/docs').get().asFile
     doFirst {
         delete dest
@@ -909,7 +910,7 @@ tasks.register('gatherJpkgReleaseDocs', Copy) {
         ])
         filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
     }
-    from 'docs'
+    from file('docs')
     into file(dest)
 }
 
@@ -980,6 +981,9 @@ tasks.jpackage {
 tasks.register("linuxDebDist", JPackageTask) {
     dependsOn jpackage
     group 'distribution'
+    onlyIf {
+        condition(exePresent('dpkg-deb'), 'dpkg-deb command is not installed')
+    }
 
     appName = application.applicationName
     vendor = distAppVendor
@@ -1012,6 +1016,9 @@ tasks.register("linuxDebDist", JPackageTask) {
 tasks.register("linuxRpmDist", JPackageTask) {
     dependsOn jpackage
     group 'distribution'
+    onlyIf {
+        condition(exePresent('rpm'), 'rpm command is not installed')
+    }
 
     appName = application.applicationName
     vendor = distAppVendor

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -7,12 +7,12 @@ steps:
         mkdir -p $(System.ArtifactsDirectory)/asset
         cd $(System.ArtifactsDirectory)/asset || exit 1
         jres=(
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.9_9.tar.gz
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.9_9.tar.gz 
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_linux_hotspot_17.0.9_9.tar.gz 
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_mac_hotspot_17.0.9_9.tar.gz 
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_windows_hotspot_17.0.9_9.zip
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x86-32_windows_hotspot_17.0.9_9.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.9_9.tar.gz
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.9_9.tar.gz 
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_x64_linux_hotspot_17.0.9_9.tar.gz 
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_x64_mac_hotspot_17.0.9_9.tar.gz 
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_x64_windows_hotspot_17.0.9_9.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_x86-32_windows_hotspot_17.0.9_9.zip
         )
         for url in "${jres[@]}"; do
           curl -L -O "$url"
@@ -32,7 +32,7 @@ steps:
     displayName: 'Preparation for build'
   - task: Gradle@3
     inputs:
-      tasks: build
+      tasks: 'updateManuals sourceDistZip distZip mac linux win'
       options: '--build-cache -PenvIsCi -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.17'
     displayName: 'Build distribution packages and docs'


### PR DESCRIPTION
Fix weekly release tasks

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Hopefully fix a build failure of zip extraction of win64 JRE
- Fix dependency for jpackage tasks
- Tweak CI build task not to duplicate run of test/check 


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
