### PR TITLE
[BUGS#1239] feat: glossary support optional sort by src length

### DIFF
--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -286,7 +286,24 @@
           displayed on the same line.</para>
         </listitem>
       </varlistentry>
-    </variablelist>
+
+	  <varlistentry id="dialogs.preferences.glossary.sort.by.source.term.length">
+		  <term id="dialogs.preference.glossary.sort.by.source.term.length.title"><option>Sort by source
+			  text term length</option></term>
+		  <listitem>
+			  <para>If some glossary items are similar in a source term text,
+				  and one contains another term text, sort by a length of source text.</para>
+		  </listitem>
+	  </varlistentry>
+
+		<varlistentry id="dialogs.preferences.glossary.sort.by.target.term.length">
+			<term id="dialogs.preference.glossary.sort.by.target.term.length.title"><option>Sort by source
+				text term length</option></term>
+			<listitem>
+				<para>If a glossary item has multiple definitions, sort by a length of definition text.</para>
+			</listitem>
+		</varlistentry>
+	</variablelist>
   </section>
 
   <section id="dialogs.preferences.dictionary">

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1886,6 +1886,7 @@ GUI_GLOSSARYWINDOW_insertselection=Insert Selection
 GUI_GLOSSARYWINDOW_SETTINGS_NOTIFICATIONS=Notify Me When a Segment Has Glossary Hits
 
 GUI_GLOSSARYWINDOW_SETTINGS_OPEN_FILE=Open Writable Glossary File
+GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_SRC_LENGTH=Sort by Source Term Length
 GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_LENGTH=Sort by Target Term Length
 
 GUI_MATCHWINDOW_SUBWINDOWTITLE_Dictionary=Dictionaries
@@ -2764,6 +2765,8 @@ PREFS_GLOSSARY_STEMMING=Use &stemming
 PREFS_GLOSSARY_REPLACE_ON_INSERT=Replace matches when inserting source text
 PREFS_GLOSSARY_REQUIRE_SIMILAR_CASE=&Ignore matches with very different case (e.g. FOO vs foo)
 PREFS_GLOSSARY_MERGE_ALTERNATE_DEFINITIONS=Merge alternate definitions of the same term
+PREFS_GLOSSARY_SORT_BY_SRC_LENGTH=Sort by Source Term Length
+PREFS_GLOSSARY_SORT_BY_LENGTH=Sort by Target Term Length
 
 PREFS_GLOSSARY_LAYOUT=&Layout:
 GLOSSARY_RENDERER_DEFAULT=Default

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -181,8 +181,7 @@ public class GlossarySearcher {
 
     protected static boolean isCjkMatch(String fullText, String term) {
         // This is a CJK word and our source language is not space-delimited, so
-        // include if
-        // word appears anywhere in source string.
+        // include if word appears anywhere in source string.
         IProject project = Core.getProject();
         return project.isProjectLoaded()
                 && !project.getProjectProperties().getSourceLanguage().isSpaceDelimited()
@@ -191,8 +190,7 @@ public class GlossarySearcher {
 
     private static List<Token[]> getCjkMatchingTokens(String fullText, String term) {
         // This is a CJK word and our source language is not space-delimited, so
-        // include if
-        // word appears anywhere in source string.
+        // include if word appears anywhere in source string.
         IProject project = Core.getProject();
         if (!project.isProjectLoaded()
                 || project.getProjectProperties().getSourceLanguage().isSpaceDelimited()) {

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2017 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -49,6 +50,7 @@ import org.omegat.util.Token;
  * A class encapsulating glossary matching logic.
  *
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  */
 public class GlossarySearcher {
     private final ITokenizer tok;
@@ -66,7 +68,8 @@ public class GlossarySearcher {
         List<GlossaryEntry> result = new ArrayList<>();
 
         // Compute source entry tokens
-        Token[] strTokens = tokenize(ste.getSrcText(), TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
+        Token[] strTokens = tokenize(ste.getSrcText(),
+                TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
 
         for (GlossaryEntry glosEntry : entries) {
             checkCancelled();
@@ -90,7 +93,8 @@ public class GlossarySearcher {
 
     public List<Token[]> searchSourceMatchTokens(SourceTextEntry ste, GlossaryEntry entry) {
         // Compute source entry tokens
-        Token[] strTokens = tokenize(ste.getSrcText(), TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
+        Token[] strTokens = tokenize(ste.getSrcText(),
+                TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
 
         List<Token[]> toks = getMatchingTokens(strTokens, ste.getSrcText(), entry.getSrcText());
         if (toks.isEmpty()) {
@@ -117,7 +121,8 @@ public class GlossarySearcher {
     }
 
     /**
-     * Override this to throw an exception (that you will catch) to abort matching.
+     * Override this to throw an exception (that you will catch) to abort
+     * matching.
      */
     protected void checkCancelled() {
     }
@@ -160,7 +165,8 @@ public class GlossarySearcher {
     }
 
     private static boolean keepMatch(Token[] tokens, String srcTxt, String locTxt) {
-        // Filter out matches where the glossary entry is all caps but the source-text match is not.
+        // Filter out matches where the glossary entry is all caps but the
+        // source-text match is not.
         if (Preferences.isPreferenceDefault(Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE,
                 Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE_DEFAULT) && StringUtil.isUpperCase(locTxt)) {
             for (Token tok : tokens) {
@@ -174,18 +180,22 @@ public class GlossarySearcher {
     }
 
     protected static boolean isCjkMatch(String fullText, String term) {
-        // This is a CJK word and our source language is not space-delimited, so include if
+        // This is a CJK word and our source language is not space-delimited, so
+        // include if
         // word appears anywhere in source string.
         IProject project = Core.getProject();
-        return project.isProjectLoaded() && !project.getProjectProperties().getSourceLanguage().isSpaceDelimited()
+        return project.isProjectLoaded()
+                && !project.getProjectProperties().getSourceLanguage().isSpaceDelimited()
                 && StringUtil.isCJK(term) && fullText.contains(term);
     }
 
     private static List<Token[]> getCjkMatchingTokens(String fullText, String term) {
-        // This is a CJK word and our source language is not space-delimited, so include if
+        // This is a CJK word and our source language is not space-delimited, so
+        // include if
         // word appears anywhere in source string.
         IProject project = Core.getProject();
-        if (!project.isProjectLoaded() || project.getProjectProperties().getSourceLanguage().isSpaceDelimited()) {
+        if (!project.isProjectLoaded()
+                || project.getProjectProperties().getSourceLanguage().isSpaceDelimited()) {
             return Collections.emptyList();
         }
         if (!StringUtil.isCJK(term)) {
@@ -206,7 +216,8 @@ public class GlossarySearcher {
     private Token[] tokenize(String str) {
         // Make comparison case-insensitive
         String strLower = str.toLowerCase(lang.getLocale());
-        if (Preferences.isPreferenceDefault(Preferences.GLOSSARY_STEMMING, Preferences.GLOSSARY_STEMMING_DEFAULT)) {
+        if (Preferences.isPreferenceDefault(Preferences.GLOSSARY_STEMMING,
+                Preferences.GLOSSARY_STEMMING_DEFAULT)) {
             return tok.tokenizeWords(strLower, StemmingMode.GLOSSARY);
         } else {
             return tok.tokenizeVerbatim(strLower);
@@ -229,7 +240,8 @@ public class GlossarySearcher {
 
     private static boolean tokenInTag(Token tok, List<Tag> tags) {
         for (Tag tag : tags) {
-            if (tok.getOffset() >= tag.pos && tok.getOffset() + tok.getLength() <= tag.pos + tag.tag.length()) {
+            if (tok.getOffset() >= tag.pos
+                    && tok.getOffset() + tok.getLength() <= tag.pos + tag.tag.length()) {
                 return true;
             }
         }
@@ -242,11 +254,13 @@ public class GlossarySearcher {
             int p2 = o2.getPriority() ? 1 : 2;
             int c = p1 - p2;
             if (c == 0 && Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false)
-                    && (o2.getSrcText().contains(o1.getSrcText()) || o1.getSrcText().contains(o2.getSrcText()))) {
+                    && (o2.getSrcText().contains(o1.getSrcText())
+                            || o1.getSrcText().contains(o2.getSrcText()))) {
                 // longer is better if one contains another
                 c = o2.getSrcText().length() - o1.getSrcText().length();
             }
-            // sort source text alphabetically, first ignore a case, then consider a case
+            // sort source text alphabetically, first ignore a case, then
+            // consider a case
             if (c == 0) {
                 c = o1.getSrcText().compareToIgnoreCase(o2.getSrcText());
             }
@@ -263,7 +277,8 @@ public class GlossarySearcher {
         });
     }
 
-    private static List<GlossaryEntry> filterGlossary(List<GlossaryEntry> result, boolean mergeAltDefinitions) {
+    private static List<GlossaryEntry> filterGlossary(List<GlossaryEntry> result,
+            boolean mergeAltDefinitions) {
         // First check that entries exist in the list.
         if (result.isEmpty()) {
             return result;
@@ -396,9 +411,9 @@ public class GlossarySearcher {
                 priorities[j] = prios.get(j);
             }
 
-            GlossaryEntry combineEntry = new GlossaryEntry(srcTxt, locTxts.toArray(new String[locTxts.size()]),
-                    comTxts.toArray(new String[comTxts.size()]), priorities,
-                    origins.toArray(new String[origins.size()]));
+            GlossaryEntry combineEntry = new GlossaryEntry(srcTxt,
+                    locTxts.toArray(new String[locTxts.size()]), comTxts.toArray(new String[comTxts.size()]),
+                    priorities, origins.toArray(new String[origins.size()]));
             returnList.add(combineEntry);
         }
         return returnList;

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -251,7 +251,7 @@ public class GlossarySearcher {
             int p1 = o1.getPriority() ? 1 : 2;
             int p2 = o2.getPriority() ? 1 : 2;
             int c = p1 - p2;
-            if (c == 0 && Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false)
+            if (c == 0 && Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, true)
                     && (o2.getSrcText().contains(o1.getSrcText())
                             || o1.getSrcText().contains(o2.getSrcText()))) {
                 // longer is better if one contains another

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -79,9 +79,10 @@ public class GlossarySearcher {
         // After the matched entries have been tokenized and listed,
         // we reorder entries as
         // 1) by priority
-        // 2) by alphabet of source term
-        // 3) by length of localized term (optional)
-        // 4) by alphabet of localized term
+        // 2) by length of source text if one contains another (optional)
+        // 3) by alphabet of source term
+        // 4) by length of localized term (optional)
+        // 5) by alphabet of localized term
         // Then remove the duplicates and combine the synonyms.
         sortGlossaryEntries(result);
         return filterGlossary(result, mergeAltDefinitions);
@@ -240,14 +241,19 @@ public class GlossarySearcher {
             int p1 = o1.getPriority() ? 1 : 2;
             int p2 = o2.getPriority() ? 1 : 2;
             int c = p1 - p2;
+            if (c == 0 && Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false)
+                    && (o2.getSrcText().contains(o1.getSrcText()) || o1.getSrcText().contains(o2.getSrcText()))) {
+                // longer is better if one contains another
+                c = o2.getSrcText().length() - o1.getSrcText().length();
+            }
+            // sort source text alphabetically, first ignore a case, then consider a case
             if (c == 0) {
                 c = o1.getSrcText().compareToIgnoreCase(o2.getSrcText());
             }
             if (c == 0) {
                 c = o1.getSrcText().compareTo(o2.getSrcText());
             }
-            if (c == 0 && Preferences.isPreferenceDefault(
-                    Preferences.GLOSSARY_SORT_BY_LENGTH, false)) {
+            if (c == 0 && Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_LENGTH, false)) {
                 c = o2.getLocText().length() - o1.getLocText().length();
             }
             if (c == 0) {

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -433,6 +433,13 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         });
         menu.add(notify);
         menu.addSeparator();
+        final JMenuItem sortOrderSrcLength = new JCheckBoxMenuItem(
+                OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_SRC_LENGTH"));
+        sortOrderSrcLength
+                .setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false));
+        sortOrderSrcLength.addActionListener(actionEvent -> Preferences
+                .setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, sortOrderSrcLength.isSelected()));
+        menu.add(sortOrderSrcLength);
         final JMenuItem sortOrderLocLength = new JCheckBoxMenuItem(
                 OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_SORT_BY_LENGTH"));
         sortOrderLocLength

--- a/src/org/omegat/gui/glossary/TransTipsPopup.java
+++ b/src/org/omegat/gui/glossary/TransTipsPopup.java
@@ -39,7 +39,6 @@ import javax.swing.text.JTextComponent;
 import org.omegat.core.Core;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
-import org.omegat.util.StringUtil;
 import org.omegat.util.Token;
 import org.omegat.util.gui.MenuItemPager;
 
@@ -62,7 +61,7 @@ public class TransTipsPopup implements IPopupMenuConstructor {
             return;
         }
 
-        // is mouse in active entry's source ?
+        // is mouse in active entry's source?
         final int startSource = sb.getStartSourcePosition();
         int len = sb.getSourceText().length();
         if (mousepos < startSource || mousepos > startSource + len) {
@@ -73,21 +72,21 @@ public class TransTipsPopup implements IPopupMenuConstructor {
         for (GlossaryEntry ge : GlossaryTextArea.nowEntries) {
             for (Token[] toks : Core.getGlossaryManager().searchSourceMatchTokens(sb.getSourceTextEntry(), ge)) {
                 for (Token tok : toks) {
-                    // is inside found word ?
+                    // is it on found word?
                     if (startSource + tok.getOffset() <= mousepos
                             && mousepos <= startSource + tok.getOffset() + tok.getLength()) {
                         // Create the MenuItems
+
                         for (String s : ge.getLocTerms(true)) {
                             if (!added.contains(s)) {
                                 JMenuItem it = pager.add(new JMenuItem(s));
                                 it.addActionListener(e -> Core.getEditor().insertText(s));
+                                StringBuilder tooltip = new StringBuilder();
+                                tooltip.append(ge.getSourceText()).append(": ").append(ge.getCommentText());
                                 it.addMouseListener(new MouseAdapter() {
                                     @Override
                                     public void mouseEntered(final MouseEvent e) {
-                                        String comment = ge.getCommentText();
-                                        if (!StringUtil.isEmpty(comment)) {
-                                            it.setToolTipText(comment);
-                                        }
+                                        it.setToolTipText(tooltip.toString());
                                     }
 
                                     @Override

--- a/src/org/omegat/gui/preferences/view/GlossaryPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/GlossaryPreferencesController.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2016 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -37,6 +38,7 @@ import org.omegat.util.gui.DelegatingComboBoxRenderer;
 
 /**
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  */
 public class GlossaryPreferencesController extends BasePreferencesController {
 
@@ -76,11 +78,16 @@ public class GlossaryPreferencesController extends BasePreferencesController {
         panel.useStemmingCheckBox.setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_STEMMING,
                 Preferences.GLOSSARY_STEMMING_DEFAULT));
         panel.replaceHitsCheckBox.setSelected(Preferences.isPreference(Preferences.GLOSSARY_REPLACE_ON_INSERT));
-        panel.requireSimilarCaseCheckBox.setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE,
-                Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE_DEFAULT));
+        panel.requireSimilarCaseCheckBox.setSelected(Preferences.isPreferenceDefault(
+                Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE, Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE_DEFAULT));
         panel.cbGlossaryLayout.setSelectedItem(GlossaryRenderers.getPreferredGlossaryRenderer());
-        panel.mergeAlternateDefinitionsCheckBox.setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS, 
+        panel.mergeAlternateDefinitionsCheckBox.setSelected(Preferences.isPreferenceDefault(
+                Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS,
                 Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS_DEFAULT));
+        panel.sortBySrcTextLengthCheckBox.setSelected(Preferences.isPreferenceDefault(
+                Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false));
+        panel.sortByTextLengthCheckBox.setSelected(Preferences.isPreferenceDefault(Preferences.GLOSSARY_SORT_BY_LENGTH,
+                false));
     }
 
     @Override
@@ -92,6 +99,8 @@ public class GlossaryPreferencesController extends BasePreferencesController {
         panel.requireSimilarCaseCheckBox.setSelected(Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE_DEFAULT);
         panel.cbGlossaryLayout.setSelectedItem(GlossaryRenderers.DEFAULT_RENDERER);
         panel.mergeAlternateDefinitionsCheckBox.setSelected(Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS_DEFAULT);
+        panel.sortBySrcTextLengthCheckBox.setSelected(false);
+        panel.sortByTextLengthCheckBox.setSelected(false);
     }
 
     @Override
@@ -100,8 +109,13 @@ public class GlossaryPreferencesController extends BasePreferencesController {
         Preferences.setPreference(Preferences.GLOSSARY_NOT_EXACT_MATCH, panel.useSeparateTermsCheckBox.isSelected());
         Preferences.setPreference(Preferences.GLOSSARY_STEMMING, panel.useStemmingCheckBox.isSelected());
         Preferences.setPreference(Preferences.GLOSSARY_REPLACE_ON_INSERT, panel.replaceHitsCheckBox.isSelected());
-        Preferences.setPreference(Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE, panel.requireSimilarCaseCheckBox.isSelected());
+        Preferences.setPreference(Preferences.GLOSSARY_REQUIRE_SIMILAR_CASE,
+                panel.requireSimilarCaseCheckBox.isSelected());
         GlossaryRenderers.setPreferredGlossaryRenderer((IGlossaryRenderer) panel.cbGlossaryLayout.getSelectedItem());
-        Preferences.setPreference(Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS, panel.mergeAlternateDefinitionsCheckBox.isSelected());
+        Preferences.setPreference(Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS,
+                panel.mergeAlternateDefinitionsCheckBox.isSelected());
+        Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH, panel.sortByTextLengthCheckBox.isSelected());
+        Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH,
+                panel.sortBySrcTextLengthCheckBox.isSelected());
     }
 }

--- a/src/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.form
+++ b/src/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.form
@@ -154,5 +154,25 @@
         <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
       </AuxValues>
     </Component>
+    <Component class="javax.swing.JCheckBox" name="sortBySrcTextLengthCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="OStrings.getString(&quot;PREFS_GLOSSARY_SORT_BY_SRC_LENGTH&quot;)" type="code"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="sortByTextLengthCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="OStrings.getString(&quot;PREFS_GLOSSARY_SORT_BY_LENGTH&quot;)" type="code"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
+    </Component>
   </SubComponents>
 </Form>

--- a/src/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.java
+++ b/src/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.java
@@ -60,6 +60,8 @@ public class GlossaryPreferencesPanel extends JPanel {
         cbGlossaryLayout = new javax.swing.JComboBox<>();
         filler2 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 10));
         mergeAlternateDefinitionsCheckBox = new javax.swing.JCheckBox();
+        sortBySrcTextLengthCheckBox = new javax.swing.JCheckBox();
+        sortByTextLengthCheckBox = new javax.swing.JCheckBox();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
         setMinimumSize(new java.awt.Dimension(250, 200));
@@ -94,6 +96,12 @@ public class GlossaryPreferencesPanel extends JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(mergeAlternateDefinitionsCheckBox, OStrings.getString("PREFS_GLOSSARY_MERGE_ALTERNATE_DEFINITIONS")); // NOI18N
         add(mergeAlternateDefinitionsCheckBox);
+
+        org.openide.awt.Mnemonics.setLocalizedText(sortBySrcTextLengthCheckBox, OStrings.getString("PREFS_GLOSSARY_SORT_BY_SRC_LENGTH"));
+        add(sortBySrcTextLengthCheckBox);
+
+        org.openide.awt.Mnemonics.setLocalizedText(sortByTextLengthCheckBox, OStrings.getString("PREFS_GLOSSARY_SORT_BY_LENGTH"));
+        add(sortByTextLengthCheckBox);
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -106,6 +114,8 @@ public class GlossaryPreferencesPanel extends JPanel {
     javax.swing.JCheckBox mergeAlternateDefinitionsCheckBox;
     javax.swing.JCheckBox replaceHitsCheckBox;
     javax.swing.JCheckBox requireSimilarCaseCheckBox;
+    javax.swing.JCheckBox sortBySrcTextLengthCheckBox;
+    javax.swing.JCheckBox sortByTextLengthCheckBox;
     javax.swing.JCheckBox useSeparateTermsCheckBox;
     javax.swing.JCheckBox useStemmingCheckBox;
     // End of variables declaration//GEN-END:variables

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -498,6 +498,7 @@ public final class Preferences {
     public static final String THEME_CLASS_NAME = "theme_class_name";
     public static final String THEME_DARK_CLASS_NAME = "theme_dark_class_name";
     public static final String THEME_COLOR_MODE = "theme_color_mode";
+    public static final String GLOSSARY_SORT_BY_SRC_LENGTH = "glossary_sort_by_src_length";
     public static final String GLOSSARY_SORT_BY_LENGTH = "glossary_sort_by_length";
     public static final String MENUUI_CLASS_NAME = "menuui_class_name";
 

--- a/test/src/org/omegat/gui/glossary/FindGlossaryThreadTest.java
+++ b/test/src/org/omegat/gui/glossary/FindGlossaryThreadTest.java
@@ -43,7 +43,11 @@ public class FindGlossaryThreadTest extends TestCore {
         entries.add(new GlossaryEntry("cat", "mikeneko", "ccat", false, null));
         entries.add(new GlossaryEntry("zzz", "zzz", "czzz", true, null));
         entries.add(new GlossaryEntry("horse", "catty", "chorse", false, null));
+        entries.add(new GlossaryEntry("向上", "enhance", "", false, null));
+        entries.add(new GlossaryEntry("向", "direct", "", false, null));
+        entries.add(new GlossaryEntry("上", "up", "", false, null));
         Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH, true);
+        Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false);
         GlossarySearcher.sortGlossaryEntries(entries);
         assertEquals("zzz", entries.get(0).getSrcText());
         assertEquals("cat", entries.get(1).getSrcText());
@@ -61,5 +65,20 @@ public class FindGlossaryThreadTest extends TestCore {
         assertEquals("mikeneko", entries.get(2).getLocText());
         assertEquals("dog", entries.get(3).getSrcText());
         assertEquals("horse", entries.get(4).getSrcText());
+        assertEquals("up", entries.get(5).getLocText());
+        assertEquals("direct", entries.get(6).getLocText());
+        assertEquals("enhance", entries.get(7).getLocText());
+        Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, true);
+        GlossarySearcher.sortGlossaryEntries(entries);
+        assertEquals("zzz", entries.get(0).getSrcText());
+        assertEquals("cat", entries.get(1).getSrcText());
+        assertEquals("catty", entries.get(1).getLocText());
+        assertEquals("cat", entries.get(2).getSrcText());
+        assertEquals("mikeneko", entries.get(2).getLocText());
+        assertEquals("dog", entries.get(3).getSrcText());
+        assertEquals("horse", entries.get(4).getSrcText());
+        assertEquals("enhance", entries.get(5).getLocText());
+        assertEquals("up", entries.get(6).getLocText());
+        assertEquals("direct", entries.get(7).getLocText());
     }
 }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Glossary popups behavior changed unintended way
- https://sourceforge.net/p/omegat/bugs/1239/

## What does this PR change?

- Support sort by length of a source text when one contains another.
- It prioritizes a longer match to be shown in tooltips
- Introduce a new preference GLOSSARY_SORT_BY_SRC_LENGTH
- Configurable on glossary pane configuration button
- Configurable on preference dialog
- Update manual to add description of preference -> glossary

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
![glossary_sort_order_config](https://github.com/omegat-org/omegat/assets/123720/c5752044-b6db-48f8-9ae7-3f8f9473a5ef)
