### PR TITLE
chore: Bump wiremock@3.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,7 +326,7 @@ dependencies {
 
     testFixturesApi(libs.junit4)
     // for http connection test
-    testFixturesApi(libs.wiremock.jre8) {
+    testFixturesApi(libs.wiremock) {
         exclude module: 'guava'
     }
     testFixturesApi(libs.slf4j.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ jackson = "2.16.1"
 bc = "1.77"
 nashorn = "15.4"
 caffeine = "3.1.8"
-wiremock = "3.0.1"
+wiremock = "3.4.2"
 vldocking = "3.0.5-2"
 xmlunit = "2.10.0"
 appbundler = "1.2.1"
@@ -106,7 +106,7 @@ fifesoft-languagesupport = {group = "com.fifesoft", name = "languagesupport", ve
 fifesoft-autocomplete = {group = "com.fifesoft", name = "autocomplete", version = "3.3.1"}
 caffeine = {group = "com.github.ben-manes.caffeine", name ="caffeine", version.ref = "caffeine"}
 caffeine-jcache =  {group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine"}
-wiremock-jre8 = {group = "com.github.tomakehurst", name = "wiremock-jre8", version.ref = "wiremock"}
+wiremock = {group = "org.wiremock", name = "wiremock", version.ref = "wiremock"}
 omegat-vldocking = {group = "org.omegat", name = "vldocking", version.ref = "vldocking"}
 xmlunit-legacy = {group = "org.xmlunit", name = "xmlunit-legacy", version.ref = "xmlunit"}
 omegat-appbundler = {group = "org.omegat", name = "appbundler", version.ref = "appbundler"}


### PR DESCRIPTION
OmegaT use WireMock for connection test mocking.
WireMock project moves groupID to "org.wiremock" and improve versions.
This PR to bump wiremock to version 3.4.2 from 3.0.1

## Pull request type

- Other (describe below)
refactoring

## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/ee7e06c3-68ef-463c-ad51-15cc1bcafb80%40northside.tokyo/#msg58769984

## What does this PR change?

- Change groupId to org.wiremock

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
