### PR TITLE
refactor: EditorController to access menu through IMainMenu API

### DIFF
--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -106,7 +106,7 @@ import org.omegat.gui.editor.mark.ComesFromMTMarker;
 import org.omegat.gui.editor.mark.EntryMarks;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.gui.main.DockablePanel;
-import org.omegat.gui.main.MainWindow;
+import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.main.MainWindowStatusBar;
 import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.notes.INotes;
@@ -181,7 +181,7 @@ public class EditorController implements IEditor {
     private String emptyProjectPaneTitle;
     private JTextPane introPane;
     private JTextPane emptyProjectPane;
-    protected final MainWindow mw;
+    protected final IMainWindow mw;
 
     /** Currently displayed segments info. */
     protected SegmentBuilder[] m_docSegList;
@@ -227,7 +227,7 @@ public class EditorController implements IEditor {
      */
     private IProject.AllTranslations previousTranslations;
 
-    public EditorController(final MainWindow mainWindow) {
+    public EditorController(final IMainWindow mainWindow) {
         this.mw = mainWindow;
 
         segmentExportImport = new SegmentExportImport(this);
@@ -857,10 +857,12 @@ public class EditorController implements IEditor {
 
     private void setMenuEnabled() {
         // update history menu items
-        mw.menu.gotoHistoryBackMenuItem.setEnabled(history.hasPrev());
-        mw.menu.gotoHistoryForwardMenuItem.setEnabled(history.hasNext());
-        mw.menu.editMultipleDefault.setEnabled(!m_docSegList[displayedEntryIndex].isDefaultTranslation());
-        mw.menu.editMultipleAlternate.setEnabled(m_docSegList[displayedEntryIndex].isDefaultTranslation());
+        mw.getMainMenu().enableMenuItem("goto_history_back_menuitem", history.hasPrev());
+        mw.getMainMenu().enableMenuItem("goto_history_forward_menuitem", history.hasNext());
+        mw.getMainMenu().enableMenuItem("edit_multiple_default",
+                !m_docSegList[displayedEntryIndex].isDefaultTranslation());
+        mw.getMainMenu().enableMenuItem("edit_multiple_alternate",
+                m_docSegList[displayedEntryIndex].isDefaultTranslation());
     }
 
     /**

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -105,6 +105,7 @@ import org.omegat.gui.editor.mark.CalcMarkersThread;
 import org.omegat.gui.editor.mark.ComesFromMTMarker;
 import org.omegat.gui.editor.mark.EntryMarks;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.gui.main.BaseMainWindowMenu;
 import org.omegat.gui.main.DockablePanel;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.main.MainWindowStatusBar;
@@ -857,11 +858,11 @@ public class EditorController implements IEditor {
 
     private void setMenuEnabled() {
         // update history menu items
-        mw.getMainMenu().enableMenuItem("goto_history_back_menuitem", history.hasPrev());
-        mw.getMainMenu().enableMenuItem("goto_history_forward_menuitem", history.hasNext());
-        mw.getMainMenu().enableMenuItem("edit_multiple_default",
+        mw.getMainMenu().enableMenuItem(BaseMainWindowMenu.GOTO_HISTORY_BACK_MENUITEM, history.hasPrev());
+        mw.getMainMenu().enableMenuItem(BaseMainWindowMenu.GOTO_HISTORY_FORWARD_MENUITEM, history.hasNext());
+        mw.getMainMenu().enableMenuItem(BaseMainWindowMenu.EDIT_MULTIPLE_DEFAULT,
                 !m_docSegList[displayedEntryIndex].isDefaultTranslation());
-        mw.getMainMenu().enableMenuItem("edit_multiple_alternate",
+        mw.getMainMenu().enableMenuItem(BaseMainWindowMenu.EDIT_MULTIPLE_ALTERNATE,
                 m_docSegList[displayedEntryIndex].isDefaultTranslation());
     }
 

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -37,6 +37,7 @@
 
 package org.omegat.gui.main;
 
+import java.awt.Component;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -958,36 +959,94 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         projectClearRecentMenuItem.setEnabled(!items.isEmpty());
     }
 
+    // Implement IMainMenu APIs
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getMachineTranslationMenu() {
         return optionsMachineTranslateMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getOptionsMenu() {
         return optionsMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getToolsMenu() {
         return toolsMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getGlossaryMenu() {
         return optionsGlossaryMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getProjectMenu() {
         return projectMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getAutoCompletionMenu() {
         return optionsAutoCompleteMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getHelpMenu() {
         return helpMenu;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JMenu getMenu(MenuExtender.MenuKey marker) {
         return menus.get(marker);
+    }
+
+    protected JMenuItem getMenuItemWithName(String name) {
+        for (var menuEntry : menus.entrySet()) {
+            JMenu menu = menuEntry.getValue();
+            for (int i = 0; i < menu.getMenuComponentCount(); i++) {
+                Component c = menu.getMenuComponent(i);
+                if (name.equals(c.getName()) && c instanceof JMenuItem) {
+                    return (JMenuItem) c;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enableMenuItem(String name, boolean enabled) {
+        JMenuItem item = getMenuItemWithName(name);
+        if (item != null) {
+            item.setEnabled(enabled);
+        }
     }
 
     JMenuItem cycleSwitchCaseMenuItem;

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -113,6 +113,10 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
     public static final String HELP_MENU = "help_menu";
     public static final String HELP_ABOUT_MENUITEM = "help_about_menuitem";
+    public static final String GOTO_HISTORY_BACK_MENUITEM = "goto_history_back_menuitem";
+    public static final String GOTO_HISTORY_FORWARD_MENUITEM = "goto_history_forward_menuitem";
+    public static final String EDIT_MULTIPLE_DEFAULT = "edit_multiple_default";
+    public static final String EDIT_MULTIPLE_ALTERNATE = "edit_multiple_alternate";
 
     /** MainWindow instance. */
     protected final IMainWindow mainWindow;
@@ -298,6 +302,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         editRegisterUntranslatedMenuItem = createMenuItem("TF_MENU_EDIT_UNTRANSLATED_TRANSLATION");
         editRegisterEmptyMenuItem = createMenuItem("TF_MENU_EDIT_EMPTY_TRANSLATION");
         editRegisterIdenticalMenuItem = createMenuItem("TF_MENU_EDIT_IDENTICAL_TRANSLATION");
+        editMultipleDefault.setName(EDIT_MULTIPLE_DEFAULT);
+        editMultipleAlternate.setName(EDIT_MULTIPLE_ALTERNATE);
 
         lowerCaseMenuItem = createMenuItem("TF_EDIT_MENU_SWITCH_CASE_TO_LOWER");
         upperCaseMenuItem = createMenuItem("TF_EDIT_MENU_SWITCH_CASE_TO_UPPER");
@@ -325,6 +331,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         gotoHistoryForwardMenuItem = createMenuItem("TF_MENU_GOTO_FORWARD_IN_HISTORY");
         gotoNotesPanelMenuItem = createMenuItem("TF_MENU_GOTO_NOTES_PANEL");
         gotoEditorPanelMenuItem = createMenuItem("TF_MENU_GOTO_EDITOR_PANEL");
+        gotoHistoryBackMenuItem.setName(GOTO_HISTORY_BACK_MENUITEM);
+        gotoHistoryForwardMenuItem.setName(GOTO_HISTORY_FORWARD_MENUITEM);
 
         viewMarkTranslatedSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
                 "TF_MENU_DISPLAY_MARK_TRANSLATED");

--- a/src/org/omegat/gui/main/IMainMenu.java
+++ b/src/org/omegat/gui/main/IMainMenu.java
@@ -6,6 +6,7 @@
  Copyright (C) 2008 Alex Buloichik
                2011 Didier Briel
                2016 Aaron Madlon-Kay
+ 2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -37,23 +38,70 @@ import org.omegat.util.gui.MenuExtender;
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Didier Briel
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  */
 public interface IMainMenu {
+    /**
+     * Get Machine Translation menu object.
+     *
+     * @return machine translation menu.
+     */
     JMenu getMachineTranslationMenu();
 
+    /**
+     * Get Options menu object.
+     *
+     * @return options menu.
+     */
     JMenu getOptionsMenu();
 
+    /**
+     * Get tools menu object.
+     * @return tools menu.
+     */
     JMenu getToolsMenu();
 
+    /**
+     * Get Glossary menu object.
+     * @return glossary menu.
+     */
     JMenu getGlossaryMenu();
 
+    /**
+     * Get Project menu object.
+     * @return project menu.
+     */
     JMenu getProjectMenu();
 
+    /**
+     * Get AutoCompletion JMenu object.
+     * @return auto completion menu.
+     */
     JMenu getAutoCompletionMenu();
 
+    /**
+     * Get Help menu's JMenu object.
+     * @return help menu.
+     */
     JMenu getHelpMenu();
 
+    /**
+     * Get menu item specified in MenuKey marker.
+     *
+     * @param marker a menu item key.
+     * @return JMenu object.
+     */
     JMenu getMenu(MenuExtender.MenuKey marker);
+
+    /**
+     * Enable/Disable menu item.
+     * When it is JCheckBoxMenuItem and JRadioButtonMenuItem, a specified
+     * item will be selected.
+     *
+     * @param name    a component name of menu item.
+     * @param enabled true when make it enabled, otherwise make it disabled.
+     */
+    void enableMenuItem(String name, boolean enabled);
 
     void invokeAction(String action, int modifiers);
 }

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -665,6 +665,10 @@ public final class TestTeamIntegrationChild {
                 return null;
             }
 
+            @Override
+            public void enableMenuItem(final String name, final boolean enabled) {
+            }
+
             public void invokeAction(String action, int modifiers) {
             }
         };

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -196,6 +196,10 @@ public abstract class TestCore {
                 }
             }
 
+            @Override
+            public void enableMenuItem(final String name, final boolean enabled) {
+            }
+
             private JMenu getGotoMenu() {
                 if (gotoMenu.getItemCount() == 0) {
                     gotoMenu.add(new JMenuItem("gotoNextUntranslatedMenuItem"));


### PR DESCRIPTION
In order to implement acceptance GUI test, it is important to decouple UI components from real main window object.
EditorController enable/disable some menu items through `mainwindow.menu` access.
This change decouple it.

To make things working, I add `IMainMenu#enableMenuItem` API. 
This allow other components to enable/disable menu item like as `Core.getMainWindow().getMainMenu().enableMenuItem(name, true)` 

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

- Add IMainMenu#enableMenuItem API
- Implement enableMenuItem methods
- EditorContoller enable/disable menu item through the API
-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
