### PR TITLE
refactor/gui: fix modules initialization

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.ResourceBundle;
 
 import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
 
 import org.openide.awt.Mnemonics;
 
@@ -55,10 +56,11 @@ public final class AlignerModule {
      */
     public static void loadPlugins() {
         alignerListener = new IApplicationEventListener() {
-            private final JMenuItem alignerMenu = new JMenuItem();
+            private JMenuItem alignerMenu;
+
             @Override
             public void onApplicationStartup() {
-                registerMenu();
+                SwingUtilities.invokeLater(this::registerMenu);
             }
 
             @Override
@@ -71,6 +73,7 @@ public final class AlignerModule {
             }
 
             private void registerMenu() {
+                alignerMenu = new JMenuItem();
                 Mnemonics.setLocalizedText(alignerMenu, BUNDLE.getString("TF_MENU_TOOLS_ALIGN_FILES"));
                 alignerMenu.addActionListener(actionEvent -> alignerShow());
                 MenuExtender.addMenuItem(MenuExtender.MenuKey.TOOLS, alignerMenu);

--- a/src/org/omegat/gui/scripting/ScriptsMonitor.java
+++ b/src/org/omegat/gui/scripting/ScriptsMonitor.java
@@ -33,6 +33,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 
+import javax.swing.SwingUtilities;
+
 import org.apache.commons.io.FilenameUtils;
 
 import org.omegat.core.CoreEvents;
@@ -120,7 +122,9 @@ public class ScriptsMonitor implements DirectoryMonitor.DirectoryCallback, Direc
         }
 
         Collections.sort(scriptsList);
-        m_scriptingWindow.setScriptItems(scriptsList);
+        SwingUtilities.invokeLater(() -> {
+            m_scriptingWindow.setScriptItems(scriptsList);
+        });
 
         if (SCRIPTING_EVENTS) {
             hookApplicationEvent();

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayController.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayController.java
@@ -53,12 +53,14 @@ public final class TipOfTheDayController {
     private static final boolean ENABLED = false;
     private static final String TIPOFTHEDAY_SHOW_ON_STARTUP = "tipoftheday_show_on_start";
     private static final String TIPOFTHEDAY_CURRENT_TIP = "tipoftheday_current_tip";
-    private static final JMenuItem totdMenu = new JMenuItem();
     static final String INDEX_YAML = "tips.yaml";
 
     @SuppressWarnings("unused")
     public static void loadPlugins() {
         CoreEvents.registerApplicationEventListener(new IApplicationEventListener() {
+
+            private JMenuItem totdMenu;
+
             @Override
             public void onApplicationStartup() {
                 if (ENABLED && TipOfTheDayUtils.hasIndex()) {
@@ -79,6 +81,7 @@ public final class TipOfTheDayController {
             }
 
             private void initMenu() {
+                totdMenu = new JMenuItem();
                 totdMenu.setText(UIManager.getDefaults().getString("TipOfTheDay.menuItemText"));
                 totdMenu.setToolTipText(UIManager.getDefaults().getString("TipOfTheDay.menuToolTipText"));
                 // show Tip of the Day dialog on startup.


### PR DESCRIPTION
These modules initialize Swing GUI parts in static context. It can be error on non-GUI environment and test environment. This fix changes these are initialized in application start event handler.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

- Initialize Menu Item in Swing thread
- Avoid static initialization of Swing component in module
-

## Other information

spin off change from PR #964