### PR TITLE
[BUGS#1243] fix: restartGUI when jpackage distribution

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -17,7 +17,7 @@
 #               2015 Yu Tang, Aaron Madlon-Kay, Didier Briel, Hiroshi Miura
 #               2016 Alex Buloichik, Aaron Madlon-Kay, Didier Briel, Briac Pilpre
 #               2017 Didier Briel
-#               2020-2022 Hiroshi Miura
+#               2020-2024 Hiroshi Miura
 #               Home page: https://www.omegat.org/
 #               Support centre: https://omegat.org/support
 #
@@ -1971,13 +1971,10 @@ HCU_RESPONSE_ERROR=Got unexpected HTTP response {0}
 # Log
 
 LOG_LEVEL_SEVERE=Error
-
 LOG_LEVEL_WARNING=Warning
-
 LOG_LEVEL_INFO=Info
-
 LOG_STARTUP_INFO=Java: {0} ver. {1}, executed from '{2}'
-
+LOG_RESTART_FAILED_NOT_FOUND=Abort restart, because launcher or java executable is not found.
 LOG_MENU_CLICK=Click on '{0}' menu item
 
 LOG_INFO_EVENT_PROJECT_CHANGE=Event: project change - "{0}"

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.time.ZonedDateTime;
@@ -97,6 +98,7 @@ import org.omegat.util.Platform;
 import org.omegat.util.Preferences;
 import org.omegat.util.ProjectFileStorage;
 import org.omegat.util.RuntimePreferences;
+import org.omegat.util.StaticUtils;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TMXWriter2;
 import org.omegat.util.gui.OSXIntegration;
@@ -237,20 +239,34 @@ public final class Main {
     }
 
     public static void restartGUI(String projectDir) {
-        Log.log("===         Restart OmegaT           ===");
-        String javaBin = String.join(File.separator, System.getProperty("java.home"), "bin", "java");
-        // Build command: java -cp ... org.omegat.Main
+        // Check we have `java` command in java.home
+        Path javaBin = Paths.get(System.getProperty("java.home")).resolve("bin/java");
         List<String> command = new ArrayList<>();
-        command.add(javaBin);
-        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-        command.addAll(runtimeMxBean.getInputArguments()); // JVM args
-        command.add("-cp");
-        command.add(runtimeMxBean.getClassPath());
-        command.add(Main.class.getName());
-        command.addAll(CLIParameters.unparseArgs(PARAMS));
+        if (javaBin.toFile().exists()) {
+            // Build command: java -cp ... org.omegat.Main
+            command.add(javaBin.toString());
+            RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+            command.addAll(runtimeMxBean.getInputArguments()); // JVM args
+            command.add("-cp");
+            command.add(runtimeMxBean.getClassPath());
+            command.add(Main.class.getName());
+            command.addAll(CLIParameters.unparseArgs(PARAMS));
+        } else {
+            // assumes jpackage
+            javaBin = Paths.get(StaticUtils.installDir()).getParent().resolve("bin/OmegaT");
+            if (!javaBin.toFile().exists()) {
+                // abort restart
+                Core.getMainWindow().displayWarningRB("LOG_RESTART_FAILED_NOT_FOUND");
+                return;
+            }
+            command.add(javaBin.toString());
+            command.addAll(CLIParameters.unparseArgs(PARAMS));
+        }
         if (projectDir != null) {
             command.add(projectDir);
         }
+        // Now ready to restart.
+        Log.log("===         Restart OmegaT           ===");
         ProcessBuilder builder = new ProcessBuilder(command);
         try {
             builder.start();


### PR DESCRIPTION
jpackage distribution don't have `bin/java` executable. It need to find a launcher `bin/OmegaT` and execute it. This change is to check existence of `$JAVA_HOME/bin/java`, and when not found, try to check
 `<OmegaT installed folder>/bin/OmegaT`.
If both java or launcher exectable are not found, the attempt is aborted and show waring message.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- #1243 When restart GUI on deb/rpm packaged OmegaT, it failed with java not found
- https://sourceforge.net/p/omegat/bugs/1243/

## What does this PR change?

- Update Main#restartGUI method

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
