### PR TITLE
[6.0][BUGS#1166]fix: write the project properties in the backup instead  of copying file

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -34,6 +34,9 @@
   - Content of notes elements are not displayed correctly with Xliff filter
   https://sourceforge.net/p/omegat/bugs/1192/
 
+  - Error when trying to backup the project file on Windows
+  https://sourceforge.net/p/omegat/bugs/1166/
+
 ----------------------------------------------------------------------
  OmegaT 6.0.0 (2023-06-22)
 ----------------------------------------------------------------------

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -649,7 +649,8 @@ public final class ProjectUICommands {
                             backup.getName());
                     Core.getProject().saveProjectProperties();
                 } else if (FileUtil.getRecentBackup(projectFile) == null) {
-                    FileUtil.backupFile(projectFile);
+                    File backup = new File(projectRootFolder, FileUtil.getBackupFilename(projectFile));
+                    ProjectFileStorage.writeProjectFile(backup, propsP);
                 } else if (finalNewProjectFile != null) {
                     FileUtils.deleteQuietly(finalNewProjectFile);
                 }

--- a/src/org/omegat/util/FileUtil.java
+++ b/src/org/omegat/util/FileUtil.java
@@ -127,15 +127,25 @@ public final class FileUtil {
      * @return Backup file.
      */
     public static File backupFile(File original) {
-        long fileMillis = original.lastModified();
-        String str = new SimpleDateFormat("yyyyMMddHHmm").format(new Date(fileMillis));
-        File backup = new File(original.getPath() + "." + str + OConsts.BACKUP_EXTENSION);
+        File backup = new File(original.getParentFile(), getBackupFilename(original));
         try {
             FileUtils.copyFile(original, backup);
         } catch (IOException ex) {
             Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_CREATE_BACKUP_FILE", original.getName());
         }
         return backup;
+    }
+
+    /**
+     * Generates a name for the file to be backuped, in the form of <code>[original_name].yyyyMMddHHmm.bak</code>.
+     *
+     * @param original the file to be backuped
+     * @return the name of the backuped file
+     */
+    public static String getBackupFilename(File original) {
+        return String.format("%s.%s%s", original.getName(),
+                new SimpleDateFormat("yyyyMMddHHmm").format(new Date(original.lastModified())),
+                OConsts.BACKUP_EXTENSION);
     }
 
     /**

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -195,10 +195,16 @@ public final class ProjectFileStorage {
     }
 
     /**
-     * Saves project file to disk.
+     * Saves project file to disk to default `omegat.project` file.
      */
     public static void writeProjectFile(ProjectProperties props) throws Exception {
-        File outFile = new File(props.getProjectRoot(), OConsts.FILE_PROJECT);
+        writeProjectFile(new File(props.getProjectRoot(), OConsts.FILE_PROJECT), props);
+    }
+
+    /**
+￼     * Saves project file to disk.
+￼     */
+    public static void writeProjectFile(File outFile, ProjectProperties props) throws Exception {
         String root = outFile.getAbsoluteFile().getParent();
 
         Omegat om = new Omegat();

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -202,8 +202,8 @@ public final class ProjectFileStorage {
     }
 
     /**
-￼     * Saves project file to disk.
-￼     */
+     * Saves project file to disk.
+     */
     public static void writeProjectFile(File outFile, ProjectProperties props) throws Exception {
         String root = outFile.getAbsoluteFile().getParent();
 


### PR DESCRIPTION
This is the backport from PR #575

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->
 - Error when trying to backup the project file on Windows
-  https://sourceforge.net/p/omegat/bugs/1166/


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
