### PR TITLE
chore: fix: integ-test failed with no X11 screen error

### DIFF
--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -160,18 +160,9 @@ public final class TestTeamIntegrationChild {
                 setRootGitRepositoryMapping(projectProperties.getRepositories(), repo);
             }
             projectProperties.autocreateDirectories();
-            Core.getAutoSave().disable();
-            RealProject p = new TestRealProject(projectProperties);
-            Core.setProject(p);
+            Core.setProject(new NotLoadedProject());
             glossaryManager = new GlossaryManager(new TestGlossaryTextArea());
-            // load project
-            p.loadProject(true);
-            if (p.isProjectLoaded()) {
-                Core.getAutoSave().enable();
-                CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
-            } else {
-                throw new Exception("Project can't be loaded");
-            }
+            loadProject(projectProperties);
 
             key = new EntryKey[segCount];
             ste = new SourceTextEntry[segCount];
@@ -210,7 +201,7 @@ public final class TestTeamIntegrationChild {
             });
 
             // load again and check
-            ProjectFactory.loadProject(projectProperties, true);
+            loadProject(projectProperties);
             checkAll();
 
             checkGlossaryEntries();
@@ -222,6 +213,25 @@ public final class TestTeamIntegrationChild {
         } catch (Throwable ex) {
             ex.printStackTrace();
             System.exit(1);
+        }
+    }
+
+    /**
+     * replacement of ProjectFactory.loadProject for test.
+     * @param projectProperties
+     * @throws Exception
+     */
+    static void loadProject(ProjectProperties projectProperties) throws Exception {
+        Core.getAutoSave().disable();
+        RealProject p = new TestRealProject(projectProperties);
+        Core.setProject(p);
+        // load project
+        p.loadProject(true);
+        if (p.isProjectLoaded()) {
+            Core.getAutoSave().enable();
+            CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        } else {
+            throw new Exception("Project can't be loaded");
         }
     }
 


### PR DESCRIPTION
Integration Test can failed with No X11 DISPLAY variable set error. It is because Integ-Test uses ProjectFactory.loadProject but it does not use `TestRealProject` overrides then it use `RealProject#mergeTmx` instead of `TestRealProject#mergeTmx` which is modified to run without X11 screen.


<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

integration test when weekly reelases in 9 Mar. and 16 Mar 2024.

## What does this PR change?

- Avoid using ProjectFactory.loadProject function
- Add TestIntegrationChild.loadProject function for replacement
- Do same thing when TestIntegrationTest load at first.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
 The stack trace is like as follows
TF_LOAD_ERROR
java.awt.HeadlessException:
No X11 DISPLAY variable was set,
but this program performed an operation which requires it.
	at java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:166)
	at java.desktop/java.awt.Window.init(Window.java:501)
	at java.desktop/java.awt.Window.<init>(Window.java:453)
	at java.desktop/java.awt.Window.<init>(Window.java:608)
	at java.desktop/java.awt.Dialog.<init>(Dialog.java:675)
	at java.desktop/javax.swing.JDialog.<init>(JDialog.java:593)
	at org.madlonkay.supertmxmerge.gui.MergeWindow.newAsDialog(MergeWindow.java:61)
	at org.madlonkay.supertmxmerge.MergeController$1.resolve(MergeController.java:98)
	aat org.madlonkay.supertmxmerge.MergeController.resolve(MergeController.java:232)
	aat org.madlonkay.supertmxmerge.SuperTmxMerge.merge(SuperTmxMerge.java:86)
	aat org.omegat.core.data.RealProject.mergeTMX(RealProject.java:1173)
	aat org.omegat.core.data.RealProject$1.rebaseAndSave(RealProject.java:1050)
	aat org.omegat.core.team2.RebaseAndCommit.rebaseAndCommit(RebaseAndCommit.java:178)
	aat org.omegat.core.data.RealProject.rebaseAndCommitProject(RealProject.java:1029)
	aat org.omegat.core.data.RealProject.loadProject(RealProject.java:383)
	aat org.omegat.core.data.ProjectFactory.loadProject(ProjectFactory.java:72)
	aat org.omegat.core.data.TestTeamIntegrationChild.main(TestTeamIntegrationChild.java:213)
