### PR TITLE
feat: IMainMenu#getMenuItemForNames API

### DIFF
--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -1048,23 +1048,23 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     }
 
     public JMenu getMenu(MenuExtender.MenuKey marker) {
-        switch(marker) {
-            case PROJECT:
-                return projectMenu;
-            case EDIT:
-                return editMenu;
-            case VIEW:
-                return viewMenu;
-            case GOTO:
-                return gotoMenu;
-            case TOOLS:
-                return toolsMenu;
-            case OPTIONS:
-                return optionsMenu;
-            case HELP:
-                return helpMenu;
-            default:
-                return null;
+        switch (marker) {
+        case PROJECT:
+            return projectMenu;
+        case EDIT:
+            return editMenu;
+        case VIEW:
+            return viewMenu;
+        case GOTO:
+            return gotoMenu;
+        case TOOLS:
+            return toolsMenu;
+        case OPTIONS:
+            return optionsMenu;
+        case HELP:
+            return helpMenu;
+        default:
+            return null;
         }
     }
 

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -202,15 +202,16 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         optionsMenu = createMenu(OPTIONS_MENU, "MW_OPTIONSMENU");
         helpMenu = createMenu(HELP_MENU, "TF_MENU_HELP");
 
-        projectNewMenuItem = createMenuItem("TF_MENU_FILE_CREATE");
-        projectTeamNewMenuItem = createMenuItem("TF_MENU_FILE_TEAM_CREATE");
-        projectOpenMenuItem = createMenuItem("TF_MENU_FILE_OPEN");
+        projectNewMenuItem = createMenuItem(PROJECT_NEW_MENUITEM, "TF_MENU_FILE_CREATE");
+        projectTeamNewMenuItem = createMenuItem(PROJECT_NEW_TEAM_MENUITEM, "TF_MENU_FILE_TEAM_CREATE");
+        projectOpenMenuItem = createMenuItem(PROJECT_OPEN_MENUITEM, "TF_MENU_FILE_OPEN");
         projectOpenRecentMenuItem = createMenu(PROJECT_OPEN_RECENT_SUBMENU, "TF_MENU_FILE_OPEN_RECENT");
-        projectClearRecentMenuItem = createMenuItem("TF_MENU_FILE_CLEAR_RECENT");
+        projectClearRecentMenuItem = createMenuItem(PROJECT_CLEAR_RECENT_MENUITEM,
+                "TF_MENU_FILE_CLEAR_RECENT");
 
-        projectReloadMenuItem = createMenuItem("TF_MENU_PROJECT_RELOAD");
-        projectCloseMenuItem = createMenuItem("TF_MENU_FILE_CLOSE");
-        projectSaveMenuItem = createMenuItem("TF_MENU_FILE_SAVE");
+        projectReloadMenuItem = createMenuItem(PROJECT_RELOAD_MENUITEM, "TF_MENU_PROJECT_RELOAD");
+        projectCloseMenuItem = createMenuItem(PROJECT_CLOSE_MENUITEM, "TF_MENU_FILE_CLOSE");
+        projectSaveMenuItem = createMenuItem(PROJECT_SAVE_MENUITEM, "TF_MENU_FILE_SAVE");
         projectImportMenuItem = createMenuItem("TF_MENU_FILE_IMPORT");
         projectWikiImportMenuItem = createMenuItem("TF_MENU_WIKI_IMPORT");
         projectCommitSourceFiles = createMenuItem("TF_MENU_FILE_COMMIT");
@@ -224,7 +225,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
         projectAccessProjectFilesMenu = createMenu(PROJECT_ACCESS_PROJECT_FILES_SUBMENU,
                 "TF_MENU_FILE_ACCESS_PROJECT_FILES");
-        projectAccessRootMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_ROOT");
+        projectAccessRootMenuItem = createMenuItem(PROJECT_ACCESS_ROOT_MENUITEM, "TF_MENU_FILE_ACCESS_ROOT");
         projectAccessDictionaryMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_DICTIONARY");
         projectAccessGlossaryMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_GLOSSARY");
         projectAccessSourceMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_SOURCE");
@@ -249,8 +250,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         projectAccessCurrentTargetDocumentMenuItem = createMenuItem(
                 "TF_MENU_FILE_ACCESS_CURRENT_TARGET_DOCUMENT");
         projectAccessWriteableGlossaryMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_WRITEABLE_GLOSSARY");
-        projectRestartMenuItem = createMenuItem("TF_MENU_FILE_RESTART");
-        projectExitMenuItem = createMenuItem("TF_MENU_FILE_QUIT");
+        projectRestartMenuItem = createMenuItem(PROJECT_RESTART_MENUITEM, "TF_MENU_FILE_RESTART");
+        projectExitMenuItem = createMenuItem(PROJECT_EXIT_MENUITEM, "TF_MENU_FILE_QUIT");
 
         editUndoMenuItem = createMenuItem("TF_MENU_EDIT_UNDO");
         editRedoMenuItem = createMenuItem("TF_MENU_EDIT_REDO");
@@ -264,7 +265,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         editTagPainterMenuItem = createMenuItem("TF_MENU_EDIT_TAGPAINT");
         editTagNextMissedMenuItem = createMenuItem("TF_MENU_EDIT_TAG_NEXT_MISSED");
         editExportSelectionMenuItem = createMenuItem("TF_MENU_EDIT_EXPORT_SELECTION");
-        editCreateGlossaryEntryMenuItem = createMenuItem("TF_MENU_EDIT_CREATE_GLOSSARY_ENTRY");
+        editCreateGlossaryEntryMenuItem = createMenuItem(EDIT_CREATE_GLOSSARY_ENTRY_MENUITEM,
+                "TF_MENU_EDIT_CREATE_GLOSSARY_ENTRY");
         editFindInProjectMenuItem = createMenuItem("TF_MENU_EDIT_FIND");
         editReplaceInProjectMenuItem = createMenuItem("TF_MENU_EDIT_REPLACE");
         editSearchDictionaryMenuItem = createMenuItem("TF_MENU_EDIT_SEARCH_DICTIONARY");
@@ -423,9 +425,9 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         optionsAccessConfigDirMenuItem = createMenuItem("MW_OPTIONSMENU_ACCESS_CONFIG_DIR");
 
         helpContentsMenuItem = createMenuItem("TF_MENU_HELP_CONTENTS");
-        helpAboutMenuItem = createMenuItem("TF_MENU_HELP_ABOUT");
+        helpAboutMenuItem = createMenuItem(HELP_ABOUT_MENUITEM, "TF_MENU_HELP_ABOUT");
         helpLastChangesMenuItem = createMenuItem("TF_MENU_HELP_LAST_CHANGES");
-        helpLogMenuItem = createMenuItem("TF_MENU_HELP_LOG");
+        helpLogMenuItem = createMenuItem(HELP_LOG_MENUITEM, "TF_MENU_HELP_LOG");
         helpUpdateCheckMenuItem = createMenuItem("TF_MENU_HELP_CHECK_FOR_UPDATES");
 
     }
