### PR TITLE
chore(ci): full test on github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20

--- a/.github/workflows/gradle-build-master.yml
+++ b/.github/workflows/gradle-build-master.yml
@@ -1,0 +1,39 @@
+name: Run Gradle test
+
+on:
+  push:
+    branches:
+      - master
+      - releases/*
+  pull_request:
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        distribution: 'temurin'
+    - uses: gradle/wrapper-validation-action@v1
+      name: validate gradle wrapper
+    - name: Agree gradle-scan terms
+      run: cat ci/gradle/gradle-scan.init.gradle >> settings.gradle
+    - uses: gradle/gradle-build-action@v2
+      name: Setup Gradle
+      id: setup-gradle
+    - name: Run gradle build
+      run: ./gradlew -PenvIsCi --scan build
+    - name: "Add Build Scan URL as PR comment"
+      uses: actions/github-script@v5
+      if: github.event_name == 'pull_request' && failure()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
+          })

--- a/ci/azure-pipelines/test_steps.yml
+++ b/ci/azure-pipelines/test_steps.yml
@@ -8,7 +8,7 @@ steps:
       umask a+w
       mkdir -p build
       chmod -R a+w doc_src
-      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test build
+      $(Build.SourcesDirectory)/gradlew --build-cache -PenvIsCi clean test
     displayName: 'Run Gradle clean, test and test on Java17'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results build/test-results/**/TEST-*.xml'

--- a/ci/gradle/gradle-scan.init.gradle
+++ b/ci/gradle/gradle-scan.init.gradle
@@ -1,0 +1,6 @@
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+    id 'com.gradle.enterprise' version '3.16.1'
 }
 rootProject.name = 'OmegaT'
 include("machinetranslators:apertium",


### PR DESCRIPTION
## Pull request type


- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- CI: add dependabot
- CI: add gradle build check on github actions with gradle scan
- CI: drop build check from azure-pipelines
- Gradle: add gradle-enterprise plugin to allow gradle scan in CI
- CI: Automatically put Gradle Scan URL on PR when failure

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

When using Gradle Scan service, we need to agree to term of use.
https://gradle.com/legal/terms-of-use/


