### PR TITLE
chore: Update gradle plugin ben-manes.version@0.50.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -178,5 +178,5 @@ spotless = {id = "com.diffplug.spotless", version = "6.19.0"}
 git-version = {id = "com.palantir.git-version", version = "0.13.0"}
 nexus-publish = {id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0-rc-1"}
 launch4j = {id = "edu.sc.seis.launch4j", version = "3.0.3"}
-versions = {id = "com.github.ben-manes.versions", version = "0.39.0"}
+versions = {id = "com.github.ben-manes.versions", version = "0.50.0"}
 ssh = {id = "org.hidetake.ssh", version = "2.10.1"}


### PR DESCRIPTION
## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Bump gradle plugin com.github.ban-manes.version@0.50.0 
- Support for Gradle 8.x

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
