### PR TITLE
chore: use hash of commit when git export

### DIFF
--- a/.git-archival.properties
+++ b/.git-archival.properties
@@ -1,0 +1,3 @@
+node=$Format:%H$
+date=$Format:%cI$
+describe=$Format:%(describe:tags=true,match=v[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
+#
+# https://help.github.com/articles/dealing-with-line-endings/
+#
+# Linux start script should use lf
+/gradlew        text eol=lf
+# These are Windows script files and should use crlf
+*.bat           text eol=crlf
+# Test data
 test/data/filters/pdf/file-PdfFilter-gold.txt text eol=lf
+# archive version
+.git-archival.properties  export-subst

--- a/build.gradle
+++ b/build.gradle
@@ -1216,8 +1216,11 @@ tasks.findAll { it.name =~ /[dD]istTar$/ && !it.name.contains('linux') }.each { 
 tasks.findAll { it.name =~ /[dD]istZip$/ && it.name.contains('linux') }.each { it.enabled = false }
 
 def provided = findProperty('repoRevision') ?: ''
+def gitArchival = loadProperties(file('.git-archival.properties')).getProperty('node')
 def git = file('.git').directory ? providers.exec {commandLine("git", "rev-parse", "--short", "HEAD")}.standardOutput.asText.get().trim() : ''
-def revision = [provided, omtVersion.revision, git, 'unknown'].find { it != '@dev@' && !it.empty }
+def revision = [provided, gitArchival, omtVersion.revision, git, 'unknown'].find {
+    !it.empty && it != '@dev@' && it != '$Format:%H$'
+}
 processResources {
     /*
      Set the revision number included in version strings. The value is


### PR DESCRIPTION
Use .gitattribute substitution for git-archival.properties file to determine version of git export archive.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
