### PR TITLE
feat(editor,filters2/xliff,core): inactive translation when XLIFF state="final"

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -70,10 +70,10 @@
     <suppress files="PluginInformation\.java" checks="NeedBraces" lines="167-192"/>
     <!-- core/data/* -->
     <suppress checks="ParameterNumber" files="PluginInformation\.java" lines="60"/>
-    <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="136,198,233,277"/>
+    <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="143,203,216,254,302,335"/>
     <suppress checks="ParameterNumber" files="ExternalTMFactory\.java" lines="256,263"/>
     <suppress checks="FileLength" files="RealProject\.java"/>
-    <suppress checks="ParameterNumber" files="RealProject\.java" lines="1871"/>
+    <suppress checks="ParameterNumber" files="RealProject\.java" lines="1871,1882"/>
     <!-- util/Platform -->
     <suppress files="Platform\.java" checks="ConstantName" lines="61-80"/>
     <!-- util/Preferences -->

--- a/src/org/omegat/core/data/ParseEntry.java
+++ b/src/org/omegat/core/data/ParseEntry.java
@@ -74,7 +74,8 @@ public abstract class ParseEntry implements IParseCallback {
          */
         for (ParseEntryQueueItem item : parseQueue) {
             addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts, item.segmentTranslation,
-                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path);
+                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path,
+                    item.isFinal);
         }
 
         /*

--- a/src/org/omegat/core/data/ParseEntry.java
+++ b/src/org/omegat/core/data/ParseEntry.java
@@ -47,8 +47,8 @@ import org.omegat.util.StringUtil;
 /**
  * Process one entry on parse source file.
  *
- * This class caches segments for one file, then flushes they. It required to ability to link prev/next
- * segments.
+ * This class caches segments for one file, then flushes they. It required to
+ * ability to link prev/next segments.
  *
  * @author Maxym Mykhalchuk
  * @author Henry Pijffers
@@ -73,9 +73,9 @@ public abstract class ParseEntry implements IParseCallback {
          * Flush queue.
          */
         for (ParseEntryQueueItem item : parseQueue) {
-            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts, item.segmentTranslation,
-                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path,
-                    item.isFinal);
+            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts,
+                    item.segmentTranslation, item.segmentTranslationFuzzy, item.props, item.prevSegment,
+                    item.nextSegment, item.path, item.isFinal);
         }
 
         /*
@@ -107,7 +107,8 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      *
      * @param id
      *            ID of entry, if format supports it
@@ -116,16 +117,21 @@ public abstract class ParseEntry implements IParseCallback {
      * @param translation
      *            translation of the source string, if format supports it
      * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
      *            reference during translation.
      * @param props
-     *            a staggered array of non-uniquely-identifying key=value properties (metadata) for the entry.
-     *            If property is org.omegat.core.data.SegmentProperties.REFERENCE, the entire segment is added only to
-     *            the generated 'reference' TMX, a special TMX that is used as extra reference during translation.
-     *            The segment is not added to the list of translatable segments.
-     *            Property can also be org.omegat.core.data.SegmentProperties.COMMENT, which shown in the comment panel.
-     *            Other properties are possible, but have no special meaning in OmegaT.
+     *            a staggered array of non-uniquely-identifying key=value
+     *            properties (metadata) for the entry. If property is
+     *            org.omegat.core.data.SegmentProperties.REFERENCE, the entire
+     *            segment is added only to the generated 'reference' TMX, a
+     *            special TMX that is used as extra reference during
+     *            translation. The segment is not added to the list of
+     *            translatable segments. Property can also be
+     *            org.omegat.core.data.SegmentProperties.COMMENT, which shown in
+     *            the comment panel. Other properties are possible, but have no
+     *            special meaning in OmegaT.
      * @param path
      *            path of entry in file
      * @param filter
@@ -134,8 +140,9 @@ public abstract class ParseEntry implements IParseCallback {
      *            protected parts
      */
     @Override
-    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-            String path, IFilter filter, List<ProtectedPart> protectedParts, boolean isFinal) {
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts,
+            boolean isFinal) {
         if (StringUtil.isEmpty(source)) {
             // empty string - not need to save
             return;
@@ -182,24 +189,28 @@ public abstract class ParseEntry implements IParseCallback {
                     String onesrc = segments.get(i);
                     List<ProtectedPart> segmentProtectedParts = ProtectedPart.extractFor(protectedParts,
                             onesrc);
-                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts, isFinal);
+                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts,
+                            isFinal);
                 }
             }
         } else {
-            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts, isFinal);
+            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts,
+                    isFinal);
         }
     }
 
     @Override