@@ -1219,12 +1221,15 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     public static final String PROJECT_OPEN_RECENT_SUBMENU = "project_open_recent_submenu";
     public static final String PROJECT_CLEAR_RECENT_MENUITEM = "project_clear_recent_menuitem";
     public static final String PROJECT_ACCESS_PROJECT_FILES_SUBMENU = "project_access_project_files_submenu";
+    public static final String PROJECT_RESTART_MENUITEM = "project_restart_menuitem";
+    public static final String PROJECT_SAVE_MENUITEM = "project_save_menuitem";
+    public static final String PROJECT_CLOSE_MENUITEM = "project_close_menuitem";
     public static final String PROJECT_EXIT_MENUITEM = "project_exit_menuitem";
-    public static final String PROJECT_RELOAD_MENU = "project_reload_menu";
-    public static final String PROJECT_ACCESS_ROOT_MENU = "project_access_root_menu";
+    public static final String PROJECT_RELOAD_MENUITEM = "project_reload_menuitem";
+    public static final String PROJECT_ACCESS_ROOT_MENUITEM = "project_access_root_menu";
     public static final String PROJECT_VIEW_FILE_LIST_MENUITEM = "project_view_file_list_menuitem";
     public static final String SELECT_FUZZY_SUBMENU = "select_fuzzy_submenu";
-    public static final String EDIT_CREATE_GLOSSARY_MENUITEM = "edit_create_glossary_menuitem";
+    public static final String EDIT_CREATE_GLOSSARY_ENTRY_MENUITEM = "edit_create_glossary_entry_menuitem";
     public static final String INSERT_CHARS_SUBMENU = "insert_chars_submenu";
     public static final String GOTO_X_ENTRY_SUBMENU = "goto_x_entry_submenu";
     public static final String VIEW_MODIFICATION_INFO_SUBMENU = "view_modification_info_submenu";
@@ -1232,8 +1237,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     public static final String VIEW_MARK_UNTRANSLATED_SEGMENTS_CHECKBOX = "view_mark_untranslated_segments_checkbox";
     public static final String VIEW_MARK_PARAGRAPH_START_CHECKBOX = "view_mark_paragraph_start_checkbox";
     public static final String VIEW_DISPLAY_SEGMENT_SOURCE_CHECKBOX = "view_display_segment_source_checkbox";
-    public static final String VIEW_DISPLAY_MODIFICATION_INFO_NONE_RADIO_BUTTON =
-            "view_display_modification_info_none_radio_button";
     public static final String VIEW_MARK_NON_UNIQUE_SEGMENTS_CHECKBOX = "view_mark_non_unique_segments_checkbox";
     public static final String VIEW_MARK_NOTED_SEGMENTS_CHECKBOX = "view_mark_noted_segments_checkbox";
     public static final String VIEW_MARK_WHITE_SPACE_CHECKBOX = "view_mark_white_space_checkbox";

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -37,6 +37,7 @@
 
 package org.omegat.gui.main;
 
+import java.awt.Component;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -44,9 +45,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -118,8 +117,6 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
     /** MainWindow menu handler instance. */
     protected final MainWindowMenuHandler mainWindowMenuHandler;
