### PR TITLE
refactor: migrate markers as first class plugins

### DIFF
--- a/Plugins.properties
+++ b/Plugins.properties
@@ -50,6 +50,12 @@ plugin=org.omegat.filters3.xml.xliff.XLIFFFilter \
     org.omegat.tokenizer.HunspellTokenizer \
     org.omegat.gui.scripting.ScriptingWindow \
     org.omegat.externalfinder.ExternalFinder \
+    org.omegat.gui.glossary.TransTipsMarker \
+    org.omegat.gui.editor.mark.BidiMarkers \
+    org.omegat.gui.editor.mark.ComesFromAutoTMMarker \
+    org.omegat.gui.editor.mark.FontFallbackMarker \
+    org.omegat.gui.editor.mark.ReplaceMarker \
+    org.omegat.gui.editor.mark.WhitespaceMarker \
     org.omegat.gui.theme.DefaultFlatTheme \
     org.omegat.gui.theme.DefaultClassicTheme \
     org.omegat.util.gui.HtmlMediaSupport \

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -101,7 +101,6 @@
     <suppress files="(BidiUtils|Java8Compat|MagicComment|JnaLoader)\.java" checks="HideUtilityClassConstructor"/>
     <suppress files="JTextPaneLinkifier\.java" checks="EmptyBlock"/>
     <suppress files="RepositoriesMappingController\.java:" checks="MethodLength"/>
-    <suppress files="EditorSettings\.java" checks="ParameterNumber" lines="497"/>
     <suppress files="(IssuesPanel|PreferencesWindow)Controller\.java" checks="MethodLength"/>
     <suppress files="MatchesVarExpansion\.java" checks="InnerAssignment"/>
     <suppress files="EditorTextArea3\.java" checks="MethodLength"/>

--- a/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/DefaultSpellChecker.java
+++ b/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/DefaultSpellChecker.java
@@ -55,11 +55,13 @@ import tokyo.northside.logging.LoggerFactory;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.spellchecker.ISpellChecker;
 import org.omegat.core.spellchecker.ISpellCheckerProvider;
 import org.omegat.core.spellchecker.SpellCheckerDummy;
 import org.omegat.core.spellchecker.SpellCheckerManager;
+import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.preferences.PreferencesControllers;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.util.Language;
@@ -112,6 +114,18 @@ public class DefaultSpellChecker implements ISpellChecker {
     public static void loadPlugins() {
         Core.registerSpellCheckClass(DefaultSpellChecker.class);
         PreferencesControllers.addSupplier(SpellcheckerConfigurationController::new);
+        Core.registerMarkerClass(SpellCheckerMarker.class);
+        CoreEvents.registerApplicationEventListener(new IApplicationEventListener() {
+            @Override
+            public void onApplicationStartup() {
+                IEditor ec = Core.getEditor();
+                ec.registerPopupMenuConstructors(100, new SpellCheckerPopup(ec));
+            }
+
+            @Override
+            public void onApplicationShutdown() {
+            }
+        });
     }
 
     public static void unloadPlugins() {

--- a/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerMarker.java
+++ b/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerMarker.java
@@ -23,11 +23,12 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
 
-package org.omegat.core.spellchecker;
+package org.omegat.spellchecker;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
@@ -50,6 +51,15 @@ public class SpellCheckerMarker implements IMarker {
         highlightPainter = new UnderlineFactory.WaveUnderline(Styles.EditorColor.COLOR_SPELLCHECK.getColor());
     }
 
+    /**
+     *
+     * @param ste
+     * @param sourceText might be null!
+     * @param translationText might be null!
+     * @param isActive is this an active segment in the document?
+     * @return
+     * @throws Exception
+     */
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)
             throws Exception {
@@ -57,7 +67,7 @@ public class SpellCheckerMarker implements IMarker {
             // translation is not displayed
             return null;
         }
-        if (!Core.getEditor().getSettings().isAutoSpellChecking()) {
+        if (!isEnabled()) {
             // spell checker disabled
             return null;
         }
@@ -68,5 +78,33 @@ public class SpellCheckerMarker implements IMarker {
             m.painter = highlightPainter;
             return m;
         }).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        Core.getEditor().getSettings().setAutoSpellChecking(val);
+        if (Core.getProject().isProjectLoaded()) {
+            Core.getEditor().remarkOneMarker(SpellCheckerMarker.class.getName());
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Core.getEditor().getSettings().isAutoSpellChecking();
     }
 }

--- a/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerPopup.java
+++ b/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerPopup.java
@@ -1,0 +1,174 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2009 Didier Briel
+               2010 Wildrich Fourie
+               2011 Alex Buloichik, Didier Briel
+               2015 Aaron Madlon-Kay
+               2023 Thomas Cordonnier
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.spellchecker;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.JTextComponent;
+
+import org.openide.awt.Mnemonics;
+
+import org.omegat.core.Core;
+import org.omegat.gui.editor.EditorController;
+import org.omegat.gui.editor.IEditor;
+import org.omegat.gui.editor.IPopupMenuConstructor;
+import org.omegat.gui.editor.SegmentBuilder;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.util.Log;
+import org.omegat.util.OStrings;
+import org.omegat.util.Token;
+import org.omegat.util.gui.UIThreadsUtil;
+
+/**
+ * create the spell checker popup menu - suggestions for a wrong word, add
+ * and ignore. Works only for the active segment, for the translation
+ */
+public class SpellCheckerPopup implements IPopupMenuConstructor {
+    protected final IEditor ec;
+
+    public SpellCheckerPopup(IEditor ec) {
+        this.ec = ec;
+    }
+
+    public void addItems(JPopupMenu menu, final JTextComponent comp, int mousepos,
+                         boolean isInActiveEntry, boolean isInActiveTranslation, SegmentBuilder sb) {
+        if (!ec.getSettings().isAutoSpellChecking()) {
+            // spellchecker disabled
+            return;
+        }
+        if (!isInActiveTranslation) {
+            // there is no need to display suggestions
+            return;
+        }
+
+        // Use the project's target tokenizer to determine the word that was right-clicked.
+        // EditorUtils.getWordEnd() and getWordStart() use Java's built-in BreakIterator
+        // under the hood, which leads to inconsistent results when compared to other spell-
+        // checking functionality in OmegaT.
+        String translation = ec.getCurrentTranslation();
+        Token tok = null;
+        int relOffset = ((EditorController) ec).getPositionInEntryTranslation(mousepos);
+        for (Token t : Core.getProject().getTargetTokenizer().tokenizeWords(translation, ITokenizer.StemmingMode.NONE)) {
+            if (t.getOffset() <= relOffset && relOffset < t.getOffset() + t.getLength()) {
+                tok = t;
+                break;
+            }
+        }
+
+        if (tok == null) {
+            return;
+        }
+
+        final String word = tok.getTextFromString(translation);
+        // The wordStart must be the absolute offset in the Editor document.
+        final int wordStart = mousepos - relOffset + tok.getOffset();
+        final int wordLength = tok.getLength();
+        final AbstractDocument xlDoc = (AbstractDocument) comp.getDocument();
+
+        if (!Core.getSpellChecker().isCorrect(word)) {
+            // get the suggestions and create a menu
+            List<String> suggestions = Core.getSpellChecker().suggest(word);
+
+            // the suggestions
+            for (final String replacement : suggestions) {
+                JMenuItem item = menu.add(replacement);
+                item.addActionListener(new ActionListener() {
+                    // the action: replace the word with the selected
+                    // suggestion
+                    public void actionPerformed(ActionEvent e) {
+                        try {
+                            int pos = comp.getCaretPosition();
+                            xlDoc.replace(wordStart, wordLength, replacement, null);
+                            comp.setCaretPosition(pos);
+                        } catch (BadLocationException exc) {
+                            Log.log(exc);
+                        }
+                    }
+                });
+            }
+
+            // what if no action is done?
+            if (suggestions.isEmpty()) {
+                JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_NO_SUGGESTIONS")));
+                item.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        // just hide the menu
+                    }
+                });
+            }
+
+            menu.addSeparator();
+
+            // let us ignore it
+            JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_IGNORE_ALL")));
+            item.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    addIgnoreWord(word, wordStart, false);
+                }
+            });
+
+            // or add it to the dictionary
+            item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_ADD_TO_DICTIONARY")));
+            item.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    addIgnoreWord(word, wordStart, true);
+                }
+            });
+
+            menu.addSeparator();
+
+        }
+    }
+
+    /**
+     * add a new word to the spell checker or ignore a word
+     *
+     * @param word   : the word in question
+     * @param offset : the offset of the word in the editor
+     * @param add    : true for add, false for ignore
+     */
+    protected void addIgnoreWord(final String word, final int offset, final boolean add) {
+        UIThreadsUtil.mustBeSwingThread();
+
+        if (add) {
+            Core.getSpellChecker().learnWord(word);
+        } else {
+            Core.getSpellChecker().ignoreWord(word);
+        }
+
+        ec.remarkOneMarker(SpellCheckerMarker.class.getName());
+    }
+}

