### PR TITLE
[6.0]Temporarily inactivate XLSX for StaX filter (known bug ticket #1260)

### DIFF
--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -239,7 +239,7 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
-        return new Instance[] { new Instance("*.doc?"), new Instance("*.dotx"), new Instance("*.xls?"),
+        return new Instance[] { new Instance("*.doc?"), new Instance("*.dotx"), //new Instance("*.xls?"),
                 new Instance("*.ppt?"), new Instance("*.vsdx") };
     }
 

--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -239,6 +239,7 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     @Override
     public Instance[] getDefaultInstances() {
+        // disable a link for MS Excel files: https://sourceforge.net/p/omegat/bugs/1260
         return new Instance[] { new Instance("*.doc?"), new Instance("*.dotx"), //new Instance("*.xls?"),
                 new Instance("*.ppt?"), new Instance("*.vsdx") };
     }


### PR DESCRIPTION
Temporarily inactivate Stax filter for Excel until I can debug it
(it is still here but user would have to manually add it in the filters list to use it)

