### PR TITLE
feat: support Unix-like OSes

### DIFF
--- a/docs_devel/docs/27.UtilityClasses.md
+++ b/docs_devel/docs/27.UtilityClasses.md
@@ -89,6 +89,8 @@ the platform type.
 - `Platform.isMacOS`
 - `Platform.isWindows`
 - `Platform.isLinux`
+- `Platform.isUnix`
+- `Platform.isBSD`
 
 There are also some informational constants.
 

--- a/docs_devel/docs/27.UtilityClasses.md
+++ b/docs_devel/docs/27.UtilityClasses.md
@@ -89,7 +89,7 @@ the platform type.
 - `Platform.isMacOS`
 - `Platform.isWindows`
 - `Platform.isLinux`
-- `Platform.isUnix`
+- `Platform.isUnixLike`
 - `Platform.isBSD`
 
 There are also some informational constants.

--- a/src/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/org/omegat/gui/preferences/view/AppearanceController.java
@@ -159,7 +159,7 @@ public class AppearanceController extends BasePreferencesController {
                 OStrings.getString("MW_OPTIONMENU_APPEARANCE_DARK_THEME_LABEL"));
         Mnemonics.setLocalizedText(panel.syncWithOSColorRB,
                 OStrings.getString("MW_OPTIONMENU_APPEARANCE_SYNC_WITH_OS_COLOR"));
