### PR TITLE
[BUGS#1235] fix: hardening plugin installer utility class

### DIFF
--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -1687,8 +1687,19 @@ ${filePath}></programlisting></para>
 	linkend="application.folder">application</link> folder.</para>
 
 	<para>Additional plugins can be found on the <ulink
-	url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT development
-	site</ulink>.</para>
+	url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT wiki
+	site</ulink>.
+	Use the <guibutton>Install</guibutton> button to install or upgrade your
+	plugin. You can install a plugin file which should be JAR file that has
+	a filename with ".jar" file extension.
+	OmegaT can also accept a zip archive file that contents includes plugin
+	JAR file. Typically third party plugins are distributed as a zip archive
+	format, bundled with README.txt, License.txt file and the plugin jar file.
+	</para>
+	<warning>
+		<para>The plugin installer feature only accepts an archive with a plugin file,
+		 not a plugin jar that has a filename with ".zip" extension.</para>
+	</warning>
   </section>
 
   <section id="dialogs.preferences.updates">

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -1690,15 +1690,14 @@ ${filePath}></programlisting></para>
 	url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT wiki
 	site</ulink>.
 	Use the <guibutton>Install</guibutton> button to install or upgrade your
-	plugin. You can install a plugin file which should be JAR file that has
-	a filename with ".jar" file extension.
-	OmegaT can also accept a zip archive file that contents includes plugin
-	JAR file. Typically third party plugins are distributed as a zip archive
-	format, bundled with README.txt, License.txt file and the plugin jar file.
+	plugin. The plugin file should be a JAR file with a <filename>.jar</filename> file extension.
+	OmegaT can also accept a zip archive file that contains one or more JAR file plugins.
+	Third party plugins are typically distributed as zip archives bundled with the plugin as well as
+	README.txt and License.txt files.
 	</para>
 	<warning>
-		<para>The plugin installer feature only accepts an archive with a plugin file,
-		 not a plugin jar that has a filename with ".zip" extension.</para>
+		<para>The plugin installer only accepts archives containing one or more JAR plugin files.
+		 It does not recognize plugin JAR files with a <filename>.zip</filename> extension.</para>
 	</warning>
   </section>
 

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -1688,16 +1688,16 @@ ${filePath}></programlisting></para>
 
 	<para>Additional plugins can be found on the <ulink
 	url="https://sourceforge.net/p/omegat/wiki/Plugins/">OmegaT wiki
-	site</ulink>.
-	Use the <guibutton>Install</guibutton> button to install or upgrade your
-	plugin. The plugin file should be a JAR file with a <filename>.jar</filename> file extension.
-	OmegaT can also accept a zip archive file that contains one or more JAR file plugins.
-	Third party plugins are typically distributed as zip archives bundled with the plugin as well as
-	README.txt and License.txt files.
+	site</ulink>.</para>
+	<para>Use the <guibutton>Install plugin from disk</guibutton> button to install or upgrade your
+	plugin. Plugin files are JAR files with a <filename>.jar</filename> extension.
+	OmegaT also accepts zip archives that contain one or more JAR plugin files.
+	Third party plugins are typically distributed as zip archives that contain the plugin file
+	itself, as well as README and LICENSE files.
 	</para>
 	<warning>
-		<para>The plugin installer only accepts archives containing one or more JAR plugin files.
-		 It does not recognize plugin JAR files with a <filename>.zip</filename> extension.</para>
+		<para>The plugin installer only accepts archives containing one or more JAR plugins.
+		 It does not recognize plugin files renamed with a <filename>.zip</filename> extension.</para>
 	</warning>
   </section>
 

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -1691,12 +1691,12 @@ ${filePath}></programlisting></para>
 	site</ulink>.</para>
 	<para>Use the <guibutton>Install plugin from disk</guibutton> button to install or upgrade your
 	plugin. Plugin files are JAR files with a <filename>.jar</filename> extension.
-	OmegaT also accepts zip archives that contain one or more JAR plugin files.
+	OmegaT also accepts zip archives that contain a JAR plugin file.
 	Third party plugins are typically distributed as zip archives that contain the plugin file
 	itself, as well as README and LICENSE files.
 	</para>
 	<warning>
-		<para>The plugin installer only accepts archives containing one or more JAR plugins.
+		<para>The plugin installer only accepts archives containing a JAR plugin.
 		 It does not recognize plugin files renamed with a <filename>.zip</filename> extension.</para>
 	</warning>
   </section>

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2906,12 +2906,18 @@ PREFS_PLUGINS_COL_VERSION=Version
 PREFS_PLUGINS_COL_AUTHOR=Author
 PREFS_PLUGINS_COL_DESCRIPTION=Description
 PREFS_PLUGINS_INSTALL_FROM_DISK=&Install plugin from disk
-PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Install plugin file
-PREFS_PLUGINS_CONFIRM_UPGRADE=Upgrade/override plugin {0}\n\
-   current: {1}\n\
-   new version: {2}
-PREFS_PLUGINS_CONFIRM_INSTALL=Install plugin {0} {1}
-PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
+PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Confirmation of a plugin installation
+PREFS_PLUGINS_CONFIRM_UPGRADE=Do you want to upgrade a plugin "{0}"?\n\
+   installed version: {1}\n\
+   specified plugin version: {2}\n\
+   if select CANCEL, the process will be aborted.
+PREFS_PLUGINS_CONFIRM_OVERRIDE=Do you want to override a plugin "{0}"?\n\
+   installed version: {1}\n\
+   specified plugin version: {2}\n\
+   if select CANCEL, the process will be aborted.
+PREFS_PLUGINS_CONFIRM_INSTALL=Do you want to install plugin {0} {1} ?
+PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation is failed.
+PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation is succeeded. Please restart OmegaT.
 PREFS_PLUGINS_UNKNOWN_ARCHIVE=This file is not a plugin archive.
 
 # PREFERENCES - UPDATES

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2136,7 +2136,7 @@ GUI_DICTIONARY_INSTALLER_AVAILABLE=Available languages:
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
 GUI_PLUGIN_INSTALLER_TITLE=Plugin Installer
-GUI_PLUGIN_OPEN=Select a plugin file (*.jar, *.zip)
+GUI_PLUGIN_OPEN=Select a plugin file (*.jar), or a zip archive include a plugin jar (*.zip)
 GUI_PLUGIN_INSTALLER_INSTALL=Install
 
 # matches text area popup menu

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2136,7 +2136,7 @@ GUI_DICTIONARY_INSTALLER_AVAILABLE=Available languages:
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
 GUI_PLUGIN_INSTALLER_TITLE=Plugin Installer
-GUI_PLUGIN_OPEN=Select a plugin file (*.jar), or a zip archive include a plugin jar (*.zip)
+GUI_PLUGIN_OPEN=Select a plugin file (*.jar) or a zip archive (*.zip) that contains one or more plugin jar files.
 GUI_PLUGIN_INSTALLER_INSTALL=Install
 
 # matches text area popup menu

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2906,18 +2906,15 @@ PREFS_PLUGINS_COL_VERSION=Version
 PREFS_PLUGINS_COL_AUTHOR=Author
 PREFS_PLUGINS_COL_DESCRIPTION=Description
 PREFS_PLUGINS_INSTALL_FROM_DISK=&Install plugin from disk
-PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Confirmation of a plugin installation
-PREFS_PLUGINS_CONFIRM_UPGRADE=Do you want to upgrade a plugin "{0}"?\n\
-   installed version: {1}\n\
-   specified plugin version: {2}\n\
-   if select CANCEL, the process will be aborted.
-PREFS_PLUGINS_CONFIRM_OVERRIDE=Do you want to override a plugin "{0}"?\n\
-   installed version: {1}\n\
-   specified plugin version: {2}\n\
-   if select CANCEL, the process will be aborted.
-PREFS_PLUGINS_CONFIRM_INSTALL=Do you want to install plugin {0} {1} ?
-PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation is failed.
-PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation is succeeded. Please restart OmegaT.
+PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Install Plugin
+PREFS_PLUGINS_CONFIRM_UPGRADE=Upgrade the {0} plugin?\n\
+   Current version: {1}\n\
+   New version: {2}
+PREFS_PLUGINS_CONFIRM_OVERWRITE=Version {1} is allready installed.\n\
+   Reinstall the {0} plugin?\n\   
+PREFS_PLUGINS_CONFIRM_INSTALL=Install the {0} {1} plugin?
+PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
+PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Rstart OmegaT to activate it.
 PREFS_PLUGINS_UNKNOWN_ARCHIVE=This file is not a plugin archive.
 
 # PREFERENCES - UPDATES

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2136,7 +2136,7 @@ GUI_DICTIONARY_INSTALLER_AVAILABLE=Available languages:
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
 GUI_PLUGIN_INSTALLER_TITLE=Plugin Installer
-GUI_PLUGIN_OPEN=Select a plugin file (*.jar) or a zip archive (*.zip) that contains one or more plugin jar files.
+GUI_PLUGIN_OPEN=Select a plugin file (*.jar) or a zip archive (*.zip) that contains a plugin jar file.
 GUI_PLUGIN_INSTALLER_INSTALL=Install
 
 # matches text area popup menu

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2917,6 +2917,9 @@ PREFS_PLUGINS_CONFIRM_INSTALL=Install the {0} {1} plugin?
 PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
 PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Restart OmegaT to activate it.
 PREFS_PLUGINS_UNKNOWN_ARCHIVE=This file is not a plugin archive.
+PREFS_PLUGINS_TITLE_NAME=Plugin Name
+PREFS_PLUGINS_TITLE_CURRENT_VERSION=Installed
+PREFS_PLUGINS_TITLE_TARGET_VERSION=Selected
 
 # PREFERENCES - UPDATES
 VERSION_CHECK_UP_TO_DATE=You already have the latest version.

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2907,14 +2907,15 @@ PREFS_PLUGINS_COL_AUTHOR=Author
 PREFS_PLUGINS_COL_DESCRIPTION=Description
 PREFS_PLUGINS_INSTALL_FROM_DISK=&Install plugin from disk
 PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Install Plugin
+PREFS_PLUGINS_TITLE_CONFIRM_UPGRADE=Upgrade Plugin
 PREFS_PLUGINS_CONFIRM_UPGRADE=Upgrade the {0} plugin?\n\
    Current version: {1}\n\
    New version: {2}
-PREFS_PLUGINS_CONFIRM_OVERWRITE=Version {1} is allready installed.\n\
-   Reinstall the {0} plugin?\n\   
+PREFS_PLUGINS_CONFIRM_OVERWRITE=Version {1} is already installed.\n\
+   Reinstall the {0} plugin?\n
 PREFS_PLUGINS_CONFIRM_INSTALL=Install the {0} {1} plugin?
 PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
-PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Rstart OmegaT to activate it.
+PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Restart OmegaT to activate it.
 PREFS_PLUGINS_UNKNOWN_ARCHIVE=This file is not a plugin archive.
 
 # PREFERENCES - UPDATES

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -309,9 +309,13 @@ public final class Main {
      */
     protected static int runGUI() {
         ClassLoader cl = ClassLoader.getSystemClassLoader();
-        MainClassLoader mainClassLoader = (cl instanceof MainClassLoader) ? (MainClassLoader) cl
-                : new MainClassLoader(cl);
-        PluginUtils.getThemePluginJars().forEach(mainClassLoader::add);
+        MainClassLoader mainClassLoader;
+        if (cl instanceof MainClassLoader) {
+            mainClassLoader = (MainClassLoader) cl;
+        } else {
+            mainClassLoader = new MainClassLoader(cl);
+        }
+        PluginUtils.getThemePluginJars().forEach(mainClassLoader::addJarToClasspath);
         UIManager.put("ClassLoader", mainClassLoader);
 
         // macOS-specific - they must be set BEFORE any GUI calls

--- a/src/org/omegat/MainClassLoader.java
+++ b/src/org/omegat/MainClassLoader.java
@@ -42,20 +42,9 @@ public final class MainClassLoader extends URLClassLoader {
         registerAsParallelCapable();
     }
 
-    private String name;
-
-    /**
-     * Java9 compatible class loader constructor.
-     * @param name name of class loader
-     * @param parent
-     */
-    public MainClassLoader(String name, ClassLoader parent) {
-        this(parent);
-        this.name = name;
-    }
-
     /*
-     * Required when this classloader is used as the system classloader
+     * Java9 compatible class loader constructor.
+     * @param parent system class loader.
      */
     public MainClassLoader(ClassLoader parent) {
         this(new URL[0], parent);
@@ -73,13 +62,12 @@ public final class MainClassLoader extends URLClassLoader {
      * Main class can add jar classpath for plugins in dynamic manner.
      * @param url
      */
-    synchronized void add(URL url) {
+    public synchronized void add(URL url) {
         addURL(url);
     }
 
-    synchronized void addJarToClasspath(String jarName)
-            throws MalformedURLException {
-        URL url = new File(jarName).toURI().toURL();
+    public synchronized void addJarToClasspath(File jarFile) throws MalformedURLException {
+        URL url = jarFile.toURI().toURL();
         addURL(url);
     }
 

--- a/src/org/omegat/MainClassLoader.java
+++ b/src/org/omegat/MainClassLoader.java
@@ -59,14 +59,19 @@ public final class MainClassLoader extends URLClassLoader {
     }
 
     /**
-     * Main class can add jar classpath for plugins in dynamic manner.
-     * @param url
+     * Add URL to classpath.
+     * @param url to added.
      */
-    public synchronized void add(URL url) {
+    public void addJarToClasspath(URL url) {
         addURL(url);
     }
 
-    public synchronized void addJarToClasspath(File jarFile) throws MalformedURLException {
+    /**
+     * Add Jar file into classpath.
+     * @param jarFile JAR file to add to classpath.
+     * @throws MalformedURLException when a malformed File object is passed.
+     */
+    public void addJarToClasspath(File jarFile) throws MalformedURLException {
         URL url = jarFile.toURI().toURL();
         addURL(url);
     }
@@ -86,6 +91,6 @@ public final class MainClassLoader extends URLClassLoader {
      */
     @SuppressWarnings("unused")
     private void appendToClassPathForInstrumentation(String jarfile) throws IOException {
-        add(Paths.get(jarfile).toRealPath().toUri().toURL());
+        addJarToClasspath(Paths.get(jarfile).toRealPath().toUri().toURL());
     }
 }

--- a/src/org/omegat/MainClassLoader.java
+++ b/src/org/omegat/MainClassLoader.java
@@ -91,6 +91,6 @@ public final class MainClassLoader extends URLClassLoader {
      */
     @SuppressWarnings("unused")
     private void appendToClassPathForInstrumentation(String jarfile) throws IOException {
-        addJarToClasspath(Paths.get(jarfile).toRealPath().toUri().toURL());
+        addJarToClasspath(Paths.get(jarfile).toRealPath().toFile());
     }
 }

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -194,12 +194,10 @@ public final class PluginUtils {
                 try (InputStream in = mu.openStream()) {
                     Manifest m = new Manifest(in);
                     if ("org.omegat.Main".equals(m.getMainAttributes().getValue("Main-Class"))) {
-                        // found main manifest - not in development mode
+                        // found a main manifest - not in development mode
                         foundMain = true;
-                        loadFromManifest(m, pluginsClassLoader, null);
-                    } else {
-                        loadFromManifest(m, pluginsClassLoader, mu);
                     }
+                    loadFromManifest(m, pluginsClassLoader, mu);
                     if ("theme".equals(m.getMainAttributes().getValue("Plugin-Category"))) {
                         String target = mu.toString();
                         for (URL url : urlList) {

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -209,9 +209,7 @@ public final class PluginUtils {
                 } catch (ClassNotFoundException e) {
                     Log.log(e);
                 } catch (UnsupportedClassVersionError e) {
-                    JarURLConnection connection = (JarURLConnection) mu.openConnection();
-                    URL url = connection.getJarFileURL();
-                    Log.logWarningRB("PLUGIN_JAVA_VERSION_ERROR", url);
+                    Log.logWarningRB("PLUGIN_JAVA_VERSION_ERROR", getJarFileUrlFromResourceUrl(mu));
                 }
             }
         } catch (IOException ex) {
@@ -630,5 +628,10 @@ public final class PluginUtils {
 
     public static Collection<PluginInformation> getPluginInformations() {
         return Collections.unmodifiableSet(PLUGIN_INFORMATIONS);
+    }
+
+    public static URL getJarFileUrlFromResourceUrl(URL url) throws IOException {
+        JarURLConnection connection = (JarURLConnection) url.openConnection();
+        return connection.getJarFileURL();
     }
 }

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -33,6 +33,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -52,7 +53,6 @@ import org.omegat.core.Core;
 import org.omegat.core.data.PluginInformation;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.preferences.view.PluginsPreferencesController;
-
 
 /**
  * Plugin installer utility class.
@@ -107,17 +107,17 @@ public final class PluginInstaller {
         }
 
         // confirm installation
-        if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
-                    message,
-                    OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"),
-                    JOptionPane.OK_CANCEL_OPTION, JOptionPane.ERROR_MESSAGE)) {
+        if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
+                Core.getMainWindow().getApplicationFrame(), message,
+                OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.ERROR_MESSAGE)) {
             if (doInstall(currentInfo, pluginJarFile.toFile())) {
                 return true;
             }
             JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
                     OStrings.getString("PREFS_PLUGINS_INSTALLATION_FAILED"),
-                    OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"),
-                    JOptionPane.YES_OPTION, JOptionPane.ERROR_MESSAGE);
+                    OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.YES_OPTION,
+                    JOptionPane.ERROR_MESSAGE);
         }
         return false;
     }
@@ -153,21 +153,28 @@ public final class PluginInstaller {
 
     /**
      * Check if jarFile is placed in OmegaT installed system directory.
-     * @param jarFile a file determine.
-     * @return true when a file is under installed directory, otherwise return false.
+     * 
+     * @param jarFile
+     *            a file determine.
+     * @return true when a file is under installed directory, otherwise return
+     *         false.
      */
     private static boolean jarFileInInstallDir(File jarFile) {
-        String installDir = StaticUtils.installDir();
-        return jarFile.getAbsolutePath().contains(installDir);
+        Path installDir = Paths.get(StaticUtils.installDir()).normalize();
+        Path jarPath = jarFile.toPath().normalize();
+        return jarPath.startsWith(installDir);
     }
 
     /**
      * Unpack a plugin file when necessary and copy it.
      *
-     * @param sourceFile plugin source file to be installed (jar or zip)
-     * @param targetPath target path to be installed.
+     * @param sourceFile
+     *            plugin source file to be installed (jar or zip)
+     * @param targetPath
+     *            target path to be installed.
      * @return jar file path of installed plugin.
-     * @throws IOException when source file is corrupted.
+     * @throws IOException
+     *             when source file is corrupted.
      */
     static Path unpackPlugin(File sourceFile, Path targetPath) throws IOException {
         Path target;
@@ -177,7 +184,8 @@ public final class PluginInstaller {
         } else if (sourceFile.getName().endsWith(".zip")) {
             try (InputStream inputStream = Files.newInputStream(sourceFile.toPath())) {
                 Predicate<String> expected = f -> f.endsWith(OConsts.JAR_EXTENSION);
-                List<String> extracted = StaticUtils.extractFromZip(inputStream, targetPath.toFile(), expected);
+                List<String> extracted = StaticUtils.extractFromZip(inputStream, targetPath.toFile(),
+                        expected);
                 if (extracted.isEmpty()) {
                     throw new FileNotFoundException("Could not extract a jar file from zip");
                 }
@@ -193,7 +201,9 @@ public final class PluginInstaller {
 
     /**
      * Parse Manifest from plugin jar file.
-     * @param pluginJarFile plugin jar file
+     * 
+     * @param pluginJarFile
+     *            plugin jar file
      * @return PluginInformation
      */
     static Set<PluginInformation> parsePluginJarFileManifest(File pluginJarFile) throws IOException {
@@ -213,7 +223,8 @@ public final class PluginInstaller {
 
     /**
      *
-     * @param manifestUrl URL of MANIFEST.MF file
+     * @param manifestUrl
+     *            URL of MANIFEST.MF file
      * @return plugin information
      */
     static Set<PluginInformation> parsePluginJarFileManifest(URL manifestUrl) throws IOException {
@@ -250,6 +261,7 @@ public final class PluginInstaller {
 
     /**
      * Return installed plugins.
+     * 
      * @return Map of PluginInformation
      */
     private static Map<String, PluginInformation> getInstalledPlugins() {

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -30,7 +30,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,10 +48,10 @@ import javax.swing.JOptionPane;
 
 import org.apache.commons.io.FileUtils;
 
+import org.omegat.MainClassLoader;
 import org.omegat.core.Core;
 import org.omegat.core.data.PluginInformation;
 import org.omegat.filters2.master.PluginUtils;
-import org.omegat.gui.preferences.view.PluginsPreferencesController;
 
 /**
  * Plugin installer utility class.
@@ -208,10 +207,8 @@ public final class PluginInstaller {
      */
     static Set<PluginInformation> parsePluginJarFileManifest(File pluginJarFile) throws IOException {
         Set<PluginInformation> pluginInfo = new HashSet<>();
-        URL[] urls = new URL[1];
-        urls[0] = pluginJarFile.toURI().toURL();
-        try (URLClassLoader pluginsClassLoader = new URLClassLoader(urls,
-                PluginsPreferencesController.class.getClassLoader())) {
+        try (MainClassLoader pluginsClassLoader = new MainClassLoader()) {
+            pluginsClassLoader.addJarToClasspath(pluginJarFile);
             for (Enumeration<URL> mlist = pluginsClassLoader.getResources("META-INF/MANIFEST.MF"); mlist
                     .hasMoreElements();) {
                 URL mu = mlist.nextElement();

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -110,7 +110,7 @@ public final class PluginInstaller {
         if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
                 Core.getMainWindow().getApplicationFrame(), message,
                 OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.OK_CANCEL_OPTION,
-                JOptionPane.ERROR_MESSAGE)) {
+                JOptionPane.WARNING_MESSAGE)) {
             if (doInstall(currentInfo, pluginJarFile.toFile())) {
                 return true;
             }

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -98,8 +98,13 @@ public final class PluginInstaller {
         PluginInformation currentInfo = getInstalledPlugins().getOrDefault(info.getClassName(), null);
         String message;
         if (currentInfo != null) {
-            message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_UPGRADE"), pluginName,
-                    currentInfo.getVersion(), version);
+            if (currentInfo.getVersion().equals(version)) {
+                message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_OVERRIDE"), pluginName,
+                        currentInfo.getVersion(), version);
+            } else {
+                message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_UPGRADE"), pluginName,
+                        currentInfo.getVersion(), version);
+            }
         } else {
             message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_INSTALL"), pluginName,
                     version);
@@ -109,8 +114,10 @@ public final class PluginInstaller {
         if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
                 Core.getMainWindow().getApplicationFrame(), message,
                 OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.OK_CANCEL_OPTION,
-                JOptionPane.WARNING_MESSAGE)) {
+                JOptionPane.INFORMATION_MESSAGE)) {
             if (doInstall(currentInfo, pluginJarFile.toFile())) {
+                JOptionPane.showMessageDialog(Core.getMainWindow().getApplicationFrame(), OStrings.getString(
+                        "PREFS_PLUGINS_INSTALLATION_SUCCEED"));
                 return true;
             }
             JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -100,7 +100,7 @@ public final class PluginInstaller {
         String message;
         if (currentInfo != null) {
             if (currentInfo.getVersion().equals(version)) {
-                message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_OVERRIDE"), pluginName,
+                message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_OVERWRITE"), pluginName,
                         currentInfo.getVersion(), version);
             } else {
                 message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_UPGRADE"), pluginName,

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -137,8 +137,13 @@ public final class PluginInstaller {
         JTextArea msg = new JTextArea(message);
         msg.setEditable(false);
         if (Math.max(installed.size(), currentSet.size()) > 1) {
+            String[] titles = {OStrings.getString("PREFS_PLUGINS_TITLE_NAME"),
+                OStrings.getString("PREFS_PLUGINS_TITLE_CURRENT_VERSION"),
+                OStrings.getString("PREFS_PLUGINS_TITLE_TARGET_VERSION")
+            };
             JTable compareTable = new JTable();
-            compareTable.setModel(new PluginInstallerTableModel(currentSet, infoSet));
+            compareTable.setModel(new PluginInstallerTableModel(titles, currentSet,
+                    infoSet));
             confirmPanel.setPreferredSize(new Dimension(400, 200));
             confirmPanel.add(compareTable.getTableHeader(), BorderLayout.NORTH);
             confirmPanel.add(new JScrollPane(compareTable), BorderLayout.CENTER);
@@ -324,9 +329,11 @@ public final class PluginInstaller {
         private final List<PluginInformation> current = new ArrayList<>();
         private final List<PluginInformation> installer = new ArrayList<>();
         private final List<String> classes = new ArrayList<>();
-        private final String[] titles = { "Name", "Installed", "Version" };
+        private final String[] titles;
 
-        PluginInstallerTableModel(Set<PluginInformation> current, Set<PluginInformation> installer) {
+        PluginInstallerTableModel(String[] titles, Set<PluginInformation> current,
+                Set<PluginInformation> installer) {
+            this.titles = titles;
             this.current.addAll(current);
             this.installer.addAll(installer);
             classes.addAll(
@@ -364,14 +371,15 @@ public final class PluginInstaller {
             if (columnIndex == 1) {
                 var currentPlugin = current.stream().filter(i -> i.getClassName().equals(target)).findFirst();
                 if (currentPlugin.isPresent()) {
-                    return currentPlugin.map(PluginInformation::getVersion).filter(v -> !v.isEmpty()).orElse("N.A.");
+                    return currentPlugin.map(PluginInformation::getVersion).filter(v -> !v.isEmpty())
+                            .orElse("N.A.");
                 } else {
                     return "-";
                 }
             }
             if (columnIndex == 2) {
                 return installer.stream().filter(i -> i.getClassName().equals(target)).findFirst()
-                    .map(PluginInformation::getVersion).filter(v -> !v.isEmpty()).orElse("N.A.");
+                        .map(PluginInformation::getVersion).filter(v -> !v.isEmpty()).orElse("N.A.");
             }
             return null;
         }

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -97,24 +97,27 @@ public final class PluginInstaller {
         String version = info.getVersion();
         // detect current installation
         PluginInformation currentInfo = getInstalledPlugins().getOrDefault(info.getClassName(), null);
+        String title = "";
         String message;
         if (currentInfo != null) {
             if (currentInfo.getVersion().equals(version)) {
+                title = OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION");
                 message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_OVERWRITE"), pluginName,
                         currentInfo.getVersion(), version);
             } else {
+                title = OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_UPGRADE");
                 message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_UPGRADE"), pluginName,
                         currentInfo.getVersion(), version);
             }
         } else {
+            title = OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION");
             message = StringUtil.format(OStrings.getString("PREFS_PLUGINS_CONFIRM_INSTALL"), pluginName,
                     version);
         }
 
         // confirm installation
         if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
-                Core.getMainWindow().getApplicationFrame(), message,
-                OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.OK_CANCEL_OPTION,
+                Core.getMainWindow().getApplicationFrame(), message, title, JOptionPane.OK_CANCEL_OPTION,
                 JOptionPane.INFORMATION_MESSAGE)) {
             if (doInstall(currentInfo, pluginJarFile.toFile())) {
                 JOptionPane.showMessageDialog(Core.getMainWindow().getApplicationFrame(), OStrings.getString(

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -324,7 +324,7 @@ public final class PluginInstaller {
         private final List<String> classes = new ArrayList<>();
         private final String[] titles = { "Name(Current)", "Version(Current)", "Name", "Version" };
 
-        public PluginInstallerTableModel(Set<PluginInformation> current, Set<PluginInformation> installer) {
+        PluginInstallerTableModel(Set<PluginInformation> current, Set<PluginInformation> installer) {
             this.current.addAll(current);
             this.installer.addAll(installer);
             classes.addAll(


### PR DESCRIPTION
Hardening plugin installer class

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  PluginInstaller throws NPE in certain condition
- https://sourceforge.net/p/omegat/bugs/1235/

dev-ml
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/78b810a2-34f6-4416-b28e-6e1dda659f4b%40northside.tokyo/#msg58712660

## What does this PR change?
- Refactor PluginUtils#loadPlugins to register "jarFile!className" URL even when it is main jar file.
- Check nullity of `currentInfo.getUrl()` and skip retrieving of jarFile object when null.
- Check jar file path that is not under installDir system directory, when try to remove it.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
