### PR TITLE
[BUGS#1247]  xliff1: multiple original file source produce broken output

### DIFF
--- a/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -99,10 +100,13 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     // --------------------- AbstractXmlFilter part -----------------------
 
     /* -- Data about current unit */
-    protected String path = "/", ignoreScope = null;
+    protected String path = "/";
+    protected String ignoreScope = null;
     protected List<XMLEvent> currentBuffer = null;
     protected boolean inTarget = false;
-    protected List<XMLEvent> source = new LinkedList<>(), target = null, note = new LinkedList<>();
+    protected List<XMLEvent> source = new LinkedList<>();
+    protected List<XMLEvent> target = null;
+    protected List<XMLEvent> note = new LinkedList<>();
 
     protected void cleanBuffers() {
         source.clear();
@@ -205,7 +209,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
                         break;
                     }
                 }
-                pairedHolders.put(pairId.getValue(), "" + prefix + count);
+                pairedHolders.put(Objects.requireNonNull(pairId).getValue(), "" + prefix + count);
             }
             return "<" + prefix + count + (isEmpty ? "/" : "") + ">";
         }

--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -99,7 +99,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 try {
                     processStartElement(
                             eFactory.createStartElement(reader.getName(), attributes.iterator(), null), null);
-                } catch (Exception ex) {
+                } catch (Exception ignored) {
+                    // XXX: Can we really skip?
                 }
             }
         }
@@ -239,8 +240,17 @@ public class Xliff1Filter extends AbstractXliffFilter {
                 ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
             }
             break;
-        case "group":
         case "file":
+            path = "/";
+            cleanBuffers();
+            if (endElement.getName().getLocalPart().equals(ignoreScope)) {
+                ignoreScope = null;
+            } else if (ignoreScope != null
+                    && ignoreScope.startsWith("!" + endElement.getName().getLocalPart())) {
+                ignoreScope = ignoreScope.substring(endElement.getName().getLocalPart().length() + 2);
+            }
+            break;
+        case "group":
             path = path.substring(0, path.lastIndexOf('/'));
             cleanBuffers();
             if (endElement.getName().getLocalPart().equals(ignoreScope)) {

--- a/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
+++ b/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
@@ -10,7 +10,7 @@
             </trans-unit>
         </body>
     </file>
-    <file target-language="be" source-language="en" original="text.txt">
+    <file target-language="be" source-language="en" original="text.txt" datatype="plaintext">
         <body>
             <trans-unit id="id3">
                 <source><![CDATA[This is <test]]></source>

--- a/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
+++ b/test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1">
-    <file target-language="be" source-language="en" original="text3.txt">
+<xliff version='1.2' xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file target-language="be" source-language="en" original="text3.txt" datatype='plaintext'>
         <body>
-            <trans-unit id="1">
+            <trans-unit id="id1">
                 <source>This is test2</source>
             </trans-unit>
-            <trans-unit id="2">
+            <trans-unit id="id2">
                 <source>test21</source>
             </trans-unit>
         </body>
     </file>
     <file target-language="be" source-language="en" original="text.txt">
         <body>
-            <trans-unit id="3">
+            <trans-unit id="id3">
                 <source><![CDATA[This is <test]]></source>
                 <target><![CDATA[tr1=This is <test]]></target>
             </trans-unit>
-            <trans-unit id="4">
+            <trans-unit id="id4">
                 <source>test2</source>
                 <target>tr2=test2</target>
             </trans-unit>

--- a/test/data/filters/xliff/filters4-xliff1/file-XLIFFFilter1-multiple-file-tag.xlf
+++ b/test/data/filters/xliff/filters4-xliff1/file-XLIFFFilter1-multiple-file-tag.xlf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version='1.2' xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="be" source-language="en" original="text3.txt" datatype='plaintext'>
+    <body>
+        <trans-unit id="id1">
+            <source>This is text3</source>
+        </trans-unit>
+    </body>
+</file>
+<file target-language="be" source-language="en" original="text.txt" datatype='plaintext'>
+    <body>
+        <trans-unit id="id2">
+            <source>test2</source>
+        </trans-unit>
+    </body>
+</file>
+</xliff>

--- a/test/src/org/omegat/filters4/Xliff1FilterTest.java
+++ b/test/src/org/omegat/filters4/Xliff1FilterTest.java
@@ -121,8 +121,9 @@ public class Xliff1FilterTest extends org.omegat.filters.TestFilterBase {
     }
 
     @Test
-    public void testBugs418() throws Exception {
+    public void testBugs1247() throws Exception {
         Xliff1Filter filter = new Xliff1Filter();
-        translateXML(filter, "test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf");
+        translateXML(filter,
+                "test/data/filters/xliff/filters4-xliff1/file-XLIFFFilter1-multiple-file-tag.xlf");
     }
 }

--- a/test/src/org/omegat/filters4/Xliff1FilterTest.java
+++ b/test/src/org/omegat/filters4/Xliff1FilterTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.omegat.core.data.IProject;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters4.xml.xliff.Xliff1Filter;
@@ -126,4 +127,17 @@ public class Xliff1FilterTest extends org.omegat.filters.TestFilterBase {
         translateXML(filter,
                 "test/data/filters/xliff/filters4-xliff1/file-XLIFFFilter1-multiple-file-tag.xlf");
     }
+
+    @Test
+    public void testBugs1247_2() throws Exception {
+        String f = "test/data/filters/xliff/filters4-xliff1/file-XLIFFFilter1-multiple-file-tag.xlf";
+        Xliff1Filter filter = new Xliff1Filter();
+        IProject.FileInfo fi = loadSourceFiles(filter, f);
+        checkMultiStart(fi, f);
+        checkMultiNoPrevNext("This is text3", "id1", "//text3.txt", null);
+        checkMultiNoPrevNext("test2", "id2", "//text.txt", null);
+        checkMultiEnd();
+    }
+
+
 }

--- a/test/src/org/omegat/filters4/Xliff1FilterTest.java
+++ b/test/src/org/omegat/filters4/Xliff1FilterTest.java
@@ -119,4 +119,10 @@ public class Xliff1FilterTest extends org.omegat.filters.TestFilterBase {
         translate(filter, filename, Collections.emptyMap(),
                 Collections.singletonMap("Should translate in result.", "Devrait traduire dans le r\u00E9sultat."));
     }
+
+    @Test
+    public void testBugs418() throws Exception {
+        Xliff1Filter filter = new Xliff1Filter();
+        translateXML(filter, "test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf");
+    }
 }

--- a/test/src/org/omegat/filters4/Xliff1FilterTest.java
+++ b/test/src/org/omegat/filters4/Xliff1FilterTest.java
@@ -122,6 +122,13 @@ public class Xliff1FilterTest extends org.omegat.filters.TestFilterBase {
     }
 
     @Test
+    public void testBugs418() throws Exception {
+        Xliff1Filter filter = new Xliff1Filter();
+        translateXML(filter,
+                "test/data/filters/xliff/filters3/file-XLIFFFilter-cdata-bugs418.xlf");
+    }
+
+    @Test
     public void testBugs1247() throws Exception {
         Xliff1Filter filter = new Xliff1Filter();
         translateXML(filter,


### PR DESCRIPTION
xliff1 filter produce a broken output file when XLIFF1 file has multiple `<file>` element.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

-  XLIFF1 filter produce broken trasnalated file
- https://sourceforge.net/p/omegat/bugs/1247/

## What does this PR change?

- `AbstractXmlFilter#processFile`: when it calls `checkCurrentPosition`, it should be checks `isEventMode` immediately.
- Several style improvements
- Add regression tests

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
