### PR TITLE
chore: resolve conflict in annotations jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,7 @@ dependencies {
         implementation(libs.languagetool.core) {
             exclude module: 'guava'
             exclude module: 'language-detector'
+            exclude group: 'com.google.android'
         }
         implementation(libs.language.detector)
 


### PR DESCRIPTION
There are two annotations jar files in dependency library. We observe annotations-23.0.0.jar (jetbrains) and annotations-1.1.4.jar (google-android). This change excludes android annotation library because OmegaT does not support android.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type


- Dependencies

## Which ticket is resolved?
## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
