### PR TITLE
fix: docker/nerdctl detection

### DIFF
--- a/ci/iscc
+++ b/ci/iscc
@@ -32,7 +32,10 @@ WORKDIR /work
 ENTRYPOINT ["iscc"]
 __EOF__
 
-CMD="$(type -p docker)" || [[ -e $CMD ]] || CMD="$(type -p nerdctl)"
+CMD="$(type -p docker)" || [[ -e $CMD ]] && $CMD info >/dev/null 2>1 || CMD="$(type -p nerdctl)"
+echo select container CLI: $CMD
+$CMD info || false
+
 if ! $CMD build -t $IMAGE $CONTEXT ; then
   echo Container build error for ISCC, abort...
   exit 1

--- a/ci/osslsigncode
+++ b/ci/osslsigncode
@@ -15,14 +15,9 @@ bindpaths() {
     done
 }
 
-if type nerdctl &> /dev/null ; then
-    CMD=nerdctl
-elif type docker &> /dev/null ; then
-    CMD=docker
-else
-  echo Please install docker or nerdctl!
-  exit 2
-fi
+CMD="$(type -p docker)" || [[ -e $CMD ]] && $CMD info >/dev/null 2>1 || CMD="$(type -p nerdctl)"
+echo select container CLI: $CMD
+$CMD info || false
 
 # build container image
 CTX=$(mktemp -d)

--- a/doc_src/docgen
+++ b/doc_src/docgen
@@ -22,7 +22,10 @@ mkdir -p $TARGET
 chmod -R a+rw $SHELL_PATH/$LANGUAGE 2&> /dev/null
 chmod -R a+rw $TARGET 2&> /dev/null
 
-CMD="$(type -p docker)" || [[ -e $CMD ]] || CMD="$(type -p nerdctl)"
+CMD="$(type -p docker)" || [[ -e $CMD ]] && $CMD info >/dev/null 2>1 || CMD="$(type -p nerdctl)"
+echo select container CLI: $CMD
+$CMD info || false
+
 EXIT_CODE=0
 $CMD run -i --rm -u  `id -u`:`id -g` -v "$(dirname "$PWD")":/work/root omegatorg/docgen "$@"
 EXIT_CODE=$?


### PR DESCRIPTION
When using Rancher-desktop for container execution, it installs both docker and nerdctl commands. Because a execution of docker command with Rancher Desktop fails, check a status of `docker info` command, and wen failed, we select nerdctl. nerdctl can also be failed when user forget to start Rancher desktop. We run ``$CMD info` after the selection, then user can recognize a error with warning message to launch Rancher desktop.

The change does not affect other environment, beucase we use it when docker info or nerdctl info succeeded.

## Pull request type


- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?


## What does this PR change?

- update docgen, iscc  shell script
- replace nerdctl/docker detection 
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
