### PR TITLE
fix: MT execution condition

### DIFF
--- a/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
+++ b/src/org/omegat/gui/exttrans/MachineTranslateTextArea.java
@@ -263,28 +263,28 @@ public class MachineTranslateTextArea extends EntryInfoThreadPane<MachineTransla
         }
 
         private String getTranslation(Language source, Language target) {
-            if (!force) {
-                if (!Preferences.isPreferenceDefault(Preferences.MT_AUTO_FETCH, true)) {
-                    return translator.getCachedTranslation(source, target, src);
+            try {
+                if (force) {
+                    return translator.getTranslation(source, target, src);
                 }
-                if (Preferences.isPreference(Preferences.MT_ONLY_UNTRANSLATED)) {
+                if (Preferences.isPreferenceDefault(Preferences.MT_AUTO_FETCH, false)) {
+                    if (!Preferences.isPreference(Preferences.MT_ONLY_UNTRANSLATED)) {
+                        return translator.getCachedTranslation(source, target, src);
+                    }
+                    // call translator only when visiting untranslated segment.
                     TMXEntry entry = Core.getProject().getTranslationInfo(currentlyProcessedEntry);
-                    if (entry.isTranslated()) {
+                    if (!entry.isTranslated()) {
                         return translator.getCachedTranslation(source, target, src);
                     }
                 }
-            }
-            try {
-                return translator.getTranslation(source, target, src);
             } catch (MachineTranslateError e) {
                 Log.log(e);
                 Core.getMainWindow().showTimedStatusMessageRB("MT_ENGINE_ERROR", translator.getName(),
                         e.getLocalizedMessage());
-                return null;
             } catch (Exception e) {
                 Log.logErrorRB(e, "MT_ENGINE_EXCEPTION");
-                return null;
             }
+            return null;
         }
     }
 


### PR DESCRIPTION
OmegaT execute MT connector to translate even when auto-fetch is disabled, if some connectors are enabled. This changes logic to be better to understand a condition and respect the configuration.


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

Report on azure translator plugin issue
https://github.com/omegat-org/azure-translate-plugin/issues/7

## What does this PR change?

- Refactor MachineTranslateTextArea#getTranaslation
- Don't go to MT#getTranslate in default action. 


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
