### PR TITLE
[bugs:#965] Delay autocompleter popup until 100ms after last input

### DIFF
--- a/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -37,7 +37,7 @@ import javax.swing.JLabel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
@@ -75,6 +75,7 @@ public class AutoCompleter implements IAutoCompleter {
 
     public static final int PAGE_ROW_COUNT = 10;
 
+    private final Timer popupTimer;
     boolean didPopUpAutomatically = false;
 
     /**
@@ -92,6 +93,13 @@ public class AutoCompleter implements IAutoCompleter {
 
     public AutoCompleter(EditorTextArea3 editor) {
         this.editor = editor;
+
+        popupTimer = new Timer(100, e -> {
+            Point p = getDisplayPoint();
+            popup.show(editor, p.x, p.y);
+            editor.requestFocus();
+        });
+        popupTimer.setRepeats(false);
 
         scroll = new JScrollPane();
         scroll.setBorder(new EmptyBorder(0, 0, 0, 0));
@@ -379,15 +387,9 @@ public class AutoCompleter implements IAutoCompleter {
 
     public void setVisible(boolean isVisible) {
         if (isVisible) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    Point p = getDisplayPoint();
-                    popup.show(editor, p.x, p.y);
-                    editor.requestFocus();
-                }
-            });
+            popupTimer.restart();
         } else {
+            popupTimer.stop();
             popup.setVisible(false);
             didPopUpAutomatically = false;
         }

--- a/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -68,9 +68,10 @@ public class AutoCompleter implements IAutoCompleter {
 
     private static final int MIN_VIEWPORT_HEIGHT = 50;
     private static final int MAX_POPUP_WIDTH = 500;
+    private static final int POPUP_DELAY = 100;
 
-    JPopupMenu popup = new JPopupMenu();
-    private EditorTextArea3 editor;
+    private final JPopupMenu popup = new JPopupMenu();
+    private final EditorTextArea3 editor;
     private AutoCompleterKeys keys;
 
     public static final int PAGE_ROW_COUNT = 10;
@@ -94,7 +95,7 @@ public class AutoCompleter implements IAutoCompleter {
     public AutoCompleter(EditorTextArea3 editor) {
         this.editor = editor;
 
-        popupTimer = new Timer(100, e -> {
+        popupTimer = new Timer(POPUP_DELAY, e -> {
             Point p = getDisplayPoint();
             popup.show(editor, p.x, p.y);
             editor.requestFocus();


### PR DESCRIPTION
@aaron proposed the fix for OmegaT 5.3 development window,  but it was not merged.

> I've already cut the release, so it won't be included. The next release it could be included in would be 5.3.0, which won't be released probably for a while.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  Autosuggestion and IME malfunctioning
- https://sourceforge.net/p/omegat/bugs/965/


## What does this PR change?

- autocomplete pop-ups raised 100ms after input.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
