### PR TITLE
refactor: markers: avoid unnecessary static

### DIFF
--- a/src/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -39,18 +39,22 @@ import org.omegat.util.gui.Styles;
 
 /**
  * Spell checker marker implementation. All words for displayed file will be
- * cached, because check spelling is enough long operation.
+ * cached, because check spelling is enough long operations.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class SpellCheckerMarker implements IMarker {
-    protected static final HighlightPainter PAINTER = new UnderlineFactory.WaveUnderline(Styles.EditorColor.COLOR_SPELLCHECK.getColor());
+    protected final HighlightPainter highlightPainter;
+
+    public SpellCheckerMarker() {
+        highlightPainter = new UnderlineFactory.WaveUnderline(Styles.EditorColor.COLOR_SPELLCHECK.getColor());
+    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)
             throws Exception {
         if (translationText == null) {
-            // translation not displayed
+            // translation is not displayed
             return null;
         }
         if (!Core.getEditor().getSettings().isAutoSpellChecking()) {
@@ -61,7 +65,7 @@ public class SpellCheckerMarker implements IMarker {
             int st = tok.getOffset();
             int en = st + tok.getLength();
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, st, en);
-            m.painter = PAINTER;
+            m.painter = highlightPainter;
             return m;
         }).collect(Collectors.toList());
     }

--- a/src/org/omegat/gui/editor/mark/BidiMarkers.java
+++ b/src/org/omegat/gui/editor/mark/BidiMarkers.java
@@ -40,7 +40,6 @@ import org.omegat.util.gui.Styles;
  * Collection of Markers for Bidirectional control characters.
  */
 public class BidiMarkers extends AbstractMarker {
-    private static final List<Mark> EMPTY_LIST = Collections.emptyList();
 
     static final int LRM = 0x200e;
     static final int RLM = 0x200f;
@@ -50,17 +49,17 @@ public class BidiMarkers extends AbstractMarker {
     static final int LRO = 0x202d;
     static final int RLO = 0x202e;
 
-    static final HighlightPainter LRE_BIDI_PAINTER = new BidiPainter(LRE,
+    private final HighlightPainter lreBidiPainter = new BidiPainter(LRE,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    static final HighlightPainter RLE_BIDI_PAINTER = new BidiPainter(RLE,
+    private final HighlightPainter rleBidiPainter = new BidiPainter(RLE,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    static final HighlightPainter LRM_BIDI_PAINTER = new BidiPainter(LRM,
+    private final HighlightPainter lrmBidiPainter = new BidiPainter(LRM,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    static final HighlightPainter RLM_BIDI_PAINTER = new BidiPainter(RLM,
+    private final HighlightPainter rlmBidiPainter = new BidiPainter(RLM,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    static final HighlightPainter RLO_BIDI_PAINTER = new BidiPainter(RLO,
+    private final HighlightPainter rloBidiPainter = new BidiPainter(RLO,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    static final HighlightPainter LRO_BIDI_PAINTER = new BidiPainter(LRO,
+    private final HighlightPainter lroBidiPainter = new BidiPainter(LRO,
             Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
 
     public BidiMarkers() throws Exception {
@@ -74,7 +73,7 @@ public class BidiMarkers extends AbstractMarker {
             return null;
         }
         if (!isActive || text == null || text.trim().isEmpty()) {
-            return EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         text = StringUtil.normalizeUnicode(text);
@@ -93,16 +92,16 @@ public class BidiMarkers extends AbstractMarker {
                 Mark mark = new Mark(Mark.ENTRY_PART.TRANSLATION, startPos, i);
                 switch (markCodePoint) {
                 case LRE:
-                    mark.painter = LRE_BIDI_PAINTER;
+                    mark.painter = lreBidiPainter;
                     break;
                 case RLE:
-                    mark.painter = RLE_BIDI_PAINTER;
+                    mark.painter = rleBidiPainter;
                     break;
                 case LRO:
-                    mark.painter = LRO_BIDI_PAINTER;
+                    mark.painter = lroBidiPainter;
                     break;
                 case RLO:
-                    mark.painter = RLO_BIDI_PAINTER;
+                    mark.painter = rloBidiPainter;
                     break;
                 }
                 marks.add(mark);
@@ -111,7 +110,7 @@ public class BidiMarkers extends AbstractMarker {
                 markCodePoint = -1;
             } else if (cp == LRM || cp == RLM) {
                 Mark mark = new Mark(Mark.ENTRY_PART.TRANSLATION, i, i + 1);
-                mark.painter = cp == LRM ? LRM_BIDI_PAINTER : RLM_BIDI_PAINTER;
+                mark.painter = cp == LRM ? lrmBidiPainter : rlmBidiPainter;
                 marks.add(mark);
             } else {
                 markCodePoint = cp;
@@ -123,16 +122,16 @@ public class BidiMarkers extends AbstractMarker {
             Mark mark = new Mark(Mark.ENTRY_PART.TRANSLATION, startPos, startPos);
             switch (markCodePoint) {
             case LRE:
-                mark.painter = LRE_BIDI_PAINTER;
+                mark.painter = lreBidiPainter;
                 break;
             case RLE:
-                mark.painter = RLE_BIDI_PAINTER;
+                mark.painter = rleBidiPainter;
                 break;
             case LRO:
-                mark.painter = LRO_BIDI_PAINTER;
+                mark.painter = lroBidiPainter;
                 break;
             case RLO:
-                mark.painter = RLO_BIDI_PAINTER;
+                mark.painter = rloBidiPainter;
                 break;
             }
             marks.add(mark);

--- a/src/org/omegat/gui/editor/mark/BidiMarkers.java
+++ b/src/org/omegat/gui/editor/mark/BidiMarkers.java
@@ -49,21 +49,27 @@ public class BidiMarkers extends AbstractMarker {
     static final int LRO = 0x202d;
     static final int RLO = 0x202e;
 
-    private final HighlightPainter lreBidiPainter = new BidiPainter(LRE,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    private final HighlightPainter rleBidiPainter = new BidiPainter(RLE,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    private final HighlightPainter lrmBidiPainter = new BidiPainter(LRM,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    private final HighlightPainter rlmBidiPainter = new BidiPainter(RLM,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    private final HighlightPainter rloBidiPainter = new BidiPainter(RLO,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-    private final HighlightPainter lroBidiPainter = new BidiPainter(LRO,
-            Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+    private final HighlightPainter lreBidiPainter;
+    private final HighlightPainter rleBidiPainter;
+    private final HighlightPainter lrmBidiPainter;
+    private final HighlightPainter rlmBidiPainter;
+    private final HighlightPainter rloBidiPainter;
+    private final HighlightPainter lroBidiPainter;
 
     public BidiMarkers() throws Exception {
         super();
+        lreBidiPainter = new BidiPainter(LRE,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+        rleBidiPainter = new BidiPainter(RLE,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+        lrmBidiPainter = new BidiPainter(LRM,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+        rlmBidiPainter = new BidiPainter(RLM,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+        rloBidiPainter = new BidiPainter(RLO,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
+        lroBidiPainter = new BidiPainter(LRO,
+                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
     }
 
     @Override

--- a/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -42,13 +42,13 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ComesFromAutoTMMarker implements IMarker {
-    protected static final HighlightPainter PAINTER_XICE = new TransparentHighlightPainter(
+    private final HighlightPainter painterXice = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE.getColor(), 0.5F);
-    protected static final HighlightPainter PAINTER_X100PC = new TransparentHighlightPainter(
+    private final HighlightPainter painterX100Pc = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC.getColor(), 0.5F);
-    protected static final HighlightPainter PAINTER_XAUTO = new TransparentHighlightPainter(
+    private final HighlightPainter painterXauto = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor(), 0.5F);
-    protected static final HighlightPainter PAINTER_XENFORCED = new TransparentHighlightPainter(
+    private final HighlightPainter painterXenforced = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED.getColor(), 0.5F);
 
     @Override
@@ -64,16 +64,16 @@ public class ComesFromAutoTMMarker implements IMarker {
         Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
         switch (e.linked) {
         case xICE:
-            m.painter = PAINTER_XICE;
+            m.painter = painterXice;
             break;
         case x100PC:
-            m.painter = PAINTER_X100PC;
+            m.painter = painterX100Pc;
             break;
         case xAUTO:
-            m.painter = PAINTER_XAUTO;
+            m.painter = painterXauto;
             break;
         case xENFORCED:
-            m.painter = PAINTER_XENFORCED;
+            m.painter = painterXenforced;
         }
         return Collections.singletonList(m);
     }

--- a/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -42,14 +42,21 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ComesFromAutoTMMarker implements IMarker {
-    private final HighlightPainter painterXice = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE.getColor(), 0.5F);
-    private final HighlightPainter painterX100Pc = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC.getColor(), 0.5F);
-    private final HighlightPainter painterXauto = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor(), 0.5F);
-    private final HighlightPainter painterXenforced = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED.getColor(), 0.5F);
+    private final HighlightPainter painterXice;
+    private final HighlightPainter painterX100Pc;
+    private final HighlightPainter painterXauto;
+    private final HighlightPainter painterXenforced;
+
+    public ComesFromAutoTMMarker() {
+        painterXice = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE.getColor(), 0.5F);
+        painterX100Pc = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC.getColor(), 0.5F);
+        painterXauto = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor(), 0.5F);
+        painterXenforced = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED.getColor(), 0.5F);
+    }
 
     @Override
     public synchronized List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText,

--- a/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
@@ -42,7 +42,7 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ComesFromMTMarker implements IMarker {
-    protected static final HighlightPainter PAINTER = new TransparentHighlightPainter(
+    private final HighlightPainter highlightPainter = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_COMES_FROM_TM.getColor(), 0.5F);
 
     private SourceTextEntry markedSte;
@@ -78,7 +78,7 @@ public class ComesFromMTMarker implements IMarker {
             }
         }
         Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
-        m.painter = PAINTER;
+        m.painter = highlightPainter;
         return Collections.singletonList(m);
     }
 }

--- a/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
+++ b/src/org/omegat/gui/editor/mark/ComesFromMTMarker.java
@@ -42,9 +42,7 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ComesFromMTMarker implements IMarker {
-    private final HighlightPainter highlightPainter = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_COMES_FROM_TM.getColor(), 0.5F);
-
+    private final HighlightPainter highlightPainter;
     private SourceTextEntry markedSte;
     private String markedText;
 
@@ -60,6 +58,8 @@ public class ComesFromMTMarker implements IMarker {
                 }
             }
         });
+        highlightPainter = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM.getColor(), 0.5F);
     }
 
     public void setMark(SourceTextEntry ste, String text) {

--- a/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -49,9 +49,9 @@ import org.omegat.util.gui.Styles;
  * @author Aaron Madlon-Kay
  */
 public class ProtectedPartsMarker implements IMarker {
-    protected static final HighlightPainter PAINTER_RTL = new TransparentHighlightPainter(
+    private final HighlightPainter painterRtl = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
-    protected static final AttributeSet ATTRIBUTES_LTR = Styles
+    private final AttributeSet attributesLtr = Styles
             .createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null, null);
 
     @Override
@@ -60,11 +60,11 @@ public class ProtectedPartsMarker implements IMarker {
         HighlightPainter painter;
         AttributeSet attrs;
         if (Core.getEditor().isOrientationAllLtr()) {
-            attrs = ATTRIBUTES_LTR;
+            attrs = attributesLtr;
             painter = null;
         } else {
             attrs = null;
-            painter = PAINTER_RTL;
+            painter = painterRtl;
         }
 
         if (ste.getProtectedParts().length == 0) {

--- a/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -49,10 +49,15 @@ import org.omegat.util.gui.Styles;
  * @author Aaron Madlon-Kay
  */
 public class ProtectedPartsMarker implements IMarker {
-    private final HighlightPainter painterRtl = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
-    private final AttributeSet attributesLtr = Styles
-            .createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null, null);
+    private final HighlightPainter painterRtl;
+    private final AttributeSet attributesLtr;
+
+    public ProtectedPartsMarker() {
+        painterRtl = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
+        attributesLtr = Styles
+                .createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null, null);
+    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)

--- a/src/org/omegat/gui/editor/mark/ReplaceMarker.java
+++ b/src/org/omegat/gui/editor/mark/ReplaceMarker.java
@@ -44,7 +44,7 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ReplaceMarker implements IMarker {
-    protected static final HighlightPainter PAINTER = new TransparentHighlightPainter(
+    private final HighlightPainter highlightPainter = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
 
     @Override
@@ -52,7 +52,7 @@ public class ReplaceMarker implements IMarker {
             boolean isActive) throws Exception {
 
         IEditorFilter filter = Core.getEditor().getFilter();
-        if (filter == null || !(filter instanceof ReplaceFilter)) {
+        if (!(filter instanceof ReplaceFilter)) {
             return Collections.emptyList();
         }
 
@@ -62,10 +62,10 @@ public class ReplaceMarker implements IMarker {
             return Collections.emptyList();
         }
 
-        List<Mark> r = new ArrayList<Mark>(matches.size());
+        List<Mark> r = new ArrayList<>(matches.size());
         for (SearchMatch s : matches) {
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, s.getStart(), s.getEnd());
-            m.painter = PAINTER;
+            m.painter = highlightPainter;
             r.add(m);
         }
         return r;

--- a/src/org/omegat/gui/editor/mark/ReplaceMarker.java
+++ b/src/org/omegat/gui/editor/mark/ReplaceMarker.java
@@ -44,8 +44,12 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ReplaceMarker implements IMarker {
-    private final HighlightPainter highlightPainter = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
+    private final HighlightPainter highlightPainter;
+
+    public ReplaceMarker() {
+        highlightPainter = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
+    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,

--- a/src/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
+++ b/src/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
@@ -42,8 +42,8 @@ import org.omegat.gui.editor.UnderlineFactory.Underliner;
  * @author Martin Fleurke
  */
 public class TransparentHighlightPainter extends Underliner {
-    private Color color;
-    private AlphaComposite alphaComposite;
+    private final Color color;
+    private final AlphaComposite alphaComposite;
 
     /**
      *

--- a/src/org/omegat/gui/editor/mark/WhitespaceMarker.java
+++ b/src/org/omegat/gui/editor/mark/WhitespaceMarker.java
@@ -43,9 +43,6 @@ import org.omegat.util.gui.Styles;
 @SuppressWarnings("unused")
 public final class WhitespaceMarker implements IMarker {
 
-    public WhitespaceMarker() {
-    }
-
     public static void loadPlugins() {
         Core.registerMarkerClass(WhitespaceMarker.class);
     }
@@ -53,23 +50,25 @@ public final class WhitespaceMarker implements IMarker {
     public static void unloadPlugins() {
     }
 
-    private final SymbolPainter spacePainter =
-            new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(),
-            "·");
+    private final SymbolPainter spacePainter;
     /**
      * Marker for tab
      */
-    private final SymbolPainter tabPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(),
-            "»");
+    private final SymbolPainter tabPainter;
+
     /**
      * Marker for linefeed.
      *
      * There is a linefeed symbol: U+240A. But it is so small / hard to see,
      * that instead we use U+00B6 as the symbol to show, like other applications do.
      */
-    private final SymbolPainter lfPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(),
-            "¶");
-    //no need for CR marker. There are no CR's.
+    private final SymbolPainter lfPainter;
+
+    public WhitespaceMarker() {
+        spacePainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "·");
+        tabPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "»");
+        lfPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "¶");
+    }
 
     /**
      * Marker for whitespaces.

--- a/src/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/org/omegat/gui/glossary/TransTipsMarker.java
@@ -47,8 +47,12 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class TransTipsMarker implements IMarker {
-    private final HighlightPainter transtipsUnderliner = new UnderlineFactory.SolidBoldUnderliner(
-            Styles.EditorColor.COLOR_TRANSTIPS.getColor());
+    private final HighlightPainter transtipsUnderliner;
+
+    public TransTipsMarker() {
+        transtipsUnderliner = new UnderlineFactory.SolidBoldUnderliner(
+                Styles.EditorColor.COLOR_TRANSTIPS.getColor());
+    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,

--- a/src/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/org/omegat/gui/glossary/TransTipsMarker.java
@@ -47,7 +47,7 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class TransTipsMarker implements IMarker {
-    protected static final HighlightPainter TRANSTIPS_UNDERLINER = new UnderlineFactory.SolidBoldUnderliner(
+    private final HighlightPainter transtipsUnderliner = new UnderlineFactory.SolidBoldUnderliner(
             Styles.EditorColor.COLOR_TRANSTIPS.getColor());
 
     @Override
@@ -64,7 +64,7 @@ public class TransTipsMarker implements IMarker {
             return null;
         }
 
-        List<Mark> marks = new ArrayList<Mark>();
+        List<Mark> marks = new ArrayList<>();
 
         IGlossaryRenderer renderer = GlossaryRenderers.getPreferredGlossaryRenderer();
         for (GlossaryEntry ent : glossaryEntries) {
@@ -75,7 +75,7 @@ public class TransTipsMarker implements IMarker {
         return marks;
     }
 
-    private static List<Mark> getMarksForTokens(List<Token[]> tokens, String srcText, String tooltip) {
+    private List<Mark> getMarksForTokens(List<Token[]> tokens, String srcText, String tooltip) {
         if (tokens.isEmpty() || srcText.isEmpty()) {
             return Collections.emptyList();
         }
@@ -99,14 +99,14 @@ public class TransTipsMarker implements IMarker {
                     newMark = new Mark(Mark.ENTRY_PART.SOURCE, currStart, currEnd);
                     result.add(newMark);
                 }
-                newMark.painter = TRANSTIPS_UNDERLINER;
+                newMark.painter = transtipsUnderliner;
                 newMark.toolTipText = tooltip;
             }
         }
         return result;
     }
 
-    private static boolean canCloseSpan(String text, int start, int end) {
+    private boolean canCloseSpan(String text, int start, int end) {
         if (start < 0 || end > text.length()) {
             throw new IndexOutOfBoundsException();
         }


### PR DESCRIPTION
There are unnecessary static variable initialization and static functions. These break registering Markers as plugins.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

- avoid all `Styles` static reference in static initialization, because the reference should be happened after theme modules initialization.  
-
-

## Other information

Bring improvements from #951