-
-    private final Map<MenuExtender.MenuKey, JMenu> menus = new EnumMap<>(MenuExtender.MenuKey.class);
 
     public BaseMainWindowMenu(final MainWindow mainWindow,
             final MainWindowMenuHandler mainWindowMenuHandler) {
@@ -197,18 +194,18 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     abstract void createMenuBar();
 
     protected void createComponents() {
-        projectMenu = createMenu("TF_MENU_FILE", MenuExtender.MenuKey.PROJECT);
-        editMenu = createMenu("TF_MENU_EDIT", MenuExtender.MenuKey.EDIT);
-        gotoMenu = createMenu("MW_GOTOMENU", MenuExtender.MenuKey.GOTO);
-        viewMenu = createMenu("MW_VIEW_MENU", MenuExtender.MenuKey.VIEW);
-        toolsMenu = createMenu("TF_MENU_TOOLS", MenuExtender.MenuKey.TOOLS);
-        optionsMenu = createMenu("MW_OPTIONSMENU", MenuExtender.MenuKey.OPTIONS);
-        helpMenu = createMenu("TF_MENU_HELP", MenuExtender.MenuKey.HELP);
+        projectMenu = createMenu(PROJECT_MENU, "TF_MENU_FILE");
+        editMenu = createMenu(EDIT_MENU, "TF_MENU_EDIT");
+        gotoMenu = createMenu(GOTO_MENU, "MW_GOTOMENU");
+        viewMenu = createMenu(VIEW_NEMU, "MW_VIEW_MENU");
+        toolsMenu = createMenu(TOOLS_MENU, "TF_MENU_TOOLS");
+        optionsMenu = createMenu(OPTIONS_MENU, "MW_OPTIONSMENU");
+        helpMenu = createMenu(HELP_MENU, "TF_MENU_HELP");
 
         projectNewMenuItem = createMenuItem("TF_MENU_FILE_CREATE");
         projectTeamNewMenuItem = createMenuItem("TF_MENU_FILE_TEAM_CREATE");
         projectOpenMenuItem = createMenuItem("TF_MENU_FILE_OPEN");
-        projectOpenRecentMenuItem = createMenu("TF_MENU_FILE_OPEN_RECENT");
+        projectOpenRecentMenuItem = createMenu(PROJECT_OPEN_RECENT_SUBMENU, "TF_MENU_FILE_OPEN_RECENT");
         projectClearRecentMenuItem = createMenuItem("TF_MENU_FILE_CLEAR_RECENT");
 
         projectReloadMenuItem = createMenuItem("TF_MENU_PROJECT_RELOAD");
@@ -223,9 +220,10 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         projectMedOpenMenuItem = createMenuItem("TF_MENU_FILE_MED_OPEN");
         projectMedCreateMenuItem = createMenuItem("TF_MENU_FILE_MED_CREATE");
         projectEditMenuItem = createMenuItem("MW_PROJECTMENU_EDIT");
-        viewFileListMenuItem = createMenuItem("TF_MENU_FILE_PROJWIN");
+        viewFileListMenuItem = createMenuItem(PROJECT_VIEW_FILE_LIST_MENUITEM, "TF_MENU_FILE_PROJWIN");
 
-        projectAccessProjectFilesMenu = createMenu("TF_MENU_FILE_ACCESS_PROJECT_FILES");
+        projectAccessProjectFilesMenu = createMenu(PROJECT_ACCESS_PROJECT_FILES_SUBMENU,
+                "TF_MENU_FILE_ACCESS_PROJECT_FILES");
         projectAccessRootMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_ROOT");
         projectAccessDictionaryMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_DICTIONARY");
         projectAccessGlossaryMenuItem = createMenuItem("TF_MENU_FILE_ACCESS_GLOSSARY");
@@ -270,8 +268,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         editFindInProjectMenuItem = createMenuItem("TF_MENU_EDIT_FIND");
         editReplaceInProjectMenuItem = createMenuItem("TF_MENU_EDIT_REPLACE");
         editSearchDictionaryMenuItem = createMenuItem("TF_MENU_EDIT_SEARCH_DICTIONARY");
-        switchCaseSubMenu = createMenu("TF_EDIT_MENU_SWITCH_CASE");
-        selectFuzzySubMenu = createMenu("TF_MENU_EDIT_COMPARE");
+        switchCaseSubMenu = createMenu(SWITCH_CASE_SUBMENU, "TF_EDIT_MENU_SWITCH_CASE");
+        selectFuzzySubMenu = createMenu(SELECT_FUZZY_SUBMENU, "TF_MENU_EDIT_COMPARE");
 
         editSelectFuzzyPrevMenuItem = createMenuItem("TF_MENU_EDIT_COMPARE_PREV");
         editSelectFuzzyNextMenuItem = createMenuItem("TF_MENU_EDIT_COMPARE_NEXT");
@@ -281,7 +279,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         editSelectFuzzy4MenuItem = createMenuItem("TF_MENU_EDIT_COMPARE_4");
         editSelectFuzzy5MenuItem = createMenuItem("TF_MENU_EDIT_COMPARE_5");
 
-        insertCharsSubMenu = createMenu("TF_MENU_EDIT_INSERT_CHARS");
+        insertCharsSubMenu = createMenu(INSERT_CHARS_SUBMENU, "TF_MENU_EDIT_INSERT_CHARS");
         insertCharsLRM = createMenuItem("TF_MENU_EDIT_INSERT_CHARS_LRM");
         insertCharsRLM = createMenuItem("TF_MENU_EDIT_INSERT_CHARS_RLM");
         insertCharsLRE = createMenuItem("TF_MENU_EDIT_INSERT_CHARS_LRE");
@@ -309,7 +307,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         gotoPreviousNoteMenuItem = createMenuItem("TF_MENU_EDIT_PREV_NOTE");
         gotoNextUniqueMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_UNIQUE");
         gotoMatchSourceSegment = createMenuItem("TF_MENU_GOTO_SELECTED_MATCH_SOURCE");
-        gotoXEntrySubmenu = createMenu("TF_MENU_GOTO_X_SUBMENU");
+        gotoXEntrySubmenu = createMenu(GOTO_X_ENTRY_SUBMENU, "TF_MENU_GOTO_X_SUBMENU");
 
         gotoNextXAutoMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_XAUTO");
         gotoPrevXAutoMenuItem = createMenuItem("TF_MENU_GOTO_PREV_XAUTO");
@@ -321,24 +319,34 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         gotoNotesPanelMenuItem = createMenuItem("TF_MENU_GOTO_NOTES_PANEL");
         gotoEditorPanelMenuItem = createMenuItem("TF_MENU_GOTO_EDITOR_PANEL");
 
-        viewMarkTranslatedSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
-                "TF_MENU_DISPLAY_MARK_TRANSLATED");
+        viewMarkTranslatedSegmentsCheckBoxMenuItem =
+                createCheckboxMenuItem(VIEW_MARK_TRANSLATED_SEGMENTS_CHECKBOX, "TF_MENU_DISPLAY_MARK_TRANSLATED");
         viewMarkUntranslatedSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
-                "TF_MENU_DISPLAY_MARK_UNTRANSLATED");
-        viewMarkParagraphStartCheckBoxMenuItem = createCheckboxMenuItem("TF_MENU_DISPLAY_MARK_PARAGRAPH");
+                VIEW_MARK_UNTRANSLATED_SEGMENTS_CHECKBOX, "TF_MENU_DISPLAY_MARK_UNTRANSLATED");
+        viewMarkParagraphStartCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_PARAGRAPH_START_CHECKBOX, "TF_MENU_DISPLAY_MARK_PARAGRAPH");
         viewDisplaySegmentSourceCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_DISPLAY_SEGMENT_SOURCE_CHECKBOX,
                 "MW_VIEW_MENU_DISPLAY_SEGMENT_SOURCES");
         viewMarkNonUniqueSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
