### PR TITLE
chore: skip doc build when property specified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -640,7 +640,7 @@ distributions {
                         TRANSLATION_NOTICE: ''
                 ])
                 filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
-            project.hasProperty('macCodesignIdentity'), 'Code signing property not set']}
+            }
             project.tasks.matching {it.name.startsWith('firstSteps') || it.name.startsWith('instantStart')}.forEach {
                 from(it.outputs) { into 'docs/greetings' }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -487,7 +487,8 @@ manualIndexXmls.each { xml ->
         workingDir = 'doc_src'
         commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/pdfs", 'pdf'
         onlyIf {
-            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'])
+            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
+                    [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])
         }
         doLast {
             copy {
@@ -506,7 +507,8 @@ manualIndexXmls.each { xml ->
         outputs.files fileTree(dir: layout.buildDirectory.file("docs/manual/${lang}/"),
                 includes: ['*.html', 'OmegaT.css', 'images/*.png', '_wh/**/*.js', '_wh/wh.css'])
         onlyIf {
-            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'])
+            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
+                [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])
         }
         workingDir = 'doc_src'
         commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/manual/${lang}", 'html5'
@@ -548,7 +550,8 @@ firstStepsXmls.each { xml ->
         outputs.files fileTree(dir: layout.buildDirectory.file('docs/greetings/'),
                 includes: ["${lang}/first_steps.html", "${lang}/OmegaT.css"])
         onlyIf {
-            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'])
+            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
+                    [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])
         }
         workingDir = 'doc_src'
         commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/greetings/${lang}", 'first-steps'
@@ -566,7 +569,8 @@ instantStartXmls.each { xml ->
         outputs.files fileTree(dir: layout.buildDirectory.file('docs/greetings/'),
                 includes: ["${lang}/first_steps.html", "${lang}/images/InstantGuide*png", "${lang}/OmegaT.css"])
         onlyIf {
-            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'])
+            conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
+                    [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])
         }
         workingDir = 'doc_src'
         commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/greetings/${lang}", 'instant-start'
@@ -636,7 +640,7 @@ distributions {
                         TRANSLATION_NOTICE: ''
                 ])
                 filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
-            }
+            project.hasProperty('macCodesignIdentity'), 'Code signing property not set']}
             project.tasks.matching {it.name.startsWith('firstSteps') || it.name.startsWith('instantStart')}.forEach {
                 from(it.outputs) { into 'docs/greetings' }
             }

--- a/docs_devel/docs/02.HowToBuild.md
+++ b/docs_devel/docs/02.HowToBuild.md
@@ -5,8 +5,7 @@ available tasks. Run `gradlew build` to build all possible distfiles and run the
 main tests. Tasks skipped due to missing requirements will be noted in the
 output.
 
-OmegaT will run on the latest Java, but is required to be compatible with Java
-1.8.
+OmegaT will run on the latest Java, but is required to be compatible with Java 11.
 
 Eclipse and NetBeans are recommended IDEs for working with OmegaT source
 code. NetBeans is required to modify *.form-based GUI layouts (install the
@@ -17,6 +16,17 @@ produce Javadoc by running `gradlew javadoc`, or browse online:
 
   [https://omegat.sourceforge.io/javadoc-latest/](https://omegat.sourceforge.io/javadoc-latest/)
 
+## Prerequisite
+
+As in Dec., 2023, Here is a condition to build OmegaT binaries;
+
+1. Java Development kit 11 or later. When you want to build 
+   a linux deb/rpm package, JDK 17 or later is required.
+2. Requires `docker` or `nerdctl` command to launch containerized processes.
+   Build process for documentation and windows packages will be skipped
+   when  neither `docker` nor `nerdctl` command is not found. 
+3. JDK 21 has not been supported yet to launch Gradle build tool,
+   but it works well as an OmegaT runtime.
 
 ## Configuring Build Tasks
 
@@ -24,6 +34,9 @@ Some build tasks, such as signed installers, require additional configuration
 via a `local.properties` file placed at the root of the source tree. See
 `local.properties.example`.
 
+When specified a Gradle property `forceSkipDocumentBuild`, the build task 
+will skip build processes to generate greeting documents, `FirstStep.html`
+in languages, and bundled manuals. You can edit `local.properties` or
 
 ## Build Assets
 

--- a/local.properties.example
+++ b/local.properties.example
@@ -51,3 +51,8 @@ signing.secretKeyRingFile=
 sourceforgeWebUser=
 # Not required when using SSH auth
 sourceforgeWebPassword=
+
+## Uncomment when force skipping build of documentation
+## equivalent with command line option -PforceSkipDocumentBuild=1 or
+## an environment variable ORG_GRADLE_PROJECT_forceSkipDocumentBuild=1
+# forceSkipDocumentBuild=1


### PR DESCRIPTION
- Introduce "forceSkipDocumentBuild" property which indicate to skip document build steps.
- Developer can specify Gradle property with "-P" option, such as "gradle -PforceSkipDocumentBuild=1" or via environment variable ORG_GRADLE_PROJECT_forceSkipDocumentBuild=1 
- see https://docs.gradle.org/current/userguide/project_properties.html

## Pull request type


- Build and release changes -> [build/release]

## Which ticket is resolved?

Dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/F86A5D44-20F7-492D-9F12-98E1C7A9DA97%40traduction-libre.org/#msg58712422

## What does this PR change?

- add document build condition to check property in addition to check of existence of docker command 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