--- a/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerPopup.java
+++ b/spellchecker/hunspell-jmyspell/src/main/java/org/omegat/spellchecker/SpellCheckerPopup.java
@@ -42,7 +42,6 @@ import javax.swing.text.JTextComponent;
 import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
-import org.omegat.gui.editor.EditorController;
 import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.SegmentBuilder;
@@ -80,7 +79,7 @@ public class SpellCheckerPopup implements IPopupMenuConstructor {
         // checking functionality in OmegaT.
         String translation = ec.getCurrentTranslation();
         Token tok = null;
-        int relOffset = ((EditorController) ec).getPositionInEntryTranslation(mousepos);
+        int relOffset = ec.getPositionInEntryTranslation(mousepos);
         for (Token t : Core.getProject().getTargetTokenizer().tokenizeWords(translation, ITokenizer.StemmingMode.NONE)) {
             if (t.getOffset() <= relOffset && relOffset < t.getOffset() + t.getLength()) {
                 tok = t;

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -122,8 +122,6 @@ public final class Core {
     private static final List<String> PLUGINS_LOADING_ERRORS = Collections
             .synchronizedList(new ArrayList<String>());
 
-    private static final List<IMarker> MARKERS = new ArrayList<IMarker>();
-
     /** Get project instance. */
     public static IProject getProject() {
         return currentProject;
@@ -246,7 +244,6 @@ public final class Core {
         MainWindow me = new MainWindow();
         mainWindow = me;
 
-        MarkerController.init();
         LanguageToolWrapper.init();
 
         segmenter = new Segmenter(Preferences.getSRX());
@@ -309,11 +306,12 @@ public final class Core {
      *            marker implementation
      */
     public static void registerMarker(IMarker marker) {
-        MARKERS.add(marker);
+        MarkerController.registerMarker(marker);
     }
 
+    @Deprecated
     public static List<IMarker> getMarkers() {
-        return MARKERS;
+        return MarkerController.getMarkers();
     }
 
     public static Map<String, String> getParams() {

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -200,7 +200,7 @@ public class EditorController implements IEditor {
     protected int displayedEntryIndex;
 
     /** Object which store history of moving by segments. */
-    private SegmentHistory history = new SegmentHistory();
+    private final SegmentHistory history = new SegmentHistory();
 
     protected final EditorSettings settings;
 
@@ -217,7 +217,7 @@ public class EditorController implements IEditor {
     volatile IEditorFilter entriesFilter;
     private Component entriesFilterControlComponent;
 
-    private SegmentExportImport segmentExportImport;
+    private final SegmentExportImport segmentExportImport;
 
     protected String currentEntryOrigin;
     protected String translationFromOrigin;
@@ -237,7 +237,6 @@ public class EditorController implements IEditor {
         setFont(mainWindow.getApplicationFont());
 
         markerController = new MarkerController(this);
-
         createUI();
 
         settings = new EditorSettings(this);
@@ -2213,4 +2212,5 @@ public class EditorController implements IEditor {
     public IAutoCompleter getAutoCompleter() {
         return editor.autoCompleter;
     }
+
 }

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -1761,6 +1761,7 @@ public class EditorController implements IEditor {
      * Returns the relative caret position in the editable translation for a
      * given absolute index into the overall editor document.
      */
+    @Override
     public int getPositionInEntryTranslation(int pos) {
         UIThreadsUtil.mustBeSwingThread();
 

--- a/src/org/omegat/gui/editor/EditorPopups.java
+++ b/src/org/omegat/gui/editor/EditorPopups.java
@@ -39,24 +39,17 @@ import java.util.List;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
-import javax.swing.text.AbstractDocument;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 
 import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.spellchecker.SpellCheckerMarker;
-import org.omegat.tokenizer.ITokenizer.StemmingMode;
-import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TagUtil;
 import org.omegat.util.TagUtil.Tag;
-import org.omegat.util.Token;
 import org.omegat.util.gui.MenuItemPager;
-import org.omegat.util.gui.UIThreadsUtil;
 
 /**
  * Some standard editor popups.
@@ -69,7 +62,6 @@ import org.omegat.util.gui.UIThreadsUtil;
  */
 public final class EditorPopups {
     public static void init(EditorController ec) {
-        ec.registerPopupMenuConstructors(100, new SpellCheckerPopup(ec));
         ec.registerPopupMenuConstructors(200, new GoToSegmentPopup(ec));
         ec.registerPopupMenuConstructors(400, new DefaultPopup());
         ec.registerPopupMenuConstructors(500, new DuplicateSegmentsPopup(ec));
@@ -79,133 +71,6 @@ public final class EditorPopups {
     }
 
     private EditorPopups() {
-    }
-    
-    /**
-     * create the spell checker popup menu - suggestions for a wrong word, add
-     * and ignore. Works only for the active segment, for the translation
-     *
-     * @param point
-     *            : where should the popup be shown
-     */
-    public static class SpellCheckerPopup implements IPopupMenuConstructor {
-        protected final EditorController ec;
-
-        public SpellCheckerPopup(EditorController ec) {
-            this.ec = ec;
-        }
-
-        public void addItems(JPopupMenu menu, final JTextComponent comp, int mousepos,
-                boolean isInActiveEntry, boolean isInActiveTranslation, SegmentBuilder sb) {
-            if (!ec.getSettings().isAutoSpellChecking()) {
-                // spellchecker disabled
-                return;
-            }
-            if (!isInActiveTranslation) {
-                // there is no need to display suggestions
-                return;
-            }
-
-            // Use the project's target tokenizer to determine the word that was right-clicked.
-            // EditorUtils.getWordEnd() and getWordStart() use Java's built-in BreakIterator
-            // under the hood, which leads to inconsistent results when compared to other spell-
-            // checking functionality in OmegaT.
-            String translation = ec.getCurrentTranslation();
-            Token tok = null;
-            int relOffset = ec.getPositionInEntryTranslation(mousepos);
-            for (Token t : Core.getProject().getTargetTokenizer().tokenizeWords(translation, StemmingMode.NONE)) {
-                if (t.getOffset() <= relOffset && relOffset < t.getOffset() + t.getLength()) {
-                    tok = t;
-                    break;
-                }
-            }
-
-            if (tok == null) {
-                return;
-            }
-
-            final String word = tok.getTextFromString(translation);
-            // The wordStart must be the absolute offset in the Editor document.
-            final int wordStart = mousepos - relOffset + tok.getOffset();
-            final int wordLength = tok.getLength();
-            final AbstractDocument xlDoc = (AbstractDocument) comp.getDocument();
-
-            if (!Core.getSpellChecker().isCorrect(word)) {
-                // get the suggestions and create a menu
-                List<String> suggestions = Core.getSpellChecker().suggest(word);
-
-                // the suggestions
-                for (final String replacement : suggestions) {
-                    JMenuItem item = menu.add(replacement);
-                    item.addActionListener(new ActionListener() {
-                        // the action: replace the word with the selected
-                        // suggestion
-                        public void actionPerformed(ActionEvent e) {
-                            try {
-                                int pos = comp.getCaretPosition();
-                                xlDoc.replace(wordStart, wordLength, replacement, null);
-                                comp.setCaretPosition(pos);
-                            } catch (BadLocationException exc) {
-                                Log.log(exc);
-                            }
-                        }
-                    });
-                }
-
-                // what if no action is done?
-                if (suggestions.isEmpty()) {
-                    JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_NO_SUGGESTIONS")));
-                    item.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            // just hide the menu
-                        }
-                    });
-                }
-
-                menu.addSeparator();
-
-                // let us ignore it
-                JMenuItem item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_IGNORE_ALL")));
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        addIgnoreWord(word, wordStart, false);
-                    }
-                });
-
-                // or add it to the dictionary
-                item = menu.add(Mnemonics.removeMnemonics(OStrings.getString("SC_ADD_TO_DICTIONARY")));
-                item.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        addIgnoreWord(word, wordStart, true);
-                    }
-                });
-
-                menu.addSeparator();
-
-            }
-        }
-
-        /**
-         * add a new word to the spell checker or ignore a word
-         *
-         * @param word
-         *            : the word in question
-         * @param offset
-         *            : the offset of the word in the editor
-         * @param add
-         *            : true for add, false for ignore
-         */
-        protected void addIgnoreWord(final String word, final int offset, final boolean add) {
-            UIThreadsUtil.mustBeSwingThread();
-
-            if (add) {
-                Core.getSpellChecker().learnWord(word);
-            } else {
-                Core.getSpellChecker().ignoreWord(word);
-            }
-
-            ec.remarkOneMarker(SpellCheckerMarker.class.getName());
-        }
     }
 
     public static class DefaultPopup implements IPopupMenuConstructor {

--- a/src/org/omegat/gui/editor/EditorSettings.java
+++ b/src/org/omegat/gui/editor/EditorSettings.java
@@ -35,7 +35,6 @@ import javax.swing.text.AttributeSet;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry.DUPLICATE;
-import org.omegat.core.spellchecker.SpellCheckerMarker;
 import org.omegat.util.Preferences;
 import org.omegat.util.gui.Styles;
 import org.omegat.util.gui.UIThreadsUtil;
@@ -91,9 +90,9 @@ public class EditorSettings implements IEditorSettings {
         markNonUniqueSegments = Preferences.isPreferenceDefault(Preferences.MARK_NON_UNIQUE_SEGMENTS,
                MARK_NON_UNIQUE_SEGMENTS_DEFAULT);
         markNoted = Preferences.isPreference(Preferences.MARK_NOTED_SEGMENTS);
-        markNBSP  = Preferences.isPreference(Preferences.MARK_NBSP);
         markParagraphDelimitations = Preferences.isPreferenceDefault(Preferences.MARK_PARA_DELIMITATIONS,
                 MARK_PARA_DELIMITATIONS_DEFAULT);
+        markNBSP  = Preferences.isPreference(Preferences.MARK_NBSP);
         markWhitespace  = Preferences.isPreference(Preferences.MARK_WHITESPACE);
         markBidi  = Preferences.isPreference(Preferences.MARK_BIDI);
         displayModificationInfo = Preferences.getPreferenceDefault(Preferences.DISPLAY_MODIFICATION_INFO,
@@ -211,6 +210,7 @@ public class EditorSettings implements IEditorSettings {
     public boolean isMarkNBSP() {
         return markNBSP;
     }
+
     /**
      * mark whitespace?
      * @return true when set, false otherwise
@@ -285,6 +285,7 @@ public class EditorSettings implements IEditorSettings {
             parent.activateEntry();
         }
     }
+
     public void setMarkWhitespace(boolean markWhitespace) {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -432,7 +433,6 @@ public class EditorSettings implements IEditorSettings {
         if (Core.getProject().isProjectLoaded()) {
             // parent.loadDocument();
             parent.activateEntry();
-            parent.remarkOneMarker(SpellCheckerMarker.class.getName());
         }
     }
 
@@ -490,12 +490,10 @@ public class EditorSettings implements IEditorSettings {
      *            is it an active segment?
      * @param translationExists
      *            does a translation already exist
-     * @param isNBSP
-     *            is the text a non-breakable space
      * @return proper AttributeSet to use on displaying the segment.
      */
     public AttributeSet getAttributeSet(boolean isSource, boolean isPlaceholder, boolean isRemoveText,
-            DUPLICATE duplicate, boolean active, boolean translationExists, boolean hasNote, boolean isNBSP) {
+            DUPLICATE duplicate, boolean active, boolean translationExists, boolean hasNote) {
         // determine foreground color
         Color fg = null;
 
@@ -584,9 +582,6 @@ public class EditorSettings implements IEditorSettings {
                 bg = nonUniqueBg;
                 break;
             }
-        }
-        if (isNBSP && isMarkNBSP()) { //overwrite others, because space is smallest.
-            bg = Styles.EditorColor.COLOR_NBSP.getColor();
         }
 
         //determine bold

--- a/src/org/omegat/gui/editor/IEditor.java
+++ b/src/org/omegat/gui/editor/IEditor.java
@@ -499,4 +499,10 @@ public interface IEditor {
     default boolean isOrientationAllLtr() {
         return true;
     }
+
+    int getCurrentPositionInEntryTranslation();
+
+    int getPositionInEntryTranslation(int mousepos);
+
+    void setCaretPosition(CaretPosition pos);
 }

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -543,7 +543,7 @@ public class SegmentBuilder {
         int prevOffset = offset;
         boolean rtl = BiDiUtils.isRtl(language.getLanguageCode());
         insertDirectionEmbedding(false);
-        AttributeSet normal = attrs(true, false, false, false);
+        AttributeSet normal = attrs(true, false, false);
         insert(language.getLanguage() + ": ", normal);
         insertDirectionEndEmbedding();
 
@@ -641,7 +641,7 @@ public class SegmentBuilder {
     }
 
     void createInputAttributes(Element element, MutableAttributeSet set) {
-        set.addAttributes(attrs(false, false, false, false));
+        set.addAttributes(attrs(false, false, false));
     }
 
     private void insert(String text, AttributeSet attrs) throws BadLocationException {
@@ -698,13 +698,11 @@ public class SegmentBuilder {
      *            or regular text inside the segment?
      * @param isRemoveText
      *            is it text that should be removed in the translation?
-     * @param isNBSP
-     *            is the text a non-breakable space?
      * @return the attributes to format the text
      */
-    public AttributeSet attrs(boolean isSource, boolean isPlaceholder, boolean isRemoveText, boolean isNBSP) {
+    public AttributeSet attrs(boolean isSource, boolean isPlaceholder, boolean isRemoveText) {
         return settings.getAttributeSet(isSource, isPlaceholder, isRemoveText, ste.getDuplicate(), active,
-                transExist, noteExist, isNBSP);
+                transExist, noteExist);
     }
 
     /**
@@ -720,7 +718,7 @@ public class SegmentBuilder {
         if (!isSource && hasRTL && controller.targetLangIsRTL) {
             text = EditorUtils.addBidiAroundTags(text, ste);
         }
-        AttributeSet normal = attrs(isSource, false, false, false);
+        AttributeSet normal = attrs(isSource, false, false);
         insert(text, normal);
         return text;
     }
@@ -731,19 +729,19 @@ public class SegmentBuilder {
             if (posSourceBeg != null) {
                 int sBeg = posSourceBeg.getOffset();
                 int sLen = posSourceLength;
-                AttributeSet attrs = attrs(true, false, false, false);
+                AttributeSet attrs = attrs(true, false, false);
                 doc.setCharacterAttributes(sBeg, sLen, attrs, true);
             }
             if (active) {
                 int tBeg = doc.getTranslationStart();
                 int tEnd = doc.getTranslationEnd();
-                AttributeSet attrs = attrs(false, false, false, false);
+                AttributeSet attrs = attrs(false, false, false);
                 doc.setCharacterAttributes(tBeg, tEnd - tBeg, attrs, true);
             } else {
                 if (posTranslationBeg != null) {
                     int tBeg = posTranslationBeg.getOffset();
                     int tLen = posTranslationLength;
-                    AttributeSet attrs = attrs(false, false, false, false);
+                    AttributeSet attrs = attrs(false, false, false);
                     doc.setCharacterAttributes(tBeg, tLen, attrs, true);
                 }
             }

--- a/src/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -147,7 +147,7 @@ public class ReplaceFilter implements IEditorFilter {
     }
 
     private void skip() {
-        EditorController ec = (EditorController) Core.getEditor();
+        IEditor ec = Core.getEditor();
 
         // try to find in current entry
         int pos = ec.getCurrentPositionInEntryTranslation();

--- a/src/org/omegat/gui/editor/mark/AbstractMarker.java
+++ b/src/org/omegat/gui/editor/mark/AbstractMarker.java
@@ -63,7 +63,7 @@ public abstract class AbstractMarker implements IMarker {
      * @return true when enabled (markers are painted). false when disabled (no
      *         markers painted)
      */
-    protected abstract boolean isEnabled();
+    public abstract boolean isEnabled();
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)

--- a/src/org/omegat/gui/editor/mark/BidiMarkers.java
+++ b/src/org/omegat/gui/editor/mark/BidiMarkers.java
@@ -29,10 +29,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.main.MainMenuIcons;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.Styles;
 
@@ -40,7 +42,6 @@ import org.omegat.util.gui.Styles;
  * Collection of Markers for Bidirectional control characters.
  */
 public class BidiMarkers extends AbstractMarker {
-
     static final int LRM = 0x200e;
     static final int RLM = 0x200f;
     static final int LRE = 0x202a;
@@ -55,6 +56,16 @@ public class BidiMarkers extends AbstractMarker {
     private final HighlightPainter rlmBidiPainter;
     private final HighlightPainter rloBidiPainter;
     private final HighlightPainter lroBidiPainter;
+
+    /**
+     * register marker class.
+     */
+    public static void loadPlugins() {
+        Core.registerMarkerClass(BidiMarkers.class);
+    }
+
+    public static void unloadPlugins() {
+    }
 
     public BidiMarkers() throws Exception {
         super();
@@ -147,7 +158,28 @@ public class BidiMarkers extends AbstractMarker {
     }
 
     @Override
-    protected boolean isEnabled() {
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+    }
+
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        Core.getEditor().getSettings().setMarkBidi(val);
+    }
+
+    @Override
+    public boolean isEnabled() {
         return Core.getEditor().getSettings().isMarkBidi();
     }
 

--- a/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -29,11 +29,15 @@ package org.omegat.gui.editor.mark;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
+import org.omegat.gui.main.MainMenuIcons;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -58,10 +62,20 @@ public class ComesFromAutoTMMarker implements IMarker {
                 Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED.getColor(), 0.5F);
     }
 
+    /**
+     * register marker class.
+     */
+    public static void loadPlugins() {
+        Core.registerMarkerClass(ComesFromAutoTMMarker.class);
+    }
+
+    public static void unloadPlugins() {
+    }
+
     @Override
     public synchronized List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText,
             String translationText, boolean isActive) {
-        if (!Core.getEditor().getSettings().isMarkAutoPopulated()) {
+        if (!enabled) {
             return null;
         }
         TMXEntry e = Core.getProject().getTranslationInfo(ste);
@@ -83,5 +97,32 @@ public class ComesFromAutoTMMarker implements IMarker {
             m.painter = painterXenforced;
         }
         return Collections.singletonList(m);
+    }
+
+    private boolean enabled = true;
+
+    @Override
+    public String getMarkerName() {
+        return OStrings.getString("MW_VIEW_MENU_MARK_AUTOPOPULATED");
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor());
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return Preferences.MARK_AUTOPOPULATED;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        enabled = val;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
@@ -28,6 +28,7 @@ package org.omegat.gui.editor.mark;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.CoreEvents;
@@ -80,5 +81,32 @@ public class ComesFromMTMarker implements IMarker {
         Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
         m.painter = highlightPainter;
         return Collections.singletonList(m);
+    }
+
+    private boolean enabled = true;
+
+    @Override
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        enabled = val;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/src/org/omegat/gui/editor/mark/FontFallbackMarker.java
+++ b/src/org/omegat/gui/editor/mark/FontFallbackMarker.java
@@ -29,6 +29,8 @@ import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.Icon;
+import javax.swing.UIManager;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.SimpleAttributeSet;
@@ -37,11 +39,24 @@ import javax.swing.text.StyleConstants;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.main.MainMenuIcons;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.gui.FontFallbackManager;
 
 public class FontFallbackMarker implements IMarker {
 
     private Font editorFont;
+
+    /**
+     * register marker class.
+     */
+    public static void loadPlugins() {
+        Core.registerMarkerClass(FontFallbackMarker.class);
+    }
+
+    public static void unloadPlugins() {
+    }
 
     public FontFallbackMarker() {
         editorFont = Core.getMainWindow().getApplicationFont();
@@ -77,8 +92,29 @@ public class FontFallbackMarker implements IMarker {
         return marks;
     }
 
-    private boolean isEnabled() {
-        return Core.getEditor().getSettings().isDoFontFallback();
+    @Override
+    public String getMarkerName() {
+        return OStrings.getString("MW_VIEW_MENU_MARK_FONT_FALLBACK");
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newTextIcon(
+                UIManager.getColor("Label.foreground"), new Font("Serif", Font.ITALIC, 16), 'F');
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return Preferences.FONT_FALLBACK;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        Core.getEditor().getSettings().setDoFontFallback(!val);
+    }
+
+    public boolean isEnabled() {
+        return !Core.getEditor().getSettings().isDoFontFallback();
     }
 
     private void createMarks(List<Mark> acc, Mark.ENTRY_PART part, String text, int firstMissing) {

--- a/src/org/omegat/gui/editor/mark/IMarker.java
+++ b/src/org/omegat/gui/editor/mark/IMarker.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2010-2013 Alex Buloichik
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -27,12 +28,15 @@ package org.omegat.gui.editor.mark;
 
 import java.util.List;
 
+import javax.swing.Icon;
+
 import org.omegat.core.data.SourceTextEntry;
 
 /**
- * Interface to calculate marks in editor.
+ * Interface to calculate marks in the editor pane.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
+ * @author Hiroshi Miura
  */
 public interface IMarker {
     /**
@@ -52,4 +56,32 @@ public interface IMarker {
      */
     List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)
             throws Exception;
+
+    /**
+     * Human-readable marker name.
+     * <p>
+     * It is a name used in menu items. Marker plugin may return
+     * localized name.
+     */
+    String getMarkerName();
+
+    Icon getIcon();
+
+    /**
+     * Return preference key.
+     * @return key of preference.
+     */
+    String getPreferenceKey();
+
+    /**
+     * Set marker status as specified value.
+     * @param val true when want to enable, otherwise false.
+     */
+    void setEnabled(boolean val);
+
+    /**
+     * Whether marker is enabled?
+     * @return true when enabled, otherwise return false.
+     */
+    boolean isEnabled();
 }

--- a/src/org/omegat/gui/editor/mark/NBSPMarker.java
+++ b/src/org/omegat/gui/editor/mark/NBSPMarker.java
@@ -25,8 +25,12 @@
 
 package org.omegat.gui.editor.mark;
 
+import javax.swing.Icon;
+
 import org.omegat.core.Core;
+import org.omegat.gui.main.MainMenuIcons;
 import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -35,12 +39,33 @@ import org.omegat.util.gui.Styles;
  * @author Martin Fleurke
  */
 public class NBSPMarker extends AbstractMarker {
+
     public NBSPMarker() throws Exception {
         painter = new TransparentHighlightPainter(Styles.EditorColor.COLOR_NBSP.getColor(), 0.5F);
         toolTip = OStrings.getString("MARKER_NBSP");
         patternChar = '\u00a0';
     }
-    protected boolean isEnabled() {
+
+    public boolean isEnabled() {
         return Core.getEditor().getSettings().isMarkNBSP();
+    }
+
+    public void setEnabled(boolean val) {
+        Core.getEditor().getSettings().setMarkNBSP(val);
+    }
+
+    @Override
+    public String getMarkerName() {
+        return OStrings.getString("MW_VIEW_MENU_MARK_NBSP");
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return Preferences.MARK_NBSP;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_NBSP.getColor());
     }
 }

--- a/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 
+import javax.swing.Icon;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Highlighter.HighlightPainter;
 
@@ -139,5 +140,28 @@ public class ProtectedPartsMarker implements IMarker {
         }
         // standalone tag
         return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    @Override
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+    }
+
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/src/org/omegat/gui/editor/mark/RemoveTagMarker.java
+++ b/src/org/omegat/gui/editor/mark/RemoveTagMarker.java
@@ -27,6 +27,7 @@
 
 package org.omegat.gui.editor.mark;
 
+import javax.swing.Icon;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Highlighter.HighlightPainter;
 
@@ -59,7 +60,26 @@ public class RemoveTagMarker extends AbstractMarker {
     }
 
     @Override
-    protected boolean isEnabled() {
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+    }
+
+    @Override
+    public boolean isEnabled() {
         return true;
     }
 

--- a/src/org/omegat/gui/editor/mark/ReplaceMarker.java
+++ b/src/org/omegat/gui/editor/mark/ReplaceMarker.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
@@ -49,6 +50,16 @@ public class ReplaceMarker implements IMarker {
     public ReplaceMarker() {
         highlightPainter = new TransparentHighlightPainter(
                 Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
+    }
+
+    /**
+     * register marker class.
+     */
+    public static void loadPlugins() {
+        Core.registerMarkerClass(ReplaceMarker.class);
+    }
+
+    public static void unloadPlugins() {
     }
 
     @Override
@@ -73,5 +84,29 @@ public class ReplaceMarker implements IMarker {
             r.add(m);
         }
         return r;
+    }
+
+    @Override
+    public String getMarkerName() {
+        return null;
+    }
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return null;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/src/org/omegat/gui/editor/mark/WhitespaceMarker.java
+++ b/src/org/omegat/gui/editor/mark/WhitespaceMarker.java
@@ -30,9 +30,13 @@ package org.omegat.gui.editor.mark;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.Icon;
+
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.main.MainMenuIcons;
 import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -148,7 +152,29 @@ public final class WhitespaceMarker implements IMarker {
         return marks;
     }
 
-   public boolean isEnabled() {
+    @Override
+    public String getMarkerName() {
+        return OStrings.getString("MW_VIEW_MENU_MARK_WHITESPACE");
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_WHITESPACE.getColor());
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return Preferences.MARK_WHITESPACE;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        Core.getEditor().getSettings().setMarkWhitespace(val);
+    }
+
+    @Override
+    public boolean isEnabled() {
         return Core.getEditor().getSettings().isMarkWhitespace();
     }
+
 }

--- a/src/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/org/omegat/gui/glossary/TransTipsMarker.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
@@ -38,6 +39,9 @@ import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.gui.main.MainMenuIcons;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.Token;
 import org.omegat.util.gui.Styles;
 
@@ -54,13 +58,23 @@ public class TransTipsMarker implements IMarker {
                 Styles.EditorColor.COLOR_TRANSTIPS.getColor());
     }
 
+    /**
+     * register marker class.
+     */
+    public static void loadPlugins() {
+        Core.registerMarkerClass(TransTipsMarker.class);
+    }
+
+    public static void unloadPlugins() {
+    }
+
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
             boolean isActive) {
         if (!isActive || sourceText == null) {
             return null;
         }
-        if (!Core.getEditor().getSettings().isMarkGlossaryMatches()) {
+        if (!isEnabled()) {
             return null;
         }
         List<GlossaryEntry> glossaryEntries = Core.getGlossary().getDisplayedEntries();
@@ -77,6 +91,31 @@ public class TransTipsMarker implements IMarker {
             marks.addAll(getMarksForTokens(tokens, ste.getSrcText(), tooltip));
         }
         return marks;
+    }
+
+    @Override
+    public String getMarkerName() {
+        return OStrings.getString("MW_VIEW_GLOSSARY_MARK");
+    }
+
+    @Override
+    public Icon getIcon() {
+        return MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_TRANSTIPS.getColor());
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return Preferences.MARK_GLOSSARY_MATCHES;
+    }
+
+    @Override
+    public void setEnabled(final boolean val) {
+        Core.getEditor().getSettings().setMarkGlossaryMatches(val);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Core.getEditor().getSettings().isMarkGlossaryMatches();
     }
 
     private List<Mark> getMarksForTokens(List<Token[]> tokens, String srcText, String tooltip) {

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -37,7 +37,6 @@
 
 package org.omegat.gui.main;
 
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -59,7 +58,6 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.KeyStroke;
-import javax.swing.UIManager;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
@@ -331,13 +329,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMarkNonUniqueSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
                 "MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS");
         viewMarkNotedSegmentsCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NOTED_SEGMENTS");
-        viewMarkNBSPCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NBSP");
-        viewMarkWhitespaceCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_WHITESPACE");
-        viewMarkBidiCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_BIDI");
-        viewMarkAutoPopulatedCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_AUTOPOPULATED");
-        viewMarkGlossaryMatchesCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_GLOSSARY_MARK");
-        viewMarkLanguageCheckerCheckBoxMenuItem = createCheckboxMenuItem("LT_OPTIONS_MENU_ENABLED");
-        viewMarkFontFallbackCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_FONT_FALLBACK");
         viewModificationInfoMenu = createMenu("MW_VIEW_MENU_MODIFICATION_INFO");
 
         ButtonGroup viewModificationInfoMenuBG = new ButtonGroup();
@@ -358,21 +349,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 .setIcon(MainMenuIcons.newTextIcon(Styles.EditorColor.COLOR_NON_UNIQUE.getColor(), 'M'));
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_NOTED.getColor()));
-        viewMarkNBSPCheckBoxMenuItem
-                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_NBSP.getColor()));
-        viewMarkWhitespaceCheckBoxMenuItem
-                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_WHITESPACE.getColor()));
-        viewMarkBidiCheckBoxMenuItem
-                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_BIDIMARKERS.getColor()));
         viewModificationInfoMenu.setIcon(MainMenuIcons.newBlankIcon());
-        viewMarkAutoPopulatedCheckBoxMenuItem.setIcon(
-                MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor()));
-        viewMarkGlossaryMatchesCheckBoxMenuItem
-                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_TRANSTIPS.getColor()));
-        viewMarkLanguageCheckerCheckBoxMenuItem
-                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_LANGUAGE_TOOLS.getColor()));
-        viewMarkFontFallbackCheckBoxMenuItem.setIcon(MainMenuIcons.newTextIcon(
-                UIManager.getColor("Label.foreground"), new Font("Serif", Font.ITALIC, 16), 'F'));
 
         viewRestoreGUIMenuItem = createMenuItem("MW_OPTIONSMENU_RESTORE_GUI");
 
