### PR TITLE
[BUGS#1240]chore: windows: search JRE in PATH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,7 +420,8 @@ launch4j {
     jreMinVersion = '11'
     jreMaxVersion = '21'
     copyConfigurable = [] // hack: don't copy dependencies to $libraryDir
-    bundledJrePath = 'jre' // assume bundled JRE is located in jre/
+    // assume bundled JRE in jre/, fallback to JAVA_HOME env then PATH
+    bundledJrePath = 'jre;%JAVA_HOME%;%PATH%'
     requires64Bit = false  // support 32bit distribution
     restartOnCrash = false
     stayAlive = false

--- a/build.gradle
+++ b/build.gradle
@@ -417,8 +417,8 @@ launch4j {
     icon = "${projectDir}/images/OmegaT.ico"
     errTitle = 'OmegaT'
     headerType = 'gui'
-    jreMinVersion = '11'
-    jreMaxVersion = '21'
+    jreMinVersion = '11.0'
+    jreMaxVersion = '21.1'
     copyConfigurable = [] // hack: don't copy dependencies to $libraryDir
     // assume bundled JRE in jre/, fallback to JAVA_HOME env then PATH
     bundledJrePath = 'jre;%JAVA_HOME%;%PATH%'

--- a/build.gradle
+++ b/build.gradle
@@ -424,8 +424,8 @@ launch4j {
     bundledJrePath = 'jre;%JAVA_HOME%;%PATH%'
     requires64Bit = false  // support 32bit distribution
     copyright = "The GNU General Public License, Version 3.0"
-    version = omtVersion
-    textVersion = omtVersoin.version
+    version = omtVersion.version
+    textVersion = omtVersion.version
     companyName = distAppVendor
     fileDescription = shortDescription
     restartOnCrash = false

--- a/build.gradle
+++ b/build.gradle
@@ -423,6 +423,11 @@ launch4j {
     // assume bundled JRE in jre/, fallback to JAVA_HOME env then PATH
     bundledJrePath = 'jre;%JAVA_HOME%;%PATH%'
     requires64Bit = false  // support 32bit distribution
+    copyright = "The GNU General Public License, Version 3.0"
+    version = omtVersion
+    textVersion = omtVersion
+    companyName = distAppVendor
+    fileDescription = shortDescription
     restartOnCrash = false
     stayAlive = false
     priority = 'normal'

--- a/build.gradle
+++ b/build.gradle
@@ -425,7 +425,7 @@ launch4j {
     requires64Bit = false  // support 32bit distribution
     copyright = "The GNU General Public License, Version 3.0"
     version = omtVersion
-    textVersion = omtVersion
+    textVersion = omtVersoin.version
     companyName = distAppVendor
     fileDescription = shortDescription
     restartOnCrash = false


### PR DESCRIPTION
Current configuration for launch4j specified to JRE path to be jre/ in OmegaT installation directory. This changes to be fallback to JAVA_HOME environment varialbe and PATH.


## Pull request type

- Build and release changes -> [build/release]


## Which ticket is resolved?

- Windows launcher does not launch when witout_JRE installer used
- https://sourceforge.net/p/omegat/bugs/1240/

## What does this PR change?

- Change `build.gradle` a section `launch4j` parameter `jrePath` to be `"jre;%JAVA_HOME%;%PATH%"`

## Other information


In order to debug the created executable call it with the command line argument `--l4j-debug`. This will create the log file `launch4j.log` next to the executable. please take care of write permission of `C:\Program Files\OmegaT` folder on debug session.