-                "MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS");
-        viewMarkNotedSegmentsCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NOTED_SEGMENTS");
-        viewMarkNBSPCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NBSP");
-        viewMarkWhitespaceCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_WHITESPACE");
-        viewMarkBidiCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_BIDI");
-        viewMarkAutoPopulatedCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_AUTOPOPULATED");
-        viewMarkGlossaryMatchesCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_GLOSSARY_MARK");
-        viewMarkLanguageCheckerCheckBoxMenuItem = createCheckboxMenuItem("LT_OPTIONS_MENU_ENABLED");
-        viewMarkFontFallbackCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_FONT_FALLBACK");
-        viewModificationInfoMenu = createMenu("MW_VIEW_MENU_MODIFICATION_INFO");
+                VIEW_MARK_NON_UNIQUE_SEGMENTS_CHECKBOX, "MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS");
+        viewMarkNotedSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_NOTED_SEGMENTS_CHECKBOX, "MW_VIEW_MENU_MARK_NOTED_SEGMENTS");
+        viewMarkNBSPCheckBoxMenuItem = createCheckboxMenuItem(VIEW_MARK_NBSP_CHECKBOX, "MW_VIEW_MENU_MARK_NBSP");
+        viewMarkWhitespaceCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_WHITE_SPACE_CHECKBOX, "MW_VIEW_MENU_MARK_WHITESPACE");
+        viewMarkBidiCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_BIDI_CHECKBOX, "MW_VIEW_MENU_MARK_BIDI");
+        viewMarkAutoPopulatedCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_AUTO_POPULATED_CHECKBOX, "MW_VIEW_MENU_MARK_AUTOPOPULATED");
+        viewMarkGlossaryMatchesCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_GLOSSARY_MATCHES_CHECKBOX, "MW_VIEW_GLOSSARY_MARK");
+        viewMarkLanguageCheckerCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_LANGUAGE_CHECKER_CHECKBOX, "LT_OPTIONS_MENU_ENABLED");
+        viewMarkFontFallbackCheckBoxMenuItem = createCheckboxMenuItem(
+                VIEW_MARK_FONT_FALLBACK_CHECKBOX, "MW_VIEW_MENU_MARK_FONT_FALLBACK");
+        viewModificationInfoMenu = createMenu(VIEW_MODIFICATION_INFO_SUBMENU,
+                "MW_VIEW_MENU_MODIFICATION_INFO");
 
         ButtonGroup viewModificationInfoMenuBG = new ButtonGroup();
         viewDisplayModificationInfoNoneRadioButtonMenuItem = createRadioButtonMenuItem(
@@ -384,24 +392,30 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 "TF_MENU_TOOLS_STATISTICS_MATCHES_PER_FILE");
         optionsPreferencesMenuItem = createMenuItem("MW_OPTIONSMENU_PREFERENCES");
 
-        optionsMachineTranslateMenu = createMenu("TF_OPTIONSMENU_MACHINETRANSLATE");
+        optionsMachineTranslateMenu = createMenu(OPTIONS_MACHINE_TRANSLATE_SUBMENU,
+                "TF_OPTIONSMENU_MACHINETRANSLATE");
 