@@ -547,13 +524,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMenu.add(viewDisplaySegmentSourceCheckBoxMenuItem);
         viewMenu.add(viewMarkNonUniqueSegmentsCheckBoxMenuItem);
         viewMenu.add(viewMarkNotedSegmentsCheckBoxMenuItem);
-        viewMenu.add(viewMarkNBSPCheckBoxMenuItem);
-        viewMenu.add(viewMarkWhitespaceCheckBoxMenuItem);
-        viewMenu.add(viewMarkBidiCheckBoxMenuItem);
-        viewMenu.add(viewMarkAutoPopulatedCheckBoxMenuItem);
-        viewMenu.add(viewMarkGlossaryMatchesCheckBoxMenuItem);
-        viewMenu.add(viewMarkLanguageCheckerCheckBoxMenuItem);
-        viewMenu.add(viewMarkFontFallbackCheckBoxMenuItem);
         viewMenu.add(viewModificationInfoMenu);
 
         viewModificationInfoMenu.add(viewDisplayModificationInfoNoneRadioButtonMenuItem);
@@ -887,17 +857,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 .setSelected(Core.getEditor().getSettings().isMarkNonUniqueSegments());
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkNotedSegments());
-        viewMarkNBSPCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkNBSP());
-        viewMarkWhitespaceCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkWhitespace());
-        viewMarkBidiCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkBidi());
-        viewMarkAutoPopulatedCheckBoxMenuItem
-                .setSelected(Core.getEditor().getSettings().isMarkAutoPopulated());
-        viewMarkGlossaryMatchesCheckBoxMenuItem
-                .setSelected(Core.getEditor().getSettings().isMarkGlossaryMatches());
-        viewMarkLanguageCheckerCheckBoxMenuItem
-                .setSelected(Core.getEditor().getSettings().isMarkLanguageChecker());
-        viewMarkFontFallbackCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isDoFontFallback());
-
         viewDisplayModificationInfoNoneRadioButtonMenuItem
                 .setSelected(EditorSettings.DISPLAY_MODIFICATION_INFO_NONE
                         .equals(Core.getEditor().getSettings().getDisplayModificationInfo()));
