### PR TITLE
refactor: keep Core.initializeGUI() as deprecated

### DIFF
--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -216,6 +216,21 @@ public final class Core {
     }
 
     /**
+     * initialize GUI.
+     * <p>
+     * An interface that was introduced in v5.6.0 when supporting theme plugin.
+     *
+     * @param cl class loader.
+     * @param params CLI parameters.
+     * @throws Exception when error occurred.
+     */
+    @Deprecated(since = "6.1.0")
+    @SuppressWarnings("unused")
+    public static void initializeGUI(ClassLoader cl, Map<String, String> params) throws Exception {
+        initializeGUI(params);
+    }
+
+    /**
      * Initialize application components.
      */
     public static void initializeGUI(final Map<String, String> params) throws Exception {


### PR DESCRIPTION
Pull-Request #915 should keep the interface signature `Core.initializeGUI(ClassLoader, Map)` as deprecated flag.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
