### PR TITLE
[BUGS#1233] fix: Give a proper feedback when filter got character encoding error

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1252,6 +1252,9 @@ FILTERMASTER_ERROR_LOADING_FILTER=Filter '{0}' could not be loaded from '{1}'
 
 FILTERMASTER_ERROR_SRC_TRG_SAME_FILE=Translated file path cannot be identical to the source file path:\n{0}
 
+FILTERMASTER_ERROR_UNKNOWN_ENCODING=Detect a wrong character encoding or wrong character in specified encoding when \
+  output to translation file. Please check your project configuration and translations.
+
 # Filters.java
 
 FILTERS_FILE_FORMAT=File format

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -37,6 +37,8 @@ package org.omegat.filters2.master;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -55,6 +57,7 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.apache.commons.io.FileUtils;
 
+import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.IAlignCallback;
@@ -269,6 +272,9 @@ public class FilterMaster {
         IFilter filterObject = lookup.filterObject;
         try {
             filterObject.translateFile(inFile, outFile, lookup.config, fc, translateCallback);
+        } catch (UnsupportedEncodingException | CharacterCodingException ex) {
+            Log.logErrorRB(ex, "FILTERMASTER_ERROR_UNKNOWN_ENCODING");
+            Core.getMainWindow().displayErrorRB(ex, "FILTERMASTER_ERROR_UNKNOWN_ENCODING");
         } catch (Exception ex) {
             Log.log(ex);
         }


### PR DESCRIPTION
When character encoding error happened,  it is just logging but  no notification.
It is a fix to notify the problem for translators, because resulted translation files can not be completed.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- java.nio.charset.UnmappableCharacterException: Input length = 1
- Bugs: https://sourceforge.net/p/omegat/bugs/1233/

## What does this PR change?

- Catch UnsupportedEncodingException, and UnmappableCharacterException and MalformedInputException in `FilterMaster#translateFile`
- The latter 2 exceptions are inherited from  CharacterCodingException.
- Raise a dialog to notify translator the problems.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