-        optionsMTAutoFetchCheckboxMenuItem = createCheckboxMenuItem("MT_AUTO_FETCH");
-        optionsGlossaryMenu = createMenu("TF_OPTIONSMENU_GLOSSARY");
-        optionsGlossaryFuzzyMatchingCheckBoxMenuItem = createCheckboxMenuItem(
+        optionsMTAutoFetchCheckboxMenuItem = createCheckboxMenuItem(OPTIONS_MT_AUTO_FETCH_CHECKBOX_MENUITEM,
+                "MT_AUTO_FETCH");
+        optionsGlossaryMenu = createMenu(OPTIONS_GLOSSARY_SUBMENU, "TF_OPTIONSMENU_GLOSSARY");
+        optionsGlossaryFuzzyMatchingCheckBoxMenuItem =
+                createCheckboxMenuItem(OPTIONS_GLOSSARY_FUZZY_MATCHING_CHECKBOX_MENUITEM,
                 "TF_OPTIONSMENU_GLOSSARY_FUZZY");
 
-        optionsDictionaryMenu = createMenu("TF_OPTIONSMENU_DICTIONARY");
-        optionsDictionaryFuzzyMatchingCheckBoxMenuItem = createCheckboxMenuItem(
-                "TF_OPTIONSMENU_DICTIONARY_FUZZY");
+        optionsDictionaryMenu = createMenu(OPTIONS_DICTIONARY_SUBMENU, "TF_OPTIONSMENU_DICTIONARY");
+        optionsDictionaryFuzzyMatchingCheckBoxMenuItem =
+                createCheckboxMenuItem(OPTIONS_DICTIONARY_FUZZY_MATCHING_CHECKBOX, "TF_OPTIONSMENU_DICTIONARY_FUZZY");
 
-        optionsAutoCompleteMenu = createMenu("MW_OPTIONSMENU_AUTOCOMPLETE");
+        optionsAutoCompleteMenu = createMenu(OPTIONS_AUTOCOMPLETE_SUBMENU, "MW_OPTIONSMENU_AUTOCOMPLETE");
         // add any autocomplete view configuration menu items below
-        optionsAutoCompleteShowAutomaticallyItem = createCheckboxMenuItem(
+        optionsAutoCompleteShowAutomaticallyItem =
+                createCheckboxMenuItem(OPTIONS_AUTO_COMPLETE_SHOW_AUTOMATICALLY_MENUITEM,
                 "MW_OPTIONSMENU_AUTOCOMPLETE_SHOW_AUTOMATICALLY");
-        optionsAutoCompleteHistoryCompletionMenuItem = createCheckboxMenuItem(
+        optionsAutoCompleteHistoryCompletionMenuItem =
+                createCheckboxMenuItem(OPTIONS_AUTO_COMPLETE_HISTORY_COMPLETION_MENUITEM,
                 "MW_OPTIONSMENU_AUTOCOMPLETE_HISTORY_COMPLETION");
-        optionsAutoCompleteHistoryPredictionMenuItem = createCheckboxMenuItem(
+        optionsAutoCompleteHistoryPredictionMenuItem =
+                createCheckboxMenuItem(OPTIONS_AUTO_COMPLETE_HISTORY_PREDICTION_MENUITEM,
                 "MW_OPTIONSMENU_AUTOCOMPLETE_HISTORY_PREDICTION");
         optionsSetupFileFiltersMenuItem = createMenuItem("TF_MENU_DISPLAY_GLOBAL_FILTERS");
         optionsSentsegMenuItem = createMenuItem("MW_OPTIONSMENU_GLOBAL_SENTSEG");
@@ -728,21 +742,17 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     /**
      * Create menu instance and set title.
      *
+     * @param name
+     *            name of menu.
      * @param titleKey
      *            title name key in resource bundle
      * @return menu instance
      */
-    protected JMenu createMenu(String titleKey) {
-        return createMenu(titleKey, null);
-    }
-
-    protected JMenu createMenu(String titleKey, MenuExtender.MenuKey menuKey) {
+    protected JMenu createMenu(String name, String titleKey) {
         JMenu result = new JMenu();
+        result.setName(name);
         Mnemonics.setLocalizedText(result, OStrings.getString(titleKey));
         result.addMenuListener(this);
-        if (menuKey != null) {
-            menus.put(menuKey, result);
-        }
         return result;
     }
 
@@ -760,6 +770,14 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         return result;
     }
 
+    protected JMenuItem createMenuItem(String name, String titleKey) {
+        JMenuItem result = new JMenuItem();
+        result.setName(name);
+        Mnemonics.setLocalizedText(result, OStrings.getString(titleKey));
+        result.addActionListener(this);
+        return result;
+    }
+
     /**
      * Create menu item instance and set title.
      *
@@ -769,6 +787,14 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
      */
     protected JCheckBoxMenuItem createCheckboxMenuItem(final String titleKey) {
         JCheckBoxMenuItem result = new JCheckBoxMenuItem();
+        Mnemonics.setLocalizedText(result, OStrings.getString(titleKey));
+        result.addActionListener(this);
+        return result;
+    }
+
+    protected JCheckBoxMenuItem createCheckboxMenuItem(String name, String titleKey) {
+        JCheckBoxMenuItem result = new JCheckBoxMenuItem();
+        result.setName(name);
         Mnemonics.setLocalizedText(result, OStrings.getString(titleKey));
         result.addActionListener(this);
         return result;
@@ -852,6 +878,44 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 && Core.getProject().getProjectProperties().getSourceDir().isUnderRoot());
         projectCommitTargetFiles.setEnabled(isProjectOpened && Core.getProject().isRemoteProject()
                 && Core.getProject().getProjectProperties().getTargetDir().isUnderRoot());
+    }
+
+    protected JMenu getMenu(String menuName) {
+        for (int i = 0; i < mainMenu.getMenuCount(); i++) {
+            JMenu menu = mainMenu.getMenu(i);
+            if (menuName.equals(menu.getName())) {
+                return menu;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public JMenuItem getMenuItemForNames(String menuName, String itemName) {
+        JMenu menu = getMenu(menuName);
+        if (menu == null) {
+            return null;
+        }
+        return getMenuItemFromMenuForName(menu, itemName);
+    }
+
+    protected JMenuItem getMenuItemFromMenuForName(JMenu menu, String name) {
+        for (int i = 0; i < menu.getMenuComponentCount(); i++) {
+            Component item = menu.getMenuComponent(i);
+            if (item == null || item.getName() == null) {
+                continue;
+            }
+            if (item instanceof JMenuItem && item.getName().equals(name)) {
+                return (JMenuItem) item;
+            }
+            if (item instanceof JMenu) {
+                JMenuItem c = getMenuItemFromMenuForName((JMenu) item, name);
+                if (c != null) {
+                    return c;
+                }
+            }
+        }
+        return null;
     }
 
     protected JMenuItem getItemForPreference(String preference) {
@@ -982,7 +1046,24 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     }
 
     public JMenu getMenu(MenuExtender.MenuKey marker) {
-        return menus.get(marker);
+        switch(marker) {
+            case PROJECT:
+                return projectMenu;
+            case EDIT:
+                return editMenu;
+            case VIEW:
+                return viewMenu;
+            case GOTO:
+                return gotoMenu;
+            case TOOLS:
+                return toolsMenu;
+            case OPTIONS:
+                return optionsMenu;
+            case HELP:
+                return helpMenu;
+            default:
+                return null;
+        }
     }
 
     JMenuItem cycleSwitchCaseMenuItem;
@@ -1124,4 +1205,61 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     JCheckBoxMenuItem viewMarkUntranslatedSegmentsCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkParagraphStartCheckBoxMenuItem;
     JMenu viewMenu;
+
+    public static final String PROJECT_MENU = "project_menu";
+    public static final String EDIT_MENU = "edit_menu";
+    public static final String GOTO_MENU = "goto_menu;";
+    public static final String VIEW_NEMU = "view_menu";
+    public static final String TOOLS_MENU = "tools_menu";
+    public static final String OPTIONS_MENU = "options_menu";
+    public static final String HELP_MENU = "help_menu";
+    public static final String PROJECT_NEW_MENUITEM = "project_new_menuitem";
+    public static final String PROJECT_NEW_TEAM_MENUITEM = "project_new_team_menuitem";
+    public static final String PROJECT_OPEN_MENUITEM = "project_open_menuitem";
+    public static final String PROJECT_OPEN_RECENT_SUBMENU = "project_open_recent_submenu";
+    public static final String PROJECT_CLEAR_RECENT_MENUITEM = "project_clear_recent_menuitem";
+    public static final String PROJECT_ACCESS_PROJECT_FILES_SUBMENU = "project_access_project_files_submenu";
+    public static final String PROJECT_EXIT_MENUITEM = "project_exit_menuitem";
+    public static final String PROJECT_RELOAD_MENU = "project_reload_menu";
+    public static final String PROJECT_ACCESS_ROOT_MENU = "project_access_root_menu";
+    public static final String PROJECT_VIEW_FILE_LIST_MENUITEM = "project_view_file_list_menuitem";
+    public static final String SELECT_FUZZY_SUBMENU = "select_fuzzy_submenu";
+    public static final String EDIT_CREATE_GLOSSARY_MENUITEM = "edit_create_glossary_menuitem";
+    public static final String INSERT_CHARS_SUBMENU = "insert_chars_submenu";
+    public static final String GOTO_X_ENTRY_SUBMENU = "goto_x_entry_submenu";
+    public static final String VIEW_MODIFICATION_INFO_SUBMENU = "view_modification_info_submenu";
+    public static final String VIEW_MARK_TRANSLATED_SEGMENTS_CHECKBOX = "view_mark_translated_segment_checkbox";
+    public static final String VIEW_MARK_UNTRANSLATED_SEGMENTS_CHECKBOX = "view_mark_untranslated_segments_checkbox";
+    public static final String VIEW_MARK_PARAGRAPH_START_CHECKBOX = "view_mark_paragraph_start_checkbox";
+    public static final String VIEW_DISPLAY_SEGMENT_SOURCE_CHECKBOX = "view_display_segment_source_checkbox";
+    public static final String VIEW_DISPLAY_MODIFICATION_INFO_NONE_RADIO_BUTTON =
+            "view_display_modification_info_none_radio_button";
+    public static final String VIEW_MARK_NON_UNIQUE_SEGMENTS_CHECKBOX = "view_mark_non_unique_segments_checkbox";
+    public static final String VIEW_MARK_NOTED_SEGMENTS_CHECKBOX = "view_mark_noted_segments_checkbox";
+    public static final String VIEW_MARK_WHITE_SPACE_CHECKBOX = "view_mark_white_space_checkbox";
+    public static final String VIEW_MARK_NBSP_CHECKBOX = "view_mark_nbsp_checkbox";
+    public static final String VIEW_MARK_BIDI_CHECKBOX = "view_mark_bidi_checkbox";
+    public static final String VIEW_MARK_AUTO_POPULATED_CHECKBOX = "view_mark_auto_populated_checkbox";
+    public static final String VIEW_MARK_GLOSSARY_MATCHES_CHECKBOX = "view_mark_glossary_matches_checkbox";
+    public static final String VIEW_MARK_LANGUAGE_CHECKER_CHECKBOX = "view_mark_language_checker_checkbox";
+    public static final String VIEW_MARK_FONT_FALLBACK_CHECKBOX = "view_mark_font_fallback_checkbox";
+    public static final String OPTIONS_MACHINE_TRANSLATE_SUBMENU = "options_machine_translate_submenu";
+    public static final String OPTIONS_DICTIONARY_SUBMENU = "options_dictionary_submenu";
+    public static final String OPTIONS_GLOSSARY_SUBMENU = "options_glossary_submenu";
+    public static final String OPTIONS_GLOSSARY_FUZZY_MATCHING_CHECKBOX_MENUITEM =
+            "options_glossary_fuzzy_matching_checkbox_menuitem";
+    public static final String OPTIONS_AUTOCOMPLETE_SUBMENU = "options_autocomplete_submenu";
+    public static final String OPTIONS_DICTIONARY_FUZZY_MATCHING_CHECKBOX =
+            "options_dictionary_fuzzy_matching_checkbox";
+    public static final String OPTIONS_MT_AUTO_FETCH_CHECKBOX_MENUITEM =
+            "options_mt_auto_fetch_checkbox";
+    public static final String OPTIONS_AUTO_COMPLETE_HISTORY_PREDICTION_MENUITEM =
+            "options_auto_complete_history_prediction_menuitem";
+    public static final String OPTIONS_AUTO_COMPLETE_HISTORY_COMPLETION_MENUITEM =
+            "options_auto_complete_history_completion_menuitem";
+    public static final String OPTIONS_AUTO_COMPLETE_SHOW_AUTOMATICALLY_MENUITEM =
+            "options_auto_complete_show_automatically_menuitem";
+    public static final String HELP_ABOUT_MENUITEM = "help_about_menuitem";
+    public static final String HELP_LOG_MENUITEM = "help_log_menuitem";
+    public static final String SWITCH_CASE_SUBMENU = "switch_case_submenu";
 }

--- a/src/org/omegat/gui/main/IMainMenu.java
+++ b/src/org/omegat/gui/main/IMainMenu.java
@@ -28,6 +28,7 @@
 package org.omegat.gui.main;
 
 import javax.swing.JMenu;
+import javax.swing.JMenuItem;
 
 import org.omegat.util.gui.MenuExtender;
 
@@ -54,6 +55,8 @@ public interface IMainMenu {
     JMenu getHelpMenu();
 
     JMenu getMenu(MenuExtender.MenuKey marker);
+
+    JMenuItem getMenuItemForNames(String menuName, String itemName);
 
     void invokeAction(String action, int modifiers);
 }

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -43,6 +43,8 @@ import java.io.File;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import javax.swing.JDialog;
+import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
 import javax.swing.text.JTextComponent;
@@ -110,7 +112,7 @@ public final class MainWindowMenuHandler {
 
     private final MainWindow mainWindow;
 
-    public MainWindowMenuHandler(final MainWindow mainWindow) {
+    public MainWindowMenuHandler(MainWindow mainWindow) {
         this.mainWindow = mainWindow;
     }
 
@@ -187,7 +189,7 @@ public final class MainWindowMenuHandler {
      */
     public void projectCompileMenuItemActionPerformed() {
         if (!checkTags()) {
-                return;
+            return;
         }
 
         ProjectUICommands.projectCompile();
@@ -195,6 +197,7 @@ public final class MainWindowMenuHandler {
 
     /**
      * Check whether tags are OK
+     * 
      * @return false is there is a tag issue, true otherwise
      */
     private boolean checkTags() {
@@ -210,7 +213,7 @@ public final class MainWindowMenuHandler {
 
     public void projectCommitTargetFilesActionPerformed() {
         if (!checkTags()) {
-                return;
+            return;
         }
 
         ProjectUICommands.projectCompileAndCommit();
@@ -251,7 +254,8 @@ public final class MainWindowMenuHandler {
 
     public void viewFileListMenuItemActionPerformed() {
         if (mainWindow.projWin == null) {
-            mainWindow.menu.viewFileListMenuItem.setSelected(false);
+            mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.PROJECT_MENU,
+                    BaseMainWindowMenu.PROJECT_VIEW_FILE_LIST_MENUITEM).setSelected(false);
             return;
         }
 
@@ -363,7 +367,8 @@ public final class MainWindowMenuHandler {
 
     private void openFile(File path) {
         try {
-            path = path.getCanonicalFile(); // Normalize file name in case it is displayed
+            // Normalize file name in case it is displayed
+            path = path.getCanonicalFile();
         } catch (Exception ex) {
             // Ignore
         }
@@ -396,7 +401,8 @@ public final class MainWindowMenuHandler {
 
     protected void prepareForExit(Runnable onCompletion) {
         // Bug #902: commit the current entry first
-        // We do it before checking project status, so that it can eventually change it
+        // We do it before checking project status, so that it can eventually
+        // change it
         if (Core.getProject().isProjectLoaded()) {
             Core.getEditor().commitAndLeave();
         }
@@ -495,7 +501,8 @@ public final class MainWindowMenuHandler {
     }
 
     /**
-     * replaces entire edited segment text with a the source text of a segment at cursor position
+     * replaces entire edited segment text with a the source text of a segment
+     * at cursor position
      */
     public void editOverwriteSourceMenuItemActionPerformed() {
         if (!Core.getProject().isProjectLoaded()) {
@@ -796,84 +803,81 @@ public final class MainWindowMenuHandler {
     }
 
     public void viewMarkTranslatedSegmentsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkTranslated(mainWindow.menu.viewMarkTranslatedSegmentsCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_TRANSLATED_SEGMENTS_CHECKBOX);
+        Core.getEditor().getSettings().setMarkTranslated(menuItem.isSelected());
     }
 
     public void viewMarkUntranslatedSegmentsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkUntranslated(
-                        mainWindow.menu.viewMarkUntranslatedSegmentsCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_UNTRANSLATED_SEGMENTS_CHECKBOX);
+        Core.getEditor().getSettings().setMarkUntranslated(menuItem.isSelected());
     }
 
     public void viewMarkParagraphStartCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkParagraphDelimitations(
-                        mainWindow.menu.viewMarkParagraphStartCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_PARAGRAPH_START_CHECKBOX);
+        Core.getEditor().getSettings().setMarkParagraphDelimitations(menuItem.isSelected());
     }
 
     public void viewDisplaySegmentSourceCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setDisplaySegmentSources(
-                        mainWindow.menu.viewDisplaySegmentSourceCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_DISPLAY_SEGMENT_SOURCE_CHECKBOX);
+        Core.getEditor().getSettings().setDisplaySegmentSources(menuItem.isSelected());
     }
 
     public void viewMarkNonUniqueSegmentsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkNonUniqueSegments(
-                        mainWindow.menu.viewMarkNonUniqueSegmentsCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_NON_UNIQUE_SEGMENTS_CHECKBOX);
+        Core.getEditor().getSettings().setMarkNonUniqueSegments(menuItem.isSelected());
     }
 
     public void viewMarkNotedSegmentsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkNotedSegments(
-                        mainWindow.menu.viewMarkNotedSegmentsCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_NOTED_SEGMENTS_CHECKBOX);
+        Core.getEditor().getSettings().setMarkNotedSegments(menuItem.isSelected());
     }
 
     public void viewMarkNBSPCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkNBSP(
-                        mainWindow.menu.viewMarkNBSPCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_NBSP_CHECKBOX);
+        Core.getEditor().getSettings().setMarkNBSP(menuItem.isSelected());
     }
 
     public void viewMarkWhitespaceCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkWhitespace(
-                        mainWindow.menu.viewMarkWhitespaceCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_WHITE_SPACE_CHECKBOX);
+        Core.getEditor().getSettings().setMarkWhitespace(menuItem.isSelected());
     }
 
     public void viewMarkBidiCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkBidi(
-                        mainWindow.menu.viewMarkBidiCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_BIDI_CHECKBOX);
+        Core.getEditor().getSettings().setMarkBidi(menuItem.isSelected());
     }
 
     public void viewMarkAutoPopulatedCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkAutoPopulated(mainWindow.menu.viewMarkAutoPopulatedCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_AUTO_POPULATED_CHECKBOX);
+        Core.getEditor().getSettings().setMarkAutoPopulated(menuItem.isSelected());
     }
 
     public void viewMarkGlossaryMatchesCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkGlossaryMatches(mainWindow.menu.viewMarkGlossaryMatchesCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_GLOSSARY_MATCHES_CHECKBOX);
+        Core.getEditor().getSettings().setMarkGlossaryMatches(menuItem.isSelected());
     }
 
     public void viewMarkLanguageCheckerCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setMarkLanguageChecker(mainWindow.menu.viewMarkLanguageCheckerCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_LANGUAGE_CHECKER_CHECKBOX);
+        Core.getEditor().getSettings().setMarkLanguageChecker(menuItem.isSelected());
     }
 
     public void viewMarkFontFallbackCheckBoxMenuItemActionPerformed() {
-        Core.getEditor().getSettings()
-                .setDoFontFallback(mainWindow.menu.viewMarkFontFallbackCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.VIEW_NEMU,
+                BaseMainWindowMenu.VIEW_MARK_FONT_FALLBACK_CHECKBOX);
+        Core.getEditor().getSettings().setDoFontFallback(menuItem.isSelected());
     }
 
     public void viewDisplayModificationInfoNoneRadioButtonMenuItemActionPerformed() {
@@ -906,7 +910,8 @@ public final class MainWindowMenuHandler {
     }
 
     /**
-     * Identify all the placeholders in the source text and automatically inserts them into the target text.
+     * Identify all the placeholders in the source text and automatically
+     * inserts them into the target text.
      */
     public void editTagPainterMenuItemActionPerformed() {
         // insert tags
@@ -935,67 +940,79 @@ public final class MainWindowMenuHandler {
     }
 
     public void toolsShowStatisticsMatchesPerFileMenuItemActionPerformed() {
-        new StatisticsWindow(Core.getMainWindow().getApplicationFrame(), StatisticsWindow.STAT_TYPE.MATCHES_PER_FILE)
-                .setVisible(true);
+        new StatisticsWindow(Core.getMainWindow().getApplicationFrame(),
+                StatisticsWindow.STAT_TYPE.MATCHES_PER_FILE).setVisible(true);
     }
 
     public void optionsAutoCompleteShowAutomaticallyItemActionPerformed() {
-        Preferences.setPreference(Preferences.AC_SHOW_SUGGESTIONS_AUTOMATICALLY,
-                mainWindow.menu.optionsAutoCompleteShowAutomaticallyItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                BaseMainWindowMenu.OPTIONS_AUTO_COMPLETE_SHOW_AUTOMATICALLY_MENUITEM);
+        Preferences.setPreference(Preferences.AC_SHOW_SUGGESTIONS_AUTOMATICALLY, menuItem.isSelected());
     }
 
     public void optionsAutoCompleteHistoryCompletionMenuItemActionPerformed() {
-        Preferences.setPreference(Preferences.AC_HISTORY_COMPLETION_ENABLED,
-                mainWindow.menu.optionsAutoCompleteHistoryCompletionMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                BaseMainWindowMenu.OPTIONS_AUTO_COMPLETE_HISTORY_COMPLETION_MENUITEM);
+        Preferences.setPreference(Preferences.AC_HISTORY_COMPLETION_ENABLED, menuItem.isSelected());
     }
 
     public void optionsAutoCompleteHistoryPredictionMenuItemActionPerformed() {
-        Preferences.setPreference(Preferences.AC_HISTORY_PREDICTION_ENABLED,
-                mainWindow.menu.optionsAutoCompleteHistoryPredictionMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                BaseMainWindowMenu.OPTIONS_AUTO_COMPLETE_HISTORY_PREDICTION_MENUITEM);
+        Preferences.setPreference(Preferences.AC_HISTORY_PREDICTION_ENABLED, menuItem.isSelected());
     }
 
     public void optionsMTAutoFetchCheckboxMenuItemActionPerformed() {
-        boolean enabled = mainWindow.menu.optionsMTAutoFetchCheckboxMenuItem.isSelected();
-        Preferences.setPreference(Preferences.MT_AUTO_FETCH, enabled);
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                BaseMainWindowMenu.OPTIONS_MT_AUTO_FETCH_CHECKBOX_MENUITEM);
+        Preferences.setPreference(Preferences.MT_AUTO_FETCH, menuItem.isSelected());
     }
 
     public void optionsGlossaryFuzzyMatchingCheckBoxMenuItemActionPerformed() {
-        Preferences.setPreference(Preferences.GLOSSARY_STEMMING,
-                mainWindow.menu.optionsGlossaryFuzzyMatchingCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                BaseMainWindowMenu.OPTIONS_GLOSSARY_FUZZY_MATCHING_CHECKBOX_MENUITEM);
+        Preferences.setPreference(Preferences.GLOSSARY_STEMMING, menuItem.isSelected());
         Preferences.save();
     }
 
     public void optionsDictionaryFuzzyMatchingCheckBoxMenuItemActionPerformed() {
-        Preferences.setPreference(Preferences.DICTIONARY_FUZZY_MATCHING,
-                mainWindow.menu.optionsDictionaryFuzzyMatchingCheckBoxMenuItem.isSelected());
+        JMenuItem menuItem = mainWindow.getMainMenu().getMenuItemForNames(BaseMainWindowMenu.OPTIONS_MENU,
+                        BaseMainWindowMenu.OPTIONS_DICTIONARY_FUZZY_MATCHING_CHECKBOX);
+        Preferences.setPreference(Preferences.DICTIONARY_FUZZY_MATCHING, menuItem.isSelected());
         Preferences.save();
     }
 
+
     /**
-     * Displays the filters setup dialog to allow customizing file filters in detail.
+     * Displays the filters setup dialog to allow customizing file filters in
+     * detail.
      */
     public void optionsSetupFileFiltersMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), FiltersCustomizerController.class);
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(),
+                FiltersCustomizerController.class);
     }
 
     /**
-     * Displays the segmentation setup dialog to allow customizing the segmentation rules in detail.
+     * Displays the segmentation setup dialog to allow customizing the
+     * segmentation rules in detail.
      */
     public void optionsSentsegMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), SegmentationCustomizerController.class);
-
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(),
+                SegmentationCustomizerController.class);
     }
 
     /**
-     * Displays the workflow setup dialog to allow customizing the diverse workflow options.
+     * Displays the workflow setup dialog to allow customizing the diverse
+     * workflow options.
      */
     public void optionsWorkflowMenuItemActionPerformed() {
-        new PreferencesWindowController().show(mainWindow.getApplicationFrame(), EditingBehaviorController.class);
+        new PreferencesWindowController().show(mainWindow.getApplicationFrame(),
+                EditingBehaviorController.class);
     }
 
     /**
-     * Restores defaults for all dockable parts. May be expanded in the future to reset the entire GUI to its
-     * defaults.
+     * Restores defaults for all dockable parts. May be expanded in the future
+     * to reset the entire GUI to its defaults.
      */
     public void viewRestoreGUIMenuItemActionPerformed() {
         MainWindowUI.resetDesktopLayout(mainWindow);
@@ -1012,9 +1029,8 @@ public final class MainWindowMenuHandler {
         try {
             Help.showHelp();
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(mainWindow.getApplicationFrame(), ex.getLocalizedMessage(), OStrings.getString(
-                    "ERROR_TITLE"),
-                    JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(mainWindow.getApplicationFrame(), ex.getLocalizedMessage(),
+                    OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
             Log.log(ex);
         }
     }
@@ -1023,7 +1039,8 @@ public final class MainWindowMenuHandler {
      * Shows About dialog
      */
     public void helpAboutMenuItemActionPerformed() {
-        new AboutDialog(mainWindow).setVisible(true);
+        JDialog aboutDialog = new AboutDialog(mainWindow.getApplicationFrame());
+        aboutDialog.setVisible(true);
     }
 
     /**

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.swing.JFrame;
 import javax.swing.JMenu;
+import javax.swing.JMenuItem;
 
 import org.madlonkay.supertmxmerge.StmProperties;
 import org.madlonkay.supertmxmerge.SuperTmxMerge;
@@ -652,6 +653,11 @@ public final class TestTeamIntegrationChild {
 
             @Override
             public JMenu getMenu(MenuKey marker) {
+                return null;
+            }
+
+            @Override
+            public JMenuItem getMenuItemForNames(String menuName, String itemName) {
                 return null;
             }
 

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -196,6 +196,11 @@ public abstract class TestCore {
                 }
             }
 
+            @Override
+            public JMenuItem getMenuItemForNames(final String menuName, final String itemName) {
+                return null;
+            }
+
             private JMenu getGotoMenu() {
                 if (gotoMenu.getItemCount() == 0) {
                     gotoMenu.add(new JMenuItem("gotoNextUntranslatedMenuItem"));


### PR DESCRIPTION
Extend `IMainMenu` API and use the API in `MainWindowMenuHandler` instead of accessing `MainWindowMenu` object methods.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

dev-ML
https://sourceforge.net/p/omegat/mailman/message/58747200/

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Define menu and menu items "name"
- Add new API getMenuItemForNames to help manipulating or retrieving status of menu item.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
TODO:

- [ ] unit tests
- [ ] define all component names