### PR TITLE
[BUGS#1131] fix: Redraw duplicate segments only when changed

### DIFF
--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -1165,22 +1165,24 @@ public class EditorController implements IEditor {
                 Core.getProject().getTranslationInfo(m_docSegList[displayedEntryIndex].ste), defaultTranslation);
 
         // find all identical sources and redraw them
-        for (int i = 0; i < m_docSegList.length; i++) {
-            if (i == displayedEntryIndex) {
-                // current entry, skip
-                continue;
-            }
-            SegmentBuilder builder = m_docSegList[i];
-            if (!builder.hasBeenCreated()) {
-                // Skip because segment has not been drawn yet
-                continue;
-            }
-            if (builder.ste.getSrcText().equals(entry.getSrcText())) {
-                // the same source text - need to update
-                builder.createSegmentElement(false,
-                        Core.getProject().getTranslationInfo(builder.ste), !defaultTranslation);
-                // then add new marks
-                markerController.reprocessImmediately(builder);
+        if (translationChanged || noteChanged) {
+            for (int i = 0; i < m_docSegList.length; i++) {
+                if (i == displayedEntryIndex) {
+                    // current entry, skip
+                    continue;
+                }
+                SegmentBuilder builder = m_docSegList[i];
+                if (!builder.hasBeenCreated()) {
+                    // Skip because segment has not been drawn yet
+                    continue;
+                }
+                if (builder.ste.getSrcText().equals(entry.getSrcText())) {
+                    // the same source text - need to update
+                    builder.createSegmentElement(false,
+                            Core.getProject().getTranslationInfo(builder.ste), !defaultTranslation);
+                    // then add new marks
+                    markerController.reprocessImmediately(builder);
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Very slow segment switching with a lot of duplicates
  * https://sourceforge.net/p/omegat/bugs/1131/
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- A check is added if a segment or its note is changed before redrawing identical segments 

## Other information

This bug seems to be specific to some environments. OmegaT on Debian testing x64 with OpenJDK from Debian repository is affected for sure. I also have a report that Arm Mac build suffers as well.

I've been using this fix for a year and never found any regressions.