### PR TITLE
fix: always use MainWindow#getApplicationFrame

### DIFF
--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -408,7 +408,7 @@ public final class MainWindowMenuHandler {
         // RFE 1302358
         // Add Yes/No Warning before OmegaT quits
         if (projectModified || Preferences.isPreference(Preferences.ALWAYS_CONFIRM_QUIT)) {
-            if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(mainWindow,
+            if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(mainWindow.getApplicationFrame(),
                     OStrings.getString("MW_QUIT_CONFIRM"), OStrings.getString("CONFIRM_DIALOG_TITLE"),
                     JOptionPane.YES_NO_OPTION)) {
                 return;
@@ -602,7 +602,7 @@ public final class MainWindowMenuHandler {
 
     private String getTrimmedSelectedTextInMainWindow() {
         String selection = null;
-        Component component = mainWindow.getMostRecentFocusOwner();
+        Component component = mainWindow.getApplicationFrame().getMostRecentFocusOwner();
         if (component instanceof JTextComponent) {
             selection = ((JTextComponent) component).getSelectedText();
             if (!StringUtil.isEmpty(selection)) {
@@ -770,7 +770,7 @@ public final class MainWindowMenuHandler {
      */
     public void gotoSegmentMenuItemActionPerformed() {
         // Create a dialog for input
-        GoToSegmentDialog dialog = new GoToSegmentDialog(mainWindow);
+        GoToSegmentDialog dialog = new GoToSegmentDialog(mainWindow.getApplicationFrame());
         dialog.setVisible(true);
 
         int jumpTo = dialog.getResult();
@@ -894,7 +894,7 @@ public final class MainWindowMenuHandler {
     public void toolsCheckIssuesMenuItemActionPerformed() {
         if (!Preferences.isPreference(Preferences.ISSUE_PROVIDERS_DONT_ASK)) {
             IssueProvidersSelectorController dialog = new IssueProvidersSelectorController();
-            if (!dialog.show(mainWindow)) {
+            if (!dialog.show(mainWindow.getApplicationFrame())) {
                 return;
             }
         }
@@ -975,14 +975,14 @@ public final class MainWindowMenuHandler {
      * Displays the filters setup dialog to allow customizing file filters in detail.
      */
     public void optionsSetupFileFiltersMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow, FiltersCustomizerController.class);
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), FiltersCustomizerController.class);
     }
 
     /**
      * Displays the segmentation setup dialog to allow customizing the segmentation rules in detail.
      */
     public void optionsSentsegMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow, SegmentationCustomizerController.class);
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), SegmentationCustomizerController.class);
 
     }
 
@@ -990,7 +990,7 @@ public final class MainWindowMenuHandler {
      * Displays the workflow setup dialog to allow customizing the diverse workflow options.
      */
     public void optionsWorkflowMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow, EditingBehaviorController.class);
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), EditingBehaviorController.class);
     }
 
     /**
@@ -1012,7 +1012,8 @@ public final class MainWindowMenuHandler {
         try {
             Help.showHelp();
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(mainWindow, ex.getLocalizedMessage(), OStrings.getString("ERROR_TITLE"),
+            JOptionPane.showMessageDialog(mainWindow.getApplicationFrame(), ex.getLocalizedMessage(), OStrings.getString(
+                    "ERROR_TITLE"),
                     JOptionPane.ERROR_MESSAGE);
             Log.log(ex);
         }
@@ -1029,20 +1030,20 @@ public final class MainWindowMenuHandler {
      * Shows Last changes
      */
     public void helpLastChangesMenuItemActionPerformed() {
-        new LastChangesDialog(mainWindow).setVisible(true);
+        new LastChangesDialog(mainWindow.getApplicationFrame()).setVisible(true);
     }
 
     /**
      * Show log
      */
     public void helpLogMenuItemActionPerformed() {
-        new LogDialog(mainWindow).setVisible(true);
+        new LogDialog(mainWindow.getApplicationFrame()).setVisible(true);
     }
 
     /**
      * Check for updates
      */
     public void helpUpdateCheckMenuItemActionPerformed() {
-        VersionCheckDialog.checkAndShowResultAsync(mainWindow);
+        VersionCheckDialog.checkAndShowResultAsync(mainWindow.getApplicationFrame());
     }
 }


### PR DESCRIPTION
fix `MainWindowMenuHandler`  to use `MainWindow#getApplicationFrame`  to get Swing JFrame component from `MainWindow` object.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->
- Other (describe below)
refactor

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

Dev-ML
https://sourceforge.net/p/omegat/mailman/message/58742917/

## What does this PR change?
- do not assume MainWindow class as JFrame object
- Use MainWindow#getApplicationFrame when expect parent frame
- The enforcement helps an internal change of MainWindow class

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

Spin out from #964 topic branch