-    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-                                       String path, IFilter filter, List<ProtectedPart> protectedParts) {
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
         addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts, false);
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      * <p>
-     * Old call for filters that only support extracting a "comment" property. Kept for compatibility.
+     * Old call for filters that only support extracting a "comment" property.
+     * Kept for compatibility.
      */
     @Override
     public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
@@ -209,9 +220,11 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      * <p>
-     * Old call without path, for compatibility. Comment is converted to a property.
+     * Old call without path, for compatibility. Comment is converted to a
+     * property.
      *
      * @param id
      *            ID of entry, if format supports it
@@ -220,8 +233,9 @@ public abstract class ParseEntry implements IParseCallback {
      * @param translation
      *            translation of the source string, if format supports it
      * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
      *            reference during translation.
      * @param comment
      *            entry's comment, if format supports it
@@ -237,9 +251,9 @@ public abstract class ParseEntry implements IParseCallback {
     /**
      * Add segment to queue because we possible need to link prev/next segments.
      */
-    private void internalAddSegment(String id, short segmentIndex, String segmentSource, String segmentTranslation,
-            boolean segmentTranslationFuzzy, String[] props, String path, List<ProtectedPart> protectedParts,
-                                    boolean isFinal) {
+    private void internalAddSegment(String id, short segmentIndex, String segmentSource,
+            String segmentTranslation, boolean segmentTranslationFuzzy, String[] props, String path,
+            List<ProtectedPart> protectedParts, boolean isFinal) {
         if (segmentSource.trim().isEmpty()) {
             // skip empty segments
             return;
@@ -283,14 +297,13 @@ public abstract class ParseEntry implements IParseCallback {
      * @param path
      *            path of segment
      * @param isFinal
-     *           (since 6.1.0) translation is final state.
+     *            (since 6.1.0) translation is final state.
      */
     protected void addSegment(String id, short segmentIndex, String segmentSource,
-                              List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
-                              String[] props, String prevSegment, String nextSegment, String path,
-                              boolean isFinal) {
-        addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
-                props, prevSegment, nextSegment, path);
+            List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
+            String[] props, String prevSegment, String nextSegment, String path, boolean isFinal) {
+        addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation,
+                segmentTranslationFuzzy, props, prevSegment, nextSegment, path);
     }
 
     /**

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1869,11 +1869,11 @@ public class RealProject implements IProject {
          * {@inheritDoc}
          */
         protected void addSegment(String id, short segmentIndex, String segmentSource,
-                                  List<ProtectedPart> protectedParts, String segmentTranslation,
-                                  boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
-                                  String path) {
-            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
-                    props, prevSegment, nextSegment, path, false);
+                List<ProtectedPart> protectedParts, String segmentTranslation,
+                boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
+                String path) {
+            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation,
+                    segmentTranslationFuzzy, props, prevSegment, nextSegment, path, false);
         }
 
         /**

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1869,9 +1869,20 @@ public class RealProject implements IProject {
          * {@inheritDoc}
          */
         protected void addSegment(String id, short segmentIndex, String segmentSource,
+                                  List<ProtectedPart> protectedParts, String segmentTranslation,
+                                  boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
+                                  String path) {
+            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
+                    props, prevSegment, nextSegment, path, false);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        protected void addSegment(String id, short segmentIndex, String segmentSource,
                 List<ProtectedPart> protectedParts, String segmentTranslation,
                 boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
-                String path) {
+                String path, boolean isFinal) {
             // if the source string is empty, don't add it to TM
             if (segmentSource.trim().isEmpty()) {
                 throw new RuntimeException("Segment must not be empty");
@@ -1888,7 +1899,7 @@ public class RealProject implements IProject {
                 segmentTranslation = null;
             }
             SourceTextEntry srcTextEntry = new SourceTextEntry(ek, allProjectEntries.size() + 1, props,
-                    segmentTranslation, protectedParts, segmentIndex == 0);
+                    segmentTranslation, protectedParts, segmentIndex == 0, isFinal);
             srcTextEntry.setSourceTranslationFuzzy(segmentTranslationFuzzy);
 
             if (SegmentProperties.isReferenceEntry(props)) {

--- a/src/org/omegat/core/data/SourceTextEntry.java
+++ b/src/org/omegat/core/data/SourceTextEntry.java
@@ -61,7 +61,7 @@ public class SourceTextEntry {
     private boolean sourceTranslationFuzzy;
 
     /** Flag indicating if the segment is located at the start of a paragraph. */
-    private boolean paragraphStart;
+    private final boolean paragraphStart;
 
     public enum DUPLICATE {
         /** There is no entries with the same source. */
@@ -93,6 +93,8 @@ public class SourceTextEntry {
      */
     private final ProtectedPart[] protectedParts;
 
+    private boolean finalState;
+
     /**
      * Creates a new source text entry.
      *
@@ -104,8 +106,15 @@ public class SourceTextEntry {
      *            optional entry metadata
      * @param sourceTranslation
      *            translation from source file
+     * @param protectedParts
+     *             protected parts
+     * @param paragraphStart
+     *             indicate it is a start of paragraph.
+     * @param finalState
+     *             indicate it is a final state (as in XLIFF).
      */
-    public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation, List<ProtectedPart> protectedParts, boolean paragraphStart) {
+    public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation,
+                           List<ProtectedPart> protectedParts, boolean paragraphStart, boolean finalState) {
         this.key = key;
         m_entryNum = entryNum;
         this.props = props;
@@ -121,10 +130,16 @@ public class SourceTextEntry {
                     i--;
                 }
             }
-            this.protectedParts = protectedParts.toArray(new ProtectedPart[protectedParts.size()]);
+            this.protectedParts = protectedParts.toArray(new ProtectedPart[0]);
         }
         this.duplicates = null;
         this.firstInstance = null;
+        this.finalState = finalState;
+    }
+
+    public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation,
+                           List<ProtectedPart> protectedParts, boolean paragraphStart) {
+        this(key,  entryNum, props, sourceTranslation, protectedParts, paragraphStart, false);
     }
 
     public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation, List<ProtectedPart> protectedParts) {
@@ -162,7 +177,7 @@ public class SourceTextEntry {
         return m_entryNum;
     }
 
-    /** If entry with the same source already exist in project. */
+    /** If entry with the same source already exists in a project. */
     public DUPLICATE getDuplicate() {
         if (firstInstance != null) {
             return DUPLICATE.NEXT;
@@ -170,6 +185,10 @@ public class SourceTextEntry {
         return duplicates == null ? DUPLICATE.NONE : DUPLICATE.FIRST;
     }
 
+    /**
+     * Tell a number of duplications.
+     * @return a number of duplications.
+     */
     public int getNumberOfDuplicates() {
         if (firstInstance != null) {
             return firstInstance.getNumberOfDuplicates();
@@ -177,6 +196,10 @@ public class SourceTextEntry {
         return duplicates == null ? 0 : duplicates.size();
     }
 
+    /**
+     * Give STEs which are duplicated.
+     * @return list of STEs which are duplicated.
+     */
     public List<SourceTextEntry> getDuplicates() {
         if (firstInstance != null) {
             List<SourceTextEntry> result = new ArrayList<SourceTextEntry>(firstInstance.getDuplicates());
@@ -191,23 +214,51 @@ public class SourceTextEntry {
         }
     }
 
+    /**
+     * Give source translation.
+     * @return source translation.
+     */
     public String getSourceTranslation() {
         return sourceTranslation;
     }
 
+    /**
+     * Is source transaltion flagged fuzzy.
+     * @return true when fuzzy, otherwise, false.
+     */
     public boolean isSourceTranslationFuzzy() {
         return sourceTranslationFuzzy;
     }
 
+    /**
+     * Set translation as fuzzy.
+     * @param sourceTranslationFuzzy false when reset a status, true indicate fuzzy.
+     */
     public void setSourceTranslationFuzzy(boolean sourceTranslationFuzzy) {
         this.sourceTranslationFuzzy = sourceTranslationFuzzy;
     }
 
+    /**
+     * Return protected parts.
+     * @return an array of protected parts.
+     */
     public ProtectedPart[] getProtectedParts() {
         return protectedParts;
     }
 
+    /**
+     * Indicate the STE is the start of paragraph.
+     * @return true when start of paragraph, otherwise, false.
+     */
     public boolean isParagraphStart() {
         return paragraphStart;
+    }
+
+    /**
+     * Indicate the STE is the final state.
+     * @return true when final, otherwise, false.
+     */
+    public boolean isFinalState() {
+        return finalState;
     }
 }

--- a/src/org/omegat/core/data/SourceTextEntry.java
+++ b/src/org/omegat/core/data/SourceTextEntry.java
@@ -49,8 +49,8 @@ public class SourceTextEntry {
     private final EntryKey key;
 
     /**
-     * String properties from source file. Contents are alternating
-     * key (even index), value (odd index) strings. Should be of even length.
+     * String properties from source file. Contents are alternating key (even
+     * index), value (odd index) strings. Should be of even length.
      */
     private final String[] props;
 
@@ -60,7 +60,9 @@ public class SourceTextEntry {
     /** Translation from source files is fuzzy. */
     private boolean sourceTranslationFuzzy;
 
-    /** Flag indicating if the segment is located at the start of a paragraph. */
+    /**
+     * Flag indicating if the segment is located at the start of a paragraph.
+     */
     private final boolean paragraphStart;
 
     public enum DUPLICATE {
@@ -68,13 +70,16 @@ public class SourceTextEntry {
         NONE,
         /** There is entries with the same source, and this is first entry. */
         FIRST,
-        /** There is entries with the same source, and this is not first entry. */
+        /**
+         * There is entries with the same source, and this is not first entry.
+         */
         NEXT
     };
 
     /**
-     * A list of duplicates of this STE. Will be non-null for the FIRST duplicate,
-     * null for NONE and NEXT STEs. See {@link #getDuplicate()} for full logic.
+     * A list of duplicates of this STE. Will be non-null for the FIRST
+     * duplicate, null for NONE and NEXT STEs. See {@link #getDuplicate()} for
+     * full logic.
      */
     List<SourceTextEntry> duplicates;
 
@@ -107,14 +112,14 @@ public class SourceTextEntry {
      * @param sourceTranslation
      *            translation from source file
      * @param protectedParts
-     *             protected parts
+     *            protected parts
      * @param paragraphStart
-     *             indicate it is a start of paragraph.
+     *            indicate it is a start of paragraph.
      * @param finalState
-     *             indicate it is a final state (as in XLIFF).
+     *            indicate it is a final state (as in XLIFF).
      */
     public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation,
-                           List<ProtectedPart> protectedParts, boolean paragraphStart, boolean finalState) {
+            List<ProtectedPart> protectedParts, boolean paragraphStart, boolean finalState) {
         this.key = key;
         m_entryNum = entryNum;
         this.props = props;
@@ -138,12 +143,13 @@ public class SourceTextEntry {
     }
 
     public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation,
-                           List<ProtectedPart> protectedParts, boolean paragraphStart) {
-        this(key,  entryNum, props, sourceTranslation, protectedParts, paragraphStart, false);
+            List<ProtectedPart> protectedParts, boolean paragraphStart) {
+        this(key, entryNum, props, sourceTranslation, protectedParts, paragraphStart, false);
     }
 
-    public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation, List<ProtectedPart> protectedParts) {
-        this(key,  entryNum, props, sourceTranslation, protectedParts, true);
+    public SourceTextEntry(EntryKey key, int entryNum, String[] props, String sourceTranslation,
+            List<ProtectedPart> protectedParts) {
+        this(key, entryNum, props, sourceTranslation, protectedParts, true);
     }
 
     public EntryKey getKey() {
@@ -187,6 +193,7 @@ public class SourceTextEntry {
 
     /**
      * Tell a number of duplications.
+     * 
      * @return a number of duplications.
      */
     public int getNumberOfDuplicates() {
@@ -198,6 +205,7 @@ public class SourceTextEntry {
 
     /**
      * Give STEs which are duplicated.
+     * 
      * @return list of STEs which are duplicated.
      */
     public List<SourceTextEntry> getDuplicates() {
@@ -216,6 +224,7 @@ public class SourceTextEntry {
 
     /**
      * Give source translation.
+     * 
      * @return source translation.
      */
     public String getSourceTranslation() {
@@ -224,6 +233,7 @@ public class SourceTextEntry {
 
     /**
      * Is source transaltion flagged fuzzy.
+     * 
      * @return true when fuzzy, otherwise, false.
      */
     public boolean isSourceTranslationFuzzy() {
@@ -232,7 +242,9 @@ public class SourceTextEntry {
 
     /**
      * Set translation as fuzzy.
-     * @param sourceTranslationFuzzy false when reset a status, true indicate fuzzy.
+     * 
+     * @param sourceTranslationFuzzy
+     *            false when reset a status, true indicate fuzzy.
      */
     public void setSourceTranslationFuzzy(boolean sourceTranslationFuzzy) {
         this.sourceTranslationFuzzy = sourceTranslationFuzzy;
@@ -240,6 +252,7 @@ public class SourceTextEntry {
 
     /**
      * Return protected parts.
+     * 
      * @return an array of protected parts.
      */
     public ProtectedPart[] getProtectedParts() {
@@ -248,6 +261,7 @@ public class SourceTextEntry {
 
     /**
      * Indicate the STE is the start of paragraph.
+     * 
      * @return true when start of paragraph, otherwise, false.
      */
     public boolean isParagraphStart() {
@@ -256,6 +270,7 @@ public class SourceTextEntry {
 
     /**
      * Indicate the STE is the final state.
+     * 
      * @return true when final, otherwise, false.
      */
     public boolean isFinalState() {

--- a/src/org/omegat/filters2/IParseCallback.java
+++ b/src/org/omegat/filters2/IParseCallback.java
@@ -59,9 +59,9 @@ public interface IParseCallback {
      * @param isFinal
      *            (since 6.1.0) true if translation state is final
      */
-    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-                                        String path, IFilter filter, List<ProtectedPart> protectedParts,
-                                        boolean isFinal) {
+    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts,
+            boolean isFinal) {
         addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
     }
 

--- a/src/org/omegat/filters2/IParseCallback.java
+++ b/src/org/omegat/filters2/IParseCallback.java
@@ -56,7 +56,15 @@ public interface IParseCallback {
      *            filter which produces entry
      * @param protectedParts
      *            (since 3.0.6) protected parts
+     * @param isFinal
+     *            (since 6.1.0) true if translation state is final
      */
+    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
+                                        String path, IFilter filter, List<ProtectedPart> protectedParts,
+                                        boolean isFinal) {
+        addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
+    }
+
     void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
             String path, IFilter filter, List<ProtectedPart> protectedParts);
 

--- a/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -68,6 +68,7 @@ public class XLIFFFilter extends XMLFilter {
     private HashSet<String> altIDCache = new HashSet<String>();
 
     private String id;
+    private String state;
 
     /**
      * Sets whether alternative translations are identified by previous and next
@@ -209,6 +210,7 @@ public class XLIFFFilter extends XMLFilter {
             // resname may or may not be present.
             resname = atts.getValue("resname");
             id = atts.getValue("id");
+            state = atts.getValue("state");
         }
         // not all <group> tags have resname attribute
         if (path.endsWith("/group")) {
@@ -246,14 +248,16 @@ public class XLIFFFilter extends XMLFilter {
                     addProperty("resname", resname);
                 }
 
+                boolean isFinal = "final".equals(state);
                 for (int i = 0; i < entryText.size(); i++) {
                     entryParseCallback.addEntryWithProperties(getSegID(), entryText.get(i), null, false,
-                            finalizeProperties(), null, this, protectedParts.get(i), false);
+                            finalizeProperties(), null, this, protectedParts.get(i), isFinal);
                 }
             }
 
             id = null;
             resname = null;
+            state = null;
             props.clear();
             entryText.clear();
             protectedParts.clear();

--- a/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -248,7 +248,7 @@ public class XLIFFFilter extends XMLFilter {
 
                 for (int i = 0; i < entryText.size(); i++) {
                     entryParseCallback.addEntryWithProperties(getSegID(), entryText.get(i), null, false,
-                            finalizeProperties(), null, this, protectedParts.get(i));
+                            finalizeProperties(), null, this, protectedParts.get(i), false);
                 }
             }
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -794,11 +794,19 @@ public class EditorController implements IEditor {
 
         previousTranslations = Core.getProject().getAllTranslations(ste);
         TMXEntry currentTranslation = previousTranslations.getCurrentTranslation();
+
+        if (ste.isFinalState()) {
+            builder.createSegmentElement(false, currentTranslation);
+            Core.getNotes().setNoteText(currentTranslation.note);
+            scrollForDisplayNearestSegments(pos);
+            editor.autoCompleter.setVisible(false);
+            editor.repaint();
+            return;
+        }
+
         // forget about old marks
         builder.createSegmentElement(true, currentTranslation);
-
         Core.getNotes().setNoteText(currentTranslation.note);
-
         // then add new marks
         markerController.reprocessImmediately(builder);
 

--- a/test/data/filters/xliff/filters3/file-XLIFFFilter-state-final.xlf
+++ b/test/data/filters/xliff/filters3/file-XLIFFFilter-state-final.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1">
+    <file target-language="be" source-language="en" original="text.txt">
+        <body>
+            <trans-unit>
+                <source>This is test</source>
+                <target>tr1=This is test</target>
+            </trans-unit>
+            <trans-unit state="final">
+                <source>test2</source>
+                <target>tr2=test2</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/test/src/org/omegat/filters/TestFilterBase.java
+++ b/test/src/org/omegat/filters/TestFilterBase.java
@@ -103,15 +103,19 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the parseFile method of a given filter without options;
-     * returns a list of source segments that the
-     * filter-under-test finds in the given file and returns to the IParseCallback.addEntry method.
-     * NB: Id, comments, fuzzyness, path, properties etc is all ignored.
+     * Helper function for testing the parseFile method of a given filter
+     * without options; returns a list of source segments that the
+     * filter-under-test finds in the given file and returns to the
+     * IParseCallback.addEntry method. NB: Id, comments, fuzzyness, path,
+     * properties etc is all ignored.
      *
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
      * @return list of source segments
-     * @throws Exception when the filter throws an exception on parseFile.
+     * @throws Exception
+     *             when the filter throws an exception on parseFile.
      */
     protected List<String> parse(AbstractFilter filter, String filename) throws Exception {
         final List<String> result = new ArrayList<String>();
@@ -122,15 +126,14 @@ public abstract class TestFilterBase extends TestCore {
                 addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
             }
 
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntry(String id, String source, String translation, boolean isFuzzy,
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 if (!source.isEmpty()) {
                     result.add(source);
                 }
@@ -144,16 +147,21 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the parseFile method of a given filter using some options;
-     * returns a list of source segments that
-     * the filter-under-test finds in the given file and returns to the IParseCallback.addEntry method.
-     * NB: Id, comments, fuzzyness, path, properties etc is all ignored.
+     * Helper function for testing the parseFile method of a given filter using
+     * some options; returns a list of source segments that the
+     * filter-under-test finds in the given file and returns to the
+     * IParseCallback.addEntry method. NB: Id, comments, fuzzyness, path,
+     * properties etc is all ignored.
      *
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param options the filter options/config to use
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param options
+     *            the filter options/config to use
      * @return list of source segments
-     * @throws Exception when the filter throws an exception on parseFile.
+     * @throws Exception
+     *             when the filter throws an exception on parseFile.
      */
     protected List<String> parse(AbstractFilter filter, String filename, Map<String, String> options)
             throws Exception {
@@ -165,15 +173,14 @@ public abstract class TestFilterBase extends TestCore {
                 addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
             }
 
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntry(String id, String source, String translation, boolean isFuzzy,
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 if (!source.isEmpty()) {
                     result.add(source);
                 }
@@ -187,19 +194,25 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the parseFile method of a given filter without options.
-     * The given 'result' map is filled with
-     * key=source, value=translation as the filter-under-test finds in the given file and returns to the
-     * IParseCallback.addEntry method, if the translation is not fuzzy.
-     * The given legacyTMX map is filled too, but also including fuzzy translations,
-     * where <code>key=[&lt;fuzzyMark&gt;] source</code>
-     * NB: Id, comments, path, properties etc is all ignored.
+     * Helper function for testing the parseFile method of a given filter
+     * without options. The given 'result' map is filled with key=source,
+     * value=translation as the filter-under-test finds in the given file and
+     * returns to the IParseCallback.addEntry method, if the translation is not
+     * fuzzy. The given legacyTMX map is filled too, but also including fuzzy
+     * translations, where <code>key=[&lt;fuzzyMark&gt;] source</code> NB: Id,
+     * comments, path, properties etc is all ignored.
      *
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param result a map to fill by the filter with key=source, value=translation
-     * @param legacyTMX a map to fill by the filter with key=source or key=[&lt;fuzzyMark&gt;] source, value=translation
-     * @throws Exception when the filter throws an exception on parseFile.
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param result
+     *            a map to fill by the filter with key=source, value=translation
+     * @param legacyTMX
+     *            a map to fill by the filter with key=source or
+     *            key=[&lt;fuzzyMark&gt;] source, value=translation
+     * @throws Exception
+     *             when the filter throws an exception on parseFile.
      */
     protected void parse2(final AbstractFilter filter, final String filename,
             final Map<String, String> result, final Map<String, String> legacyTMX) throws Exception {
@@ -210,16 +223,15 @@ public abstract class TestFilterBase extends TestCore {
                 addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
             }
 
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntry(String id, String source, String translation, boolean isFuzzy,
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
             @Override
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String segTranslation = isFuzzy ? null : translation;
                 result.put(source, segTranslation);
                 if (translation != null) {
@@ -239,14 +251,20 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the parseFile method of a given filter using some options;
-     * returns a list of ParsedEntry with the
-     * attributes that the filter-under-test finds in the given file and returns to the IParseCallback.addEntry method.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param options the filter options/config to use
+     * Helper function for testing the parseFile method of a given filter using
+     * some options; returns a list of ParsedEntry with the attributes that the
+     * filter-under-test finds in the given file and returns to the
+     * IParseCallback.addEntry method.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param options
+     *            the filter options/config to use
      * @return list of found information
-     * @throws Exception when the filter throws an exception on parseFile.
+     * @throws Exception
+     *             when the filter throws an exception on parseFile.
      */
     protected List<ParsedEntry> parse3(AbstractFilter filter, String filename, Map<String, String> options)
             throws Exception {
@@ -257,6 +275,7 @@ public abstract class TestFilterBase extends TestCore {
                     String comment, IFilter filter) {
                 addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
             }
+
             public void addEntry(String id, String source, String translation, boolean isFuzzy,
                     String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
@@ -264,9 +283,8 @@ public abstract class TestFilterBase extends TestCore {
             }
 
             @Override
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 if (source.isEmpty()) {
                     return;
                 }
@@ -288,41 +306,52 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the translateFile method of a filter. Translation equals the source.
-     * Translation is written to {@link #outFile}.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @throws Exception when the filter throws an exception
+     * Helper function for testing the translateFile method of a filter.
+     * Translation equals the source. Translation is written to
+     * {@link #outFile}.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @throws Exception
+     *             when the filter throws an exception
      */
     protected void translate(AbstractFilter filter, String filename) throws Exception {
         translate(filter, filename, Collections.emptyMap());
     }
 
     /**
-     * Helper function for testing the translateFile method of a filter. Translation equals the source.
-     * Translation is written to {@link #outFile}.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param config the filter options/config to use
-     * @throws Exception when the filter throws an exception
+     * Helper function for testing the translateFile method of a filter.
+     * Translation equals the source. Translation is written to
+     * {@link #outFile}.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param config
+     *            the filter options/config to use
+     * @throws Exception
+     *             when the filter throws an exception
      */
-    protected void translate(AbstractFilter filter, String filename, Map<String, String> config) throws Exception {
-        filter.translateFile(new File(filename), outFile, config, context,
-                new ITranslateCallback() {
-                    public String getTranslation(String id, String source, String path) {
-                        return source;
-                    }
+    protected void translate(AbstractFilter filter, String filename, Map<String, String> config)
+            throws Exception {
+        filter.translateFile(new File(filename), outFile, config, context, new ITranslateCallback() {
+            public String getTranslation(String id, String source, String path) {
+                return source;
+            }
 
-                    public String getTranslation(String id, String source) {
-                        return source;
-                    }
+            public String getTranslation(String id, String source) {
+                return source;
+            }
 
-                    public void linkPrevNextSegments() {
-                    }
+            public void linkPrevNextSegments() {
+            }
 
-                    public void setPass(int pass) {
-                    }
-                });
+            public void setPass(int pass) {
+            }
+        });
     }
 
     protected void align(IFilter filter, String in, String out, IAlignCallback callback) throws Exception {
@@ -332,37 +361,50 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Asserts if the filter translateFile method produces a binary identical file from the given file, when no
-     * filter options/config given.
+     * Asserts if the filter translateFile method produces a binary identical
+     * file from the given file, when no filter options/config given.
      *
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @throws Exception when the filter throws an exception.
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @throws Exception
+     *             when the filter throws an exception.
      */
     protected void translateText(AbstractFilter filter, String filename) throws Exception {
         translateText(filter, filename, Collections.emptyMap());
     }
+
     /**
-     * Asserts if the filter translateFile method produces a binary identical file from the given file under the given
-     * filter options/config.
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @param config  the filter options/config
-     * @throws Exception when the filter throws an exception.
+     * Asserts if the filter translateFile method produces a binary identical
+     * file from the given file under the given filter options/config.
+     * 
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @param config
+     *            the filter options/config
+     * @throws Exception
+     *             when the filter throws an exception.
      */
 
-    protected void translateText(AbstractFilter filter, String filename, Map<String, String> config) throws Exception {
+    protected void translateText(AbstractFilter filter, String filename, Map<String, String> config)
+            throws Exception {
         translate(filter, filename, config);
         compareBinary(new File(filename), outFile);
     }
 
     /**
-     * Tests if the filter translateFile method produces an identical XML file from the given file, when no
-     * filter options/config given.
+     * Tests if the filter translateFile method produces an identical XML file
+     * from the given file, when no filter options/config given.
      *
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @throws Exception when the filter throws an exception.
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @throws Exception
+     *             when the filter throws an exception.
      */
     protected void translateXML(AbstractFilter filter, String filename) throws Exception {
         translate(filter, filename);
@@ -462,17 +504,17 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     protected void checkMulti(String sourceText, String id, String path, String prev, String next,
-                              String comment) {
-        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path), fi.entries.get(fiCount)
-                .getKey());
+            String comment) {
+        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path),
+                fi.entries.get(fiCount).getKey());
         assertEquals(comment, fi.entries.get(fiCount).getComment());
         fiCount++;
     }
 
     protected void checkMultiState(String sourceText, String id, String path, String prev, String next,
             String comment, boolean isFinal) {
-        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path), fi.entries.get(fiCount)
-                .getKey());
+        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path),
+                fi.entries.get(fiCount).getKey());
         assertEquals(comment, fi.entries.get(fiCount).getComment());
         assertEquals(isFinal, fi.entries.get(fiCount).isFinalState());
         fiCount++;
@@ -494,7 +536,8 @@ public abstract class TestFilterBase extends TestCore {
         fiCount++;
     }
 
-    protected SourceTextEntry checkMultiNoPrevNext(String sourceText, String id, String path, String comment) {
+    protected SourceTextEntry checkMultiNoPrevNext(String sourceText, String id, String path,
+            String comment) {
         SourceTextEntry ste = fi.entries.get(fiCount);
         assertEquals(path, ste.getKey().path);
         assertEquals(id, ste.getKey().id);
@@ -535,7 +578,8 @@ public abstract class TestFilterBase extends TestCore {
             Set<EntryKey> existKeys = new HashSet<EntryKey>();
             Map<String, ExternalTMX> transMemories = new HashMap<>();
 
-            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys, transMemories);
+            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys,
+                    transMemories);
 
             TestFileInfo fi = new TestFileInfo();
             fi.filePath = file;
@@ -591,8 +635,8 @@ public abstract class TestFilterBase extends TestCore {
     protected static class TestAlignCallback implements IAlignCallback {
         public List<AlignedEntry> entries = new ArrayList<AlignedEntry>();
 
-        public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                String path, IFilter filter) {
+        public void addTranslation(String id, String source, String translation, boolean isFuzzy, String path,
+                IFilter filter) {
             AlignedEntry en = new AlignedEntry();
             en.id = id;
             en.source = source;

--- a/test/src/org/omegat/filters/TestFilterBase.java
+++ b/test/src/org/omegat/filters/TestFilterBase.java
@@ -462,10 +462,19 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     protected void checkMulti(String sourceText, String id, String path, String prev, String next,
-            String comment) {
+                              String comment) {
         assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path), fi.entries.get(fiCount)
                 .getKey());
         assertEquals(comment, fi.entries.get(fiCount).getComment());
+        fiCount++;
+    }
+
+    protected void checkMultiState(String sourceText, String id, String path, String prev, String next,
+            String comment, boolean isFinal) {
+        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path), fi.entries.get(fiCount)
+                .getKey());
+        assertEquals(comment, fi.entries.get(fiCount).getComment());
+        assertEquals(isFinal, fi.entries.get(fiCount).isFinalState());
         fiCount++;
     }
 

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -535,4 +535,16 @@ public class XLIFFFilterTest extends TestFilterBase {
     public void testBugs1221() throws Exception {
         translateXML(filter, "test/data/filters/xliff/filters3/file-xliff-BUGS1221.xlf");
     }
+
+    @Test
+    public void testStateFinal() throws Exception {
+        String f = "test/data/filters/xliff/filters3/file-XLIFFFilter-state-final.xlf";
+        IProject.FileInfo fi = loadSourceFiles(filter, f);
+
+        checkMultiStart(fi, f);
+        checkMultiState("tr1=This is test", null, null, "", "tr2=test2", null, false);
+        checkMultiState("tr2=test2", null, null, "tr1=This is test", "", null, true);
+        checkMultiEnd();
+    }
 }
+

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -547,4 +547,3 @@ public class XLIFFFilterTest extends TestFilterBase {
         checkMultiEnd();
     }
 }
-


### PR DESCRIPTION
OmegaT  have no feature to handle a protected translation, which is shown but no allow to edit.
This is a proposal to extend OmegaT core and editor to handle a "final" state of translation.

A state is belong to "STE" not a translation. when STE is "final", OmegaT show it but locked as inactive. 

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->


## What does this PR change?

- extend SourceTextEntry class to have "finalState" field
- extend EditorPane to show inactive translation when STE is final state
- extend IParseCallback#addEntryWithProperties to accept isFinal boolean
- extend filters2/XLIFF filter to recognize state="final" attribute
- Add unit test for filters2/xliff filter 

## Other information

#805 

- Protected entries in XLIFF show translation as source text
- https://sourceforge.net/p/omegat/bugs/1215/
