### PR TITLE
refactor: MainClassLoader as ContextClassLoader

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -462,7 +462,7 @@ public class AlignFilePickerController {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
         Preferences.init();
-        PluginUtils.loadPlugins(Collections.emptyMap());
+        PluginUtils.loadPlugins();
         Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
         Core.setSegmenter(new Segmenter(SRX.getDefault()));
 

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -32,7 +32,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Vector;

--- a/src/org/omegat/MainClassLoader.java
+++ b/src/org/omegat/MainClassLoader.java
@@ -70,17 +70,24 @@ public final class MainClassLoader extends URLClassLoader {
     }
 
     /**
-     * Main class can add jar classpath for plugins in dynamic manner.
-     * @param url
+     * Add a jar classpath.
+     * @param url Jar file URL to add.
      */
     synchronized void add(URL url) {
         addURL(url);
     }
 
-    synchronized void addJarToClasspath(String jarName)
-            throws MalformedURLException {
+    /**
+     * Add a jar classpath.
+     * @param url
+     */
+    public void appendToClassPath(URL url) {
+        add(url);
+    }
+
+    void addJarToClasspath(String jarName) throws MalformedURLException {
         URL url = new File(jarName).toURI().toURL();
-        addURL(url);
+        add(url);
     }
 
     public static MainClassLoader findAncestor(ClassLoader cl) {

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -216,16 +216,28 @@ public final class Core {
     }
 
     /**
+     * initialize GUI.
+     * @param cl class loader.
+     * @param params CLI parameters.
+     * @throws Exception when error occurred.
+     */
+    @Deprecated
+    @SuppressWarnings("unused")
+    public static void initializeGUI(ClassLoader cl, Map<String, String> params) throws Exception {
+        initializeGUI(params);
+    }
+
+    /**
      * Initialize application components.
      */
-    public static void initializeGUI(ClassLoader classLoader, final Map<String, String> params) throws Exception {
+    public static void initializeGUI(final Map<String, String> params) throws Exception {
         cmdLineParams = params;
 
         // 1. Initialize project
         currentProject = new NotLoadedProject();
 
         // 2. Initialize theme
-        UIDesignManager.initialize(classLoader);
+        UIDesignManager.initialize();
 
         // 3. Initialize application frame
         MainWindow me = new MainWindow();

--- a/src/org/omegat/core/team2/TeamTool.java
+++ b/src/org/omegat/core/team2/TeamTool.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.logging.Level;
 
 import org.eclipse.jgit.api.Git;
@@ -147,7 +146,7 @@ public final class TeamTool {
 
         try {
             Preferences.init();
-            PluginUtils.loadPlugins(Collections.emptyMap());
+            PluginUtils.loadPlugins();
             if (COMMAND_INIT.equals(args[0]) && args.length == 3) {
                 initTeamProject(new File("").getAbsoluteFile(), args[1], args[2]);
                 System.exit(0);

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -98,8 +98,9 @@ public final class UIDesignManager {
         return menuPreferences;
     }
 
-    private static void setMenuUI(String menuUIPrefClassName, ClassLoader classLoader) {
+    private static void setMenuUI(String menuUIPrefClassName) {
         try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             Class<?> prefClazz = classLoader.loadClass(menuUIPrefClassName);
             if (prefClazz != null) {
                 Object o = prefClazz.getDeclaredConstructor().newInstance();
@@ -122,6 +123,11 @@ public final class UIDesignManager {
         }
     }
 
+    /**
+     * Load and set theme.
+     * @param lafClassName LookAndFeel full qualified class name.
+     * @param classLoader class loader to use.
+     */
     public static void setTheme(String lafClassName, ClassLoader classLoader) {
         try {
             Class<?> clazz = classLoader.loadClass(lafClassName);
@@ -129,15 +135,29 @@ public final class UIDesignManager {
         } catch (Exception e) {
             Log.log(e);
             if (!lafClassName.equals(LIGHT_CLASS_NAME_DEFAULT)) {
-                setTheme(LIGHT_CLASS_NAME_DEFAULT, classLoader);
+                setTheme(LIGHT_CLASS_NAME_DEFAULT);
             }
         }
     }
 
     /**
-     * Initialize docking subsystem.
+     * Load and set theme.
+     * @param lafClassName LookAndFeel full qualified class name.
      */
+    public static void setTheme(String lafClassName) {
+        setTheme(lafClassName, Thread.currentThread().getContextClassLoader());
+    }
+
+    @Deprecated
+    @SuppressWarnings("unused")
     public static void initialize(ClassLoader mainClassLoader) throws IOException {
+        initialize();
+    }
+
+    /**
+     * Initialize a docking subsystem.
+     */
+    public static void initialize() throws IOException {
         // Install VLDocking defaults
         DockingUISettings.getInstance().installUI();
         DockableContainerFactory.setFactory(new CustomContainerFactory());
@@ -161,11 +181,11 @@ public final class UIDesignManager {
         } else {
             theme = Preferences.getPreferenceDefault(Preferences.THEME_CLASS_NAME, LIGHT_CLASS_NAME_DEFAULT);
         }
-        setTheme(theme, mainClassLoader);
+        setTheme(theme);
 
         String menuUI = Preferences.getPreference(Preferences.MENUUI_CLASS_NAME);
         if (menuUI != null) {
-            setMenuUI(menuUI, mainClassLoader);
+            setMenuUI(menuUI);
         }
 
         if (UIManager.getColor("OmegaT.source") == null) {


### PR DESCRIPTION
It make `Core.initializeGUI` not to take class loader. It is as same signature as OmegaT 5.7.1, and keep support Java9+.

- Main class - set MainClassLoader in main threads context class loader - always instantiate MainClassLoader as application class loader
- MainClassLoader class - add `appendToClassPath` method - make synchronized `add` method - `addJarToClasspath` use `add` method
- Core class - `initializeGUI` get class loader from thread context
- UIDesignManager - `initialize` get clas loader from thread context
- PluginUtils - fix search order 1. user plugin 2 system plugin 3 module - use class loader given from Main class - remove `getThemePluginJars` method
- TeamTool to call `PluginUtils.loadPlugins` w/o args
- AlignFilePickerContoller.main to call `PluginUtils.loadPlugins` w/o args

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
