### PR TITLE
chore: installDist task insist of execDir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1167,8 +1167,8 @@ tasks.register("linuxRpmDist", Exec) {
 
 // We bundle our startup scripts separately, so disable startScripts.
 startScripts.enabled = false
-installDist {
-}
+// installDist insists on destination executable directory even when disable start script.
+application.executableDir = ""
 
 // Read in all our custom messages and massage them for inclusion in the .iss
 ext.getInnoSetupCustomMessages = {


### PR DESCRIPTION
- Fix preventing installDist when multiple executions

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/a72a64f2-8737-4b9f-819b-6bd1713db1c6%40northside.tokyo/#msg58753665

## What does this PR change?

- set application.executableDir 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

- [x] check behavior