### PR TITLE
refactor: test for XLIFF2 glossary module

### DIFF
--- a/test/data/filters/xliff/filters4-xliff2/ex.14.5.xlf
+++ b/test/data/filters/xliff/filters4-xliff2/ex.14.5.xlf
@@ -1,0 +1,31 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0"
+       srcLang="en" trgLang="pt"
+       xmlns:gls="urn:oasis:names:tc:xliff:glossary:2.0">
+  <file id="f1">
+    <unit id="1">
+      <gls:glossary>
+        <gls:glossEntry id="g1" ref="#m1">
+          <gls:term>bill</gls:term>
+          <gls:translation>Schnabel</gls:translation>
+          <gls:definition source="dictionary.com">The hard usually pointed
+            parts that cover a bird's mouth.</gls:definition>
+        </gls:glossEntry>
+      </gls:glossary>
+      <segment>
+        <source>It was a unique
+          <mrk id="m1" type="term"
+               ref="my_file.xlf/#f=f1/u=1/gls=g1">bill.</mrk>.
+        </source>
+        <!-- note, the ref attribute above shows the absolute fragment
+             identification. In many cases (including this example),
+             a reference to just the term will suffice, such as
+             ref="gls=g1" -->
+      </segment>
+    </unit>
+    <unit id="g1">
+      <segment>
+        <source>Many birds have unique bills.</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/test/src/org/omegat/filters4/Xliff2FilterTest.java
+++ b/test/src/org/omegat/filters4/Xliff2FilterTest.java
@@ -99,5 +99,11 @@ public class Xliff2FilterTest extends org.omegat.filters.TestFilterBase {
         // entry translated in the callback, not in the source file
         assertEquals("Oiseaux en Oregon", entries.get(0).translation); 
     }
-    
+
+    @Test
+    public void testTranslation_glossary_14_5() throws Exception {
+        Xliff2Filter filter = new Xliff2Filter();
+        String source = "test/data/filters/xliff/filters4-xliff2/ex.14.5.xlf";
+        translateXML(filter, source);
+    }
 }


### PR DESCRIPTION
## Pull request type

- Other (describe below)
Improve unit tests

## Which ticket is resolved?

## What does this PR change?

- Improve test case with extra-ordinary cases.
- Add test case when source XLIFF file has contents with an unsupported glossary extension module.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
