### PR TITLE
[6.0] feat: display(Error|Warning)RB show multi-line message

### DIFF
--- a/src/org/omegat/gui/main/MainWindow.java
+++ b/src/org/omegat/gui/main/MainWindow.java
@@ -45,6 +45,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -420,7 +421,7 @@ public class MainWindow extends JFrame implements IMainWindow {
     // /////////////////////////////////////////////////////////////
     // display oriented code
 
-    private JLabel lastDialogText;
+    private JPanel lastDialogText;
     private String lastDialogKey;
 
     /**
@@ -450,7 +451,12 @@ public class MainWindow extends JFrame implements IMainWindow {
                 }
             }
 
-            lastDialogText = new JLabel(msg);
+            lastDialogText = new JPanel();
+            lastDialogText.setLayout(new BoxLayout(lastDialogText, BoxLayout.PAGE_AXIS));
+            String[] messages = msg.split("\\n");
+            Arrays.stream(messages).forEach(m -> {
+                lastDialogText.add(new JLabel(m));
+            });
             lastDialogKey = warningKey;
 
             statusLabel.setText(msg);
@@ -478,9 +484,12 @@ public class MainWindow extends JFrame implements IMainWindow {
             pane.setLayout(new BoxLayout(pane, BoxLayout.PAGE_AXIS));
             pane.setSize(new Dimension(900, 400));
 
-            JLabel jlabel = new JLabel(msg);
-            jlabel.setAlignmentX(LEFT_ALIGNMENT);
-            pane.add(jlabel);
+            String[] messages = msg.split("\\n");
+            Arrays.stream(messages).forEach(m -> {
+                JLabel jlabel = new JLabel(m);
+                jlabel.setAlignmentX(LEFT_ALIGNMENT);
+                pane.add(jlabel);
+            });
 
             if (ex != null && ex.getLocalizedMessage() != null){
                 pane.add(Box.createRigidArea(new Dimension(0, 5)));


### PR DESCRIPTION
Extend MainWindow#displayErrorRB and MainWindow#displayWarningRB to show multiple lines of message according to "\n" in a message.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
(cherry picked from commit 17e803336a6c07d994e5184382f8bd1e6f238221)


## Pull request type

- Feature enhancement -> [enhancement]


## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/a33409e9-3b54-4f5c-82af-2dd8ed1cab19%40northside.tokyo/#msg58770293

## What does this PR change?

- back port an improvement in master branch
- display error message that have "\n" in String to be multi line dialog
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
