### PR TITLE
chore(ci): Improve weekly publish and docCI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,10 +131,12 @@ stages:
       - script: |
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
-      - template: ci/azure-pipelines/build_steps.yml
-      - template: ci/azure-pipelines/publish_weekly.yml
-        parameters:
-          omegatVersion: $(version)
+      - ${{ if and(succeeded(), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
+        - template: ci/azure-pipelines/build_steps.yml
+      - ${{ if and(succeeded(), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
+        - template: ci/azure-pipelines/publish_weekly.yml
+          parameters:
+            omegatVersion: $(version)
 
   # Release steps will run on the main and/or release branch with tags.
 - stage: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,12 +66,10 @@ stages:
         done
         echo "##vso[task.setvariable variable=changeDoc;]False"
       name: checkChangeDoc
-    - template: ci/azure-pipelines/build_doc_steps.yml
-      parameters:
-        condition: eq(variables.changeDoc, 'True')
-    - template: ci/azure-pipelines/publish_manual_snapshot.yml
-      parameters:
-        condition: and(eq(variables.changeDoc, 'True'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    - ${{ if eq(variables.changeDoc, 'True') }}:
+      - template: ci/azure-pipelines/build_doc_steps.yml
+    - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'), eq(variables.changeDoc, 'True'), eq(variables['Build.SourceBranch'], 'refs/heads/master')) }}:
+      - template: ci/azure-pipelines/publish_manual_snapshot.yml
 
 - stage: Test
   condition: not(or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'), eq(variables.isRelease, true)))
@@ -155,6 +153,7 @@ stages:
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
       - template: ci/azure-pipelines/build_steps.yml
-      - template: ci/azure-pipelines/publish_release.yml
-        parameters:
-          omegatVersion: $(version)
+      - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded') }}:
+        - template: ci/azure-pipelines/publish_release.yml
+          parameters:
+            omegatVersion: $(version)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,8 +131,7 @@ stages:
       - script: |
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
-      - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
-        - template: ci/azure-pipelines/build_steps.yml
+      - template: ci/azure-pipelines/build_steps.yml
       - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
         - template: ci/azure-pipelines/publish_weekly.yml
           parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
       - template: ci/azure-pipelines/build_steps.yml
-      - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded') }}:
+      - ${{ if in(variables['Agent.JobStatus'], 'Succeeded') }}:
         - template: ci/azure-pipelines/publish_release.yml
           parameters:
             omegatVersion: $(version)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,9 +131,9 @@ stages:
       - script: |
           version=$(./gradlew -qq printVersion | head -n -1 )
           echo "##vso[task.setvariable variable=version]$version"
-      - ${{ if and(succeeded(), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
+      - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
         - template: ci/azure-pipelines/build_steps.yml
-      - ${{ if and(succeeded(), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
+      - ${{ if and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'), or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))) }}:
         - template: ci/azure-pipelines/publish_weekly.yml
           parameters:
             omegatVersion: $(version)

--- a/build.gradle
+++ b/build.gradle
@@ -427,13 +427,18 @@ launch4j {
     priority = 'normal'
 }
 
+tasks.register('manualZips') {
+    description = 'Build ZIP manuals to bundle into application. Requires container runtime.'
+    group = 'documentation'
+}
+
 tasks.register('manualPdfs') {
-    description = 'Build PDF manuals for all languages. Requires Docker.'
+    description = 'Build PDF manuals for all languages. Requires container runtime.'
     group = 'documentation'
 }
 
 tasks.register('manualHtmls') {
-    description = 'Build HTML manuals and zip for all languages. Requires Docker.'
+    description = 'Build HTML manuals and zip for all languages. Requires container runtime.'
     group = 'documentation'
 }
 
@@ -455,7 +460,6 @@ tasks.register('genDocIndex', Copy) {
     rename('index_template.html', 'index.html')
     expand('languages': langInfos)
     filteringCharset = 'UTF-8'
-    dependsOn manualHtmls
     group = 'documentation'
 }
 
@@ -509,6 +513,7 @@ manualIndexXmls.each { xml ->
             archiveFileName = "${lang}.zip"
             destinationDirectory = file("${buildDir}/docs/manuals/")
         }
+        manualZips.dependsOn zipTaskName
         tasks.getByName(zipTaskName).dependsOn htmlTaskName
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -460,6 +460,7 @@ tasks.register('genDocIndex', Copy) {
     rename('index_template.html', 'index.html')
     expand('languages': langInfos)
     filteringCharset = 'UTF-8'
+    dependsOn manualHtmls
     group = 'documentation'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -452,11 +452,13 @@ tasks.register('genDocIndex', Copy) {
          'name': langNameExceptions[props.parentFile.name] ?:
                  Locale.forLanguageTag(props.parentFile.name.replace('_', '-')).getDisplayName(),
          'status': docVersion == omtVersion.version ? 'up-to-date' : 'out-of-date'] }
+    def inputTemplate = file('doc_src/index_template.html')
+    def outputIndex = layout.buildDirectory.file("docs/manual/index.html").get().asFile
     description = 'Generate the docs index file'
-    inputs.files docPropsFiles
-    outputs.files layout.buildDirectory.file("docs/manual/index.html")
-    from('doc_src/index_template.html')
-    into layout.buildDirectory.file("docs/manual")
+    inputs.files docPropsFiles, inputTemplate
+    outputs.files file(outputIndex)
+    from inputTemplate
+    into outputIndex.parent
     rename('index_template.html', 'index.html')
     expand('languages': langInfos)
     filteringCharset = 'UTF-8'
@@ -510,7 +512,8 @@ manualIndexXmls.each { xml ->
     if (lang.equals("en") || versionProperties.version.equals(omtVersion.version)) {
         tasks.register(zipTaskName, Zip) {
             from fileTree(dir: layout.buildDirectory.file("docs/manual/${lang}"))
-            from fileTree(dir: "doc_src/${lang}", include: "**/version*.properties")
+            exclude 'docs/manual/index.html'
+            from fileTree(dir: "doc_src/${lang}", include: '**/version*.properties')
             archiveFileName = "${lang}.zip"
             destinationDirectory = file("${buildDir}/docs/manuals/")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -631,10 +631,6 @@ distributions {
             project.tasks.matching {it.name.startsWith('manualZip')}.forEach {
                 from(it.outputs) { into 'docs/manuals' }
             }
-            from('docs') {
-                into 'docs'
-                include '**/*.properties'
-            }
             from('scripts') {
                 into 'scripts'
             }
@@ -680,7 +676,7 @@ distributions {
     source {
         contents {
             from(rootDir) {
-                include 'config/**', 'ci/iscc', 'ci/osslsigncode', 'docs/**', 'images/**', 'lib/**', 'release/**',
+                include 'config/**', 'ci/iscc', 'ci/osslsigncode', 'images/**', 'lib/**', 'release/**',
                     'src/**/*.java', 'test/**', 'test-integration/**', 'doc_src/**', 'docs_devel/**', 'scripts/**',
                     'gradle/**', 'gradle*', 'build.gradle', 'settings.gradle', 'README.md', '*.properties',
                     'tipoftheday/**', 'machinetranslators/**', 'scriptengine/**', 'LICENSE', 'compose.yml',
@@ -704,8 +700,6 @@ distributions {
                 "${application.applicationName}_${project.version}${omtVersion.beta}_Source.zip")
     }
 }
-
-sourceDistZip.dependsOn genDocIndex
 
 def hunspellJar = configurations.runtimeClasspath.files.find {
     it.name.startsWith('hunspell')
@@ -986,13 +980,11 @@ tasks.register('jars', Copy) {
 // appContent requires jpackage command in JDK 18 or later
 // this is compat task to work as same as appContent command of jpackage
 tasks.register('jpackageAppContentManuals', Copy) {
-    dependsOn jpackage
-    // Enable when manual generation is in a build dependency.
-    // dependsOn updateManuals
+    dependsOn jpackage, manualZips
 
+    from layout.buildDirectory.file('docs/manuals')
+    include '*.zip'
     into layout.buildDirectory.file("jpackage/app-image/${application.applicationName}/lib/docs")
-    from 'docs'
-    exclude 'index.html'
 }
 
 tasks.register('jpackageAppContentDocs', Copy) {

--- a/ci/azure-pipelines/build_doc_steps.yml
+++ b/ci/azure-pipelines/build_doc_steps.yml
@@ -10,8 +10,11 @@ steps:
       path: '$(GRADLE_USER_HOME)'
   - script: |
       umask a+w
-      mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean webManual
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean webManual manualZips
     displayName: 'Run Gradle webManual'
     condition: ${{ parameters.condition }}
+  - script: |
+      # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
+      ./gradlew --stop
+    displayName: Gradlew stop

--- a/ci/azure-pipelines/build_doc_steps.yml
+++ b/ci/azure-pipelines/build_doc_steps.yml
@@ -1,10 +1,6 @@
-parameters:
-  condition: false
-
 steps:
   - task: Cache@2
     displayName: 'Cache Gradle'
-    condition: ${{ parameters.condition }}
     inputs:
       key: 'gradle | $(Agent.OS) | $(Build.SourcesDirectory)/build.gradle'
       path: '$(GRADLE_USER_HOME)'
@@ -13,8 +9,14 @@ steps:
       chmod -R a+w doc_src
       $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean webManual manualZips
     displayName: 'Run Gradle webManual'
-    condition: ${{ parameters.condition }}
+  - script: echo "##vso[task.setvariable variable=result;]false"
+    condition: failed()
   - script: |
       # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
       ./gradlew --stop
+      # Check task result
+      if [[ "$(result)" == "false" ]]; then
+        exit 1
+      fi
+    condition: always()
     displayName: Gradlew stop

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -36,7 +36,14 @@ steps:
       options: '--build-cache -PenvIsCi -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.17'
     displayName: 'Build distribution packages and docs'
+  - script: echo "##vso[task.setvariable variable=result;]false"
+    conditions: failed()
   - script: |
       # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
       ./gradlew --stop
-    displayName: Gradlew stop
+      # Check task result
+      if [[ "$(result)" == "false" ]]; then
+        exit 1
+      fi
+    conditions: always()
+    displayName: Stop Gradle daemon

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -37,7 +37,7 @@ steps:
       jdkVersionOption: '1.17'
     displayName: 'Build distribution packages and docs'
   - script: echo "##vso[task.setvariable variable=result;]false"
-    conditions: failed()
+    condition: failed()
   - script: |
       # stop the Gradle daemon to ensure no files are left open (impacting the save cache operation later)
       ./gradlew --stop
@@ -45,5 +45,5 @@ steps:
       if [[ "$(result)" == "false" ]]; then
         exit 1
       fi
-    conditions: always()
+    condition: always()
     displayName: Stop Gradle daemon

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -27,12 +27,11 @@ steps:
       path: '$(GRADLE_USER_HOME)'
   - script: |
       umask a+w
-      mkdir -p build
       chmod -R a+w doc_src
     displayName: 'Preparation for build'
   - task: Gradle@3
     inputs:
-      tasks: 'sourceDistZip distZip mac linux win'
+      tasks: 'clean sourceDistZip distZip mac linux win'
       options: '--build-cache -PenvIsCi -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.17'
     displayName: 'Build distribution packages and docs'

--- a/ci/azure-pipelines/publish_manual_snapshot.yml
+++ b/ci/azure-pipelines/publish_manual_snapshot.yml
@@ -1,10 +1,6 @@
-parameters:
-  condition: false
-
 steps:
   - task: Bash@3
     displayName: 📂 SCP upload to sourceforge file management
-    condition: ${{ parameters.condition }}
     inputs:
       targetType: 'inline'
       script: |

--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -4,7 +4,6 @@ parameters:
 
 steps:
   - task: Bash@3
-    condition: or(eq(variables.isMain, true), eq(variables.isReleasesBranch, true))
     displayName: 📂 SCP upload to sourceforge file management
     inputs:
       targetType: 'inline'


### PR DESCRIPTION
## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- ci/azure-pipelines
    -  build_steps.yml always stop gradle daemon
    - Check previous step status when running publish_weekly.yml template
    - Check previous step status when running build_doc_steps.yml template
    - clean before building release packages
- build.gradle
    - Add manualZips task
    - Fix dependency problem around genDocIndex task
          - remove dependency by sourceDistZip  
          - refactoring genDocIndex task definition
    - Drop  reference to "docs" folder

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
