### PR TITLE
chore: bump gradle develocity plugin@3.17.2

### DIFF
--- a/.github/workflows/gradle-build-master.yml
+++ b/.github/workflows/gradle-build-master.yml
@@ -23,10 +23,6 @@ jobs:
     - name: Agree gradle-scan terms
       run: cat ci/gradle/gradle-scan.init.gradle >> settings.gradle
     - uses: gradle/actions/setup-gradle@v3
-      with:
-        build-scan-publish: true
-        build-scan-terms-of-service-url: https://gradle.com/terms-of-service
-        build-scan-terms-of-service-agree: yes
       name: Setup Gradle
       id: setup-gradle
     - name: Run gradle build

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,13 @@
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
-    id 'com.gradle.enterprise' version '3.16.2'
+    id 'com.gradle.develocity' version '3.17.2'
+}
+develocity {
+    buildScan {
+        publishing.onlyIf { "true".equals(System.getProperty("envIsCi")) }
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+    }
 }
 rootProject.name = 'OmegaT'
 include("machinetranslators:apertium",


### PR DESCRIPTION
- Allow scan publish on Ci environment

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

- Bump gradle plugin from enterprise to develocity@3.17.2
- Allow publish only when CI environment

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
