### PR TITLE
[6.0][BUGS#1229,1253] feat: glossary: linkify percent escaped URLs with brackets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,8 @@ dependencies {
     } else {
         implementation 'commons-io:commons-io:2.11.0'
         implementation 'commons-lang:commons-lang:2.6'
+        implementation 'commons-validator:commons-validator:1.7'
+        implementation 'commons-codec:commons-codec:1.16.1'
 
         // macOS integration
         implementation 'org.madlonkay:desktopsupport:0.6.0'

--- a/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
@@ -55,12 +55,7 @@ public class DefaultGlossaryRenderer implements IGlossaryRenderer {
         StringBuilder commentsBuf = new StringBuilder();
         for (int i = 0, commentIndex = 0; i < targets.length; i++) {
             if (i > 0 && targets[i].equals(targets[i - 1])) {
-                if (!comments[i].equals("")) {
-                    commentsBuf.append("\n");
-                    commentsBuf.append(commentIndex);
-                    commentsBuf.append(". ");
-                    commentsBuf.append(comments[i]);
-                }
+                appendCommentsBuf(commentsBuf, commentIndex, comments[i]);
                 continue;
             }
             SimpleAttributeSet attrs = new SimpleAttributeSet(TARGET_ATTRIBUTES);
@@ -74,15 +69,18 @@ public class DefaultGlossaryRenderer implements IGlossaryRenderer {
             trg.append(bracketEntry(targets[i]), attrs);
 
             commentIndex++;
-            if (!comments[i].equals("")) {
-                commentsBuf.append("\n");
-                commentsBuf.append(commentIndex);
-                commentsBuf.append(". ");
-                commentsBuf.append(comments[i]);
-            }
+            appendCommentsBuf(commentsBuf, commentIndex, comments[i]);
         }
-
         trg.append(commentsBuf.toString(), NOTES_ATTRIBUTES);
+    }
+
+    private void appendCommentsBuf(StringBuilder commentsBuf, int commentIndex, String comment) {
+        if (!comment.isEmpty()) {
+            commentsBuf.append("\n");
+            commentsBuf.append(commentIndex);
+            commentsBuf.append(". ");
+            commentsBuf.append(comment);
+        }
     }
 
     /**

--- a/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
@@ -70,7 +70,7 @@ public class DictionaryGlossaryRenderer implements IGlossaryRenderer {
                     trg.append(", ", null);
                 }
             }
-            if (!comments[i].equals("")) {
+            if (!comments[i].isEmpty()) {
                 trg.startIndent(NOTES_ATTRIBUTES);
                 trg.append("- " + comments[i], NOTES_ATTRIBUTES);
                 hasComments = true;

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -73,6 +73,7 @@ import org.omegat.gui.editor.EditorUtils;
 import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
+import org.omegat.util.HttpConnectionUtils;
 import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
@@ -384,7 +385,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
                 if (dialog.getReturnStatus() == CreateGlossaryEntry.RET_OK) {
                     String src = StringUtil.normalizeUnicode(dialog.getSourceText().getText()).trim();
                     String loc = StringUtil.normalizeUnicode(dialog.getTargetText().getText()).trim();
-                    String com = StringUtil.normalizeUnicode(dialog.getCommentText().getText()).trim();
+                    String com = HttpConnectionUtils.encodeHttpURLs(StringUtil.normalizeUnicode(
+                            dialog.getCommentText().getText()).trim());
                     if (!StringUtil.isEmpty(src) && !StringUtil.isEmpty(loc)) {
                         try {
                             GlossaryReaderTSV.append(out, new GlossaryEntry(src, loc, com, true, out.getPath()));

--- a/src/org/omegat/gui/glossary/IGlossaryRenderer.java
+++ b/src/org/omegat/gui/glossary/IGlossaryRenderer.java
@@ -34,6 +34,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.StyledDocument;
 import javax.swing.text.StyleConstants;
 
+import org.omegat.util.HttpConnectionUtils;
 import org.omegat.util.gui.Styles;
 
 public interface IGlossaryRenderer {
@@ -112,10 +113,12 @@ public interface IGlossaryRenderer {
                 if (attrColor != Color.black) {
                     String colorString = String.format("%02x%02x%02x",
                             attrColor.getRed(), attrColor.getGreen(), attrColor.getBlue());
-                    buf.append("<font color=#" + colorString + ">");
+                    buf.append("<font color=#").append(colorString).append(">");
+
                 }
             }
-            buf.append(str);
+            String doc = HttpConnectionUtils.decodeHttpURLs(str);
+            buf.append(doc);
             if (attr != null) {
                 Color attrColor = StyleConstants.getForeground(attr);
                 if (attrColor != Color.black) {

--- a/src/org/omegat/util/HttpConnectionUtils.java
+++ b/src/org/omegat/util/HttpConnectionUtils.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
@@ -44,9 +46,14 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.EncoderException;
+import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.io.IOUtils;
-
+import org.apache.commons.validator.routines.UrlValidator;
 
 /**
  * Utility collection for http connections.
@@ -70,16 +77,54 @@ public final class HttpConnectionUtils {
      */
     private static final int TIMEOUT_MS = 10_000;
 
+    // Regular Expression for URL validation
+    // From https://gist.github.com/dperini/729294
+    // and https://github.com/JetBrains/intellij-community
+    // See lib/licenses/Licenses.txt
+    private static final String REGEX_URL = "(?:https?|ftp)://" // protocol
+            + "(?:\\S+(?::\\S*)?@)?(?:(?!" // user:pass (optional)
+            + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
+            + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
+            + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
+            // IP addresses
+            + "|" + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
+            + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
+            + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)" // domain host
+            + "(?::\\d{2,5})?" // port (optional)
+            + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?"; // resources
+
+    /**
+     * Regular Expression for https and ftp URL validation.
+     * <p>
+     * You are recommended to use commons-validator instead of hand-crafted
+     * here. We leave it as is for keeping compatibility.
+     */
+    public static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern HTTP_URL_PATTERN = Pattern.compile("\\bhttps?://\\S+\\b",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Regular Expression for file URL validation.
+     */
+    public static final Pattern FILE_URL_PATTERN = Pattern
+            .compile("\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
+    private static final URLCodec codec = new URLCodec(StandardCharsets.UTF_8.name());
+
     /**
      * Don't instantiate util class.
      */
-    private HttpConnectionUtils() {}
+    private HttpConnectionUtils() {
+    }
 
     /**
      * Get resource from URL with default timeout.
-     * @param url resource URL.
+     * 
+     * @param url
+     *            resource URL.
      * @return string returned from server.
-     * @throws IOException raises when connection is failed.
+     * @throws IOException
+     *             raises when connection is failed.
      */
     public static String getURL(URL url) throws IOException {
         return getURL(url, TIMEOUT_MS);
@@ -88,10 +133,13 @@ public final class HttpConnectionUtils {
     /**
      * Download a file to memory.
      *
-     * @param url resource URL to download
-     * @param timeout timeout to connect and read.
+     * @param url
+     *            resource URL to download
+     * @param timeout
+     *            timeout to connect and read.
      * @return returned string
-     * @throws IOException when connection and read method error.
+     * @throws IOException
+     *             when connection and read method error.
      */
     public static String getURL(URL url, int timeout) throws IOException {
         URLConnection urlConn = url.openConnection();
@@ -105,12 +153,18 @@ public final class HttpConnectionUtils {
     /**
      * Download Zip file from remote site and extract it to specified directory.
      *
-     * @param url URL of zip file resource to download.
-     * @param dir target directory to extract
-     * @param expectedFiles filter extract file names
-     * @throws IOException raises when extraction is failed, maybe flaky download happened.
+     * @param url
+     *            URL of zip file resource to download.
+     * @param dir
+     *            target directory to extract
+     * @param expectedFiles
+     *            filter extract file names
+     * @throws IOException
+     *             raises when extraction is failed, maybe flaky download
+     *             happened.
      */
-    public static void downloadZipFileAndExtract(URL url, File dir, List<String> expectedFiles) throws IOException {
+    public static void downloadZipFileAndExtract(URL url, File dir, List<String> expectedFiles)
+            throws IOException {
         URLConnection conn = url.openConnection();
         conn.setConnectTimeout(TIMEOUT_MS);
         conn.setReadTimeout(TIMEOUT_MS);
@@ -127,17 +181,26 @@ public final class HttpConnectionUtils {
 
     /**
      * Downloads a binary file from a URL.
-     * @param fileURL HTTP URL of the file to be downloaded
-     * @param headers Additional HTTP headers
-     * @param expectedMime Mime type expected and check against such as ["application/octet-stream",
-     *                    "application/jar-archive"]. If getting type is differed, return false.
-     * @param saveFilePath path of the file
+     * 
+     * @param fileURL
+     *            HTTP URL of the file to be downloaded
+     * @param headers
+     *            Additional HTTP headers
+     * @param expectedMime
+     *            Mime type expected and check against such as
+     *            ["application/octet-stream", "application/jar-archive"]. If
+     *            getting type is differed, return false.
+     * @param saveFilePath
+     *            path of the file
      * @return true when succeeded, otherwise false.
-     * @throws IOException raise when connection and file write failed.
-     * @throws FlakyDownloadException raise when downloaded file length differs from expected content length.
+     * @throws IOException
+     *             raise when connection and file write failed.
+     * @throws FlakyDownloadException
+     *             raise when downloaded file length differs from expected
+     *             content length.
      */
     public static boolean downloadBinaryFile(final URL fileURL, final Map<String, String> headers,
-                                             final Set<String> expectedMime, final File saveFilePath)
+            final Set<String> expectedMime, final File saveFilePath)
             throws IOException, FlakyDownloadException {
         HttpURLConnection httpURLConnection = (HttpURLConnection) fileURL.openConnection();
         headers.forEach(httpURLConnection::setRequestProperty);
@@ -178,7 +241,8 @@ public final class HttpConnectionUtils {
      * @param target
      *            String representation of well-formed URL.
      * @return byte array or null if status is not 200 OK
-     * @throws IOException raise when connection failed.
+     * @throws IOException
+     *             raise when connection failed.
      */
     public static byte[] getURLasByteArray(String target) throws IOException {
         URL url = new URL(target);
@@ -196,10 +260,13 @@ public final class HttpConnectionUtils {
     /**
      * Method call without additional headers for possible calls from plugins.
      *
-     * @param address URL to post
-     * @param params post parameters in Map
+     * @param address
+     *            URL to post
+     * @param params
+     *            post parameters in Map
      * @return result string returned from server.
-     * @throws IOException raises when connection failed.
+     * @throws IOException
+     *             raises when connection failed.
      */
     public static String post(String address, Map<String, String> params) throws IOException {
         return post(address, params, null);
@@ -338,8 +405,8 @@ public final class HttpConnectionUtils {
      *            additional headers for request, can be null
      * @return Server output
      */
-    public static String postJSON(String address, String json,
-            Map<String, String> additionalHeaders) throws IOException {
+    public static String postJSON(String address, String json, Map<String, String> additionalHeaders)
+            throws IOException {
         URL url = new URL(address);
 
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -402,6 +469,115 @@ public final class HttpConnectionUtils {
         try (InputStream in = conn.getInputStream()) {
             return IOUtils.toString(in, charset);
         }
+    }
+
+    public static String encodeHttpURLs(String text) {
+        UrlValidator urlValidator = new UrlValidator();
+        StringBuilder result = new StringBuilder();
+        Matcher m = HTTP_URL_PATTERN.matcher(text);
+        int lastIndex = 0;
+        while (m.find()) {
+            final String url = m.group();
+            if (!urlValidator.isValid(url)) {
+                try {
+                    URI uri = new URI(url);
+                    String encodedPath = encodePath(uri.getRawPath());
+                    String encodedQuery = encodeQuery(uri.getRawQuery());
+                    result.append(text, lastIndex, m.start());
+                    result.append(uri.getScheme()).append("://").append(uri.getAuthority());
+                    if (uri.getRawUserInfo() != null) {
+                        result.append(uri.getRawUserInfo()).append("@");
+                    }
+                    if (!StringUtil.isEmpty(encodedPath)) {
+                        result.append(encodedPath);
+                    }
+                    if (!StringUtil.isEmpty(encodedQuery)) {
+                        result.append("?").append(encodedQuery);
+                    }
+                    if (uri.getRawFragment() != null) {
+                        result.append("#").append(uri.getRawFragment());
+                    }
+                } catch (EncoderException | URISyntaxException ex) {
+                    result.append(url);
+                }
+                lastIndex = m.end();
+            }
+        }
+        result.append(text.substring(lastIndex));
+        return result.toString();
+    }
+
+    public static String encodeURIComponent(String component) throws EncoderException {
+        if (component == null) {
+            return null;
+        }
+        return codec.encode(component);
+    }
+
+    public static String encodePath(String path) throws EncoderException {
+        String[] pathSegments = path.split("/");
+        StringBuilder encodedPath = new StringBuilder();
+        for (String segment : pathSegments) {
+            if (!segment.isEmpty()) {
+                encodedPath.append("/").append(codec.encode(segment));
+            }
+        }
+        return encodedPath.toString();
+    }
+
+    public static String encodeQuery(String query) throws EncoderException {
+        if (query == null) {
+            return null;
+        }
+        String[] querySegments = query.split("&");
+        StringBuilder encodedQuery = new StringBuilder();
+        for (int i = 0; i < querySegments.length; i++) {
+            final String segment = querySegments[i];
+            if (!segment.isEmpty()) {
+                if (i != 0) {
+                    encodedQuery.append("&");
+                }
+                String[] exp = segment.split("=");
+                encodedQuery.append(codec.encode(exp[0])).append("=").append(codec.encode(exp[1]));
+            }
+        }
+        return encodedQuery.toString();
+    }
+
+    public static String decodeHttpURLs(String text) {
+        UrlValidator urlValidator = new UrlValidator();
+        StringBuilder result = new StringBuilder();
+        Matcher m = HTTP_URL_PATTERN.matcher(text);
+        int lastIndex = 0;
+        while (m.find()) {
+            final String uri = m.group();
+            if (urlValidator.isValid(uri)) {
+                result.append(text, lastIndex, m.start());
+                try {
+                    result.append(codec.decode(uri));
+                } catch (DecoderException ex) {
+                    result.append(uri);
+                }
+                lastIndex = m.end();
+            }
+        }
+        result.append(text.substring(lastIndex));
+        return result.toString();
+    }
+
+    /**
+     * Validate URL string.
+     * 
+     * @param remoteUrl
+     *            URL candidate string.
+     * @return true when valid, otherwise false.
+     */
+    public static boolean checkUrl(String remoteUrl) {
+        if (remoteUrl.isEmpty()) {
+            return false;
+        }
+        UrlValidator urlValidator = new UrlValidator();
+        return urlValidator.isValid(remoteUrl);
     }
 
     /**

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -25,12 +25,8 @@
 package org.omegat.util.gui;
 
 import java.awt.Cursor;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
@@ -49,6 +45,10 @@ import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.net.URLCodec;
+import org.apache.commons.validator.routines.UrlValidator;
 
 import org.omegat.util.Java8Compat;
 import org.omegat.util.Log;
@@ -148,32 +148,13 @@ public final class JTextPaneLinkifier {
 
         private static final int REFRESH_DELAY = 200;
 
-        // Regular Expression for URL validation
-        // From https://gist.github.com/dperini/729294
-        // and https://github.com/JetBrains/intellij-community
-        // See lib/licenses/Licenses.txt
-        private static final String REGEX_URL = "(?:https?|ftp)://"  // protocol
-                + "(?:\\S+(?::\\S*)?@)?(?:(?!"  // user:pass (optional)
-                + "(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\."
-                + "(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\."
-                + "(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))"
-                // IP addresses
-                + "|"
-                + "(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+"
-                + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
-                + "\\.[a-z\\u00a1-\\uffff]{2,}\\.?)"  // domain host
-                + "(?::\\d{2,5})?"  // port (optional)
-                + "(?:[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|])?";  // resources
-        private static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL, Pattern.CASE_INSENSITIVE);
-        private static final Pattern FILE_URL_PATTERN = Pattern.compile(
-                "\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]");
-        private static final AttributeSet DEFAULT_ATTRIBUTES = new SimpleAttributeSet();
         private static final AttributeSet LINK_ATTRIBUTES;
 
         static {
             MutableAttributeSet tmp = new SimpleAttributeSet();
             StyleConstants.setUnderline(tmp, true);
             StyleConstants.setForeground(tmp, Styles.EditorColor.COLOR_HYPERLINK.getColor());
+            StyleConstants.setBackground(tmp, Styles.EditorColor.COLOR_BACKGROUND.getColor());
             LINK_ATTRIBUTES = tmp;
         }
 
@@ -184,10 +165,14 @@ public final class JTextPaneLinkifier {
         // as default constructor
         AttributeInserterDocumentFilter(StyledDocument doc, boolean extended) {
             this.doc = doc;
+            Pattern urlPattern = Pattern.compile("\\bhttps?://\\S+\\b", Pattern.CASE_INSENSITIVE);
             if (extended) {
-                urlPatterns = new Pattern[]{URL_PATTERN, FILE_URL_PATTERN};
+                Pattern filePattern = Pattern.compile(
+                        "\\\\bfile://[-A-Za-z0-9+$&@#/%?=~_|!:,.;]*[-A-Za-z0-9+$&@#/%=~_|]\\b",
+                        Pattern.CASE_INSENSITIVE);
+                urlPatterns = new Pattern[] { urlPattern, filePattern };
             } else {
-                urlPatterns = new Pattern[]{URL_PATTERN};
+                urlPatterns = new Pattern[] { urlPattern };
             }
             timer = new Timer(REFRESH_DELAY, e -> refreshPane());
             timer.setRepeats(false);
@@ -208,7 +193,8 @@ public final class JTextPaneLinkifier {
         @Override
         public void remove(FilterBypass fb, int offset, int length) throws BadLocationException {
             boolean refresh = true;
-            final AttributeSet attr = ((StyledDocument) fb.getDocument()).getCharacterElement(offset).getAttributes();
+            final AttributeSet attr = ((StyledDocument) fb.getDocument()).getCharacterElement(offset)
+                    .getAttributes();
             if (attr != null && attr.isDefined(StyleConstants.ComposedTextAttribute)) {
                 refresh = false;
             }
@@ -231,32 +217,44 @@ public final class JTextPaneLinkifier {
         }
 
         private void refreshPane() {
-            final int docLength = doc.getLength();
-            if (docLength == 0) {
+            if (doc.getLength() == 0) {
                 return;
             }
             try {
-                // clear attributes
-                for (int i = 0; i < docLength; ++i) {
-                    if (doc.getCharacterElement(i).getAttributes().containsAttributes(LINK_ATTRIBUTES)) {
-                        doc.setCharacterAttributes(i, 1, DEFAULT_ATTRIBUTES, true);
-                    }
-                }
-
                 // URL detection
+                URLCodec codec = new URLCodec("UTF-8");
+                UrlValidator urlValidator = new UrlValidator();
                 for (Pattern pattern : urlPatterns) {
-                    final String text = doc.getText(0, docLength);
+                    int shift = 0;
+                    final String text = doc.getText(0, doc.getLength());
                     final Matcher matcher = pattern.matcher(text);
                     while (matcher.find()) {
-                        final int offset = matcher.start();
-                        final int targetLength = matcher.end() - offset;
-
-                        try {
-                            // Transform into clickable text
-                            AttributeSet atts = makeAttributes(offset, new URI(matcher.group()));
-                            doc.setCharacterAttributes(offset, targetLength, atts, true);
-                        } catch (URISyntaxException ex) {
-                            Log.logWarningRB("TPL_ERROR_URL", matcher.group());
+                        final int offset = matcher.start() + shift;
+                        if (doc.getCharacterElement(offset).getAttributes()
+                                .containsAttributes(LINK_ATTRIBUTES)) {
+                            continue;
+                        }
+                        final int targetLength = matcher.end() - matcher.start();
+                        final String uri = matcher.group();
+                        if (urlValidator.isValid(uri)) {
+                            try {
+                                // Transform into clickable and readable text
+                                String decoded = codec.decode(uri);
+                                if (decoded.length() == uri.length()) {
+                                    SimpleAttributeSet atts = new SimpleAttributeSet(
+                                            doc.getCharacterElement(offset).getAttributes());
+                                    setLinkAttribute(atts, new URI(uri));
+                                    doc.setCharacterAttributes(offset, targetLength, atts, true);
+                                } else {
+                                    shift += decoded.length() - targetLength;
+                                    doc.remove(offset, targetLength);
+                                    SimpleAttributeSet atts = new SimpleAttributeSet();
+                                    setLinkAttribute(atts, new URI(uri));
+                                    doc.insertString(offset, decoded, atts);
+                                }
+                            } catch (DecoderException | URISyntaxException ex) {
+                                Log.logWarningRB("TPL_ERROR_URL", matcher.group());
+                            }
                         }
                     }
                 }
@@ -266,22 +264,17 @@ public final class JTextPaneLinkifier {
             }
         }
 
-        private AttributeSet makeAttributes(final int offset, final URI target) {
-            SimpleAttributeSet atts = new SimpleAttributeSet(doc.getCharacterElement(offset).getAttributes());
+        private void setLinkAttribute(SimpleAttributeSet atts, URI target) {
             atts.addAttributes(LINK_ATTRIBUTES);
-            atts.addAttribute(ATTR_LINK, new IAttributeAction() {
-                @Override
-                public void execute() {
-                    try {
-                        DesktopWrapper.browse(target);
-                    } catch (Exception e) {
-                        JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
-                                OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
-                        Log.log(e);
-                    }
+            atts.addAttribute(ATTR_LINK, (IAttributeAction) () -> {
+                try {
+                    DesktopWrapper.browse(target);
+                } catch (Exception e) {
+                    JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
+                            OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
+                    Log.log(e);
                 }
             });
-            return atts;
         }
     }
 }

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -44,11 +44,11 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals("koo moo", g.get(0).getLocText());
         assertEquals("question", g.get(1).getSrcText());
         assertEquals("qqqqq", g.get(1).getLocText());
-        assertEquals("\u5730\u7403\u30B7\u30B9\u30C6\u30E0", g.get(2).getSrcText());
+        assertEquals("地球システム", g.get(2).getSrcText());
         assertEquals("System Terre", g.get(2).getLocText());
         assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
                 g.get(2).getCommentText());
-        assertEquals("\uC190\uAC00\uB77D", g.get(3).getSrcText());
+        assertEquals("손가락", g.get(3).getSrcText());
         assertEquals("Korean Term", g.get(3).getLocText());
 
         g = GlossaryReaderTSV.read(new File("test/data/glossaries/testUTF16LE.txt"), false);

--- a/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -44,11 +44,11 @@ public class GlossaryReaderTSVTest extends TestCore {
         assertEquals("koo moo", g.get(0).getLocText());
         assertEquals("question", g.get(1).getSrcText());
         assertEquals("qqqqq", g.get(1).getLocText());
-        assertEquals("地球システム", g.get(2).getSrcText());
+        assertEquals("\u5730\u7403\u30B7\u30B9\u30C6\u30E0", g.get(2).getSrcText());
         assertEquals("System Terre", g.get(2).getLocText());
         assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
                 g.get(2).getCommentText());
-        assertEquals("손가락", g.get(3).getSrcText());
+        assertEquals("\uC190\uAC00\uB77D", g.get(3).getSrcText());
         assertEquals("Korean Term", g.get(3).getLocText());
 
         g = GlossaryReaderTSV.read(new File("test/data/glossaries/testUTF16LE.txt"), false);

--- a/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -98,7 +98,7 @@ public class GlossaryTextAreaTest extends TestCore {
         renderer.render(entries.get(1), doc);
         renderer.render(entries.get(2), doc);
         Thread.sleep(300);
-        String expected = doc.getText(0, doc.getLength()).replaceAll("%C3%A8", "è");
+        String expected = doc.getText(0, doc.getLength()).replaceAll("%C3%A8", "\u00E8");
         assertEquals(expected, gta.getText());
     }
 

--- a/test/src/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/test/src/org/omegat/util/HttpConnectionUtilsTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HttpConnectionUtilsTest {
+
+    @Test
+    public void testDecodeURLs() {
+        String str = "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
+    }
+
+    @Test
+    public void testDecodeURLsInText() {
+        String str = "1. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals("1. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
+    }
+
+    @Test
+    public void testDecodeURLsMultipleLines() {
+        String str = "1. https://google.com/\n2. bar\n"
+                + "3. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
+        assertEquals(
+                "1. https://google.com/\n2. bar\n"
+                        + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                HttpConnectionUtils.decodeHttpURLs(str));
+    }
+
+    @Test
+    public void testEncodeURLs() {
+        String base = "https://fr.wikipedia.org/";
+        String path = "wiki/Science_du_système_Terre";
+        String query = "?query=search&lang=en";
+        assertEquals("https://fr.wikipedia.org/", HttpConnectionUtils.encodeHttpURLs(base));
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",
+                HttpConnectionUtils.encodeHttpURLs(base + path));
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre?query=search&lang=en",
+                HttpConnectionUtils.encodeHttpURLs(base + path + query));
+    }
+}

--- a/test/src/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/test/src/org/omegat/util/HttpConnectionUtilsTest.java
@@ -34,14 +34,14 @@ public class HttpConnectionUtilsTest {
     @Test
     public void testDecodeURLs() {
         String str = "https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
-        assertEquals("https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+        assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst\u00E8me_Terre",
                 HttpConnectionUtils.decodeHttpURLs(str));
     }
 
     @Test
     public void testDecodeURLsInText() {
         String str = "1. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
-        assertEquals("1. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+        assertEquals("1. https://fr.wikipedia.org/wiki/Science_du_syst\u00E8me_Terre",
                 HttpConnectionUtils.decodeHttpURLs(str));
     }
 
@@ -51,14 +51,14 @@ public class HttpConnectionUtilsTest {
                 + "3. https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre";
         assertEquals(
                 "1. https://google.com/\n2. bar\n"
-                        + "3. https://fr.wikipedia.org/wiki/Science_du_système_Terre",
+                        + "3. https://fr.wikipedia.org/wiki/Science_du_syst\u00E8me_Terre",
                 HttpConnectionUtils.decodeHttpURLs(str));
     }
 
     @Test
     public void testEncodeURLs() {
         String base = "https://fr.wikipedia.org/";
-        String path = "wiki/Science_du_système_Terre";
+        String path = "wiki/Science_du_syst\u00E8me_Terre";
         String query = "?query=search&lang=en";
         assertEquals("https://fr.wikipedia.org/", HttpConnectionUtils.encodeHttpURLs(base));
         assertEquals("https://fr.wikipedia.org/wiki/Science_du_syst%C3%A8me_Terre",


### PR DESCRIPTION
As request by project leader, this is backport glossary URL link enhancement from master branch.
This requires many changes from master branch.
 
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?


## What does this PR change?

- Show percent escaped URL as a decoded path with Unicode characters
- Introduce HttpsConnectionUtils#decodeHttpsURLs utility method
- Add commons-validator dependency to validate URLs
- Enhance HttpConnectionUtils#checkUrl utility to use commons-validator to validate URL.
- Enhance IGlossaryRenderer.HtmlTarget#append to decode percent-encoded URLs
- Update test cases
- Document writer should suggest users to put URL with encoded form in glossary file.
- Encode URL when adding glossary term with comment that contains URL


## Other information

backport from 417fec84b2e803adad92c6093826f56427bc8d5a and from c8b2fdc315669fbc9cff0dd1f55bcef4a20b7866
