### PR TITLE
[BUGS#418] chore: xliff: add CDATA regression test

### DIFF
--- a/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
+++ b/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1">
+    <file target-language="be" source-language="en" original="text3.txt">
+        <body>
+            <trans-unit id="1">
+                <source>This is test2</source>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>test21</source>
+            </trans-unit>
+        </body>
+    </file>
+    <file target-language="be" source-language="en" original="text.txt">
+        <body>
+            <trans-unit id="3">
+                <source><![CDATA[This is <test]]></source>
+                <target><![CDATA[tr1=This is <test]]></target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>test2</source>
+                <target>tr2=test2</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/test/src/org/omegat/filters/XLIFFFilterTest.java
+++ b/test/src/org/omegat/filters/XLIFFFilterTest.java
@@ -535,4 +535,9 @@ public class XLIFFFilterTest extends TestFilterBase {
     public void testBugs1221() throws Exception {
         translateXML(filter, "test/data/filters/xliff/filters3/file-xliff-BUGS1221.xlf");
     }
+
+    @Test
+    public void testBugs418() throws Exception {
+        translateXML(filter, "test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf");
+    }
 }


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Feature enhancement -> [enhancement]
- Documentation -> [documentation]
- Build and release changes -> [build/release]
- Other (describe below)

Regression test

## Which ticket is resolved?

- XML filters: when data has CDATA, filters does not behave properly
- https://sourceforge.net/p/omegat/bugs/418/

## What does this PR change?

- BUGS#418 claims an old XLIFF filter behaves wrongly.
-  This adds a test data with CDATA in source and target of trans-unit, and add a case in XLIFFFilterTest.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
