### PR TITLE
fix: mac package does not launch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -578,7 +578,7 @@ tasks.register('genMac') {
     def appbundlerClasspath = configurations.genMac.asPath
     def outDir = layout.buildDirectory.file("appbundler").get().toString()
     def appName = application.applicationName
-    def appClass = application.mainClass
+    def appClass = application.mainClass.get()
     description = 'Generate the Mac .app skeleton. Depends AppBundler (https://github.com/TheInfiniteKind/appbundler)'
     outputs.dir layout.buildDirectory.file("appbundler")
     doLast {
@@ -1060,7 +1060,7 @@ tasks.jpackage {
     vendor = distAppVendor
     appDescription = distDescription
     mainJar = omegatJarFilename
-    mainClass = "org.omegat.Main"
+    mainClass = application.mainClass.get()
 
     // appContent requires jpackage command in JDK 18 or later
     /*


### PR DESCRIPTION
The build.gradle file was modified to correctly define the 'mainClass' in the Mac package. This change included correcting the 'appClass' definition and adjusting the 'mainClass' to reference the application's main class. It fixed a wrong 'mainClass' in the Mac package.


## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

-  OmegaT 6.1 macos-arm version does not launch on macOS arm machine
- https://sourceforge.net/p/omegat/bugs/1231/



## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
