### PR TITLE
feat: send whole locale to Apertium MT

### DIFF
--- a/machinetranslators/apertium/src/main/java/org/omegat/machinetranslators/apertium/ApertiumTranslate.java
+++ b/machinetranslators/apertium/src/main/java/org/omegat/machinetranslators/apertium/ApertiumTranslate.java
@@ -120,12 +120,12 @@ public class ApertiumTranslate extends BaseCachedTranslate {
         String locale = language.getLocaleCode();
 
         if (!StringUtil.isEmpty(language.getCountryCode())) {
-            if (locale.equalsIgnoreCase("en_us") || locale.equalsIgnoreCase("pt_br")) {
-                return locale; // We need en_US and pt_BR
-            } else if (locale.equalsIgnoreCase("oc_ar")) {
-                return "oc_aran";
+            if (locale.equalsIgnoreCase("oc_ar")) {
+                return "oci_aran";
             } else if (locale.equalsIgnoreCase("ca_va")) {
-                return "ca_valencia";
+                return "cat_valencia";
+            } else {
+                return locale;
             }
         }
 


### PR DESCRIPTION
Originally, the Apertium API was strict about pair language codes. For example, if `en-US` to `es-ES` translation was requested but only `en` to `es` translation was available, it would not fall back and instead report "The requested pair is not installed". For this reason, OmegaT stripped the country/variant part of the locale when calling the Apertium API.

From the current most recent version of the API (for reference: https://github.com/apertium/apertium-apy/releases/tag/v0.12.1), released a couple of weeks ago and already deployed to https://apertium.org, the API has a fallback mode. Now it tries to find an appropriate pair if the requested locale combination is not found directly.

For this reason, OmegaT should now send the whole locale and let the Apertium server choose a suitable pair.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

## What does this PR change?

- Apertium MT now sends whole locale code to server instead of only the language code

## Other information
