### PR TITLE
Correct SDLXLIFF comments

### DIFF
--- a/src/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -351,7 +351,7 @@ public class SdlXliff extends Xliff1Filter {
     @Override
     protected boolean processCharacters(Characters event, XMLStreamWriter writer) throws XMLStreamException {
         if (commentBuf != null) {
-            commentBuf.append(event.toString());
+            commentBuf.append(event.getData());
             if ((writer != null) && isCurrentSegmentTranslated(currentMid)) {
                 if ("last_modified_by".equals(currentProp)) {
                     writer.writeCharacters(Preferences.getPreferenceDefault(Preferences.TEAM_AUTHOR,


### PR DESCRIPTION
## Pull request type

Bug

## Which ticket is resolved?

- sdlxliff filter does not display (some) comments
- https://sourceforge.net/p/omegat/bugs/1244/

Problem mentioned by JC, but he sent me sample in private - see with him if the sample is confidential or not, in which case we may add a unit test.

## What does this PR change?

StaX filter for SDLXLIFF improperly manages comments when used with WoodstoX parser. We already corrected similar problems with other StaX filters but we forgot this one.

To be corrected in all branches (5.8, 6.0 and 6.1)

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
