### PR TITLE
[backport/6.0][BUGS#1250] fix: glossary korean degration

### DIFF
--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -150,7 +150,7 @@ public class GlossarySearcher {
 
     private static boolean rawMatch(Token[] tokens, String srcTxt, String term) {
         for (Token token : tokens) {
-            if (token.getTextFromString(srcTxt).equals(term.substring(token.getLength()))) {
+            if (term.contains(token.getTextFromString(srcTxt))) {
                 return true;
             }
         }

--- a/test/data/glossaries/test.tab
+++ b/test/data/glossaries/test.tab
@@ -1,2 +1,4 @@
 kde	koo moo
 question	qqqqq
+地球システム	System Terre	https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre
+손가락	Korean Term

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -44,20 +44,20 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals("koo moo", g.get(0).getLocText());
         assertEquals("question", g.get(1).getSrcText());
         assertEquals("qqqqq", g.get(1).getLocText());
-        assertEquals("地球システム", g.get(2).getSrcText());
+        assertEquals("\u5730\u7403\u30B7\u30B9\u30C6\u30E0", g.get(2).getSrcText());
         assertEquals("System Terre", g.get(2).getLocText());
         assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
                 g.get(2).getCommentText());
-        assertEquals("손가락", g.get(3).getSrcText());
+        assertEquals("\uC190\uAC00\uB77D", g.get(3).getSrcText());
         assertEquals("Korean Term", g.get(3).getLocText());
 
         g = GlossaryReaderTSV.read(new File("test/data/glossaries/testUTF16LE.txt"), false);
         assertEquals(2, g.size());
-        assertEquals(g.get(0).getSrcText(), "UTF");
-        assertEquals(g.get(0).getLocText(), "Unicode Transformation Format");
-        assertEquals(g.get(0).getCommentText(), "Comment #1");
-        assertEquals(g.get(1).getSrcText(), "LE");
-        assertEquals(g.get(1).getLocText(), "Little Endian");
-        assertEquals(g.get(1).getCommentText(), "Comment #2");
+        assertEquals("UTF", g.get(0).getSrcText());
+        assertEquals("Unicode Transformation Format", g.get(0).getLocText());
+        assertEquals("Comment #1", g.get(0).getCommentText());
+        assertEquals("LE", g.get(1).getSrcText());
+        assertEquals("Little Endian", g.get(1).getLocText());
+        assertEquals("Comment #2", g.get(1).getCommentText());
     }
 }

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -38,16 +38,20 @@ import org.omegat.core.TestCore;
 public class GlossaryReaderTSVTest extends TestCore {
     @Test
     public void testRead() throws Exception {
-        List<GlossaryEntry> g = GlossaryReaderTSV.read(new File(
-                "test/data/glossaries/test.tab"), false);
-        assertEquals(2, g.size());
-        assertEquals(g.get(0).getSrcText(), "kde");
-        assertEquals(g.get(0).getLocText(), "koo moo");
-        assertEquals(g.get(1).getSrcText(), "question");
-        assertEquals(g.get(1).getLocText(), "qqqqq");
+        List<GlossaryEntry> g = GlossaryReaderTSV.read(new File("test/data/glossaries/test.tab"), false);
+        assertEquals(4, g.size());
+        assertEquals("kde", g.get(0).getSrcText());
+        assertEquals("koo moo", g.get(0).getLocText());
+        assertEquals("question", g.get(1).getSrcText());
+        assertEquals("qqqqq", g.get(1).getLocText());
+        assertEquals("地球システム", g.get(2).getSrcText());
+        assertEquals("System Terre", g.get(2).getLocText());
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
+                g.get(2).getCommentText());
+        assertEquals("손가락", g.get(3).getSrcText());
+        assertEquals("Korean Term", g.get(3).getLocText());
 
-        g = GlossaryReaderTSV.read(new File(
-                "test/data/glossaries/testUTF16LE.txt"), false);
+        g = GlossaryReaderTSV.read(new File("test/data/glossaries/testUTF16LE.txt"), false);
         assertEquals(2, g.size());
         assertEquals(g.get(0).getSrcText(), "UTF");
         assertEquals(g.get(0).getLocText(), "Unicode Transformation Format");
@@ -55,10 +59,5 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals(g.get(1).getSrcText(), "LE");
         assertEquals(g.get(1).getLocText(), "Little Endian");
         assertEquals(g.get(1).getCommentText(), "Comment #2");
-    }
-
-    @Test
-    public void testCharset() throws Exception {
-        // TODO
     }
 }

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -41,6 +41,7 @@ import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneCJKTokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.tokenizer.LuceneJapaneseTokenizer;
 import org.omegat.util.Language;