@@ -1108,13 +1067,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     JCheckBoxMenuItem viewDisplaySegmentSourceCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkNonUniqueSegmentsCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkNotedSegmentsCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkNBSPCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkWhitespaceCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkBidiCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkAutoPopulatedCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkGlossaryMatchesCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkLanguageCheckerCheckBoxMenuItem;
-    JCheckBoxMenuItem viewMarkFontFallbackCheckBoxMenuItem;
     JMenu viewModificationInfoMenu;
     JRadioButtonMenuItem viewDisplayModificationInfoNoneRadioButtonMenuItem;
     JRadioButtonMenuItem viewDisplayModificationInfoSelectedRadioButtonMenuItem;

--- a/src/org/omegat/gui/main/MainMenuIcons.java
+++ b/src/org/omegat/gui/main/MainMenuIcons.java
@@ -118,7 +118,7 @@ public final class MainMenuIcons {
      * @param color background color
      * @return
      */
-    static Icon newColorIcon(final Color color) {
+    public static Icon newColorIcon(final Color color) {
         return new BaseIcon() {
             @Override
             void doPaint(Graphics2D g2, int x, int y) {
@@ -169,7 +169,7 @@ public final class MainMenuIcons {
      * @param font font to use
      * @param text char to draw
      */
-    static Icon newTextIcon(final Color color, final Font font, final char c) {
+    public static Icon newTextIcon(final Color color, final Font font, final char c) {
         final char[] chars = new char[] { c };
         return new BaseIcon() {
             @Override

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -835,47 +835,6 @@ public final class MainWindowMenuHandler {
                         mainWindow.menu.viewMarkNotedSegmentsCheckBoxMenuItem.isSelected());
     }
 
-    public void viewMarkNBSPCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkNBSP(
-                        mainWindow.menu.viewMarkNBSPCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkWhitespaceCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkWhitespace(
-                        mainWindow.menu.viewMarkWhitespaceCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkBidiCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkBidi(
-                        mainWindow.menu.viewMarkBidiCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkAutoPopulatedCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkAutoPopulated(mainWindow.menu.viewMarkAutoPopulatedCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkGlossaryMatchesCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkGlossaryMatches(mainWindow.menu.viewMarkGlossaryMatchesCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkLanguageCheckerCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkLanguageChecker(mainWindow.menu.viewMarkLanguageCheckerCheckBoxMenuItem.isSelected());
-    }
-
-    public void viewMarkFontFallbackCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setDoFontFallback(mainWindow.menu.viewMarkFontFallbackCheckBoxMenuItem.isSelected());
-    }
-
     public void viewDisplayModificationInfoNoneRadioButtonMenuItemActionPerformed() {
         Core.getEditor().getSettings()
                 .setDisplayModificationInfo(EditorSettings.DISPLAY_MODIFICATION_INFO_NONE);

--- a/src/org/omegat/gui/scripting/ConsoleBindings.java
+++ b/src/org/omegat/gui/scripting/ConsoleBindings.java
@@ -340,4 +340,18 @@ public class ConsoleBindings implements IGlossaries, IEditor, IScriptLogger {
     public boolean isOrientationAllLtr() {
         return true;
     }
+
+    @Override
+    public int getCurrentPositionInEntryTranslation() {
+        return 0;
+    }
+
+    @Override
+    public int getPositionInEntryTranslation(final int mousepos) {
+        return 0;
+    }
+
+    @Override
+    public void setCaretPosition(final CaretPosition pos) {
+    }
 }

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -30,6 +30,7 @@ package org.omegat.languagetools;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.swing.Icon;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.omegat.core.Core;
@@ -40,8 +41,11 @@ import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.gui.issues.IssueProviders;
+import org.omegat.gui.main.MainMenuIcons;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.Styles;
 
@@ -108,7 +112,7 @@ public final class LanguageToolWrapper {
     }
 
     static class LanguageToolMarker implements IMarker {
-        static final HighlightPainter PAINTER = new UnderlineFactory.WaveUnderline(
+        static final HighlightPainter painter = new UnderlineFactory.WaveUnderline(
                 Styles.EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
 
         @Override
@@ -143,13 +147,35 @@ public final class LanguageToolWrapper {
             return bridge.getCheckResults(sourceText, translationText).stream().map(match -> {
                 Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, match.start, match.end);
                 m.toolTipText = match.message;
-                m.painter = PAINTER;
+                m.painter = painter;
                 return m;
             }).collect(Collectors.toList());
         }
 
-        protected boolean isEnabled() {
-            return Core.getEditor().getSettings().isMarkLanguageChecker();
+        @Override
+        public String getMarkerName() {
+            return OStrings.getString("LT_OPTIONS_MENU_ENABLED");
+        }
+
+        @Override
+        public Icon getIcon() {
+            return  MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
+        }
+
+        @Override
+        public String getPreferenceKey() {
+            return Preferences.LT_DISABLED;
+        }
+
+        private boolean enabled = true;
+
+        @Override
+        public void setEnabled(boolean val) {
+            enabled = val;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
     }
 

--- a/src/org/omegat/util/gui/MenuExtender.java
+++ b/src/org/omegat/util/gui/MenuExtender.java
@@ -54,7 +54,7 @@ public final class MenuExtender {
         /**
          * View menu.
          */
-        VIEW("view", 13),
+        VIEW("view", 6),
         /**
          * Tools menu.
          */

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -504,6 +504,20 @@ public final class TestTeamIntegrationChild {
         public boolean isOrientationAllLtr() {
             return true;
         }
+
+        @Override
+        public int getCurrentPositionInEntryTranslation() {
+            return 0;
+        }
+
+        @Override
+        public int getPositionInEntryTranslation(final int mousepos) {
+            return 0;
+        }
+
+        @Override
+        public void setCaretPosition(final CaretPosition pos) {
+        }
     };
 
     static IMainWindow mainWindow = new IMainWindow() {

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -366,6 +366,7 @@ public abstract class TestCore {
 
             @Override
             public void setMarkNBSP(boolean markNBSP) {
+
             }
 
             @Override

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -682,6 +682,20 @@ public abstract class TestCore {
             public boolean isOrientationAllLtr() {
                 return true;
             }
+
+            @Override
+            public int getCurrentPositionInEntryTranslation() {
+                return 0;
+            }
+
+            @Override
+            public int getPositionInEntryTranslation(final int mousepos) {
+                return 0;
+            }
+
+            @Override
+            public void setCaretPosition(final CaretPosition pos) {
+            }
         });
     }
 

--- a/test/src/org/omegat/gui/editor/mark/MarkerTestBase.java
+++ b/test/src/org/omegat/gui/editor/mark/MarkerTestBase.java
@@ -466,5 +466,19 @@ public class MarkerTestBase extends TestCore {
             return true;
         }
 
+        @Override
+        public int getCurrentPositionInEntryTranslation() {
+            return 0;
+        }
+
+        @Override
+        public int getPositionInEntryTranslation(final int mousepos) {
+            return 0;
+        }
+
+        @Override
+        public void setCaretPosition(final CaretPosition pos) {
+        }
+
     }
 }

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -464,6 +464,20 @@ public class MatchesVarExpansionTest {
         public boolean isOrientationAllLtr() {
             return true;
         }
+
+        @Override
+        public int getCurrentPositionInEntryTranslation() {
+            return 0;
+        }
+
+        @Override
+        public int getPositionInEntryTranslation(final int mousepos) {
+            return 0;
+        }
+
+        @Override
+        public void setCaretPosition(final CaretPosition pos) {
+        }
     };
 
 }


### PR DESCRIPTION
- Deprecate Core.registerMarker and Core.getMarkers
- Remove MarkerController.init and WhitespaceMarkerFactory.init

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

- Make `NBSPMarker` as true plugin
- NBSP marker menu are created in the plugin
- Removal of hard coded menu creation
- When registering maker plugins with its class, and loading the plugin, static fields are initialized when `loadPlugins` static function is called. it breaks colors of markers.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
