### PR TITLE
[BUGS#1225] fix: Bring Issues Panel to front on refresh

### DIFF
--- a/src/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/org/omegat/gui/issues/IssuesPanelController.java
@@ -165,6 +165,7 @@ public class IssuesPanelController implements IIssues {
         }
 
         frame = new JFrame(OStrings.getString("ISSUES_WINDOW_TITLE"));
+        frame.setAutoRequestFocus(false);
         StaticUIUtils.setEscapeClosable(frame);
         StaticUIUtils.setWindowIcon(frame);
         if (Platform.isMacOSX()) {
@@ -515,7 +516,6 @@ public class IssuesPanelController implements IIssues {
 
     synchronized void refreshData(int jumpToEntry, List<String> jumpToTypes) {
         reset();
-        frame.toFront();
         if (!frame.isVisible()) {
             // Don't call setVisible if already visible, because the window will
             // steal focus
@@ -595,7 +595,7 @@ public class IssuesPanelController implements IIssues {
             if (isCancelled()) {
                 return;
             }
-            List<IIssue> allIssues = Collections.emptyList();
+            List<IIssue> allIssues;
             try {
                 allIssues = get();
             } catch (InterruptedException | ExecutionException e) {
@@ -632,6 +632,9 @@ public class IssuesPanelController implements IIssues {
             }
             colSizer.reset();
             colSizer.adjustTableColumns();
+            if (allIssues.isEmpty()) {
+                return;
+            }
             if (!jumpToTypes.isEmpty()) {
                 int[] indicies = ((TypeListModel) panel.typeList.getModel()).indiciesOfTypes(jumpToTypes);
                 if (indicies.length > 0) {
@@ -641,7 +644,11 @@ public class IssuesPanelController implements IIssues {
             if (jumpToEntry >= 0) {
                 IntStream.range(0, panel.table.getRowCount())
                         .filter(row -> (int) panel.table.getValueAt(row, IssueColumn.SEG_NUM.index) >= jumpToEntry)
-                        .findFirst().ifPresent(jump -> panel.table.changeSelection(jump, 0, false, false));
+                        .findFirst()
+                        .ifPresent(jump -> {
+                            panel.table.changeSelection(jump, 0, false, false);
+                            frame.toFront();
+                        });
             }
             panel.table.requestFocusInWindow();
         }

--- a/src/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/org/omegat/gui/issues/IssuesPanelController.java
@@ -608,10 +608,6 @@ public class IssuesPanelController implements IIssues {
                 return;
             }
 
-            if (allIssues.isEmpty()) {
-                panel.messageLabel.setText(OStrings.getString("ISSUES_NO_ISSUES_FOUND"));
-            }
-
             panel.progressBar.setVisible(false);
             StaticUIUtils.setHierarchyEnabled(panel, true);
             panel.typeList.setModel(new TypeListModel(allIssues));
@@ -633,6 +629,7 @@ public class IssuesPanelController implements IIssues {
             colSizer.reset();
             colSizer.adjustTableColumns();
             if (allIssues.isEmpty()) {
+                panel.messageLabel.setText(OStrings.getString("ISSUES_NO_ISSUES_FOUND"));
                 return;
             }
             if (!jumpToTypes.isEmpty()) {

--- a/src/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/org/omegat/gui/issues/IssuesPanelController.java
@@ -515,6 +515,7 @@ public class IssuesPanelController implements IIssues {
 
     synchronized void refreshData(int jumpToEntry, List<String> jumpToTypes) {
         reset();
+        frame.toFront();
         if (!frame.isVisible()) {
             // Don't call setVisible if already visible, because the window will
             // steal focus


### PR DESCRIPTION
This commit introduces a change in the IssuesPanelController where the refreshData function is modified to bring the panel to the forefront each time it refreshes. This adjustment ensure that the refreshed panel remains visible and doesn't get hidden behind main window. Resolved BUGS#1225

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- List of issues stays hidden in the background
- https://sourceforge.net/p/omegat/bugs/1225/

## What does this PR change?

- `IssuesPanelController#refreshData` does `frame.toFront()`
 
## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
