### PR TITLE
[BUGS#903] fix: not-undo a pre-existed note

### DIFF
--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -109,6 +109,8 @@ import org.omegat.gui.main.DockablePanel;
 import org.omegat.gui.main.MainWindow;
 import org.omegat.gui.main.MainWindowUI;
 import org.omegat.gui.main.ProjectUICommands;
+import org.omegat.gui.notes.INotes;
+import org.omegat.gui.notes.NotesTextArea;
 import org.omegat.help.Help;
 import org.omegat.util.BiDiUtils;
 import org.omegat.util.Language;
@@ -797,7 +799,12 @@ public class EditorController implements IEditor {
         // forget about old marks
         builder.createSegmentElement(true, currentTranslation);
 
-        Core.getNotes().setNoteText(currentTranslation.note);
+        INotes notes = Core.getNotes();
+        notes.setNoteText(currentTranslation.note);
+        if (notes instanceof NotesTextArea) {
+            // clear undo history.
+            ((NotesTextArea) notes).clearHistory();
+        }
 
         // then add new marks
         markerController.reprocessImmediately(builder);

--- a/src/org/omegat/gui/notes/NotesTextArea.java
+++ b/src/org/omegat/gui/notes/NotesTextArea.java
@@ -7,6 +7,7 @@
                2007 Zoltan Bartko
                2011 John Moran
                2015 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -57,8 +58,8 @@ public class NotesTextArea extends EntryInfoPane<String> implements INotes, IPan
 
     private static final String EXPLANATION = OStrings.getString("GUI_NOTESWINDOW_explanation");
 
-    UndoManager undoManager;
-    private DockableScrollPane scrollPane;
+    private final UndoManager undoManager;
+    private final DockableScrollPane scrollPane;
 
     /** Creates new Notes Text Area Pane */
     public NotesTextArea(IMainWindow mw) {
@@ -96,6 +97,12 @@ public class NotesTextArea extends EntryInfoPane<String> implements INotes, IPan
         undoManager.discardAllEdits();
     }
 
+    /**
+     * set note text.
+     * @param text
+     *            note's text, or null if note doesn't exist
+     */
+    @Override
     public void setNoteText(String text) {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -107,16 +114,27 @@ public class NotesTextArea extends EntryInfoPane<String> implements INotes, IPan
             }
         }
         setText(text);
-        undoManager.discardAllEdits();
         setEditable(true);
     }
 
+    /**
+     * get notes text.
+     * @return notes content.
+     */
+    @Override
     public String getNoteText() {
         UIThreadsUtil.mustBeSwingThread();
 
         String text = getText();
         // Disallow empty note. Use null to indicate lack of note.
         return text.isEmpty() ? null : text;
+    }
+
+    /**
+     * clear undo history (used when set active segment entry).
+     */
+    public void clearHistory() {
+        undoManager.discardAllEdits();
     }
 
     @Override

--- a/src/org/omegat/gui/notes/NotesTextArea.java
+++ b/src/org/omegat/gui/notes/NotesTextArea.java
@@ -107,6 +107,7 @@ public class NotesTextArea extends EntryInfoPane<String> implements INotes, IPan
             }
         }
         setText(text);
+        undoManager.discardAllEdits();
         setEditable(true);
     }
 


### PR DESCRIPTION
- Fix BUGS#903

## Pull request type


- Bug fix -> [bug]

## Which ticket is resolved?

- Ctrl+Z incorrectly erases contents of segment Note
- https://sourceforge.net/p/omegat/bugs/903/

## What does this PR change?

- When visiting segment and update note pane when segment has note, we reset a status of undoManager after put note contents.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