-        if (Platform.isUnix()) {
+        if (Platform.isUnixLike()) {
             // we don't support Sync OS color mode in linux
             panel.syncWithOSColorRB.setEnabled(false);
         }
@@ -177,7 +177,7 @@ public class AppearanceController extends BasePreferencesController {
         panel.cbDarkThemeSelect.setSelectedItem(preferredDarkThemeClass);
         if (themeMode.equals("dark")) {
             panel.useDarkThemeRB.setSelected(true);
-        } else if (themeMode.equals("sync") && !Platform.isUnix()) {
+        } else if (themeMode.equals("sync") && !Platform.isUnixLike()) {
             panel.syncWithOSColorRB.setSelected(true);
         } else {
             panel.useLightDefaultThemeRB.setSelected(true);

--- a/src/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/org/omegat/gui/preferences/view/AppearanceController.java
@@ -159,7 +159,7 @@ public class AppearanceController extends BasePreferencesController {
                 OStrings.getString("MW_OPTIONMENU_APPEARANCE_DARK_THEME_LABEL"));
         Mnemonics.setLocalizedText(panel.syncWithOSColorRB,
                 OStrings.getString("MW_OPTIONMENU_APPEARANCE_SYNC_WITH_OS_COLOR"));
-        if (Platform.isLinux()) {
+        if (Platform.isUnix()) {
             // we don't support Sync OS color mode in linux
             panel.syncWithOSColorRB.setEnabled(false);
         }
@@ -177,7 +177,7 @@ public class AppearanceController extends BasePreferencesController {
         panel.cbDarkThemeSelect.setSelectedItem(preferredDarkThemeClass);
         if (themeMode.equals("dark")) {
             panel.useDarkThemeRB.setSelected(true);
-        } else if (themeMode.equals("sync") && !Platform.isLinux()) {
+        } else if (themeMode.equals("sync") && !Platform.isUnix()) {
             panel.syncWithOSColorRB.setSelected(true);
         } else {
             panel.useLightDefaultThemeRB.setSelected(true);

--- a/src/org/omegat/util/Platform.java
+++ b/src/org/omegat/util/Platform.java
@@ -53,6 +53,9 @@ public final class Platform {
         WIN64,
         // os.arch=x86, os.name=Windows 7, os.version=6.1
         WIN32,
+        // BSD variants
+        BSD64,
+        BSD32,
         // unknown system
         OTHER
     }
@@ -61,6 +64,8 @@ public final class Platform {
     public static final boolean isWindows;
     public static final boolean isMacOS;
     public static final boolean isLinux;
+    public static final boolean isBSD;
+    public static final boolean isUnix;
     // OS versions
     public static final long osVersion;
     public static final boolean isWindows_10_orLater;
@@ -87,6 +92,8 @@ public final class Platform {
         isWindows = osName.startsWith("windows");
         isMacOS = osName.startsWith("mac");
         isLinux = osName.startsWith("linux");
+        isBSD = osName.startsWith("bsd");
+        isUnix = isLinux || isBSD;
 
         // OS versions
         osVersion = scanVersion(System.getProperty("os.version"));
@@ -107,7 +114,7 @@ public final class Platform {
         isJava_17_orLater = (javaVersion >= toVersion(17, 0, 0, 0));
 
         // UI toolkits
-        isKDE = (isLinux && System.getenv("KDE_FULL_SESSION") != null);
+        isKDE = (isUnix && System.getenv("KDE_FULL_SESSION") != null);
 
         // Windows 11 detection is implemented in Java 8u321, 11.0.14, 17.0.2
         // and 18 (or later).
@@ -120,6 +127,8 @@ public final class Platform {
             osType = is64Bit() ? OsType.MAC64 : OsType.MAC32;
         } else if (isWindows) {
             osType = is64Bit() ? OsType.WIN64 : OsType.WIN32;
+        } else if (isBSD) {
+            osType = is64Bit() ? OsType.BSD64 : OsType.BSD32;
         }
     }
 
@@ -142,6 +151,20 @@ public final class Platform {
      */
     public static boolean isLinux() {
         return isLinux;
+    }
+
+    /**
+     * Returns true if running on BSD variants
+     */
+    public static boolean isBSD() {
+        return isBSD;
+    }
+
+    /**
+     * Returns true if running on Unix variants
+     */
+    public static boolean isUnix() {
+        return isUnix;
     }
 
     /**

--- a/src/org/omegat/util/Platform.java
+++ b/src/org/omegat/util/Platform.java
@@ -65,7 +65,7 @@ public final class Platform {
     public static final boolean isMacOS;
     public static final boolean isLinux;
     public static final boolean isBSD;
-    public static final boolean isUnix;
+    public static final boolean isUnixLike;
     // OS versions
     public static final long osVersion;
     public static final boolean isWindows_10_orLater;
@@ -93,7 +93,7 @@ public final class Platform {
         isMacOS = osName.startsWith("mac");
         isLinux = osName.startsWith("linux");
         isBSD = osName.endsWith("bsd");
-        isUnix = isLinux || isBSD;
+        isUnixLike = isLinux || isBSD;
 
         // OS versions
         osVersion = scanVersion(System.getProperty("os.version"));
@@ -114,7 +114,7 @@ public final class Platform {
         isJava_17_orLater = (javaVersion >= toVersion(17, 0, 0, 0));
 
         // UI toolkits
-        isKDE = (isUnix && System.getenv("KDE_FULL_SESSION") != null);
+        isKDE = (isUnixLike && System.getenv("KDE_FULL_SESSION") != null);
 
         // Windows 11 detection is implemented in Java 8u321, 11.0.14, 17.0.2
         // and 18 (or later).
@@ -163,8 +163,8 @@ public final class Platform {
     /**
      * Returns true if running on Unix variants
      */
-    public static boolean isUnix() {
-        return isUnix;
+    public static boolean isUnixLike() {
+        return isUnixLike;
     }
 
     /**

--- a/src/org/omegat/util/Platform.java
+++ b/src/org/omegat/util/Platform.java
@@ -92,7 +92,7 @@ public final class Platform {
         isWindows = osName.startsWith("windows");
         isMacOS = osName.startsWith("mac");
         isLinux = osName.startsWith("linux");
-        isBSD = osName.startsWith("bsd");
+        isBSD = osName.endsWith("bsd");
         isUnix = isLinux || isBSD;
 
         // OS versions

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -312,7 +312,7 @@ public final class StaticUtils {
             }
             // Check for UNIX varieties
             // Solaris is generally detected as SunOS
-        } else if (Platform.isUnix()) {
+        } else if (Platform.isUnixLike()) {
             // set the config dir to the user's home dir + "/.omegat/", so it's
             // hidden
             configDir = home + UNIX_CONFIG_DIR;

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -312,7 +312,7 @@ public final class StaticUtils {
             }
             // Check for UNIX varieties
             // Solaris is generally detected as SunOS
-        } else if (Platform.isLinux()) {
+        } else if (Platform.isUnix()) {
             // set the config dir to the user's home dir + "/.omegat/", so it's
             // hidden
             configDir = home + UNIX_CONFIG_DIR;

--- a/src/org/omegat/util/gui/DesktopWrapper.java
+++ b/src/org/omegat/util/gui/DesktopWrapper.java
@@ -42,7 +42,7 @@ public final class DesktopWrapper {
 
     static {
         boolean hasXDGOpen = false;
-        if (Platform.isLinux()) {
+        if (Platform.isUnix()) {
             try {
                 hasXDGOpen = xdgOpen("--help", true);
             } catch (IOException ex) {

--- a/src/org/omegat/util/gui/DesktopWrapper.java
+++ b/src/org/omegat/util/gui/DesktopWrapper.java
@@ -42,7 +42,7 @@ public final class DesktopWrapper {
 
     static {
         boolean hasXDGOpen = false;
-        if (Platform.isUnix()) {
+        if (Platform.isUnixLike()) {
             try {
                 hasXDGOpen = xdgOpen("--help", true);
             } catch (IOException ex) {

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -419,7 +419,7 @@ public final class UIDesignManager {
         // TextPane.background is always white but should be a
         // text_background of GTK.
         // List.background is as same color as text_background.
-        if (Platform.isLinux() && Color.WHITE.equals(uiDefaults.getColor("TextPane.background"))) {
+        if (Platform.isUnix() && Color.WHITE.equals(uiDefaults.getColor("TextPane.background"))) {
             uiDefaults.put("TextPane.background", uiDefaults.getColor("List.background"));
         }
         uiDefaults.put("OmegaT.alternatingHilite", hilite);

--- a/src/org/omegat/util/gui/UIDesignManager.java
+++ b/src/org/omegat/util/gui/UIDesignManager.java
@@ -419,7 +419,7 @@ public final class UIDesignManager {
         // TextPane.background is always white but should be a
         // text_background of GTK.
         // List.background is as same color as text_background.
-        if (Platform.isUnix() && Color.WHITE.equals(uiDefaults.getColor("TextPane.background"))) {
+        if (Platform.isUnixLike() && Color.WHITE.equals(uiDefaults.getColor("TextPane.background"))) {
             uiDefaults.put("TextPane.background", uiDefaults.getColor("List.background"));
         }
         uiDefaults.put("OmegaT.alternatingHilite", hilite);

--- a/src/org/omegat/util/gui/UIScale.java
+++ b/src/org/omegat/util/gui/UIScale.java
@@ -197,7 +197,7 @@ public final class UIScale {
                 }
             }
         }
-        if (Platform.isLinux && !isSystemScaling()) {
+        if ((Platform.isUnix()) && !isSystemScaling()) {
             // see class com.sun.java.swing.plaf.gtk.PangoFonts background
             // information
             Object value = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/DPI");
@@ -228,7 +228,7 @@ public final class UIScale {
         } else if (Platform.isMacOS) {
             // the default font size on macOS is 13
             fontSizeDivider = 13f;
-        } else if (Platform.isLinux) {
+        } else if (Platform.isUnix()) {
             // the default font size for Unity and Gnome is 15 and for KDE it is
             // 13
             fontSizeDivider = Platform.isKDE ? 13f : 15f;

--- a/src/org/omegat/util/gui/UIScale.java
+++ b/src/org/omegat/util/gui/UIScale.java
@@ -197,7 +197,7 @@ public final class UIScale {
                 }
             }
         }
-        if ((Platform.isUnix()) && !isSystemScaling()) {
+        if ((Platform.isUnixLike()) && !isSystemScaling()) {
             // see class com.sun.java.swing.plaf.gtk.PangoFonts background
             // information
             Object value = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/DPI");
@@ -228,7 +228,7 @@ public final class UIScale {
         } else if (Platform.isMacOS) {
             // the default font size on macOS is 13
             fontSizeDivider = 13f;
-        } else if (Platform.isUnix()) {
+        } else if (Platform.isUnixLike()) {
             // the default font size for Unity and Gnome is 15 and for KDE it is
             // 13
             fontSizeDivider = Platform.isKDE ? 13f : 15f;

--- a/src/org/omegat/util/gui/laf/SystemDarkThemeDetector.java
+++ b/src/org/omegat/util/gui/laf/SystemDarkThemeDetector.java
@@ -37,7 +37,7 @@ public abstract class SystemDarkThemeDetector {
     public static SystemDarkThemeDetector createDetector() {
         if (Platform.isMacOSX()) {
             return new MacOSDarkThemeDetector();
-        } else if (Platform.isUnix()) {
+        } else if (Platform.isUnixLike()) {
             return new EmptyDarkThemeDetector();
         } else {
             return new WindowsDarkThemeDetector();

--- a/src/org/omegat/util/gui/laf/SystemDarkThemeDetector.java
+++ b/src/org/omegat/util/gui/laf/SystemDarkThemeDetector.java
@@ -37,7 +37,7 @@ public abstract class SystemDarkThemeDetector {
     public static SystemDarkThemeDetector createDetector() {
         if (Platform.isMacOSX()) {
             return new MacOSDarkThemeDetector();
-        } else if (Platform.isLinux()) {
+        } else if (Platform.isUnix()) {
             return new EmptyDarkThemeDetector();
         } else {
             return new WindowsDarkThemeDetector();


### PR DESCRIPTION
As discussed in [1746](https://sourceforge.net/p/omegat/feature-requests/1746/), here is the patch.

In general, `Platform.isUnix()` is preferred, which will not break Linux support.

`isX11()` was suggested. I did search in the code and the web. `(Unix|UNIX)` is used in several places in the code and the documentation. It looks to me that `UNIX(R)` is used when referring to the registered trademark, and `Unix` when referring to Unix-like and Unix variants. Thus, `isUnix()` is used in the patch.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Feature enhancement -> [enhancement]
<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

## Which ticket is resolved?

- Title #1746 Support U*ix variants
  * URL https://sourceforge.net/p/omegat/feature-requests/1746

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- Support *BSD variants.

## Other information

The build was successful, and I am using it. `xdg-open` is working.