### PR TITLE
docs: fix pdf generation and restructure manual generations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -490,19 +490,16 @@ manualIndexXmls.each { xml ->
     def lang = xml.parentFile.name
     def pdfTaskName = "manualPdf${lang.capitalize()}"
     tasks.register(pdfTaskName, Exec) {
-        inputs.files fileTree(dir: "doc_src/${lang}", include: '**/*.xml')
-        outputs.file "${buildDir}/build/docs/pdfs/OmegaT_documentation_${lang}.PDF"
-        workingDir = 'doc_src'
-        commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/pdfs", 'pdf'
+        inputs.files fileTree(dir: "doc_src/${lang}", includes: ['**/*.xml', 'images/*.png'],
+                excludes: ['xhtml5/*', 'index.xml'])
+        outputs.file layout.buildDirectory.file("docs/pdfs/OmegaT_documentation_${lang}.PDF")
         onlyIf {
             conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
                     [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])
         }
+        workingDir = 'doc_src'
+        commandLine './docgen', "-Dlanguage=${lang}", "-Dtarget=../build/docs/pdfs", 'pdf'
         doLast {
-            copy {
-                from fileTree(dir: "doc_src/${lang}/pdf", include: '*.PDF')
-                into distsDir
-            }
             delete fileTree(dir: "doc_src/${lang}", includes: ['pdf/*', 'index.xml'])
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -492,7 +492,7 @@ manualIndexXmls.each { xml ->
     tasks.register(pdfTaskName, Exec) {
         inputs.files fileTree(dir: "doc_src/${lang}", includes: ['**/*.xml', 'images/*.png'],
                 excludes: ['xhtml5/*', 'index.xml'])
-        outputs.file layout.buildDirectory.file("docs/pdfs/OmegaT_documentation_${lang}.PDF")
+        outputs.files layout.buildDirectory.file("docs/pdfs/OmegaT_documentation_${lang}.PDF")
         onlyIf {
             conditions([exePresent('docker') || exePresent('nerdctl'), 'Docker or nerdctl is not installed'],
                     [!project.hasProperty('forceSkipDocumentBuild'), 'Specified forceSkipDocumentBuild property'])

--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -41,16 +41,16 @@
     </target>
 
     <!-- The fonts must be available in the system -->
-    <condition property="font.family" value="IPAPGothic">
+    <condition property="font.family" value="Noto Sans CJK JP">
         <equals arg1="${language}" arg2="ja"/>
     </condition>
-    <condition property="monospace.font.family" value="IPAGothic">
+    <condition property="monospace.font.family" value="Noto Sans CJK JP">
         <equals arg1="${language}" arg2="ja"/>
     </condition>
-    <condition property="font.family" value="WenQuanYi Micro Hei">
+    <condition property="font.family" value="Noto Sans CJK SC">
         <equals arg1="${language}" arg2="zh_CN"/>
     </condition>
-    <condition property="monospace.font.family" value="WenQuanYi Micro Hei">
+    <condition property="monospace.font.family" value="Noto Sans CJK SC">
         <equals arg1="${language}" arg2="zh_CN"/>
     </condition>
     <property name="font.family" value="DejaVu Sans"/>

--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -63,7 +63,7 @@
               maxmemory="128m"
               classname="com.icl.saxon.StyleSheet" >
             <arg value="-o" />
-            <arg value="${language}/pdf/OmegaT_documentation.fo" />
+            <arg value="${target}/OmegaT_documentation.fo" />
             <arg value="${language}/index.xml" />
             <arg value="${dbk}/fo/docbook.xsl" />
             <arg value="paper.type=A4" />
@@ -98,16 +98,15 @@
                 <include name="*.jar"/>
             </fileset>
             <fileset dir="${fop.home.build}">
-                <include name="fop.jar"/>
-                <include name="fop-hyph.jar" />
+                <include name="fop*.jar"/>
              </fileset>
         </classpath>
     </taskdef>
 
     <target name="pdf" depends="fo">
         <fop format="application/pdf"
-             fofile="${language}/pdf/OmegaT_documentation.fo"
-             outfile="${language}/pdf/OmegaT_documentation_${language}.PDF"
+             fofile="${target}/OmegaT_documentation.fo"
+             outfile="${target}/OmegaT_documentation_${language}.PDF"
              basedir="${language}/"
              userconfig="fop.xconf"
              force="true" />

--- a/doc_src/build.xml
+++ b/doc_src/build.xml
@@ -63,7 +63,7 @@
               maxmemory="128m"
               classname="com.icl.saxon.StyleSheet" >
             <arg value="-o" />
-            <arg value="${target}/OmegaT_documentation.fo" />
+            <arg value="${target}/OmegaT_documentation_${language}.fo" />
             <arg value="${language}/index.xml" />
             <arg value="${dbk}/fo/docbook.xsl" />
             <arg value="paper.type=A4" />
@@ -105,7 +105,7 @@
 
     <target name="pdf" depends="fo">
         <fop format="application/pdf"
-             fofile="${target}/OmegaT_documentation.fo"
+             fofile="${target}/OmegaT_documentation_${language}.fo"
              outfile="${target}/OmegaT_documentation_${language}.PDF"
              basedir="${language}/"
              userconfig="fop.xconf"

--- a/doc_src/docgen
+++ b/doc_src/docgen
@@ -26,8 +26,10 @@ CMD="$(type -p docker)" || [[ -e $CMD ]] && $CMD info >/dev/null 2>1 || CMD="$(t
 echo select container CLI: $CMD
 $CMD info || false
 
+[[ "$@" =~ (^|[[:space:]])pdf($|[[:space:]]) ]] && TAG=pdfgen || TAG=alpine
+
 EXIT_CODE=0
-$CMD run -i --rm -u  `id -u`:`id -g` -v "$(dirname "$PWD")":/work/root omegatorg/docgen "$@"
+$CMD run -i --rm -u  `id -u`:`id -g` -v "$(dirname "$PWD")":/work/root omegatorg/docgen:$TAG "$@"
 EXIT_CODE=$?
 sleep 5
 if [[ -e $SHELL_PATH/$LANGUAGE/xhtml5 ]]; then

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -10,8 +10,8 @@
 	<para>The first time you start OmegaT, the main window displays the
 	following default layout:</para>
 
-		<figure id="default.omegat.layout2">
-      <title id="default.omegat.layout2.title">Default OmegaT layout on
+		<figure id="default.omegat.layout.macos">
+      <title id="default.omegat.layout.macos.title">Default OmegaT layout on
       macOS</title>
       <mediaobject>
         <imageobject role="html">

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -10,8 +10,8 @@
 	<para>The first time you start OmegaT, the main window displays the
 	following default layout:</para>
 
-		<figure id="default.omegat.layout">
-      <title id="default.omegat.layout.title">Default OmegaT layout on
+		<figure id="default.omegat.layout2">
+      <title id="default.omegat.layout2.title">Default OmegaT layout on
       macOS</title>
       <mediaobject>
         <imageobject role="html">

--- a/doc_src/ja/OmegaT_EditorsPanes.xml
+++ b/doc_src/ja/OmegaT_EditorsPanes.xml
@@ -8,8 +8,8 @@
 
 	<para>OmegaTを初めて開始するとき、メインウィンドウには次の標準レイアウトが表示されます。</para>
 
-		<figure id="default.omegat.layout2">
-      <title id="default.omegat.layout2.title">Mac OSでのデフォルトOmeaTレイアウト</title>
+		<figure id="default.omegat.layout.macos">
+      <title id="default.omegat.layout.macos.title">Mac OSでのデフォルトOmeaTレイアウト</title>
       <mediaobject>
         <imageobject role="html">
           <imagedata fileref="images/defaultOmegaTLayout.png"/>

--- a/doc_src/ja/OmegaT_EditorsPanes.xml
+++ b/doc_src/ja/OmegaT_EditorsPanes.xml
@@ -8,8 +8,8 @@
 
 	<para>OmegaTを初めて開始するとき、メインウィンドウには次の標準レイアウトが表示されます。</para>
 
-		<figure id="default.omegat.layout">
-      <title id="default.omegat.layout.title">Mac OSでのデフォルトOmeaTレイアウト</title>
+		<figure id="default.omegat.layout2">
+      <title id="default.omegat.layout2.title">Mac OSでのデフォルトOmeaTレイアウト</title>
       <mediaobject>
         <imageobject role="html">
           <imagedata fileref="images/defaultOmegaTLayout.png"/>


### PR DESCRIPTION
Fix issue in manual PDF generation

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  `OmegaT_EditorPanes.xml` has duplicated "id" that cause XML error on PDF generation
- https://sourceforge.net/p/omegat/documentation/419/


## What does this PR change?

- document: Manual source XML has duplicated "id" value which should be unique.
- chore: Update `doc_src/build.xml` not to generate files in source folder but write to under `build/`.  The task accept "target" argument and use it for the output folder.
- chore: Update `docgen` shell script to use `docge:apline` and `docgen:pdfgen` container image
- chore: Change font to "Noto" for PDF generation.
- chore: Fix `manualsPdfs` task properly detect output file. 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
