### PR TITLE
[BUGS#1234] fix: GlossarySearcher token string comparison issue

### DIFF
--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -150,7 +150,8 @@ public class GlossarySearcher {
 
     private static boolean rawMatch(Token[] tokens, String srcTxt, String term) {
         for (Token token : tokens) {
-            if (token.getTextFromString(srcTxt).equals(term.substring(token.getLength()))) {
+            if (term.length() > token.getLength()
+                    && token.getTextFromString(srcTxt).equals(term.substring(token.getLength()))) {
                 return true;
             }
         }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]
## Which ticket is resolved?

- Issue window cause exception
- https://sourceforge.net/p/omegat/bugs/1234/

## What does this PR change?
- Resolves a bug in GlossarySearcher where the string comparison cause an index out of range exception.
- A condition check has been added to ensure that term length is greater than token length before performing substring operations.
- Resolve BUGS#1234

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
