### PR TITLE
chore: update linux-deb/rpm build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ def distDescription = 'OmegaT is a free and open source multiplatform Computer A
         ' fuzzy matching, translation memory, keyword search, glossaries, and translation leveraging into updated' +
         ' projects.'
 def distAppVendor = 'The OmegaT project'
-
+def gradleOnJava17OrLater = JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)
 def javaVersion = 11;
 def localPropsFile = file('local.properties')
 ext {
@@ -990,7 +990,7 @@ tasks.register('cleanJpkgWorkdir', Delete) {
     delete jpackageWorkdir
 }
 
-tasks.register('jars', Copy) {
+tasks.register('jars', Sync) {
     from configurations.runtimeClasspath
     from(tasks.jar) { include omegatJarFilename }
     into file(layout.buildDirectory.file('jars'))
@@ -998,16 +998,14 @@ tasks.register('jars', Copy) {
 }
 
 // prepare japckage contents
-// appContent requires jpackage command in JDK 18 or later
-// this is compat task to work as same as appContent command of jpackage
-tasks.register('jpackageAppContentGreetings', Copy) {
+tasks.register('jpackageAppContentGreetings', Sync) {
     dependsOn jpackage, firstSteps
 
     from layout.buildDirectory.file('docs/greetings')
     into layout.buildDirectory.file("jpackage/app-image/${application.applicationName}/lib/docs/greetings")
 }
 
-tasks.register('jpackageAppContentManuals', Copy) {
+tasks.register('jpackageAppContentManuals', Sync) {
     dependsOn jpackage, manualZips
 
     from layout.buildDirectory.file('docs/manuals')
@@ -1065,14 +1063,8 @@ tasks.register('jpackage', Exec) {
 
     inputs.files file(layout.buildDirectory.file('jars'))
     outputs.files file(layout.buildDirectory.file("jpackage/app-image"))
+    onlyIf { gradleOnJava17OrLater }
 
-    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
-    onlyIf {
-        conditions([JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
-                'Require java17 or later to run gradle.'],
-                [exePresent(jpackageExe), 'jpackage command does not exist.']
-        )
-    }
     def osName = System.getProperty('os.name').toLowerCase()
     def icon = 'images/OmegaT.png'
     if (osName.contains('windows')) {
@@ -1080,7 +1072,7 @@ tasks.register('jpackage', Exec) {
     } else if (osName.contains('mac')) {
         icon = "images/OmegaT.icns"
     }
-    commandLine(jpackageExe,
+    commandLine(file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage")),
             '--type', 'app-image',
             '--app-version', version,
             '--description', distDescription,
@@ -1090,7 +1082,7 @@ tasks.register('jpackage', Exec) {
             '--vendor', distAppVendor,
             '--input', file(layout.buildDirectory.file('jars')),
             '--main-class', application.mainClass.get(),
-            '--main-jar',  omegatJarFilename,
+            '--main-jar', omegatJarFilename,
             '--java-options', "-Xmx1024M",
             '--java-options', "--add-opens",
             '--java-options', "java.desktop/sun.awt.X11=ALL-UNNAMED",
@@ -1106,16 +1098,9 @@ tasks.register("linuxDebDist", Exec) {
     inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
     outputs.files file(layout.buildDirectory
             .file("distributions/${application.applicationName}_${version}-${debVersion}_amd64.deb"))
+    onlyIf { gradleOnJava17OrLater && exePresent('dpkg-deb') }
 
-    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
-    onlyIf {
-        conditions([exePresent('dpkg-deb'), 'dpkg-deb command is not installed'],
-                [exePresent(jpackageExe), 'jpackage command does not exist.'],
-                [JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
-                 'Require java17 or later to run gradle.'])
-    }
-
-    commandLine(jpackageExe,
+    commandLine(file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage")),
             '--type', 'deb',
             '--app-version', version,
             '--description', distDescription,
@@ -1147,16 +1132,9 @@ tasks.register("linuxRpmDist", Exec) {
     inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
     outputs.files file(layout.buildDirectory
             .file("distributions/${application.applicationName}-${version}-${rpmVersion}.x86_64.rpm"))
+    onlyIf { gradleOnJava17OrLater && exePresent('rpm') }
 
-    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
-    onlyIf {
-        conditions([exePresent('rpm'), 'rpm command is not installed'],
-                [exePresent(jpackageExe), 'jpackage command does not exist.'],
-                [JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
-                 'Require java17 or later to run gradle.'])
-    }
-
-    commandLine(jpackageExe,
+    commandLine(file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage")),
             '--type', 'rpm',
             '--app-version', version,
             '--description', distDescription,

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
-import org.panteleyev.jpackage.JPackageTask
+import java.nio.file.Paths
 
 plugins {
     id 'application'
@@ -15,7 +15,6 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.versions)
     alias(libs.plugins.launch4j)
-    alias(libs.plugins.jpackage)
     alias(libs.plugins.ssh)
 }
 
@@ -1059,123 +1058,122 @@ tasks.register('jpackageAppContent') {
 }
 
 // construct package contents in standard file tree
-tasks.jpackage {
+tasks.register('jpackage', Exec) {
     dependsOn cleanJpkgWorkdir
     dependsOn jars
+    group 'other'
 
+    inputs.files file(layout.buildDirectory.file('jars'))
+    outputs.files file(layout.buildDirectory.file("jpackage/app-image"))
+
+    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
     onlyIf {
-        condition(JavaVersion.current() == JavaVersion.VERSION_17, 'Require java17 or later to run gradle.')
+        conditions([JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
+                'Require java17 or later to run gradle.'],
+                [exePresent(jpackageExe), 'jpackage command does not exist.']
+        )
     }
-
-    input = file(layout.buildDirectory.file('jars'))
-    destination = file(layout.buildDirectory.file("jpackage/app-image"))
-    appName = application.applicationName
-    vendor = distAppVendor
-    appDescription = distDescription
-    mainJar = omegatJarFilename
-    mainClass = application.mainClass.get()
-
-    // appContent requires jpackage command in JDK 18 or later
-    /*
-    appContent = [file(layout.buildDirectory.file('modules')),
-                  file(layout.buildDirectory.file('jpackage/docs')),'scripts', 'images']
-    */
-    // We use jpackageAppContent task for alternative
-    finalizedBy jpackageAppContent
-
-    javaOptions = ["-Xmx1024M", "--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"]
-    linux {
-        icon = "images/OmegaT.png"
-        resourceDir = "release/jpackage-specific/linux/"
-        verbose = true
-    }
-    mac {
+    def osName = System.getProperty('os.name').toLowerCase()
+    def icon = 'images/OmegaT.png'
+    if (osName.contains('windows')) {
+        icon = "images/OmegaT.ico"
+    } else if (osName.contains('mac')) {
         icon = "images/OmegaT.icns"
     }
-    windows {
-        icon = "images/OmegaT.ico"
-    }
-
-    type = 'app-image'
-    group 'other'
+    commandLine(jpackageExe,
+            '--type', 'app-image',
+            '--app-version', version,
+            '--description', distDescription,
+            '--icon', icon,
+            '--name', application.applicationName,
+            '--dest', file(layout.buildDirectory.file("jpackage/app-image")),
+            '--vendor', distAppVendor,
+            '--input', file(layout.buildDirectory.file('jars')),
+            '--main-class', application.mainClass.get(),
+            '--main-jar',  omegatJarFilename,
+            '--java-options', "-Xmx1024M",
+            '--java-options', "--add-opens",
+            '--java-options', "java.desktop/sun.awt.X11=ALL-UNNAMED",
+            '--resource-dir', file("release/jpackage-specific/linux/"))
 }
 
 // generate DEB package
-tasks.register("linuxDebDist", JPackageTask) {
+tasks.register("linuxDebDist", Exec) {
     dependsOn jpackage
     dependsOn jpackageAppContent
-
     group 'distribution'
+    def debVersion = '3'
+    inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
+    outputs.files file(layout.buildDirectory
+            .file("distributions/${application.applicationName}_${version}-${debVersion}_amd64.deb"))
+
+    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
     onlyIf {
         conditions([exePresent('dpkg-deb'), 'dpkg-deb command is not installed'],
-                [JavaVersion.current() == JavaVersion.VERSION_17, 'Require java17 or later to run gradle.'])
+                [exePresent(jpackageExe), 'jpackage command does not exist.'],
+                [JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
+                 'Require java17 or later to run gradle.'])
     }
 
-    appName = application.applicationName
-    vendor = distAppVendor
-    appDescription = shortDescription
-
-    appImage = file(layout.buildDirectory.file("jpackage/app-image/${appName}"))
-    destination = file(layout.buildDirectory.file('distributions'))
-
-    type = 'deb'
-    installDir = '/opt/omegat-org'
-    resourceDir = "release/jpackage-specific/linux/"
-    verbose = true
-
-    icon = file(layout.projectDirectory.file("images/OmegaT.png"))
-
-    aboutUrl = "https://omegat.org/"
-    licenseFile = file(layout.projectDirectory.file("LICENSE"))
-
-    linux {
-        linuxAppCategory("editors")
-        linuxAppRelease('3')
-        linuxDebMaintainer("info@omegat.org")
-        linuxMenuGroup("Office")
-        linuxPackageName("omegat")
-        linuxPackageDeps(false)
-        linuxShortcut(true)
-    }
+    commandLine(jpackageExe,
+            '--type', 'deb',
+            '--app-version', version,
+            '--description', distDescription,
+            '--icon', file(layout.projectDirectory.file("images/OmegaT.png")),
+            '--name', application.applicationName,
+            '--app-image', file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}")),
+            '--dest', file(layout.buildDirectory.file('distributions')),
+            '--vendor', distAppVendor,
+            '--resource-dir', file("release/jpackage-specific/linux/"),
+            '--about-url', "https://omegat.org/",
+            '--license-file', file(layout.projectDirectory.file("LICENSE")),
+            '--install-dir', '/opt/omegat-org',
+            '--linux-app-category', 'editors',
+            '--linux-app-release', debVersion,
+            '--linux-deb-maintainer', 'info@omegat.org',
+            '--linux-menu-group', 'Office',
+            '--linux-package-name', 'omegat',
+            '--linux-shortcut')
     tasks.getByName('linux').dependsOn linuxDebDist
     assemble.dependsOn linuxDebDist
 }
 
 // generate RPM package
-tasks.register("linuxRpmDist", JPackageTask) {
+tasks.register("linuxRpmDist", Exec) {
     dependsOn jpackage
     dependsOn jpackageAppContent
-
     group 'distribution'
+    def rpmVersion = '3'
+    inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
+    outputs.files file(layout.buildDirectory
+            .file("distributions/${application.applicationName}-${version}-${rpmVersion}.x86_64.rpm"))
+
+    def jpackageExe = file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage"))
     onlyIf {
         conditions([exePresent('rpm'), 'rpm command is not installed'],
-                [JavaVersion.current() == JavaVersion.VERSION_17, 'Require java17 or later to run gradle.'])
+                [exePresent(jpackageExe), 'jpackage command does not exist.'],
+                [JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17),
+                 'Require java17 or later to run gradle.'])
     }
 
-    appName = application.applicationName
-    vendor = distAppVendor
-    appDescription = shortDescription
-
-    appImage = file(layout.buildDirectory.file("jpackage/app-image/${appName}"))
-    destination = file(layout.buildDirectory.file('distributions'))
-
-    type = 'rpm'
-    installDir = '/opt/omegat-org'
-
-    icon = file(layout.projectDirectory.file("images/OmegaT.png"))
-
-    aboutUrl = "https://omegat.org/"
-    licenseFile = file(layout.projectDirectory.file("LICENSE"))
-
-    linux {
-        linuxAppCategory("Application/Editors")
-        linuxAppRelease('3')
-        linuxMenuGroup("Office")
-        linuxPackageName("omegat")
-        linuxPackageDeps(false)
-        linuxRpmLicenseType("GPLv3+")
-        linuxShortcut(true)
-    }
+    commandLine(jpackageExe,
+            '--type', 'rpm',
+            '--app-version', version,
+            '--description', distDescription,
+            '--icon', file(layout.projectDirectory.file("images/OmegaT.png")),
+            '--name', application.applicationName,
+            '--app-image', file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}")),
+            '--dest', file(layout.buildDirectory.file('distributions')),
+            '--vendor', distAppVendor,
+            '--about-url', "https://omegat.org/",
+            '--license-file', file(layout.projectDirectory.file("LICENSE")),
+            '--install-dir', '/opt/omegat-org',
+            '--linux-app-category', 'Application/Editors',
+            '--linux-app-release', rpmVersion,
+            '--linux-menu-group', 'Office',
+            '--linux-package-name', 'omegat',
+            '--linux-rpm-license-type', 'GPLv3+',
+            '--linux-shortcut')
     tasks.getByName('linux').dependsOn linuxRpmDist
     assemble.dependsOn linuxRpmDist
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ################################################################################
 
-# task `jpackage` delived from jpackage-gradle-plugin version 1.5.2 does not support configuration cache
-# see https://github.com/petr-panteleyev/jpackage-gradle-plugin/issues/27
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -179,6 +179,4 @@ git-version = {id = "com.palantir.git-version", version = "0.13.0"}
 nexus-publish = {id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0-rc-1"}
 launch4j = {id = "edu.sc.seis.launch4j", version = "3.0.3"}
 versions = {id = "com.github.ben-manes.versions", version = "0.39.0"}
-sphinx = {id = "tokyo.northside.sphinx", version.ref = "sphinx"}
-jpackage = {id = "org.panteleyev.jpackageplugin", version = "1.5.2"}
 ssh = {id = "org.hidetake.ssh", version = "2.10.1"}

--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -74,14 +74,17 @@ ext {
     }
 
     exePresent = { exe ->
-        ["where $exe", "which $exe"].any {
-            try {
-                def findExe = it.execute()
-                findExe.waitForProcessOutput()
-                return findExe.exitValue() == 0
-            } catch (any) {
-                return false
-            }
+        def osName = System.getProperty('os.name').toLowerCase()
+        if (osName.contains('windows')) {
+            providers.exec {
+                ignoreExitValue = true
+                commandLine('where', exe)
+            }.result.get() == 0
+        } else {
+            providers.exec {
+                ignoreExitValue = true
+                commandLine('which', exe)
+            }.result.get() == 0
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
A jpackage plugin author declined to fix the bug on gradle cache feature with my proposal to change, and express the project won't support cache feature.
The plugin has no more benefit other than a syntax sugar, so I decided to remove the plugin and migrate it as Exec task type.

Now we can enable a configuration cache and speed-up our build.

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

- Build and release changes -> [build/release]

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
