### PR TITLE
chore(ci): fix unknown task updateManuals in Weekly build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -467,8 +467,7 @@ tasks.register('manualHtmls') {
 tasks.register('webManual', Sync) {
     group = 'documentation'
     description = 'Sync the HTML manual files'
-    dependsOn manualHtmls
-    dependsOn genDocIndex
+    dependsOn manualHtmls, genDocIndex
     destinationDir file(layout.buildDirectory.file("docs/htdocs"))
     from file(layout.buildDirectory.file("docs/manual"))
     from('release') {
@@ -524,6 +523,12 @@ manualIndexXmls.each { xml ->
 tasks.register('firstSteps') {
     description = 'Build First pages for all languages at docs/greetings/. Requires Docker.'
     group = 'documentation'
+}
+
+tasks.register('updateManuals') {
+    group = 'documentation'
+    description = 'Update Instant Start guides and HTML manuals.'
+    dependsOn manualHtmls, firstSteps, genDocIndex
 }
 
 ext.firstStepsXmls = fileTree(dir: 'doc_src', include: '**/First_Steps.xml')

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -32,7 +32,7 @@ steps:
     displayName: 'Preparation for build'
   - task: Gradle@3
     inputs:
-      tasks: 'updateManuals sourceDistZip distZip mac linux win'
+      tasks: 'sourceDistZip distZip mac linux win'
       options: '--build-cache -PenvIsCi -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.17'
     displayName: 'Build distribution packages and docs'


### PR DESCRIPTION
Weekly release build in 2nd Dec 2023 failed because  "updateManuals" task is removed.
This change fix the issue by reverting removal and drop the task call in CI/CD.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Revert "updateManuals" task definition
- No necessary explicit to launch updateManuals

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
