### PR TITLE
feat(test): migrate XMLUnit legacy to assertj3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ dependencies {
     testFixturesImplementation(libs.commons.io)
     testFixturesImplementation(libs.omegat.vldocking)
 
-    testImplementation(libs.xmlunit.legacy)
+    testImplementation(libs.bundles.xmlunit)
     // LanguageTool unit tests exercise these languages
     testImplementation(libs.bundles.languagetool.tests) {
         exclude group: 'org.slf4j'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,7 +108,8 @@ caffeine = {group = "com.github.ben-manes.caffeine", name ="caffeine", version.r
 caffeine-jcache =  {group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine"}
 wiremock-jre8 = {group = "com.github.tomakehurst", name = "wiremock-jre8", version.ref = "wiremock"}
 omegat-vldocking = {group = "org.omegat", name = "vldocking", version.ref = "vldocking"}
-xmlunit-legacy = {group = "org.xmlunit", name = "xmlunit-legacy", version.ref = "xmlunit"}
+xmlunit-core = {group = "org.xmlunit", name = "xmlunit-core", version.ref = "xmlunit"}
+xmlunit-assertj = {group = "org.xmlunit", name = "xmlunit-assertj3", version.ref = "xmlunit"}
 omegat-appbundler = {group = "org.omegat", name = "appbundler", version.ref = "appbundler"}
 madlonkay-supertmxmerge = {group = "org.madlonkay", name = "supertmxmerge", version.ref = "supertmxmerge"}
 jasypt = {group = "org.jasypt", name = "jasypt", version.ref = "jasypt"}
@@ -144,6 +145,7 @@ languagetool-tests = ["languagetool-server", "languagetool-be", "languagetool-fr
 lucene = ["lucene-core", "lucene-analyzers-common", "lucene-analyzers-kuromoji", "lucene-analyzers-smartcn", "lucene-analyzers-stempel"]
 jgit = ["jgit", "jgit-agent", "jgit-http", "jgit-ssh"]
 dictionary = ["trie4j", "dsl4j", "stardict4j", "jsoup"]
+xmlunit = ["xmlunit-core", "xmlunit-assertj"]
 
 [plugins]
 spotbugs = {id = "com.github.spotbugs", version = "6.0.14"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ caffeine = "3.1.8"
 wiremock = "3.0.1"
 vldocking = "3.0.5-2"
 xmlunit = "2.10.0"
+assertj = "3.18.1"
 appbundler = "1.2.1"
 supertmxmerge = "2.0.3"
 jasypt = "1.9.3"
@@ -110,6 +111,7 @@ wiremock-jre8 = {group = "com.github.tomakehurst", name = "wiremock-jre8", versi
 omegat-vldocking = {group = "org.omegat", name = "vldocking", version.ref = "vldocking"}
 xmlunit-core = {group = "org.xmlunit", name = "xmlunit-core", version.ref = "xmlunit"}
 xmlunit-assertj = {group = "org.xmlunit", name = "xmlunit-assertj3", version.ref = "xmlunit"}
+assertj = {group = "org.assertj", name = "assertj-core", version.ref= "assertj"}
 omegat-appbundler = {group = "org.omegat", name = "appbundler", version.ref = "appbundler"}
 madlonkay-supertmxmerge = {group = "org.madlonkay", name = "supertmxmerge", version.ref = "supertmxmerge"}
 jasypt = {group = "org.jasypt", name = "jasypt", version.ref = "jasypt"}
@@ -145,7 +147,7 @@ languagetool-tests = ["languagetool-server", "languagetool-be", "languagetool-fr
 lucene = ["lucene-core", "lucene-analyzers-common", "lucene-analyzers-kuromoji", "lucene-analyzers-smartcn", "lucene-analyzers-stempel"]
 jgit = ["jgit", "jgit-agent", "jgit-http", "jgit-ssh"]
 dictionary = ["trie4j", "dsl4j", "stardict4j", "jsoup"]
-xmlunit = ["xmlunit-core", "xmlunit-assertj"]
+xmlunit = ["xmlunit-core", "xmlunit-assertj", "assertj"]
 
 [plugins]
 spotbugs = {id = "com.github.spotbugs", version = "6.0.14"}

--- a/test/src/org/omegat/filters/DocBookFilterTest.java
+++ b/test/src/org/omegat/filters/DocBookFilterTest.java
@@ -25,9 +25,10 @@
 
 package org.omegat.filters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.nio.file.Files;
@@ -45,8 +46,7 @@ public class DocBookFilterTest extends TestFilterBase {
     @Test
     public void testParse() throws Exception {
         List<String> lines = parse(new DocBookFilter(), "test/data/filters/docBook/file-DocBookFilter.xml");
-        boolean c = lines.contains("My String");
-        assertTrue("'My String' not defined'", c);
+        assertThat(lines).as("'My String' should defined'").containsAnyOf("My String");
     }
 
     @Test
@@ -61,26 +61,18 @@ public class DocBookFilterTest extends TestFilterBase {
 
     @Test
     public void testLoadInvalidXml() throws Exception {
-        try {
-            List<String> lines = parse(new DocBookFilter(),
-                    "test/data/filters/docBook/file-DocBookFilter-invalid2.xml");
-        } catch (TranslationException e) {
-            // should contain invalid tag
-            assertTrue(e.getMessage().contains("para"));
-            // should contain invalid filename
-            assertTrue(e.getMessage().contains("file-DocBookFilter-invalid2.xml"));
-            // should contain invalid file's line number
-            assertTrue(e.getMessage().contains("85"));
-            return;
-        }
-        fail("Don't catch expected TranslationException when loading invalid docBook XML.");
+        Throwable t = assertThrows("Don't catch expected TranslationException when loading invalid docBook XML.",
+                TranslationException.class, () -> parse(new DocBookFilter(),
+                "test/data/filters/docBook/file-DocBookFilter-invalid2.xml"));
+        // should contain invalid tag, filename, and its line number
+        assertThat(t.getMessage()).contains("para", "file-DocBookFilter-invalid2.xml", "85");
     }
 
     @Test
     public void testParseIntroLinux() throws Exception {
         List<String> lines = parse(new DocBookFilter(), "test/data/filters/docBook/Intro-Linux/abook.xml");
-        assertTrue("Message not exist, i.e. entities not loaded",
-                lines.contains("Why should I use an editor?"));
+        assertThat(lines).as("Messages should exist when loading entities")
+                .contains("Why should I use an editor?");
     }
 
     @Test


### PR DESCRIPTION
## Pull request type

- Other (describe below)
refactoring

## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/B21D5C68-C324-4085-A212-AA406547A4D7%40traductaire-libre.org/#msg58769981

## What does this PR change?

- use org.xmlunit:xmlunit-assertj3:2.10.0
- rewrite ProjectFileStorageTest and TestFilterBase with xmlunit assertj style assertions

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
