### PR TITLE
refactor: UIDesignManager.initialize

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -337,7 +337,7 @@ public final class Main {
 
         System.setProperty("swing.aatext", "true");
         try {
-            Core.initializeGUI(mainClassLoader, PARAMS);
+            Core.initializeGUI(PARAMS);
         } catch (Throwable ex) {
             Log.log(ex);
             showError(ex);

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -218,14 +218,14 @@ public final class Core {
     /**
      * Initialize application components.
      */
-    public static void initializeGUI(ClassLoader classLoader, final Map<String, String> params) throws Exception {
+    public static void initializeGUI(final Map<String, String> params) throws Exception {
         cmdLineParams = params;
 
         // 1. Initialize project
         currentProject = new NotLoadedProject();
 
         // 2. Initialize theme
-        UIDesignManager.initialize(classLoader);
+        UIDesignManager.initialize();
 
         // 3. Initialize application frame
         MainWindow me = new MainWindow();


### PR DESCRIPTION
- Introduce getClassLoader utility method in the class and initialize does not take classloader.
- Simplify Core.initializeGUI not to take classloader.
- Simplify Main#runGUI not to take classloader.

With this change, a signature of `Core.initializeGUI` become compatible with OmegaT 5.7.1.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

- refactor UIDesignManager.initialize
- pick a part of enhancement from #906 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
