### PR TITLE
refactor: SearchWindowController manager at MainWindowUI

### DIFF
--- a/src/org/omegat/gui/main/MainWindow.java
+++ b/src/org/omegat/gui/main/MainWindow.java
@@ -48,10 +48,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -78,7 +75,6 @@ import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.matching.NearString;
 import org.omegat.gui.matches.IMatcher;
-import org.omegat.gui.search.SearchWindowController;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.StaticUtils;
@@ -122,9 +118,6 @@ public class MainWindow implements IMainWindow {
      */
     private FontUIResource font;
 
-    /** Set of all open search windows. */
-    private final List<SearchWindowController> searches = new ArrayList<>();
-
     protected MainWindowStatusBar mainWindowStatusBar;
 
     protected DockingDesktop desktop;
@@ -144,7 +137,7 @@ public class MainWindow implements IMainWindow {
         CoreEvents.registerProjectChangeListener(eventType -> {
             updateTitle();
             if (eventType == IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE) {
-                closeSearchWindows();
+                MainWindowUI.closeSearchWindows();
             }
         });
 
@@ -297,7 +290,7 @@ public class MainWindow implements IMainWindow {
     }
 
     /** insert current fuzzy match or selection at cursor position */
-    public void doInsertTrans() {
+    public static void doInsertTrans() {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
@@ -329,7 +322,7 @@ public class MainWindow implements IMainWindow {
     }
 
     /** replace entire edit area with active fuzzy match or selection */
-    public void doRecycleTrans() {
+    public static void doRecycleTrans() {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
@@ -357,41 +350,9 @@ public class MainWindow implements IMainWindow {
         }
     }
 
-    private String getSelectedTextInMatcher() {
+    private static String getSelectedTextInMatcher() {
         IMatcher matcher = Core.getMatcher();
         return matcher instanceof JTextComponent ? ((JTextComponent) matcher).getSelectedText() : null;
-    }
-
-    protected void addSearchWindow(final SearchWindowController newSearchWindow) {
-        newSearchWindow.addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosed(WindowEvent e) {
-                removeSearchWindow(newSearchWindow);
-            }
-        });
-        synchronized (searches) {
-            searches.add(newSearchWindow);
-        }
-    }
-
-    private void removeSearchWindow(SearchWindowController searchWindow) {
-        synchronized (searches) {
-            searches.remove(searchWindow);
-        }
-    }
-
-    private void closeSearchWindows() {
-        synchronized (searches) {
-            // dispose other windows
-            for (SearchWindowController sw : searches) {
-                sw.dispose();
-            }
-            searches.clear();
-        }
-    }
-
-    protected List<SearchWindowController> getSearchWindows() {
-        return Collections.unmodifiableList(searches);
     }
 
     /**

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -76,7 +76,6 @@ import org.omegat.gui.filters2.FiltersCustomizerController;
 import org.omegat.gui.issues.IssueProvidersSelectorController;
 import org.omegat.gui.preferences.PreferencesWindowController;
 import org.omegat.gui.preferences.view.EditingBehaviorController;
-import org.omegat.gui.search.SearchWindowController;
 import org.omegat.gui.segmentation.SegmentationCustomizerController;
 import org.omegat.gui.stat.StatisticsWindow;
 import org.omegat.help.Help;
@@ -480,11 +479,11 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     public void editOverwriteTranslationMenuItemActionPerformed() {
-        mainWindow.doRecycleTrans();
+        MainWindow.doRecycleTrans();
     }
 
     public void editInsertTranslationMenuItemActionPerformed() {
-        mainWindow.doInsertTrans();
+        MainWindow.doInsertTrans();
     }
 
     public void editOverwriteMachineTranslationMenuItemActionPerformed() {
@@ -570,24 +569,16 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
-        SearchWindowController search = new SearchWindowController(SearchMode.SEARCH);
-        mainWindow.addSearchWindow(search);
-
-        search.makeVisible(getTrimmedSelectedTextInMainWindow());
+        MainWindowUI.createSearchWindow(SearchMode.SEARCH, getTrimmedSelectedTextInMainWindow());
     }
 
     void findInProjectReuseLastWindow() {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
-
-        List<SearchWindowController> windows = mainWindow.getSearchWindows();
-        for (int i = windows.size() - 1; i >= 0; i--) {
-            SearchWindowController swc = windows.get(i);
-            if (swc.getMode() == SearchMode.SEARCH) {
-                swc.makeVisible(getTrimmedSelectedTextInMainWindow());
-                return;
-            }
+        String text = getTrimmedSelectedTextInMainWindow();
+        if (!MainWindowUI.reuseSearchWindow(text)) {
+            MainWindowUI.createSearchWindow(SearchMode.SEARCH, text);
         }
         editFindInProjectMenuItemActionPerformed();
     }
@@ -596,10 +587,7 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
-        SearchWindowController search = new SearchWindowController(SearchMode.REPLACE);
-        mainWindow.addSearchWindow(search);
-
-        search.makeVisible(getTrimmedSelectedTextInMainWindow());
+        MainWindowUI.createSearchWindow(SearchMode.REPLACE, getTrimmedSelectedTextInMainWindow());
     }
 
     private String getTrimmedSelectedTextInMainWindow() {

--- a/src/org/omegat/gui/main/MainWindowUI.java
+++ b/src/org/omegat/gui/main/MainWindowUI.java
@@ -33,16 +33,22 @@ package org.omegat.gui.main;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.core.events.IProjectEventListener;
+import org.omegat.core.search.SearchMode;
+import org.omegat.gui.search.SearchWindowController;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
@@ -68,6 +74,11 @@ import com.vlsolutions.swing.docking.event.DockableStateWillChangeListener;
  * @author Aaron Madlon-Kay
  */
 public final class MainWindowUI {
+
+    /**
+     * Set of all open search windows.
+     */
+    private static final List<SearchWindowController> searches = new ArrayList<>();
 
     private MainWindowUI() {
     }
@@ -99,6 +110,51 @@ public final class MainWindowUI {
         PerProjectLayoutHandler handler = new PerProjectLayoutHandler(mainWindow);
         CoreEvents.registerProjectChangeListener(handler);
         CoreEvents.registerApplicationEventListener(handler);
+    }
+
+    static void createSearchWindow(SearchMode mode, String query) {
+        SearchWindowController search = new SearchWindowController(mode);
+        addSearchWindow(search);
+        search.makeVisible(query);
+    }
+
+    static void closeSearchWindows() {
+        synchronized (searches) {
+            // dispose other windows
+            for (SearchWindowController sw : searches) {
+                sw.dispose();
+            }
+            searches.clear();
+        }
+    }
+
+    static boolean reuseSearchWindow(String text) {
+        for (int i = searches.size() - 1; i >= 0; i--) {
+            SearchWindowController swc = searches.get(i);
+            if (swc.getMode() == SearchMode.SEARCH) {
+                swc.makeVisible(text);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addSearchWindow(final SearchWindowController newSearchWindow) {
+        newSearchWindow.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                removeSearchWindow(newSearchWindow);
+            }
+        });
+        synchronized (searches) {
+            searches.add(newSearchWindow);
+        }
+    }
+
+    private static void removeSearchWindow(SearchWindowController searchWindow) {
+        synchronized (searches) {
+            searches.remove(searchWindow);
+        }
     }
 
     private static class PerProjectLayoutHandler implements IProjectEventListener, IApplicationEventListener {


### PR DESCRIPTION
MainWindowMenuHandler requires real MainWindow object instead of access through IMainWindow interface currently. This is becuase SearchWindow management is implemented in MainWindow class. We move SearchWindow management into MainWindowUI class as static function. The change removes access from MainWindowMenuHandler to MainWindow instance method.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/cd246ce0-44c2-4c8a-a7ec-e92f390fa488%40northside.tokyo/#msg58749145

## What does this PR change?

- define Search Window manager functions in MainWindowUI class
    -  static void createSearchWindow(SearchMode mode, String query)     
    -  static void closeSearchWindows() 
    -  static boolean reuseSearchWindow(String text) 
- Remove methods with same names in MainWidow class
- make static for doRecycleTrans() and doInsertTrans() to decrease dependency for mainWindow object from the handler.
- Update MainWindowMenuHandler to use MainWindowUI functions instead of MainWindow instance methods.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
