### PR TITLE
[BUGS#847] call glossaryManager.fileChanged when sync glossary with team

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1134,6 +1134,8 @@ public class RealProject implements IProject {
 
                             @Override
                             public void reload(final File file) {
+                                logger.atDebug().setMessage("Reloading glossary file {0}").addArgument(file).log();
+                                getGlossaryManager().fileChanged(file);
                             }
 
                             @Override

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -90,6 +90,7 @@ import org.omegat.filters2.IFilter;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.gui.glossary.GlossaryEntry;
+import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.gui.glossary.GlossaryReaderTSV;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.ITokenizer;
@@ -1840,6 +1841,14 @@ public class RealProject implements IProject {
             fn = fn.replaceAll(f, t);
         }
         return StringUtil.removeXMLInvalidChars(fn);
+    }
+
+    /**
+     * Extension point for tests.
+     * @return
+     */
+    protected GlossaryManager getGlossaryManager() {
+        return Core.getGlossaryManager();
     }
 
     protected class LoadFilesCallback extends ParseEntry {

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -376,7 +376,6 @@ public class RealProject implements IProject {
             try {
                 loadTranslations(); // load project_save.tmx
                 loadSourceFiles();
-                startGlossaryManager();
 
                 // This MUST happen after calling loadTranslations()
                 if (remoteRepositoryProvider != null && isOnlineMode) {
@@ -529,7 +528,6 @@ public class RealProject implements IProject {
         flushProcessCache();
         tmMonitor.fin();
         tmOtherLanguagesMonitor.fin();
-        stopGlossaryManager();
         unlockProject();
         Log.logInfoRB("LOG_DATAENGINE_CLOSE");
     }
@@ -1847,33 +1845,11 @@ public class RealProject implements IProject {
         return StringUtil.removeXMLInvalidChars(fn);
     }
 
-    private void startGlossaryManager() {
-        GlossaryManager gm = getGlossaryManager();
-        if (gm != null) {
-            gm.start();
-        }
-    }
-
-    private void stopGlossaryManager() {
-        GlossaryManager gm = getGlossaryManager();
-        if (gm != null) {
-            gm.stop();
-        }
-    }
-
-    private void notifyGlossaryManagerFileChanged(File file) {
-        GlossaryManager gm = getGlossaryManager();
+    protected void notifyGlossaryManagerFileChanged(File file) {
+        GlossaryManager gm = Core.getGlossaryManager();
         if (gm != null) {
             gm.fileChanged(file);
         }
-    }
-
-    /**
-     * Extension point for tests.
-     * @return
-     */
-    protected GlossaryManager getGlossaryManager() {
-        return Core.getGlossaryManager();
     }
 
     protected class LoadFilesCallback extends ParseEntry {

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -376,8 +376,7 @@ public class RealProject implements IProject {
             try {
                 loadTranslations(); // load project_save.tmx
                 loadSourceFiles();
-
-                getGlossaryManager().start();
+                startGlossaryManager();
 
                 // This MUST happen after calling loadTranslations()
                 if (remoteRepositoryProvider != null && isOnlineMode) {
@@ -530,7 +529,7 @@ public class RealProject implements IProject {
         flushProcessCache();
         tmMonitor.fin();
         tmOtherLanguagesMonitor.fin();
-        getGlossaryManager().stop();
+        stopGlossaryManager();
         unlockProject();
         Log.logInfoRB("LOG_DATAENGINE_CLOSE");
     }
@@ -1135,7 +1134,7 @@ public class RealProject implements IProject {
                             @Override
                             public void reload(final File file) {
                                 logger.atDebug().setMessage("Reloading glossary file {0}").addArgument(file).log();
-                                getGlossaryManager().fileChanged(file);
+                                notifyGlossaryManagerFileChanged(file);
                             }
 
                             @Override
@@ -1846,6 +1845,27 @@ public class RealProject implements IProject {
             fn = fn.replaceAll(f, t);
         }
         return StringUtil.removeXMLInvalidChars(fn);
+    }
+
+    private void startGlossaryManager() {
+        GlossaryManager gm = getGlossaryManager();
+        if (gm != null) {
+            gm.start();
+        }
+    }
+
+    private void stopGlossaryManager() {
+        GlossaryManager gm = getGlossaryManager();
+        if (gm != null) {
+            gm.stop();
+        }
+    }
+
+    private void notifyGlossaryManagerFileChanged(File file) {
+        GlossaryManager gm = getGlossaryManager();
+        if (gm != null) {
+            gm.fileChanged(file);
+        }
     }
 
     /**

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -377,6 +377,8 @@ public class RealProject implements IProject {
                 loadTranslations(); // load project_save.tmx
                 loadSourceFiles();
 
+                getGlossaryManager().start();
+
                 // This MUST happen after calling loadTranslations()
                 if (remoteRepositoryProvider != null && isOnlineMode) {
                     Core.getMainWindow().showStatusMessageRB("TEAM_REBASE_AND_COMMIT");
@@ -528,6 +530,7 @@ public class RealProject implements IProject {
         flushProcessCache();
         tmMonitor.fin();
         tmOtherLanguagesMonitor.fin();
+        getGlossaryManager().stop();
         unlockProject();
         Log.logInfoRB("LOG_DATAENGINE_CLOSE");
     }

--- a/src/org/omegat/gui/glossary/GlossaryManager.java
+++ b/src/org/omegat/gui/glossary/GlossaryManager.java
@@ -155,7 +155,8 @@ public class GlossaryManager implements DirectoryMonitor.Callback {
         }
         if (file.exists()) {
             try {
-                List<GlossaryEntry> entries = loadGlossaryFile(file);
+                boolean isPriority = priorityGlossary != null && priorityGlossary.equals(file);
+                List<GlossaryEntry> entries = loadGlossaryFile(file, isPriority);
                 if (entries != null) {
                     synchronized (this) {
                         Log.logInfoRB("CT_LOADING_GLOSSARY_DETAILS", entries.size(), file.getName());
@@ -184,10 +185,9 @@ public class GlossaryManager implements DirectoryMonitor.Callback {
     }
 
     /**
-     * Loads one glossary file. It chooses and calls required reader.
+     * Loads one glossary file. It chooses and calls the required reader.
      */
-    private List<GlossaryEntry> loadGlossaryFile(final File file) throws Exception {
-        boolean isPriority = priorityGlossary.equals(file);
+    private List<GlossaryEntry> loadGlossaryFile(File file, boolean isPriority) throws Exception {
         String fnameLower = file.getName().toLowerCase(Locale.ENGLISH);
         if (fnameLower.endsWith(OConsts.EXT_TSV_DEF)) {
             Log.logRB("CT_LOADING_GLOSSARY", file.getName());

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -176,12 +176,14 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     @Override
     protected void onProjectOpen() {
         clear();
+        Core.getGlossaryManager().start();
     }
 
     @Override
     protected void onProjectClose() {
         clear();
         setText(EXPLANATION);
+        Core.getGlossaryManager().stop();
     }
 
     @Override

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -176,14 +176,12 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     @Override
     protected void onProjectOpen() {
         clear();
-        Core.getGlossaryManager().start();
     }
 
     @Override
     protected void onProjectClose() {
         clear();
         setText(EXPLANATION);
-        Core.getGlossaryManager().stop();
     }
 
     @Override

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -69,6 +69,7 @@ import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.team2.impl.GITRemoteRepository2;
 import org.omegat.core.team2.impl.SVNAuthenticationManager;
 import org.omegat.filters2.master.PluginUtils;
+import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.util.Language;
 import org.omegat.util.ProjectFileStorage;
 import org.omegat.util.TMXWriter2;
@@ -298,11 +299,13 @@ public final class TestTeamIntegration {
         File f = new File(origDir, "omegat/project_save.tmx");
         TMXWriter2 wr = new TMXWriter2(f, SRC_LANG, TRG_LANG, true, false, true);
         wr.close();
-
         ProjectFileStorage.writeProjectFile(config);
 
         remote.copyFilesFromProjectToRepos("omegat.project", null);
         remote.commitFiles("omegat.project", "Prepare for team test");
+        GlossaryManager.createNewWritableGlossaryFile(config.getWritableGlossaryFile().getAsFile());
+        remote.copyFilesFromProjectToRepos("glossary/glossary.txt", null);
+        remote.commitFiles("glossary/glossary.txt", "Prepare for team test");
         remote.copyFilesFromProjectToRepos("omegat/project_save.tmx", null);
         remote.commitFiles("omegat/project_save.tmx", "Prepare for team test");
 
@@ -320,6 +323,8 @@ public final class TestTeamIntegration {
             config.getRepositories().add(getDef(repoUrl, predictMainType(repoUrl), "/", "/"));
             config.getRepositories().add(getDef(MAP_REPO, MAP_REPO_TYPE, MAP_FILE, "source/" + MAP_FILE));
         }
+        config.setWriteableGlossary("glossary/glossary.txt");
+        config.setGlossaryRoot("glossary");
         return config;
     }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -619,7 +619,7 @@ public final class TestTeamIntegrationChild {
         public void lockUI() {
         }
 
-        IMainMenu menu = new IMainMenu() {
+        final IMainMenu menu = new IMainMenu() {
 
             public JMenu getToolsMenu() {
                 return null;
@@ -708,10 +708,6 @@ public final class TestTeamIntegrationChild {
             super(props);
         }
 
-        ProjectTMX mergedTMX;
-        ProjectTMX baseTMX;
-        ProjectTMX headTMX;
-
         @Override
         protected ProjectTMX mergeTMX(ProjectTMX baseTMX, ProjectTMX headTMX, StringBuilder commitDetails) {
             Log.log("Base:   " + baseTMX);
@@ -793,57 +789,6 @@ public final class TestTeamIntegrationChild {
                     && base.alternatives.keySet().stream().allMatch(other.alternatives::containsKey);
         }
 
-        protected void mergeTMXOld(ProjectTMX baseTMX, ProjectTMX headTMX) {
-            mergedTMX = new ProjectTMX();
-            this.baseTMX = baseTMX;
-            this.headTMX = headTMX;
-            String s = "info";
-            for (TMXEntry e : baseTMX.getDefaults()) {
-                use(e);
-            }
-            for (TMXEntry e : headTMX.getDefaults()) {
-                TMXEntry eb = baseTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
-                    if (v(eb) > v(e)) {
-                        throw new RuntimeException("Rebase HEAD: wrong concurrent" + s);
-                    }
-                    use(e);
-                } else if (e.source.startsWith(source + "/")) { // my segments
-                    if (v(eb) != v(e)) {
-                        throw new RuntimeException("Rebase HEAD: not equals for current project" + s);
-                    }
-                } else { // other segments
-                    if (v(eb) > v(e)) {
-                        throw new RuntimeException("Rebase HEAD: less value" + s);
-                    }
-                    use(e);
-                }
-            }
-            for (TMXEntry e : projectTMX.getDefaults()) {
-                TMXEntry em = mergedTMX.getDefaultTranslation(e.source);
-                if (CONCURRENT_NAME.equals(e.source)) { // concurrent
-                    if (v(e) > v(em)) {
-                        use(e);
-                    }
-                } else if (e.source.startsWith(source + "/")) { // my segments
-                    if (v(e) < v(em)) {
-                        throw new RuntimeException("Rebase me: less value" + s);
-                    }
-                    use(e);
-                } else { // other segments
-                    use(em);
-                }
-            }
-
-            projectTMX.replaceContent(mergedTMX);
-        }
-
-        void use(TMXEntry en) {
-            EntryKey k = new EntryKey("file", en.source, null, null, null, null);
-            SourceTextEntry ste = new SourceTextEntry(k, 0, null, en.source, Collections.emptyList());
-            mergedTMX.setTranslation(ste, en, true);
-        }
-
         long v(TMXEntry e) {
             if (e == null) {
                 return 0;
@@ -868,18 +813,9 @@ public final class TestTeamIntegrationChild {
             }
         }
 
-        String trans(ProjectTMX tmx, TMXEntry e) {
-            TMXEntry en = tmx.getDefaultTranslation(e.source);
-            if (en == null) {
-                return "null";
-            } else {
-                return en.translation;
-            }
-        }
-
         @Override
-        protected GlossaryManager getGlossaryManager() {
-            return glossaryManager;
+        protected void notifyGlossaryManagerFileChanged(File file) {
+            glossaryManager.fileChanged(file);
         }
     }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -25,8 +25,10 @@
 
 package org.omegat.core.data;
 
+
 import java.awt.Cursor;
 import java.awt.Font;
+import java.awt.Frame;
 import java.awt.HeadlessException;
 import java.io.File;
 import java.io.InputStream;
@@ -35,9 +37,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.swing.JFrame;
@@ -52,7 +56,6 @@ import org.madlonkay.supertmxmerge.data.ResolutionStrategy;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.TestCoreInitializer;
-import org.omegat.core.data.IProject.DefaultTranslationsIterator;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.threads.IAutoSave;
@@ -63,9 +66,14 @@ import org.omegat.gui.editor.IEditorFilter;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.autocompleter.IAutoCompleter;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.gui.glossary.GlossaryEntry;
+import org.omegat.gui.glossary.GlossaryManager;
+import org.omegat.gui.glossary.GlossaryReaderTSV;
+import org.omegat.gui.glossary.IGlossaries;
 import org.omegat.gui.main.IMainMenu;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Log;
+import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.ProjectFileStorage;
@@ -102,13 +110,17 @@ public final class TestTeamIntegrationChild {
     static SourceTextEntry steC;
     static long num = 0;
     static long[] v;
-    static Map<String, Long> values = new HashMap<String, Long>();
+    static Map<String, Long> values = new HashMap<>();
+    static Set<String> glossaries = new HashSet<>();
+    static long glossaryIndex = 0;
+    static GlossaryManager glossaryManager;
 
     public static void main(String[] args) throws Exception {
         if (args.length != 6) {
             System.err.println("Wrong arguments count");
             System.exit(1);
         }
+        Thread.currentThread().setName("Child-" + args[0]);
         try {
             source = args[0];
             long time = Long.parseLong(args[1]);
@@ -136,19 +148,23 @@ public final class TestTeamIntegrationChild {
             TestCoreInitializer.initEditor(editor);
 
             ProjectProperties config = TestTeamIntegration.createConfig(repo, new File(dir));
-            new RemoteRepositoryProvider(config.getProjectRootDir(), config.getRepositories(), config);
+            RemoteRepositoryProvider remoteRepositoryProvider = new RemoteRepositoryProvider(
+                    config.getProjectRootDir(), config.getRepositories(), config);
+            remoteRepositoryProvider.switchToVersion(OConsts.FILE_PROJECT, null);
+            remoteRepositoryProvider.copyFilesFromReposToProject(OConsts.FILE_PROJECT, "", false);
 
-            // load project
+            // Prepare project
             ProjectProperties projectProperties = ProjectFileStorage.loadProjectProperties(new File(dir));
-            projectProperties.autocreateDirectories();
             String remoteRepoUrl = getRootGitRepositoryMapping(projectProperties.getRepositories());
             if (!repo.equals(remoteRepoUrl)) {
                 setRootGitRepositoryMapping(projectProperties.getRepositories(), repo);
             }
-
+            projectProperties.autocreateDirectories();
             Core.getAutoSave().disable();
             RealProject p = new TestRealProject(projectProperties);
             Core.setProject(p);
+            glossaryManager = new GlossaryManager(new TestGlossaryTextArea());
+            // load project
             p.loadProject(true);
             if (p.isProjectLoaded()) {
                 Core.getAutoSave().enable();
@@ -178,16 +194,26 @@ public final class TestTeamIntegrationChild {
                     Thread.sleep(ThreadLocalRandom.current().nextInt(maxDelaySeconds * 1000) + 10);
                     checksavecheck(0);
 
+                    updateGlossary();
+
                     // change /1..N segment
                     Thread.sleep(ThreadLocalRandom.current().nextInt(maxDelaySeconds * 1000) + 10);
                     checksavecheck(c);
+
+                    checkGlossaryEntries();
                 }
             }
-            Core.getProject().closeProject();
+            // do closeProject as same way as OmegaT close
+            Core.executeExclusively(true, () -> {
+                Core.getProject().saveProject(true);
+                ProjectFactory.closeProject();
+            });
 
             // load again and check
             ProjectFactory.loadProject(projectProperties, true);
             checkAll();
+
+            checkGlossaryEntries();
 
             // check projectProperties
             checkRepoUrl(projectProperties);
@@ -260,7 +286,7 @@ public final class TestTeamIntegrationChild {
             checkTranslationFromFile(tmx, c);
         }
 
-        Core.getProject().iterateByDefaultTranslations(new DefaultTranslationsIterator() {
+        Core.getProject().iterateByDefaultTranslations(new IProject.DefaultTranslationsIterator() {
             public void iterate(String source, TMXEntry trans) {
                 Long prev = values.get(source);
                 if (prev == null) {
@@ -273,6 +299,35 @@ public final class TestTeamIntegrationChild {
                 }
             }
         });
+    }
+
+    static void checkGlossaryEntries() {
+        List<GlossaryEntry> entries = glossaryManager.getLocalEntries();
+        for (String s: glossaries) {
+            boolean found = false;
+            for (GlossaryEntry entry: entries) {
+                if (entry.getSrcText().equals(s)) {
+                    final long index = getGlossaryIndex(s);
+                    final String loc = getGlossaryLoc(index);
+                    final String com = getGlossaryCom(index);
+                    if (!loc.equals(entry.getLocText()))  {
+                        throw new RuntimeException("Glossary error : " + entry.getSrcText()
+                                + " should have loc: " + loc + " but it is " + entry.getLocText());
+                    }
+                    if (!com.equals(entry.getCommentText())) {
+                        throw new RuntimeException("Glossary error : " + entry.getSrcText()
+                                + " should have comment: " + com + " but it is " + entry.getCommentText());
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Glossary error : glossary entry missing! \"" + s + "\"");
+            }
+        }
+        Log.log("Checked my added" + glossaries.size() + " entries in total " + entries.size()
+                + " writable glossary entries.");
     }
 
     static void checkTranslation(int index) {
@@ -310,6 +365,30 @@ public final class TestTeamIntegrationChild {
         Core.getProject().setTranslation(ste, prep, true, null);
         Log.log("Wrote: " + prep.source + "=" + prep.translation);
         Core.getProject().saveProject(true);
+    }
+
+    static long getGlossaryIndex(String term) {
+        return Long.parseLong(term.substring(term.lastIndexOf('/') + 1));
+    }
+    static String getGlossaryTerm(long index) {
+        return "term/" + source + "/" + index;
+    }
+    static String getGlossaryLoc(long index) {
+        return "loc/" + source + "/" + index;
+    }
+    static String getGlossaryCom(long index) {
+        return "com/" + source + "/" + index;
+    }
+
+    static void updateGlossary() throws Exception {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        final File out = new File(props.getWriteableGlossary());
+        final String src = getGlossaryTerm(glossaryIndex);
+        final String loc = getGlossaryLoc(glossaryIndex);
+        final String com = getGlossaryCom(glossaryIndex);
+        GlossaryReaderTSV.append(out, new GlossaryEntry(src, loc, com, true, out.getPath()));
+        Log.log("Add glossary entry " + src);
+        glossaryIndex++;
     }
 
     static IAutoSave autoSave = new IAutoSave() {
@@ -796,6 +875,26 @@ public final class TestTeamIntegrationChild {
             } else {
                 return en.translation;
             }
+        }
+
+        @Override
+        protected GlossaryManager getGlossaryManager() {
+            return glossaryManager;
+        }
+    }
+
+    private static class TestGlossaryTextArea implements IGlossaries {
+        @Override
+        public List<GlossaryEntry> getDisplayedEntries() {
+            return null;
+        }
+
+        @Override
+        public void showCreateGlossaryEntryDialog(final Frame parent) {
+        }
+
+        @Override
+        public void refresh() {
         }
     }
 }

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -120,7 +120,7 @@ public final class TestTeamIntegrationChild {
             System.err.println("Wrong arguments count");
             System.exit(1);
         }
-        Thread.currentThread().setName("Child-" + args[0]);
+        Thread.currentThread().setName(args[0]);
         try {
             source = args[0];
             long time = Long.parseLong(args[1]);


### PR DESCRIPTION
## Pull request type

- bug fix
- enhance test 

## Which ticket is resolved?

- Team projects not saving properly or stopping synchronization
- https://sourceforge.net/p/omegat/bugs/847/

## What does this PR change?

- Test a team synchronize of writable glossary file in integration test
- Start/Stop `GlossaryManager` monitor direct from `RealProject#loadProject` `RealProject#closeProject` 
- Load glossaries immediately after sync with remote

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