@@ -67,8 +68,8 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testIsCjkMatchJapanese() {
-        String sourceText = "\u5834\u6240";
-        String targetText = "\u5857\u5E03";
+        String sourceText = "場所";
+        String targetText = "塗布";
         Language language = new Language("ja");
         setupProject(language);
         assertTrue(GlossarySearcher.isCjkMatch(sourceText, sourceText));
@@ -76,8 +77,24 @@ public class GlossarySearcherTest extends TestCore {
     }
 
     @Test
+    public void testGlossarySearcherKorean() {
+        String segmentText = "열 손가락 깨물어 안 아픈 손가락이 없다";
+        String sourceText = "손가락";
+        assertTrue(segmentText.contains(sourceText));
+        String translationText = "Korean term";
+        String commentText = "comment";
+        ITokenizer tok = new LuceneCJKTokenizer();
+        Language language = new Language("ko");
+        setupProject(language);
+        List<GlossaryEntry> entries = Collections.singletonList(new GlossaryEntry(sourceText,
+                translationText, commentText, true, "origin"));
+        List<GlossaryEntry> result = glossarySearcherCommon(segmentText, tok, language, entries);
+        assertEquals(1, result.size());
+    }
+
+    @Test
     public void testGlossarySearcherJapanese1() {
-        String sourceText = "\u5834\u6240";
+        String sourceText = "場所";
         String translationText = "translation";
         String commentText = "comment";
         ITokenizer tok = new LuceneJapaneseTokenizer();

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -68,8 +68,8 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testIsCjkMatchJapanese() {
-        String sourceText = "場所";
-        String targetText = "塗布";
+        String sourceText = "\u5834\u6240";
+        String targetText = "\u5857\u5E03";
         Language language = new Language("ja");
         setupProject(language);
         assertTrue(GlossarySearcher.isCjkMatch(sourceText, sourceText));
@@ -78,8 +78,8 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testGlossarySearcherKorean() {
-        String segmentText = "열 손가락 깨물어 안 아픈 손가락이 없다";
-        String sourceText = "손가락";
+        String segmentText = "\uC5F4 \uC190\uAC00\uB77D \uAE68\uBB3C\uC5B4 \uC548 \uC544\uD508 \uC190\uAC00\uB77D\uC774 \uC5C6\uB2E4";
+        String sourceText = "\uC190\uAC00\uB77D";
         assertTrue(segmentText.contains(sourceText));
         String translationText = "Korean term";
         String commentText = "comment";
@@ -94,7 +94,7 @@ public class GlossarySearcherTest extends TestCore {
 
     @Test
     public void testGlossarySearcherJapanese1() {
-        String sourceText = "場所";
+        String sourceText = "\u5834\u6240";
         String translationText = "translation";
         String commentText = "comment";
         ITokenizer tok = new LuceneJapaneseTokenizer();


### PR DESCRIPTION
Backport #959

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- [Short glossary items are not recognized with Korean source](https://sourceforge.net/p/omegat/bugs/1250/)
- https://sourceforge.net/p/omegat/bugs/1250/


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
