### PR TITLE
[BUGS#1236] fix: make CalcMatchStatistics ignores threshold

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -79,7 +79,7 @@
     <!-- util/Preferences -->
     <suppress files="Preferences\.java" checks="LineLength" lines="197"/>
     <!-- core/stat -->
-    <suppress checks="(ParameterNumber|MethodLength)" files="FindMatches\.java" lines="164,351,461"/>
+    <suppress checks="(ParameterNumber|MethodLength)" files="FindMatches\.java" lines="164,350,459"/>
     <!-- util/xml -->
     <suppress checks="(EmptyBlock|MethodLength)" files="XMLStreamReader\.java"/>
     <!-- util -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -51,7 +51,7 @@
 
     <!-- interfaces -->
     <!-- Keep names for compatibility -->
-    <suppress files="IParseCallback\.java" checks="ParameterNumber"/>
+    <suppress files="(IParseCallback|CalcMatchStatisticsTest)\.java" checks="ParameterNumber"/>
     <suppress checks="TypeName" files="IProjectEventListener\.java" lines="35"/>
 
     <!-- ignore Auto generated source files -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -79,7 +79,7 @@
     <!-- util/Preferences -->
     <suppress files="Preferences\.java" checks="LineLength" lines="197"/>
     <!-- core/stat -->
-    <suppress checks="(ParameterNumber|MethodLength)" files="FindMatches\.java" lines="153,337,444"/>
+    <suppress checks="(ParameterNumber|MethodLength)" files="FindMatches\.java" lines="164,351,461"/>
     <!-- util/xml -->
     <suppress checks="(EmptyBlock|MethodLength)" files="XMLStreamReader\.java"/>
     <!-- util -->

--- a/src/org/omegat/core/data/NotLoadedProject.java
+++ b/src/org/omegat/core/data/NotLoadedProject.java
@@ -44,6 +44,13 @@ import org.omegat.util.Language;
  */
 public class NotLoadedProject implements IProject {
 
+    protected static final TMXEntry EMPTY_TRANSLATION;
+    static {
+        PrepareTMXEntry empty = new PrepareTMXEntry();
+        empty.source = "";
+        EMPTY_TRANSLATION = new TMXEntry(empty, true, null);
+    }
+
     @Override
     public void compileProject(String sourcePattern) throws IOException, TranslationException {
     }

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -56,15 +56,16 @@ import org.omegat.util.gui.TextUtil;
 /**
  * Thread for calculate match statistics, total and per file.
  *
- * Calculation requires two different tags stripping: one for calculate match percentage, and second for
- * calculate number of words and chars.
+ * Calculation requires two different tags stripping: one for calculate match
+ * percentage, and second for calculate number of words and chars.
  *
- * Number of words/chars calculation requires to just strip all tags, protected parts, placeholders(see
- * StatCount.java).
+ * Number of words/chars calculation requires to just strip all tags, protected
+ * parts, placeholders(see StatCount.java).
  *
- * Calculation of match percentage requires 2 steps for tags processing: 1) remove only simple XML tags for
- * find 5 nearest matches(but not protected parts' text: from "<m0>Acme</m0>" only tags should be removed, but
- * not "Acme" ), then 2) compute better percentage without any tags removing.
+ * Calculation of match percentage requires 2 steps for tags processing: 1)
+ * remove only simple XML tags for find 5 nearest matches(but not protected
+ * parts' text: from "<m0>Acme</m0>" only tags should be removed, but not "Acme"
+ * ), then 2) compute better percentage without any tags removing.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Thomas Cordonnier
@@ -76,17 +77,17 @@ public class CalcMatchStatistics extends LongProcessThread {
             OStrings.getString("CT_STATS_Characters") };
 
     private final String[] rowsTotal = new String[] { OStrings.getString("CT_STATSMATCH_RowRepetitions"),
-            OStrings.getString("CT_STATSMATCH_RowExactMatch"),
-            OStrings.getString("CT_STATSMATCH_RowMatch95"), OStrings.getString("CT_STATSMATCH_RowMatch85"),
-            OStrings.getString("CT_STATSMATCH_RowMatch75"), OStrings.getString("CT_STATSMATCH_RowMatch50"),
-            OStrings.getString("CT_STATSMATCH_RowNoMatch"), OStrings.getString("CT_STATSMATCH_Total") };
+            OStrings.getString("CT_STATSMATCH_RowExactMatch"), OStrings.getString("CT_STATSMATCH_RowMatch95"),
+            OStrings.getString("CT_STATSMATCH_RowMatch85"), OStrings.getString("CT_STATSMATCH_RowMatch75"),
+            OStrings.getString("CT_STATSMATCH_RowMatch50"), OStrings.getString("CT_STATSMATCH_RowNoMatch"),
+            OStrings.getString("CT_STATSMATCH_Total") };
     private final String[] rowsPerFile = new String[] {
             OStrings.getString("CT_STATSMATCH_RowRepetitionsWithinThisFile"),
             OStrings.getString("CT_STATSMATCH_RowRepetitionsFromOtherFiles"),
-            OStrings.getString("CT_STATSMATCH_RowExactMatch"),
-            OStrings.getString("CT_STATSMATCH_RowMatch95"), OStrings.getString("CT_STATSMATCH_RowMatch85"),
-            OStrings.getString("CT_STATSMATCH_RowMatch75"), OStrings.getString("CT_STATSMATCH_RowMatch50"),
-            OStrings.getString("CT_STATSMATCH_RowNoMatch"), OStrings.getString("CT_STATSMATCH_Total") };
+            OStrings.getString("CT_STATSMATCH_RowExactMatch"), OStrings.getString("CT_STATSMATCH_RowMatch95"),
+            OStrings.getString("CT_STATSMATCH_RowMatch85"), OStrings.getString("CT_STATSMATCH_RowMatch75"),
+            OStrings.getString("CT_STATSMATCH_RowMatch50"), OStrings.getString("CT_STATSMATCH_RowNoMatch"),
+            OStrings.getString("CT_STATSMATCH_Total") };
     private final boolean[] align = new boolean[] { false, true, true, true, true };
 
     private final IStatsConsumer callback;
@@ -97,7 +98,8 @@ public class CalcMatchStatistics extends LongProcessThread {
     private final Set<String> alreadyProcessedInFile = new HashSet<String>();
     private final Set<String> alreadyProcessedInProject = new HashSet<String>();
 
-    private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal.withInitial(LevenshteinDistance::new);
+    private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal
+            .withInitial(LevenshteinDistance::new);
     private final ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
             () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false, true));
     private final StringBuilder textForLog = new StringBuilder();
@@ -143,12 +145,13 @@ public class CalcMatchStatistics extends LongProcessThread {
         for (IProject.FileInfo fi : Core.getProject().getProjectFiles()) {
             fileNumber++;
 
-            MatchStatCounts perFile = forFile(fi);
+            MatchStatCounts perFileCounts = forFile(fi);
             checkInterrupted();
 
-            String[][] table = perFile.calcTable(rowsPerFile);
+            String[][] table = perFileCounts.calcTable(rowsPerFile);
             String outText = TextUtil.showTextTable(header, table, align);
-            String title = StringUtil.format(OStrings.getString("CT_STATSMATCH_File"), fileNumber, fi.filePath);
+            String title = StringUtil.format(OStrings.getString("CT_STATSMATCH_File"), fileNumber,
+                    fi.filePath);
             appendText(title + "\n");
             appendText(outText + "\n");
             appendTable(title, table);
@@ -181,7 +184,8 @@ public class CalcMatchStatistics extends LongProcessThread {
             StatCount count = new StatCount(ste);
             boolean isFirst = alreadyProcessedInProject.add(ste.getSrcText());
             if (Core.getProject().getTranslationInfo(ste).isTranslated()) {
-                // segment has translation - should be calculated as "Exact matched"
+                // segment has translation - should be calculated as "Exact
+                // matched"
                 result.addExact(count);
                 entryProcessed();
             } else if (!isFirst) {
@@ -256,16 +260,19 @@ public class CalcMatchStatistics extends LongProcessThread {
     }
 
     /**
-     * For the match calculation, we iterates by untranslated entries. Each untranslated entry compared with
-     * source texts of: 1) default translations, 2) alternative translations, 3) TMs(from
+     * For the match calculation, we iterates by untranslated entries. Each
+     * untranslated entry compared with source texts of: 1) default
+     * translations, 2) alternative translations, 3) TMs(from
      * project.getTransMemories()).
      *
-     * We need to find best matches, because "adjustedScore" for non-best matches can be better for some worse
-     * "score", what is not so good. It happen because some tags can be repeated many times, or since we are
-     * using not so good tokens comparison. Best matches find will produce the same similarity like in patches
-     * pane.
+     * We need to find best matches, because "adjustedScore" for non-best
+     * matches can be better for some worse "score", what is not so good. It
+     * happen because some tags can be repeated many times, or since we are
+     * using not so good tokens comparison. Best matches find will produce the
+     * same similarity like in patches pane.
      *
-     * Similarity calculates between tokens tokenized by ITokenizer.tokenizeAllExactly() (adjustedScore)
+     * Similarity calculates between tokens tokenized by
+     * ITokenizer.tokenizeAllExactly() (adjustedScore)
      */
     Optional<MatchStatCounts> calcSimilarity(List<SourceTextEntry> untranslatedEntries) {
         // If we have more than one available processor then we do the
@@ -276,13 +283,11 @@ public class CalcMatchStatistics extends LongProcessThread {
         long startTime = System.currentTimeMillis();
         MatchStatCounts result = null;
         try {
-            result = stream.collect(MatchStatCounts::new,
-                    (counts, ste) -> {
-                        checkInterrupted();
-                        counts.addForPercents(calcMaxSimilarity(ste), new StatCount(ste));
-                        entryProcessed();
-                    },
-                    MatchStatCounts::addCounts);
+            result = stream.collect(MatchStatCounts::new, (counts, ste) -> {
+                checkInterrupted();
+                counts.addForPercents(calcMaxSimilarity(ste), new StatCount(ste));
+                entryProcessed();
+            }, MatchStatCounts::addCounts);
         } catch (StoppedException | LongProcessInterruptedException ex) {
         }
         long endTime = System.currentTimeMillis();
@@ -299,7 +304,8 @@ public class CalcMatchStatistics extends LongProcessThread {
         int maxSimilarity = 0;
         CACHE: for (NearString near : nears) {
             final Token[] candTokens = localFinder.tokenizeAll(near.source);
-            int newSimilarity = FuzzyMatcher.calcSimilarity(distanceCalculator.get(), strTokensStem, candTokens);
+            int newSimilarity = FuzzyMatcher.calcSimilarity(distanceCalculator.get(), strTokensStem,
+                    candTokens);
             if (near.fuzzyMark) {
                 newSimilarity -= FindMatches.PENALTY_FOR_FUZZY;
             }
@@ -316,7 +322,8 @@ public class CalcMatchStatistics extends LongProcessThread {
     String removeXmlTags(SourceTextEntry ste) {
         String srcNoXmlTags = ste.getSrcText();
         for (ProtectedPart pp : ste.getProtectedParts()) {
-            srcNoXmlTags = srcNoXmlTags.replace(pp.getTextInSourceSegment(), pp.getReplacementMatchCalculation());
+            srcNoXmlTags = srcNoXmlTags.replace(pp.getTextInSourceSegment(),
+                    pp.getReplacementMatchCalculation());
         }
         return srcNoXmlTags;
     }

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -91,7 +91,7 @@ public class CalcMatchStatistics extends LongProcessThread {
 
     private final IStatsConsumer callback;
     private final boolean perFile;
-    private int entriesToProcess;
+    protected int entriesToProcess;
 
     /** Already processed segments. Used for repetitions detect. */
     private final Set<String> alreadyProcessedInFile = new HashSet<String>();

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -97,9 +97,9 @@ public class CalcMatchStatistics extends LongProcessThread {
     private final Set<String> alreadyProcessedInFile = new HashSet<String>();
     private final Set<String> alreadyProcessedInProject = new HashSet<String>();
 
-    private ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal.withInitial(LevenshteinDistance::new);
-    private ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
-            () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false));
+    private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal.withInitial(LevenshteinDistance::new);
+    private final ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
+            () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false, true));
     private final StringBuilder textForLog = new StringBuilder();
 
     public CalcMatchStatistics(IStatsConsumer callback, boolean perFile) {

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -101,7 +101,7 @@ public class CalcMatchStatistics extends LongProcessThread {
     private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal
             .withInitial(LevenshteinDistance::new);
     private final ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
-            () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false, true));
+            () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false, false));
     private final StringBuilder textForLog = new StringBuilder();
 
     public CalcMatchStatistics(IStatsConsumer callback, boolean perFile) {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -143,7 +143,7 @@ public class FindMatches {
      */
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
             boolean searchExactlyTheSame) {
-        this(project, maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, false);
+        this(project, maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, true);
     }
 
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -65,15 +65,17 @@ import org.omegat.util.Token;
 /**
  * Class to find matches by specified criteria.
  *
- * Since we can use stemmers to prepare tokens, we should use 3-pass comparison of similarity. Similarity will
- * be calculated in 3 steps:
+ * Since we can use stemmers to prepare tokens, we should use 3-pass comparison
+ * of similarity. Similarity will be calculated in 3 steps:
  *
- * 1. Split original segment into word-only tokens using stemmer (with stop words list), then compare tokens.
+ * 1. Split original segment into word-only tokens using stemmer (with stop
+ * words list), then compare tokens.
  *
- * 2. Split original segment into word-only tokens without stemmer, then compare tokens.
+ * 2. Split original segment into word-only tokens without stemmer, then compare
+ * tokens.
  *
- * 3. Split original segment into not-only-words tokens (including numbers and tags) without stemmer, then
- * compare tokens.
+ * 3. Split original segment into not-only-words tokens (including numbers and
+ * tags) without stemmer, then compare tokens.
  *
  * This class is not thread safe ! Must be used in the one thread only.
  *
@@ -85,9 +87,9 @@ import org.omegat.util.Token;
 public class FindMatches {
 
     /**
-    * According to gettext source code, PO fuzzies are created above 60%
-    * https://sourceforge.net/p/omegat/feature-requests/1258/
-    */
+     * According to gettext source code, PO fuzzies are created above 60%
+     * https://sourceforge.net/p/omegat/feature-requests/1258/
+     */
     static final int PENALTY_FOR_FUZZY = 40;
     private static final int PENALTY_FOR_REMOVED = 5;
     private static final int SUBSEGMENT_MATCH_THRESHOLD = 85;
@@ -134,8 +136,9 @@ public class FindMatches {
 
     /**
      * @param searchExactlyTheSame
-     *            allows to search similarities with the same text as source segment. This mode used only for
-     *            separate sentence match in paragraph project, i.e. where source is just part of current
+     *            allows to search similarities with the same text as source
+     *            segment. This mode used only for separate sentence match in
+     *            paragraph project, i.e. where source is just part of current
      *            source.
      */
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
@@ -144,7 +147,7 @@ public class FindMatches {
     }
 
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
-                       boolean searchExactlyTheSame, boolean ignoreThreshold) {
+            boolean searchExactlyTheSame, boolean ignoreThreshold) {
         this.project = project;
         this.tok = project.getSourceTokenizer();
         this.srcLocale = project.getProjectProperties().getSourceLanguage().getLocale();
@@ -158,15 +161,16 @@ public class FindMatches {
         this.ignoreThreshold = ignoreThreshold;
     }
 
-        public List<NearString> search(String searchText, boolean requiresTranslation, boolean fillSimilarityData,
-                                   IStopped stop) throws StoppedException {
+    public List<NearString> search(String searchText, boolean requiresTranslation, boolean fillSimilarityData,
+            IStopped stop) throws StoppedException {
         result = new ArrayList<>(OConsts.MAX_NEAR_STRINGS + 1);
 
         srcText = searchText;
         removedText = "";
 
         // remove part that is to be removed according to user settings.
-        // Rationale: it might be a big string influencing the 'editing distance', while it is not really part
+        // Rationale: it might be a big string influencing the 'editing
+        // distance', while it is not really part
         // of the translatable text
         if (removePattern != null) {
             StringBuilder removedBuffer = new StringBuilder();
@@ -220,10 +224,9 @@ public class FindMatches {
             }
         });
 
-
         /*
-          Penalty applied for fuzzy matches in another language (if no match in the
-          target language was found).
+         * Penalty applied for fuzzy matches in another language (if no match in
+         * the target language was found).
          */
         int foreignPenalty = Preferences.getPreferenceDefault(Preferences.PENALTY_FOR_FOREIGN_MATCHES,
                 Preferences.PENALTY_FOR_FOREIGN_MATCHES_DEFAULT);
@@ -238,7 +241,8 @@ public class FindMatches {
             for (ITMXEntry tmen : en.getValue().getEntries()) {
                 checkStopped(stop);
                 if (tmen.getSourceText() == null) {
-                    // Not all TMX entries have a source; in that case there can be no meaningful match, so skip.
+                    // Not all TMX entries have a source; in that case there can
+                    // be no meaningful match, so skip.
                     continue;
                 }
                 if (requiresTranslation && tmen.getTranslationText() == null) {
@@ -250,9 +254,10 @@ public class FindMatches {
                     tmenPenalty += foreignPenalty;
                 }
 
-                processEntry(null, tmen.getSourceText(), tmen.getTranslationText(), NearString.MATCH_SOURCE.TM, false, tmenPenalty,
-                        en.getKey(), tmen.getCreator(), tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(),
-                        tmen.getProperties(), ignoreThreshold);
+                processEntry(null, tmen.getSourceText(), tmen.getTranslationText(),
+                        NearString.MATCH_SOURCE.TM, false, tmenPenalty, en.getKey(), tmen.getCreator(),
+                        tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(), tmen.getProperties(),
+                        ignoreThreshold);
             }
         }
 
@@ -267,7 +272,8 @@ public class FindMatches {
         }
 
         if (separateSegmentMatcher != null) {
-            // split paragraph even when segmentation disabled, then find matches for every segment
+            // split paragraph even when segmentation disabled, then find
+            // matches for every segment
             List<StringBuilder> spaces = new ArrayList<StringBuilder>();
             List<Rule> brules = new ArrayList<Rule>();
             Language sourceLang = project.getProjectProperties().getSourceLanguage();
@@ -281,8 +287,8 @@ public class FindMatches {
                     String onesrc = segments.get(i);
 
                     // find match for separate segment
-                    List<NearString> segmentMatch = separateSegmentMatcher.search(onesrc, requiresTranslation, false,
-                            stop);
+                    List<NearString> segmentMatch = separateSegmentMatcher.search(onesrc, requiresTranslation,
+                            false, stop);
                     if (!segmentMatch.isEmpty()
                             && segmentMatch.get(0).scores[0].score >= SUBSEGMENT_MATCH_THRESHOLD) {
                         fsrc.add(segmentMatch.get(0).source);
@@ -342,9 +348,10 @@ public class FindMatches {
      * @param props
      *            TMX properties
      */
-    protected void processEntry(EntryKey key, String source, String translation, NearString.MATCH_SOURCE comesFrom,
-                                boolean fuzzy, int penalty, String tmxName, String creator, long creationDate,
-                                String changer, long changedDate, List<TMXProp> props, boolean ignoreThreashold) {
+    protected void processEntry(EntryKey key, String source, String translation,
+            NearString.MATCH_SOURCE comesFrom, boolean fuzzy, int penalty, String tmxName, String creator,
+            long creationDate, String changer, long changedDate, List<TMXProp> props,
+            boolean ignoreThreashold) {
         // remove part that is to be removed prior to tokenize
         String realSource = source;
         int realPenaltyForRemoved = 0;
@@ -355,7 +362,8 @@ public class FindMatches {
                 entryRemovedText.append(removeMatcher.group());
             }
             realSource = removeMatcher.replaceAll("");
-            // calculate penalty if something has been removed, otherwise different strings get 100% match.
+            // calculate penalty if something has been removed, otherwise
+            // different strings get 100% match.
             if (!entryRemovedText.toString().equals(removedText)) {
                 // penalty for different 'removed'-part
                 realPenaltyForRemoved = PENALTY_FOR_REMOVED;
@@ -410,8 +418,8 @@ public class FindMatches {
         }
 
         // BUGS#1236
-        if (!ignoreThreashold && similarityStem < fuzzyMatchThreshold && similarityNoStem < fuzzyMatchThreshold
-                && simAdjusted < fuzzyMatchThreshold) {
+        if (!ignoreThreashold && similarityStem < fuzzyMatchThreshold
+                && similarityNoStem < fuzzyMatchThreshold && simAdjusted < fuzzyMatchThreshold) {
             return;
         }
 
@@ -420,8 +428,8 @@ public class FindMatches {
     }
 
     /**
-     * Check if entry have a chance to be added to result list. If no, there is no sense to calculate other
-     * parameters.
+     * Check if entry have a chance to be added to result list. If no, there is
+     * no sense to calculate other parameters.
      *
      * @param simStem
      *            similarity with stemming
@@ -447,7 +455,8 @@ public class FindMatches {
     }
 
     /**
-     * Add near string into result list. Near strings sorted by "similarity,simAdjusted"
+     * Add near string into result list. Near strings sorted by
+     * "similarity,simAdjusted"
      */
     protected void addNearString(final EntryKey key, final String source, final String translation,
             NearString.MATCH_SOURCE comesFrom, final boolean fuzzy, final int similarity,
@@ -459,11 +468,13 @@ public class FindMatches {
         for (int i = 0; i < result.size(); i++) {
             NearString st = result.get(i);
             if (source.equals(st.source) && Objects.equals(translation, st.translation)) {
-                // Consolidate identical matches from different sources into a single NearString with
+                // Consolidate identical matches from different sources into a
+                // single NearString with
                 // multiple project entries.
-                result.set(i, NearString.merge(st, key, source, translation, comesFrom, fuzzy, similarity,
-                        similarityNoStem, simAdjusted, similarityData, tmxName, creator, creationDate,
-                        changer, changedDate, tuProperties));
+                result.set(i,
+                        NearString.merge(st, key, source, translation, comesFrom, fuzzy, similarity,
+                                similarityNoStem, simAdjusted, similarityData, tmxName, creator, creationDate,
+                                changer, changedDate, tuProperties));
                 return;
             }
             if (st.scores[0].score < similarity) {
@@ -487,9 +498,10 @@ public class FindMatches {
             pos = i + 1;
         }
 
-        result.add(pos, new NearString(key, source, translation, comesFrom, fuzzy, similarity,
-                similarityNoStem, simAdjusted, similarityData, tmxName, creator, creationDate, changer,
-                changedDate, tuProperties));
+        result.add(pos,
+                new NearString(key, source, translation, comesFrom, fuzzy, similarity, similarityNoStem,
+                        simAdjusted, similarityData, tmxName, creator, creationDate, changer, changedDate,
+                        tuProperties));
         if (result.size() > maxCount) {
             result.remove(result.size() - 1);
         }
@@ -503,36 +515,36 @@ public class FindMatches {
     Map<String, Token[]> tokenizeAllCache = new HashMap<String, Token[]>();
 
     public Token[] tokenizeStem(String str) {
-        Token[] result = tokenizeStemCache.get(str);
-        if (result == null) {
-            result = tok.tokenizeWords(str, ITokenizer.StemmingMode.MATCHING);
-            tokenizeStemCache.put(str, result);
+        Token[] tokens = tokenizeStemCache.get(str);
+        if (tokens == null) {
+            tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.MATCHING);
+            tokenizeStemCache.put(str, tokens);
         }
-        return result;
+        return tokens;
     }
 
     public Token[] tokenizeNoStem(String str) {
         // No-stemming token comparisons are intentionally case-insensitive
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
-        Token[] result = tokenizeNoStemCache.get(str);
-        if (result == null) {
-            result = tok.tokenizeWords(str, ITokenizer.StemmingMode.NONE);
-            tokenizeNoStemCache.put(str, result);
+        Token[] tokens = tokenizeNoStemCache.get(str);
+        if (tokens == null) {
+            tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.NONE);
+            tokenizeNoStemCache.put(str, tokens);
         }
-        return result;
+        return tokens;
     }
 
     public Token[] tokenizeAll(String str) {
         // Verbatim token comparisons are intentionally case-insensitive.
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
-        Token[] result = tokenizeAllCache.get(str);
-        if (result == null) {
-            result = tok.tokenizeVerbatim(str);
-            tokenizeAllCache.put(str, result);
+        Token[] tokens = tokenizeAllCache.get(str);
+        if (tokens == null) {
+            tokens = tok.tokenizeVerbatim(str);
+            tokenizeAllCache.put(str, tokens);
         }
-        return result;
+        return tokens;
     }
 
     protected void checkStopped(IStopped stop) throws StoppedException {
@@ -542,7 +554,8 @@ public class FindMatches {
     }
 
     /**
-     * Process will throw this exception if it stopped.All callers must catch it and just skip.
+     * Process will throw this exception if it stopped.All callers must catch it
+     * and just skip.
      */
     @SuppressWarnings("serial")
     public static class StoppedException extends RuntimeException {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -132,7 +132,7 @@ public class FindMatches {
 
     private final int fuzzyMatchThreshold;
 
-    private final boolean ignoreThreshold;
+    private final boolean applyThreshold;
 
     /**
      * @param searchExactlyTheSame
@@ -147,7 +147,7 @@ public class FindMatches {
     }
 
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
-            boolean searchExactlyTheSame, boolean ignoreThreshold) {
+            boolean searchExactlyTheSame, boolean applyThreshold) {
         this.project = project;
         this.tok = project.getSourceTokenizer();
         this.srcLocale = project.getProjectProperties().getSourceLanguage().getLocale();
@@ -158,7 +158,7 @@ public class FindMatches {
         }
         this.fuzzyMatchThreshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
                 OConsts.FUZZY_MATCH_THRESHOLD);
-        this.ignoreThreshold = ignoreThreshold;
+        this.applyThreshold = applyThreshold;
     }
 
     public List<NearString> search(String searchText, boolean requiresTranslation, boolean fillSimilarityData,
@@ -203,7 +203,7 @@ public class FindMatches {
                     String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
                     processEntry(null, source, trans.translation, NearString.MATCH_SOURCE.MEMORY, false, 0,
                             fileName, trans.creator, trans.creationDate, trans.changer, trans.changeDate,
-                            null, ignoreThreshold);
+                            null);
                 }
             });
         }
@@ -220,7 +220,7 @@ public class FindMatches {
                 String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
                 processEntry(source, source.sourceText, trans.translation, NearString.MATCH_SOURCE.MEMORY,
                         false, 0, fileName, trans.creator, trans.creationDate, trans.changer,
-                        trans.changeDate, null, ignoreThreshold);
+                        trans.changeDate, null);
             }
         });
 
@@ -256,8 +256,7 @@ public class FindMatches {
 
                 processEntry(null, tmen.getSourceText(), tmen.getTranslationText(),
                         NearString.MATCH_SOURCE.TM, false, tmenPenalty, en.getKey(), tmen.getCreator(),
-                        tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(), tmen.getProperties(),
-                        ignoreThreshold);
+                        tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(), tmen.getProperties());
             }
         }
 
@@ -267,7 +266,7 @@ public class FindMatches {
             if (ste.getSourceTranslation() != null) {
                 processEntry(ste.getKey(), ste.getSrcText(), ste.getSourceTranslation(),
                         NearString.MATCH_SOURCE.MEMORY, ste.isSourceTranslationFuzzy(), 0, ste.getKey().file,
-                        "", 0, "", 0, null, ignoreThreshold);
+                        "", 0, "", 0, null);
             }
         }
 
@@ -303,7 +302,7 @@ public class FindMatches {
                 // glue found translations
                 String foundTrans = Core.getSegmenter().glue(sourceLang, targetLang, ftrans, spaces, brules);
                 processEntry(null, foundSrc, foundTrans, NearString.MATCH_SOURCE.TM, false, 0, "", "", 0, "",
-                        0, null, ignoreThreshold);
+                        0, null);
             }
         }
 
@@ -350,8 +349,7 @@ public class FindMatches {
      */
     protected void processEntry(EntryKey key, String source, String translation,
             NearString.MATCH_SOURCE comesFrom, boolean fuzzy, int penalty, String tmxName, String creator,
-            long creationDate, String changer, long changedDate, List<TMXProp> props,
-            boolean ignoreThreashold) {
+            long creationDate, String changer, long changedDate, List<TMXProp> props) {
         // remove part that is to be removed prior to tokenize
         String realSource = source;
         int realPenaltyForRemoved = 0;
@@ -417,8 +415,8 @@ public class FindMatches {
             return;
         }
 
-        // BUGS#1236
-        if (!ignoreThreashold && similarityStem < fuzzyMatchThreshold
+        // BUGS#1236 - stat display does not use threshold config check
+        if (applyThreshold && similarityStem < fuzzyMatchThreshold
                 && similarityNoStem < fuzzyMatchThreshold && simAdjusted < fuzzyMatchThreshold) {
             return;
         }

--- a/test/data/filters/po/file-POFilter-match-stat-en-ca.po
+++ b/test/data/filters/po/file-POFilter-match-stat-en-ca.po
@@ -1,0 +1,382 @@
+#
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"X-Language: ca\n"
+
+msgid "Click here to activate your account"
+msgstr ""
+
+msgid "Sorry, this account has already been activated."
+msgstr ""
+
+msgid "Return to %{title}"
+msgstr ""
+
+msgid "<b>%{target_username}</b> is now an administrator."
+msgstr ""
+
+msgid ""
+"Are you sure you want <b>%{target_username} (%{target_email})</b> to be an "
+"administrator?"
+msgstr ""
+
+msgid "Grant Admin Access"
+msgstr ""
+
+msgid "Confirm Admin Account"
+msgstr ""
+
+msgid ""
+"Sorry, this account confirmation link is no longer valid. Perhaps your "
+"account is already active?"
+msgstr ""
+
+msgid ""
+"A moderator must manually approve your new account before you can access "
+"this forum. You'll get an email when your account is approved!"
+msgstr ""
+
+msgid "Continue to %{site_name}"
+msgstr ""
+
+msgid ""
+"We cannot detect if your account was created, please ensure you have cookies "
+"enabled."
+msgstr ""
+
+msgid "Your new account is confirmed; you will be redirected to the home page."
+msgstr ""
+
+msgid "Welcome to %{site_name}!"
+msgstr ""
+
+msgid "There was an error loading that post."
+msgstr ""
+
+msgid "%{attribute} %{message}"
+msgstr ""
+
+msgid "<b>%{attribute}</b>: %{message}"
+msgstr ""
+
+msgid "must be accepted"
+msgstr ""
+
+msgid "doesn't match %{attribute}"
+msgstr ""
+
+msgid "contains the following censored words: %{censored_words}"
+msgstr ""
+
+msgid "can't have emoji"
+msgstr ""
+
+msgid "can't be empty"
+msgstr ""
+
+msgid "must be equal to %{count}"
+msgstr ""
+
+msgid "must be even"
+msgstr ""
+
+msgid "is reserved"
+msgstr ""
+
+msgid "must be greater than %{count}"
+msgstr ""
+
+msgid "must be greater than or equal to %{count}"
+msgstr ""
+
+msgid "has already been used"
+msgstr ""
+
+msgid "is not included in the list"
+msgstr ""
+
+msgid "is invalid"
+msgstr ""
+
+msgid "Invalid boolean."
+msgstr ""
+
+msgid "'%{tz}' is not a valid timezone"
+msgstr ""
+
+msgid "is already included in an existing rule"
+msgstr ""
+
+msgid "seems unclear, is it a complete sentence?"
+msgstr ""
+
+msgid "must be less than %{count}"
+msgstr ""
+
+msgid "must be less than or equal to %{count}"
+msgstr ""
+
+msgid "can't have more than %{max_emojis_count} emoji"
+msgstr ""
+
+msgid "is not a number"
+msgstr ""
+
+msgid "must be an integer"
+msgstr ""
+
+msgid "must be odd"
+msgstr ""
+
+msgid "must be other than %{count}"
+msgstr ""
+
+msgid "must be blank"
+msgstr ""
+
+msgid "Validation failed: %{errors}"
+msgstr ""
+
+msgid "Cannot delete record because a dependent %{record} exists"
+msgstr ""
+
+msgid "Cannot delete record because dependent %{record} exist"
+msgstr ""
+
+msgid "has already been taken"
+msgstr ""
+
+msgid "is too long (maximum is %{count} character)"
+msgstr ""
+
+msgid "is too long (maximum is %{count} characters)"
+msgstr ""
+
+msgid "is limited to %{max} characters; you entered %{length}."
+msgstr ""
+
+msgid "is too short (minimum is %{count} character)"
+msgstr ""
+
+msgid "is too short (minimum is %{count} characters)"
+msgstr ""
+
+msgid "is the wrong length (should be %{count} character)"
+msgstr ""
+
+msgid "is the wrong length (should be %{count} characters)"
+msgstr ""
+
+msgid "You cannot select a category used in another list."
+msgstr ""
+
+msgid ""
+"You cannot enable usage of the S3 inventory unless you've enabled S3 uploads."
+msgstr ""
+
+msgid "You specified a category that does not exist"
+msgstr ""
+
+msgid ""
+"You cannot use S3 as backup location unless you've provided the "
+"'%{setting_name}'."
+msgstr ""
+
+msgid ""
+"You cannot use the same bucket for 's3_upload_bucket' and "
+"'s3_backup_bucket'. Choose a different bucket or use a different path for "
+"each bucket."
+msgstr ""
+
+msgid ""
+"You cannot enable uploads to S3 unless you've provided the "
+"'s3_upload_bucket'."
+msgstr ""
+
+msgid "There were problems with the following fields:"
+msgstr ""
+
+msgid "%{count} error prohibited this %{model} from being saved"
+msgstr ""
+
+msgid "%{count} errors prohibited this %{model} from being saved"
+msgstr ""
+
+msgid "Category Name"
+msgstr ""
+
+msgid "Body"
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid "Featured Link"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "About Me"
+msgstr ""
+
+msgid "There was an error loading that post."
+msgstr ""
+
+msgid "%{attribute} %{message}"
+msgstr ""
+
+msgid "<b>%{attribute}</b>: %{message}"
+msgstr ""
+
+msgid "must be accepted"
+msgstr ""
+
+msgid "can't be blank"
+msgstr ""
+
+msgid "doesn't match %{attribute}"
+msgstr ""
+
+msgid "You specified a category that does not exist"
+msgstr ""
+
+msgid ""
+"You cannot use S3 as backup location unless you've provided the "
+"'%{setting_name}'."
+msgstr ""
+
+msgid ""
+"You cannot use the same bucket for 's3_upload_bucket' and "
+"'s3_backup_bucket'. Choose a different bucket or use a different path for "
+"each bucket."
+msgstr ""
+
+msgid ""
+"You cannot enable uploads to S3 unless you've provided the "
+"'s3_upload_bucket'."
+msgstr ""
+
+msgid "There were problems with the following fields:"
+msgstr ""
+
+msgid "%{count} error prohibited this %{model} from being saved"
+msgstr ""
+
+msgid "Used an Emoji in a Post"
+msgstr ""
+
+msgid ""
+"This badge is granted the first time you add an Emoji to your post :"
+"thumbsup:. Emoji let you convey emotion in your posts, from happiness :"
+"smiley: to sadness :anguished: to anger :angry: and everything in between :"
+"sunglasses:. Just type a : (colon) or press the Emoji toolbar button in the "
+"editor to select from hundreds of choices :ok_hand:\n"
+msgstr ""
+
+msgid "First Emoji"
+msgstr ""
+
+msgid "Flagged a post"
+msgstr ""
+
+msgid ""
+"This badge is granted the first time you flag a post. Flagging is how we all "
+"help keep this a nice place for everyone. If you notice any posts that "
+"require moderator attention for any reason please don’t hesitate to flag. If "
+"you see a problem, :flag_black: flag it!\n"
+msgstr ""
+
+msgid "First Flag"
+msgstr ""
+
+msgid "Liked a post"
+msgstr ""
+
+msgid ""
+"This badge is granted the first time you like a post using the :heart: "
+"button. Liking posts is a great way to let your fellow community members "
+"know that what they posted was interesting, useful, cool, or fun. Share the "
+"love!\n"
+msgstr ""
+
+msgid "First Like"
+msgstr ""
+
+msgid "Added a link to another topic"
+msgstr ""
+
+msgid ""
+"This badge is granted the first time you add a link to another topic. "
+"Linking topics helps fellow readers find interesting related conversations, "
+"by showing the connections between topics in both directions. Link freely!\n"
+msgstr ""
+
+msgid "First Link"
+msgstr ""
+
+msgid "Mentioned a user in a post"
+msgstr ""
+
+msgid ""
+"This badge is granted the first time you mention someone’s @username in your "
+"post. Each mention generates a notification to that person, so they know "
+"about your post. Just begin typing @ (at symbol) to mention any user or, if "
+"allowed, group – it’s a convenient way to bring something to their "
+"attention.\n"
+msgstr ""
+
+msgid "First Mention"
+msgstr ""
+
+msgid "Posted a link that was oneboxed"
+msgstr ""
+
+msgid "Great Topic"
+msgstr ""
+
+msgid ""
+"This badge is granted when you use all %{max_likes_per_day} of your daily "
+"likes for 5 days. Thanks for taking the time actively encouraging the best "
+"conversations every day!\n"
+msgstr ""
+
+msgid "Higher Love"
+msgstr ""
+
+msgid "Posted an external link with 300 clicks"
+msgstr ""
+
+msgid ""
+"This badge is granted when a link you shared gets 300 clicks. Thanks for "
+"posting a fascinating link that drove the conversation forward and "
+"illuminated the discussion!\n"
+msgstr ""
+
+msgid "Hot Link"
+msgstr ""
+
+msgid ""
+"<a href=\"https://blog.discourse.org/2018/06/understanding-discourse-trust-"
+"levels/\">Granted</a> invitations, group messaging, more likes"
+msgstr ""
+
+msgid ""
+"This badge is granted when you reach trust level 2. Thanks for participating "
+"over a period of weeks to truly join our community. You can now send "
+"invitations from your user page or individual topics, create group personal "
+"messages, and have more likes per day.\n"
+msgstr ""
+
+msgid "New email: %{email}"
+msgstr ""
+
+msgid "Old email: %{email}"
+msgstr ""
+
+msgid "Change your email address"
+msgstr ""
+
+msgid "Ownership transferred"
+msgstr ""

--- a/test/data/tmx/empty.tmx
+++ b/test/data/tmx/empty.tmx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx11.dtd">
+<tmx version="1.1">
+  <header creationtool="OmegaT" o-tmf="OmegaT TMX" adminlang="EN-US" datatype="plaintext" creationtoolversion="6.0.0_0_1bf1729c" segtype="sentence" srclang="en"/>
+  <body>
+<!-- Default translations -->
+<!-- Alternative translations -->
+  </body>
+</tmx>

--- a/test/data/tmx/test-match-stat-en-ca.tmx
+++ b/test/data/tmx/test-match-stat-en-ca.tmx
@@ -1,0 +1,2153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+  <header creationtool="Translate Toolkit" creationtoolversion="3.10.1" segtype="sentence" o-tmf="UTF-8" adminlang="en" srclang="en" datatype="PlainText"/>
+  <body>
+    <tu> <!-- match -->
+      <tuv xml:lang="en">
+        <seg>&lt;b&gt;%{target_username}&lt;/b&gt; is now an administrator.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>&lt;b&gt;%{target_username}&lt;/b&gt; és ara administrador.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Are you sure you want &lt;b&gt;%{target_username} (%{target_email})&lt;/b&gt; to be an administrator?</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Esteu segur que voleu que &lt;b&gt;%{target_username}(%{target_email})&lt;/b&gt; sigui administrador?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Grant Admin Access</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Atorga accés d'administrador</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Confirm Admin Account</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Confirma el compte d'administrador</seg>
+      </tuv>
+    </tu>
+    <tu> <!-- partial match -->
+      <tuv xml:lang="en">
+        <seg>Sorry, this account confirmation link is no longer valid. Perhaps your account is
+        already</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquest enllaç ja no és vàlid per a confirmar el compte. Potser el vostre compte ja és actiu?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Continue to</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Continua a %{site_name} </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>We cannot detect if your account was created, please ensure you have cookies enabled.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podem detectar si el vostre compte ha estat creat. Assegureu-vos que teniu les galetes activades.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Your new account is confirmed; you will be redirected to the home page.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>El vostre nou compte està confirmat; us redirigirem a la pàgina principal.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Welcome to %{site_name}!</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Benvingut a %{site_name}!</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to &lt;br&gt;&lt;a href="https://meta.discourse.org/t/76575"&gt;https://meta.discourse.org/t/76575&lt;/a&gt;</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>L'identificador del compte de Google d'aquest compte ha canviat; es requereix la intervenció de l'equip responsable per motius de seguretat. Poseu-vos en contacte amb l'equip responsable i dirigiu-los a &lt;br&gt; &lt;a href="https://meta.discourse.org/t/76575"&gt;https://meta.discourse.org/t/76575&lt;/a&gt;</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>There was an error loading that post.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Hi ha hagut un error en carregar aquesta publicació.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{attribute} %{message}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{attribute} %{message}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>&lt;b&gt;%{attribute}&lt;/b&gt;: %{message}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>&lt;b&gt;%{attribute}&lt;/b&gt;: %{message}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be accepted</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>s'ha d'acceptar</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't be blank</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot ser buit</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>doesn't match %{attribute}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no coincideix amb %{attribute}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>contains the following censored words: %{censored_words}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>conté les següents paraules censurades: %{censored_words}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't have emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot haver-hi emojis</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't be empty</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot ser buit</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser igual a %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be even</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre parell</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is reserved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és reservat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be greater than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser més gran que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be greater than or equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser més gran o igual que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>has already been used</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja s'ha fet servir</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not included in the list</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és inclòs en la llista</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is invalid</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és vàlid</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Invalid boolean.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Booleà no vàlid.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>'%{tz}' is not a valid timezone</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>'%{tz}' no és una zona horària vàlida</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is already included in an existing rule</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja és inclòs en una regla existent</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>seems unclear, is it a complete sentence?</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no sembla clar. És una frase sencera?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be less than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser menys de %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be less than or equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser igual o menor que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't have more than %{max_emojis_count} emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot haver-hi més de %{max_emojis_count} emojis</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not a number</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és una xifra</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be an integer</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre enter</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be odd</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre senar</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be other than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser diferent de %{count}</seg>
+      </tuv>
+    </tu>
+
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Validation failed: %{errors}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha fallat la validació: %{errors}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Cannot delete record because a dependent %{record} exists</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es pot suprimir el registre perquè existeix un %{record} que en depèn.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Cannot delete record because dependent %{record} exist</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es pot suprimir el registre perquè existeix %{record} que en depèn.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>has already been taken</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja ha estat agafat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too long (maximum is %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa llarg (el màxim són %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too long (maximum is %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa llarg (el màxim són %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is limited to %{max} characters; you entered %{length}.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és limitat a %{max} caràcters; n'heu introduït %{length}.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too short (minimum is %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa curt (el mínim és %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too short (minimum is %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa curt (el mínim són %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the wrong length (should be %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>té una mida errònia (hauria de contenir %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the wrong length (should be %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>té una longitud errònia (hauria de contenir %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot select a category used in another list.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu triar una categoria emprada en una altra llista.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot enable usage of the S3 inventory unless you've enabled S3 uploads.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu habilitar l'inventari a S3 si no heu habilitat la càrrega a S3.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You specified a category that does not exist</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Heu especificat una categoria que no existeix</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot use S3 as backup location unless you've provided the '%{setting_name}'.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu fer serivr S3 com a localització de còpia de seguretat si no heu proporcionat el '%{setting_name}'.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot use the same bucket for 's3_upload_bucket' and 's3_backup_bucket'. Choose a different bucket or use a different path for each bucket.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu fer servir el mateix bucket per a 's3_upload_bucket' i 's3_backup_bucket'. Trieu un bucket diferent o feu servir un camí diferent per a cada bucket.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot enable uploads to S3 unless you've provided the 's3_upload_bucket'.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu activar càrregues a S3 si no heu proporcionat el 's3_upload_bucket'.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>There were problems with the following fields:</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Hi ha hagut problemes amb els següents camps:</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{count} error prohibited this %{model} from being saved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{count} errors ha impedit desar aquest %{model} </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{count} errors prohibited this %{model} from being saved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{count} errors han impedit desar aquest %{model} </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Category Name</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Nom de la categoria</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Body</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Cos</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Category</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Categoria</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Featured Link</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Enllaç destacat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Title</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Títol</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>About Me</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Quant a mi</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to &lt;br&gt;&lt;a href="https://meta.discourse.org/t/76575"&gt;https://meta.discourse.org/t/76575&lt;/a&gt;</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>L'identificador del compte de Google d'aquest compte ha canviat; es requereix la intervenció de l'equip responsable per motius de seguretat. Poseu-vos en contacte amb l'equip responsable i dirigiu-los a &lt;br&gt; &lt;a href="https://meta.discourse.org/t/76575"&gt;https://meta.discourse.org/t/76575&lt;/a&gt;</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>There was an error loading that post.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Hi ha hagut un error en carregar aquesta publicació.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{attribute} %{message}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{attribute} %{message}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>&lt;b&gt;%{attribute}&lt;/b&gt;: %{message}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>&lt;b&gt;%{attribute}&lt;/b&gt;: %{message}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be accepted</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>s'ha d'acceptar</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't be blank</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot ser buit</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>doesn't match %{attribute}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no coincideix amb %{attribute}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>contains the following censored words: %{censored_words}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>conté les següents paraules censurades: %{censored_words}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't have emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot haver-hi emojis</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't be empty</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot ser buit</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser igual a %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be even</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre parell</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is reserved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és reservat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be greater than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser més gran que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be greater than or equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser més gran o igual que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>has already been used</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja s'ha fet servir</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not included in the list</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és inclòs en la llista</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is invalid</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és vàlid</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Invalid boolean.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Booleà no vàlid.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>'%{tz}' is not a valid timezone</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>'%{tz}' no és una zona horària vàlida</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is already included in an existing rule</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja és inclòs en una regla existent</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>seems unclear, is it a complete sentence?</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no sembla clar. És una frase sencera?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be less than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser menys de %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be less than or equal to %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser igual o menor que %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>can't have more than %{max_emojis_count} emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no pot haver-hi més de %{max_emojis_count} emojis</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not a number</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és una xifra</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be an integer</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre enter</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be odd</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser un nombre senar</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be other than %{count}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser diferent de %{count}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be blank</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser buit</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Validation failed: %{errors}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha fallat la validació: %{errors}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Cannot delete record because a dependent %{record} exists</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es pot suprimir el registre perquè existeix un %{record} que en depèn.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Cannot delete record because dependent %{record} exist</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es pot suprimir el registre perquè existeix %{record} que en depèn.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>has already been taken</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja ha estat agafat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too long (maximum is %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa llarg (el màxim són %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too long (maximum is %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa llarg (el màxim són %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is limited to %{max} characters; you entered %{length}.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és limitat a %{max} caràcters; n'heu introduït %{length}.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too short (minimum is %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa curt (el mínim és %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is too short (minimum is %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és massa curt (el mínim són %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the wrong length (should be %{count} character)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>té una mida errònia (hauria de contenir %{count} caràcter)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the wrong length (should be %{count} characters)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>té una longitud errònia (hauria de contenir %{count} caràcters)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not a valid color</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és un color vàlid</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is already in use by another emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ja està en ús per un altre emoji</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Post and reply must belong to the same topic.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Publicació i resposta han de pertànyer al mateix tema.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Sorry, you cannot send a personal message to that user.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu enviar un missatge personal a aquest usuari.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You must select a valid user.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Heu de triar un usuari vàlid.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Reply by email has been disabled.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>La resposta per correu electrònic ha estat deshabilitada.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>One of the users you are sending this message to could not be found.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Un dels usuaris a qui envieu el missatge no s'ha pogut trobar.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You can only send warnings to one user at a time.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Sols podeu enviar avisos a un usuari cada vegada.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You can only attach warnings to personal messages.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Sols podeu adjuntar advertències als missatges personals.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is invalid. URL should include http:// or https://.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és vàlid. L'URL hauria d'incloure http:// o https://.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>must be in the future.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>ha de ser en el futur.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>New registrations are not allowed from your IP address.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es permeten nous registres des de la vostra adreça IP.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>New registrations are not allowed from your IP address (maximum limit reached). Contact a staff member.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No es permeten registres nous des de la vostra adreça IP (s'ha arribat al límit màxim). Contacteu amb un membre de l'equip responsable.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que la vostra contrasenya.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is one of the 10000 most common passwords. Please use a more secure password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és una de les 10000 contrasenyes més freqüents. Feu servir una contrasenya més segura.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your current password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que la vostra contrasenya actual.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your email. Please use a more secure password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que el vostre correu electrònic. Feu servir una contrasenya més segura.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your name.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que el vostre nom.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your username. Please use a more secure password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que la vostra identitat. Feu servir una contrasenya més segura.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>has too many repeated characters. Please use a more secure password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>té massa caràcters repetits. Trieu una contrasenya més segura.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is the same as your password.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>és igual que la vostra contrasenya.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Reassigning a primary email to another user is not allowed.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No és permès reassignar una adreça de correu primària a un altre usuari.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Too many words for that action</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Massa paraules per a aquesta acció</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>URL is invalid. URL should includes http:// or https://. And no blank is allowed.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>L'URL no és vàlid. L'URL hauria d'incloure http:// o https://. I no es permeten espais en blanc.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot select a category used in another list.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu triar una categoria emprada en una altra llista.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot enable usage of the S3 inventory unless you've enabled S3 uploads.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu habilitar l'inventari a S3 si no heu habilitat la càrrega a S3.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You specified a category that does not exist</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Heu especificat una categoria que no existeix</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot use S3 as backup location unless you've provided the '%{setting_name}'.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu fer serivr S3 com a localització de còpia de seguretat si no heu proporcionat el '%{setting_name}'.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot use the same bucket for 's3_upload_bucket' and 's3_backup_bucket'. Choose a different bucket or use a different path for each bucket.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu fer servir el mateix bucket per a 's3_upload_bucket' i 's3_backup_bucket'. Trieu un bucket diferent o feu servir un camí diferent per a cada bucket.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>You cannot enable uploads to S3 unless you've provided the 's3_upload_bucket'.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podeu activar càrregues a S3 si no heu proporcionat el 's3_upload_bucket'.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>There were problems with the following fields:</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Hi ha hagut problemes amb els següents camps:</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{count} error prohibited this %{model} from being saved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{count} errors ha impedit desar aquest %{model} </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{count} errors prohibited this %{model} from being saved</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{count} errors han impedit desar aquest %{model} </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>sent!</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>enviat!</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>[%{email_prefix}] Confirm new Admin Account</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>[%{email_prefix}] Confirmeu un nou compte d'administració</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Please confirm that you'd like to add **%{target_username} (%{target_email})** as an administrator for your forum.
+
+[Confirm Administrator Account](%{admin_confirm_url})
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Confirmeu que voleu afegir **%{target_username} (%{target_email}) ** com a administrador del fòrum.
+
+[Confirma el compte d’administrador](%{admin_confirm_url})
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Admin Confirmation</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Confirmació d'administració</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Admin Email</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Correu d'administrador</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Invalid token.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Testimoni no vàlid.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Unknown email address.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Adreça de correu electrònic desconeguda.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Send Email</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Envia un correu</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Email Sent</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Correu enviat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Anonymous</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Anònim</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This topic is now a banner. It will appear at the top of every page until it is dismissed by the user.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquest tema és ara un bàner. Apareixerà al començament de cada pàgina fins que l'usuari el descarti.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This topic is no longer a banner. It will no longer appear at the top of every page.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquest tema ja no és un bàner. Ja no apareixerà més al començament de cada pàgina.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Banner Topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Converteix el tema en bàner</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Regular Topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Tema habitual</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>(connected)</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>(connectat)</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Failed to revoke your account with %{provider_name}.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No s'ha pogut revocar el vostre compte amb %{provider_name}.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Authentication method does not exist, or has been disabled.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>El mètode d'autenticació no existeix o ha estat deshabilitat. </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Sorry, we can't find any avatar associated with that email address. Can you try uploading it again?</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No podem trobar cap avatar associat amb aquesta adreça de correu. Proveu de pujar-lo de nou.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The backup file should be a .tar.gz archive.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>La còpia de seguretat hauria de ser un arxiu .tar.gz.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The file you are trying to upload already exists.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>El fitxer que intenteu pujar ja existeix.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The backup filename contains invalid characters. Valid characters are a-z 0-9 . - _.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>El nom de la còpia de seguretat conté caràcters no vàlids. Els caràcters vàlids són a-z 0-9 . - _.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>There is not enough space on disk to upload this backup.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>No hi ha prou espai en el disc per a desar-hi aquesta còpia de seguretat.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>An operation is currently running. Can't start a new job right now.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Hi ha una operació en marxa en aquest moment. Ara no es pot començar una tasca nova.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 5 likes on 300 posts</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 5 'M'agrada' en 300 publicacions</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you receive at least 5 likes on 300 different posts. Wow! The community admires your frequent, high quality contributions to the conversations here.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan rebeu 5 'M'agrada' en 300 publicacions diferents. Molt bé! La comunitat admira les vostres aportacions freqüents i d'alta gran qualitat a les converses!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Admired</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Admirat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Visited 100 consecutive days</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Visitat 100 dies consecutius</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for visiting 100 consecutive days. That’s more than three months!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix per visitar 100 dies consecutius. Són més de tres mesos!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Aficionado</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aficionat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Active member for a year, posted at least once</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Membre actiu des de fa un any, ha publicat almenys una vegada</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you’ve been a member for a year with at least one post in that year. Thank you for sticking around and contributing to our community. We couldn’t do it without you.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan heu estat membre durant un any amb almenys una publicació durant aquest any. Gràcies per continuar aquí i per contribuir a la comunitat. No podríem fer-ho sense la vostra presència.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Anniversary</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aniversari</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 1 like on 20 posts</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 1 'M'agrada' en 20 publicacions</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you receive at least one like on 20 different posts. The community is enjoying your contributions to the conversations here!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan rebeu 20 'M'agrada' en diferents publicacions. La comunitat gaudeix amb les vostres aportacions a les converses!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Appreciated</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Apreciat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Filled out &lt;a href="%{base_uri}/my/preferences/profile"&gt;profile&lt;/a&gt; information</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Informació del &lt;a href="%{base_uri}/my/preferences/profile"&gt;perfil&lt;/a&gt; emplenada</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for filling out &lt;a href="%{base_uri}/my/preferences/profile"&gt;your user profile&lt;/a&gt; and selecting a profile picture. Letting the community know a bit more about who you are and what you’re interested in makes for a better, more connected community. Join us!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia és concedida per omplir &lt;a href="%{base_uri}/my/preferences/profile"&gt;el perfil d'usuari&lt;/a&gt; i seleccionar una foto de perfil. Permetre que la comunitat sàpiga una mica més sobre qui sou i el que us interessa contribueix a una comunitat millor i més connectada. Uniu-vos!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Autobiographer</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Autobiògraf</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>%{display_name} badge on %{site_title}</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>%{display_name} insígnia en %{site_title}</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>&lt;a href="https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"&gt;Granted&lt;/a&gt; all essential community functions</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>&lt;a href="https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"&gt;Concedides&lt;/a&gt; totes les funcions essencials de la comunitat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you reach trust level 1. Thanks for sticking around and reading a few topics to learn what our community is about. New user restrictions have been lifted; you’ve been granted all essential community abilities, such as personal messaging, flagging, wiki editing, and the ability to post multiple images and links.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan arribeu al nivell de confiança 1. Gràcies per continuar per aquí i per llegir uns quants temes per a conèixer la comunitat. S'han aixecat les restriccions a usuaris nous, i se us han concedit totes les capacitats essencials de la comunitat, com ara la missatgeria personal, el marcatge amb banderes, l'edició de wiki i la possibilitat de publicar diverses imatges i enllaços.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Basic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Bàsic</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Invited 3 basic users</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Heu convidat 3 usuaris bàsics</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you’ve invited 3 people who subsequently spent enough time on the site to become basic users. A vibrant community needs a regular infusion of newcomers who regularly participate and add new voices to the conversations.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan heu convidat 3 persones que posteriorment han passat prou temps al lloc web per a convertir-se en usuaris bàsics. Una comunitat vibrant necessita una entrada regular de nouvinguts que hi participen habitualment i aporten veus noves a les converses.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Campaigner</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Activista</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Invited 5 members</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>S'han convidat 5 membres</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you’ve invited 5 people who subsequently spent enough time on the site to become full members. Wow! Thanks for expanding the diversity of our community with new members!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan heu convidat 5 persones que posteriorment han passat prou temps en el lloc web per a convertir-se en membres plens. Bé! Gràcies per ampliar la diversitat de la comunitat amb nous membres.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Champion</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Campió</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you use all %{max_likes_per_day} of your daily likes for 20 days. Wow! You’re a role model for encouraging your fellow community members!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan utilitzeu tots els vostres %{max_likes_per_day} 'm'agrada' diaris durant vint dies. Oh! Sou un model per a animar els companys de comunitat!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Crazy in Love</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Boig d'amor</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Visited 365 consecutive days</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Heu visitat 365 dies consecutius</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for visiting 365 consecutive days. Wow, an entire year!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix per visitar 365 dies consecutius. Caram, un any sencer!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Devotee</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Devot</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First post edit</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera edició de publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you edit one of your posts. While you won’t be able to edit your posts forever, editing is encouraged — you can improve the formatting, fix small mistakes, or add anything you missed when you originally posted. Edit to make your posts even better!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que editeu una de les vostres publicacions. Tot i que no podreu editar les vostres publicacions per sempre, es recomana editar-les: podeu millorar el format, corregir petits errors o afegir qualsevol cosa que us vau descuidar de fer quan la vau fer la publicació original. Editeu per a millorar les vostres publicacions!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Editor</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Editor</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Has 500 liked posts and gave 1000 likes</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Té 500 publicacions amb 'm'agrada' i ha donat 1.000 'M'agrada'</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you have 500 liked posts and give 1000 or more likes in return. Wow! You’re a model of generosity and mutual appreciation :two_hearts:.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan teniu 500 publicacions amb 'M'agrada' i heu fet 1000 o més 'M'agrada' a canvi. Molt bé! Sou un model de generositat i apreciació mútua :two_hearts:.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Empathetic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Empàtic</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Visited 10 consecutive days</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha visitat el lloc web 10 dies consecutius</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for visiting 10 consecutive days. Thanks for sticking with us for over a week!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix per visitar 10 dies consecutius. Gràcies per mantenir-vos amb nosaltres durant més d'una setmana.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Enthusiast</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Entusiasta</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Posted an external link with 1000 clicks</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha publicat un enllaç extern amb 1.000 clics</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when a link you shared gets 1000 clicks. Wow! You posted a link that significantly improved the conversation by adding essential detail, context, and information. Great work!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan l'enllaç que heu compartit obté 1000 clics. Heu publicat un enllaç que ha millorat molt la conversa afegint detalls, context i informació essencials. Bona feina!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Famous Link</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Enllaç famós</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Used an Emoji in a Post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha fet servir un emoji en una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you add an Emoji to your post :thumbsup:. Emoji let you convey emotion in your posts, from happiness :smiley: to sadness :anguished: to anger :angry: and everything in between :sunglasses:. Just type a : (colon) or press the Emoji toolbar button in the editor to select from hundreds of choices :ok_hand:
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que afegiu un emoji a la vostra publicació :thumbsup:. Els emojis us permeten transmetre emocions en les vostres publicacions, des de  felicitat :smiley: fins a tristesa :anguished: o ira :angry: i qualsevol cosa entremig :sunglasses:.  Només cal que escriviu : (dos punts) o que premeu el botó de la barra d'eines d'emojis en l'editor per a seleccionar entre centenars d'opcions. :ok_hand:
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Emoji</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primer emoji</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Flagged a post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha marcat amb bandera una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you flag a post. Flagging is how we all help keep this a nice place for everyone. If you notice any posts that require moderator attention for any reason please don’t hesitate to flag. If you see a problem, :flag_black: flag it!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que marqueu amb bandera una publicació. El marcatge és la manera d'ajudar a mantenir aquest lloc web agradable per a tothom. Si observeu qualsevol publicació que requereixi atenció per qualsevol motiu, no dubteu a marcar-la amb bandera. Si veieu un problema, :flag_black: marqueu-lo!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Flag</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera bandera</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Liked a post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha fet 'M'agrada' a una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you like a post using the :heart: button. Liking posts is a great way to let your fellow community members know that what they posted was interesting, useful, cool, or fun. Share the love!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan feu 'M'agrada' per primera vegada usant el botó de :heart:. Fer 'M'agrada' a les publicacions és una gran manera de fer saber als membres de la comunitat que el que han publicat us ha resultat interessant o divertit. Compartiu l'amor!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Like</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primer 'M'agrada'</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Added a link to another topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>S'ha afegit un enllaç a un altre tema</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you add a link to another topic. Linking topics helps fellow readers find interesting related conversations, by showing the connections between topics in both directions. Link freely!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que afegiu un enllaç a un altre tema. Enllaçar temes ajuda la resta de lectors a trobar converses interessants mostrant connexions entre temes en totes dues direccions. Enllaceu a plaer!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Link</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primer enllaç</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Mentioned a user in a post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>S'ha mencionat un usuari en una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you mention someone’s @username in your post. Each mention generates a notification to that person, so they know about your post. Just begin typing @ (at symbol) to mention any user or, if allowed, group – it’s a convenient way to bring something to their attention.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que mencioneu el nom d'usuari d'algú en la vostra publicació. Cada menció genera una notificació a aquesta persona, de manera que estigui informat de la vostra publicació. Simplement comenceu a escriure @ per a mencionar qualsevol usuari o, si es pot, qualsevol grup. És una manera convenient de cridar l'atenció d'algú.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Mention</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera menció</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Posted a link that was oneboxed</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Publicat un enllaç en onebox</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you post a link on a line by itself, which automatically expanded into a onebox with a summary, title, and (when available) picture.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que publiqueu un enllaç tot sol en una línia, que s'expandeix automàticament a onebox amb resum, títol i (quan estigui disponible) imatge.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Onebox</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primer onebox</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Quoted a post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha citat una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you quote a post in your reply. Quoting relevant parts of earlier posts in your reply helps keep discussions connected together and on topic. The easiest way to quote is to highlight a section of a post, and then press any reply button. Quote generously!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que citeu una publicació en la vostra resposta. Citar parts rellevants de les publicacions anteriors en la vostra resposta ajuda a mantenir les discussions connectades i dins del tema. La manera més fàcil de citar és ressaltar una secció d'una publicació i, tot seguit, prémer qualsevol botó de resposta. Citeu amb generositat!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Quote</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera citació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Replied to a post via email</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>S'ha respost a una publicació per correu</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you reply to a post via email :e-mail:.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix la primera vegada que responeu a una publicació per correu :e-mail:.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Reply By Email</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera resposta per correu</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Shared a post</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha compartit una publicació</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted the first time you share a link to a reply or topic using the share button. Sharing links is a great way to show off interesting discussions with the rest of the world and grow your community.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan compartiu per primera vegada un enllaç a una resposta o a un tema usant el botó de compartir. Compartir enllaços és una gran manera de mostrar discussions interessants a la resta del món i així fer créixer la nostra comunitat.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>First Share</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Primera compartició</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Has 100 liked posts and gave 100 likes</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Té 100 publicacions amb 'm'agrada' i ha donat 100 'm'agrada'</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you have 100 liked posts and give 100 or more likes in return. Thanks for paying it forward!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan teniu 100 publicacions amb 'm'agrada' i heu fet 100 o més 'm'agrada' a canvi. Gràcies per recompensar-ho!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Gives Back</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Retorna a canvi</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 25 likes on a reply</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 25 'M'agrada' en una resposta</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when your reply gets 25 likes. Your reply was exceptional and made the conversation much more interesting.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan la vostra resposta obté 25 'M'agrada'. La vostra resposta ha estat excepcional i ha fet que la conversa fos molt més interessant.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Good Reply</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Bona resposta</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Shared a post with 300 unique visitors</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Publicació compartida amb 300 visitants únics</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for sharing a link that was clicked by 300 outside visitors. Good work! You’ve shown off a great discussion to a bunch of new people and helped this community grow.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix per haver compartit un enllaç clicat per 300 visitants externs. Bona feina! Heu mostrat una gran discussió a un grup de persones noves i heu ajudat a fer créixer la comunitat.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Good Share</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Bona compartició</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 25 likes on a topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 25 'M'agrada' en un tema</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when your topic gets 25 likes. You launched a vibrant conversation that the community rallied around.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan el vostre tema obté 25 'M'agrada'. Heu posat en marxa  una conversa vibrant al voltant de la qual s'ha aplegat la comunitat.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Good Topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Bon tema</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 50 likes on a reply</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 50 'M'agrada' en una resposta</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when your reply gets 50 likes. Wow! Your reply was inspiring, fascinating, hilarious, or insightful and the community loved it!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan la vostra resposta té 50 'M'agrada'. Molt bé! La vostra resposta ha estat inspiradora, fascinant, hilarant o perspicaç, i la comunitat n'està encantada!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Great Reply</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Gran resposta</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Shared a post with 1000 unique visitors</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Publicació compartida amb 1.000 visites úniques</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted for sharing a link that was clicked by 1000 outside visitors. Wow! You’ve promoted an interesting discussion to a huge new audience, and helped us grow our community in a big way!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix per haver compartit un enllaç en el qual han fet clic 1000 visitants externs. Molt bé! Heu promogut un debat interessant a un públic nou i enorme, i ens heu ajudat a fer créixer la comunitat en gran manera!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Great Share</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Gran compartició</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Received 50 likes on a topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha rebut 50 'M'agrada' en un tema</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when your topic gets 50 likes. You kicked off a fascinating conversation and the community loved the lively discussion that resulted!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan el vostre tema obté 50 'M'agrada'. Heu posat en marxa una conversa fascinant i a la comunitat li ha agradat l'animada discussió que ha sorgit!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Great Topic</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Gran tema</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you use all %{max_likes_per_day} of your daily likes for 5 days. Thanks for taking the time actively encouraging the best conversations every day!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan gasteu tots els %{max_likes_per_day} dels vostres 'M'agrada' diaris durant 5 dies. Gràcies per animar activament les millors converses cada dia.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Higher Love</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Un amor més elevat</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Posted an external link with 300 clicks</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Ha publicat un enllaç extern amb 300 clics</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when a link you shared gets 300 clicks. Thanks for posting a fascinating link that drove the conversation forward and illuminated the discussion!
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan un enllaç que heu compartit obté 300 clics. Gràcies per posar un enllaç tan interessant que ha il·luminat la discussió!
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Hot Link</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Enllaç popular</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>&lt;a href="https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"&gt;Granted&lt;/a&gt; global edit, pin, close, archive, split and merge, more likes</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>&lt;a href="https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"&gt;S'ha concedit&lt;/a&gt; permís per a editar globalment, destacar, tancar, arxivar, dividir i combinar, més 'M'agrada'.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>This badge is granted when you reach trust level 4. You’re a leader in this community as selected by staff, and you set a positive example for the rest of the community in your actions and words here. You have the ability to edit all posts, take common topic moderator actions such as pin, close, unlist, archive, split, and merge.
+</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>Aquesta insígnia es concedeix quan arribeu al nivell de confiança 4. Sou un líder d'aquesta comunitat seleccionat per l'equip responsable, i oferiu un exemple positiu per a la resta de la comunitat en les vostres accions i paraules. Teniu la possibilitat d'editar totes les publicacions, prendre accions habituals del moderador de tema com ara destacar temes, tancar-los, fer-los invisibles, arxivar-los, dividir-los i combinar-los.
+</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en">
+        <seg>is not allowed from that email provider. Please use another email address.</seg>
+      </tuv>
+      <tuv xml:lang="ca">
+        <seg>no és permès d'aquest proveïdor de correu. Feu servir una altra adreça de correu.</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -1,0 +1,362 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.omegat.core.statistics;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ExternalTMFactory;
+import org.omegat.core.data.ExternalTMX;
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.IFilter;
+import org.omegat.filters2.IParseCallback;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.po.PoFilter;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.Language;
+import org.omegat.util.OConsts;
+import org.omegat.util.Preferences;
+import org.omegat.util.TestPreferencesInitializer;
+
+public class CalcMatchStatisticsTest {
+
+
+    @Test
+    public void testCalcMatchStatics() {
+        int threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                OConsts.FUZZY_MATCH_THRESHOLD);
+        Assert.assertEquals(30, threshold);
+        IStatsConsumer callback = new TestStatsConsumer();
+        CalcMatchStatisticsMock calcMatchStatistics = new CalcMatchStatisticsMock(callback);
+        calcMatchStatistics.start();
+        while (calcMatchStatistics.isAlive()) {
+            calcMatchStatistics.checkInterrupted();
+        }
+        String[][] result = calcMatchStatistics.getTable();
+        Assert.assertNotNull(result);
+
+        // assertions
+        // RowRepetitions  11 90 509 583
+        Assert.assertEquals("11", result[0][1]);
+        Assert.assertEquals("90", result[0][2]);
+        Assert.assertEquals("509", result[0][3]);
+        Assert.assertEquals("583", result[0][4]);
+        // RowExactMatch 0 0 0 0
+        Assert.assertEquals("0", result[1][1]);
+        Assert.assertEquals("0", result[1][2]);
+        Assert.assertEquals("0", result[1][3]);
+        Assert.assertEquals("0", result[1][4]);
+        // RowMatch95 84 712 3606 4225
+        Assert.assertEquals("84", result[2][1]);
+        Assert.assertEquals("712", result[2][2]);
+        Assert.assertEquals("3606", result[2][3]);
+        Assert.assertEquals("4225", result[2][4]);
+        // RowMatch85 0 0 0 0
+        Assert.assertEquals("0", result[3][1]);
+        Assert.assertEquals("0", result[3][2]);
+        Assert.assertEquals("0", result[3][3]);
+        Assert.assertEquals("0", result[3][4]);
+        // RowMatch75 3 32 234 256
+        Assert.assertEquals("3", result[4][1]);
+        Assert.assertEquals("32", result[4][2]);
+        Assert.assertEquals("234", result[4][3]);
+        Assert.assertEquals("256", result[4][4]);
+        // RowMatch50 4 61 304 361
+        Assert.assertEquals("4", result[5][1]);
+        Assert.assertEquals("61", result[5][2]);
+        Assert.assertEquals("304", result[5][3]);
+        Assert.assertEquals("361", result[5][4]);
+        // RowNoMatch 6 43 241 274
+        Assert.assertEquals("6", result[6][1]);
+        Assert.assertEquals("43", result[6][2]);
+        Assert.assertEquals("241", result[6][3]);
+        Assert.assertEquals("274", result[6][4]);
+        // Total 108 938 4894 5699
+        Assert.assertEquals("108", result[7][1]);
+        Assert.assertEquals("938", result[7][2]);
+        Assert.assertEquals("4894", result[7][3]);
+        Assert.assertEquals("5699", result[7][4]);
+    }
+
+    /*
+     * Setup test project.
+     */
+
+    @Before
+    public final void setUp() throws Exception {
+        Core.initializeConsole(Collections.emptyMap());
+        TestPreferencesInitializer.init();
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        Core.setProject(new TestProject(new ProjectPropertiesTest()));
+    }
+
+    protected static class ProjectPropertiesTest extends ProjectProperties {
+        ProjectPropertiesTest() {
+            super();
+            setSourceLanguage(new Language("en"));
+            setSourceTokenizer(LuceneEnglishTokenizer.class);
+            setSentenceSegmentingEnabled(false);
+            setTargetLanguage(new Language("ca"));
+            setTargetTokenizer(DefaultTokenizer.class);
+        }
+    }
+
+    static class TestProject extends NotLoadedProject implements IProject {
+        private final ProjectProperties prop;
+
+        private final ProjectTMX projectTMX;
+        private Map<String, ExternalTMX> transMemories;
+
+        TestProject(ProjectProperties prop) throws Exception {
+            super();
+            this.prop = prop;
+            projectTMX = new ProjectTMX(new Language("en"), new Language("ca"), true,
+                    Paths.get("test/data/tmx/empty.tmx").toFile(), null);
+        }
+
+        @Override
+        public ProjectProperties getProjectProperties() {
+            return prop;
+        }
+
+        @Override
+        public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+            if (projectTMX == null) {
+                return EMPTY_TRANSLATION;
+            }
+            TMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
+            if (r == null) {
+                r = projectTMX.getDefaultTranslation(ste.getSrcText());
+            }
+            if (r == null) {
+                r = EMPTY_TRANSLATION;
+            }
+            return r;
+        }
+
+        @Override
+        public List<SourceTextEntry> getAllEntries() {
+            List<SourceTextEntry> ste = new ArrayList<>();
+            IFilter filter = new PoFilter();
+            Path testSource = Paths.get("test/data/filters/po/file-POFilter-match-stat-en-ca.po");
+            IParseCallback testCallback = new TestCallback(ste);
+            FilterContext context = new FilterContext(new Language("en"), new Language("ca"), true);
+            try {
+                filter.parseFile(testSource.toFile(), Collections.emptyMap(), context, testCallback);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return ste;
+        }
+
+        @Override
+        public ITokenizer getSourceTokenizer() {
+            return new LuceneEnglishTokenizer();
+        };
+
+        @Override
+        public ITokenizer getTargetTokenizer() {
+            return new DefaultTokenizer();
+        }
+
+        @Override
+        public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public AllTranslations getAllTranslations(SourceTextEntry ste) {
+            TestAllTranslations r = new TestAllTranslations();
+            synchronized (projectTMX) {
+                r.setDefaultTranslation(projectTMX.getDefaultTranslation(ste.getSrcText()));
+                r.setAlternativeTranslation(projectTMX.getMultipleTranslation(ste.getKey()));
+                if (r.getAlternativeTranslation() != null) {
+                    r.setCurrentTranslation(r.getAlternativeTranslation());
+                } else if (r.getDefaultTranslation() != null) {
+                    r.setCurrentTranslation(r.getDefaultTranslation());
+                } else {
+                    r.setCurrentTranslation(EMPTY_TRANSLATION);
+                }
+                if (r.getDefaultTranslation() == null) {
+                    r.setDefaultTranslation(EMPTY_TRANSLATION);
+                }
+                if (r.getAlternativeTranslation() == null) {
+                    r.setAlternativeTranslation(EMPTY_TRANSLATION);
+                }
+            }
+            return r;
+        }
+
+        @Override
+        public Map<String, ExternalTMX> getTransMemories() {
+            synchronized (projectTMX) {
+                if (transMemories == null) {
+                     transMemories = new TreeMap<>();
+                    try {
+                        ExternalTMX newTMX;
+                        Path testTmx = Paths.get("test/data/tmx/test-match-stat-en-ca.tmx");
+                        newTMX = ExternalTMFactory.load(testTmx.toFile());
+                        transMemories.put(testTmx.toString(), newTMX);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            return Collections.unmodifiableMap(transMemories);
+        }
+    }
+
+    static class TestAllTranslations extends IProject.AllTranslations {
+        public void setAlternativeTranslation(TMXEntry entry) {
+            alternativeTranslation = entry;
+        }
+
+        public void setDefaultTranslation(TMXEntry entry) {
+            defaultTranslation = entry;
+        }
+
+        public void setCurrentTranslation(TMXEntry entry) {
+            currentTranslation = entry;
+        }
+    }
+
+    static class TestCallback implements IParseCallback {
+
+        private final List<SourceTextEntry> steList;
+
+        TestCallback(final List<SourceTextEntry> ste) {
+            this.steList = ste;
+        }
+
+        @Override
+        public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                                           String[] props, String path, IFilter filter,
+                                           List<ProtectedPart> protectedParts) {
+            SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path),
+                    1, props, translation, protectedParts);
+            ste.setSourceTranslationFuzzy(isFuzzy);
+            steList.add(ste);
+        }
+
+        @Override
+        public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
+                             String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            List<String> propList = new ArrayList<>(2);
+            if (comment != null) {
+                propList.add("comment");
+                propList.add(comment);
+            }
+            String[] props = propList.toArray(new String[0]);
+            addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
+        }
+
+        @Override
+        public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
+                             IFilter filter) {
+            addEntry(id, source, translation, isFuzzy, comment, null, filter, Collections.emptyList());
+        }
+
+        @Override
+        public void linkPrevNextSegments() {
+        }
+    }
+
+    static class CalcMatchStatisticsMock extends CalcMatchStatistics {
+
+        private final String[] rowsTotal = new String[] { "RowRepetitions", "RowExactMatch", "RowMatch95", "RowMatch85",
+                "RowMatch75", "RowMatch50", "RowNoMatch", "Total" };
+
+        private MatchStatCounts result;
+
+        CalcMatchStatisticsMock(IStatsConsumer callback) {
+            super(callback, false);
+        }
+
+        @Override
+        public void run() {
+            entriesToProcess = Core.getProject().getAllEntries().size();
+            result = calcTotal(false);
+        }
+
+        public String[][] getTable() {
+            return result.calcTable(rowsTotal, i -> i != 1);
+        }
+    }
+
+    static class TestStatsConsumer implements IStatsConsumer {
+
+        @Override
+        public void appendTextData(final String result) {
+        }
+
+        @Override
+        public void appendTable(final String title, final String[] headers, final String[][] data) {
+        }
+
+        @Override
+        public void setTextData(final String data) {
+        }
+
+        @Override
+        public void setTable(final String[] headers, final String[][] data) {
+        }
+
+        @Override
+        public void setDataFile(final String path) {
+        }
+
+        @Override
+        public void finishData() {
+        }
+
+        @Override
+        public void showProgress(final int percent) {
+        }
+    }
+}

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -80,7 +80,7 @@ public class CalcMatchStatisticsTest {
         Assert.assertNotNull(result);
 
         // assertions
-        // RowRepetitions  11 90 509 583
+        // RowRepetitions 11 90 509 583
         Assert.assertEquals("11", result[0][1]);
         Assert.assertEquals("90", result[0][2]);
         Assert.assertEquals("509", result[0][3]);
@@ -140,7 +140,7 @@ public class CalcMatchStatisticsTest {
         Assert.assertNotNull(result);
 
         // assertions
-        // RowRepetitions  11 90 509 583
+        // RowRepetitions 11 90 509 583
         Assert.assertEquals("11", result[0][1]);
         Assert.assertEquals("90", result[0][2]);
         Assert.assertEquals("509", result[0][3]);
@@ -300,7 +300,7 @@ public class CalcMatchStatisticsTest {
         public Map<String, ExternalTMX> getTransMemories() {
             synchronized (projectTMX) {
                 if (transMemories == null) {
-                     transMemories = new TreeMap<>();
+                    transMemories = new TreeMap<>();
                     try {
                         ExternalTMX newTMX;
                         Path testTmx = Paths.get("test/data/tmx/test-match-stat-en-ca.tmx");
@@ -339,17 +339,16 @@ public class CalcMatchStatisticsTest {
 
         @Override
         public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
-                                           String[] props, String path, IFilter filter,
-                                           List<ProtectedPart> protectedParts) {
-            SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path),
-                    1, props, translation, protectedParts);
+                String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path), 1,
+                    props, translation, protectedParts);
             ste.setSourceTranslationFuzzy(isFuzzy);
             steList.add(ste);
         }
 
         @Override
         public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                             String path, IFilter filter, List<ProtectedPart> protectedParts) {
+                String path, IFilter filter, List<ProtectedPart> protectedParts) {
             List<String> propList = new ArrayList<>(2);
             if (comment != null) {
                 propList.add("comment");
@@ -361,7 +360,7 @@ public class CalcMatchStatisticsTest {
 
         @Override
         public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                             IFilter filter) {
+                IFilter filter) {
             addEntry(id, source, translation, isFuzzy, comment, null, filter, Collections.emptyList());
         }
 
@@ -372,8 +371,8 @@ public class CalcMatchStatisticsTest {
 
     static class CalcMatchStatisticsMock extends CalcMatchStatistics {
 
-        private final String[] rowsTotal = new String[] { "RowRepetitions", "RowExactMatch", "RowMatch95", "RowMatch85",
-                "RowMatch75", "RowMatch50", "RowNoMatch", "Total" };
+        private final String[] rowsTotal = new String[] { "RowRepetitions", "RowExactMatch", "RowMatch95",
+                "RowMatch85", "RowMatch75", "RowMatch50", "RowNoMatch", "Total" };
 
         private MatchStatCounts result;
 

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -65,7 +65,6 @@ import org.omegat.util.TestPreferencesInitializer;
 
 public class CalcMatchStatisticsTest {
 
-
     @Test
     public void testCalcMatchStatics() {
         int threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
@@ -121,6 +120,70 @@ public class CalcMatchStatisticsTest {
         Assert.assertEquals("938", result[7][2]);
         Assert.assertEquals("4894", result[7][3]);
         Assert.assertEquals("5699", result[7][4]);
+        // double check condition
+        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                OConsts.FUZZY_MATCH_THRESHOLD);
+        Assert.assertEquals(30, threshold);
+
+        // change threshold
+        Preferences.setPreference(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD, 70);
+        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                OConsts.FUZZY_MATCH_THRESHOLD);
+        Assert.assertEquals(70, threshold);
+        //
+        calcMatchStatistics = new CalcMatchStatisticsMock(callback);
+        calcMatchStatistics.start();
+        while (calcMatchStatistics.isAlive()) {
+            calcMatchStatistics.checkInterrupted();
+        }
+        result = calcMatchStatistics.getTable();
+        Assert.assertNotNull(result);
+
+        // assertions
+        // RowRepetitions  11 90 509 583
+        Assert.assertEquals("11", result[0][1]);
+        Assert.assertEquals("90", result[0][2]);
+        Assert.assertEquals("509", result[0][3]);
+        Assert.assertEquals("583", result[0][4]);
+        // RowExactMatch 0 0 0 0
+        Assert.assertEquals("0", result[1][1]);
+        Assert.assertEquals("0", result[1][2]);
+        Assert.assertEquals("0", result[1][3]);
+        Assert.assertEquals("0", result[1][4]);
+        // RowMatch95 84 712 3606 4225
+        Assert.assertEquals("84", result[2][1]);
+        Assert.assertEquals("712", result[2][2]);
+        Assert.assertEquals("3606", result[2][3]);
+        Assert.assertEquals("4225", result[2][4]);
+        // RowMatch85 0 0 0 0
+        Assert.assertEquals("0", result[3][1]);
+        Assert.assertEquals("0", result[3][2]);
+        Assert.assertEquals("0", result[3][3]);
+        Assert.assertEquals("0", result[3][4]);
+        // RowMatch75 3 32 234 256
+        Assert.assertEquals("3", result[4][1]);
+        Assert.assertEquals("32", result[4][2]);
+        Assert.assertEquals("234", result[4][3]);
+        Assert.assertEquals("256", result[4][4]);
+        // RowMatch50 4 61 304 361
+        Assert.assertEquals("4", result[5][1]);
+        Assert.assertEquals("61", result[5][2]);
+        Assert.assertEquals("304", result[5][3]);
+        Assert.assertEquals("361", result[5][4]);
+        // RowNoMatch 6 43 241 274
+        Assert.assertEquals("6", result[6][1]);
+        Assert.assertEquals("43", result[6][2]);
+        Assert.assertEquals("241", result[6][3]);
+        Assert.assertEquals("274", result[6][4]);
+        // Total 108 938 4894 5699
+        Assert.assertEquals("108", result[7][1]);
+        Assert.assertEquals("938", result[7][2]);
+        Assert.assertEquals("4894", result[7][3]);
+        Assert.assertEquals("5699", result[7][4]);
+        // double check condition
+        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                OConsts.FUZZY_MATCH_THRESHOLD);
+        Assert.assertEquals(70, threshold);
     }
 
     /*


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Match statistics are affected by fuzzy match threshold
- https://sourceforge.net/p/omegat/bugs/1236/

## What does this PR change?

- Add a reproduce case of the bug.
- Add `ignoreThreshold` constructor boolean for `FindMatches` class.
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
