### PR TITLE
refactor: test initialization of GUI component

### DIFF
--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -235,6 +235,13 @@ public final class Core {
     @SuppressWarnings("unused")
     public static void initializeGUI(ClassLoader cl, Map<String, String> params) throws Exception {
         initializeGUI(params);
+
+        initializeGUIimpl(mainWindow);
+
+        SaveThread th = new SaveThread();
+        saveThread = th;
+        th.start();
+        new VersionCheckThread(10).start();
     }
 
     /**
@@ -252,7 +259,14 @@ public final class Core {
         // 3. Initialize application frame
         MainWindow me = new MainWindow();
         mainWindow = me;
+    }
 
+    /**
+     * initialize GUI body.
+     *
+     * @throws Exception
+     */
+    static void initializeGUIimpl(IMainWindow me) throws Exception {
         MarkerController.init();
         LanguageToolWrapper.init();
 
@@ -274,12 +288,6 @@ public final class Core {
         multiple = new MultipleTransPane(me);
         new SegmentPropertiesArea(me);
         projWin = new ProjectFilesListController();
-
-        SaveThread th = new SaveThread();
-        saveThread = th;
-        th.start();
-
-        new VersionCheckThread(10).start();
     }
 
     /**

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -232,16 +232,8 @@ public final class Core {
      * @throws Exception when error occurred.
      */
     @Deprecated(since = "6.1.0")
-    @SuppressWarnings("unused")
     public static void initializeGUI(ClassLoader cl, Map<String, String> params) throws Exception {
         initializeGUI(params);
-
-        initializeGUIimpl(mainWindow);
-
-        SaveThread th = new SaveThread();
-        saveThread = th;
-        th.start();
-        new VersionCheckThread(10).start();
     }
 
     /**
@@ -259,14 +251,21 @@ public final class Core {
         // 3. Initialize application frame
         MainWindow me = new MainWindow();
         mainWindow = me;
+
+        initializeGUIimpl(me);
+
+        SaveThread th = new SaveThread();
+        saveThread = th;
+        th.start();
+        new VersionCheckThread(10).start();
     }
 
     /**
      * initialize GUI body.
-     *
+     * TODO: this should accept IMainWindow.
      * @throws Exception
      */
-    static void initializeGUIimpl(IMainWindow me) throws Exception {
+    static void initializeGUIimpl(MainWindow me) throws Exception {
         MarkerController.init();
         LanguageToolWrapper.init();
 

--- a/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
@@ -94,6 +94,8 @@ class TestMainWindow implements IMainWindow {
             }
         });
         applicationFrame.getContentPane().add(desktop, BorderLayout.CENTER);
+        MainWindowStatusBar mainWindowStatusBar = new MainWindowStatusBar();
+        applicationFrame.getContentPane().add(mainWindowStatusBar, BorderLayout.SOUTH);
 
         StaticUIUtils.setWindowIcon(applicationFrame);
 

--- a/test/fixtures/org/omegat/core/TestCoreInitializer.java
+++ b/test/fixtures/org/omegat/core/TestCoreInitializer.java
@@ -28,6 +28,7 @@ package org.omegat.core;
 import org.omegat.core.threads.IAutoSave;
 import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.glossary.IGlossaries;
+import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.gui.main.IMainWindow;
 
 /**
@@ -48,8 +49,14 @@ public final class TestCoreInitializer {
         Core.saveThread = autoSave;
     }
 
-    public static void initMainWindow(IMainWindow mainWindow) {
+    public static void initMainWindow(IMainWindow mainWindow) throws Exception {
         Core.setMainWindow(mainWindow);
+
+        if (mainWindow instanceof ConsoleWindow) {
+            return;
+        }
+
+        Core.initializeGUIimpl(mainWindow);
     }
 
     public static void initGlossary(IGlossaries glossaries) {

--- a/test/fixtures/org/omegat/core/TestCoreInitializer.java
+++ b/test/fixtures/org/omegat/core/TestCoreInitializer.java
@@ -30,6 +30,7 @@ import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.glossary.IGlossaries;
 import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.gui.main.IMainWindow;
+import org.omegat.gui.main.MainWindow;
 
 /**
  * Core initializer for unit tests.
@@ -56,7 +57,10 @@ public final class TestCoreInitializer {
             return;
         }
 
-        Core.initializeGUIimpl(mainWindow);
+        // FIXME: IMainWindow on GUI environment should be initialized
+        if (mainWindow instanceof MainWindow) {
+            Core.initializeGUIimpl((MainWindow) mainWindow);
+        }
     }
 
     public static void initGlossary(IGlossaries glossaries) {


### PR DESCRIPTION
Current acceptance test is not working because of GUI initialization failure.
It is caused by incomplete initialization of GUI parts.

This PR change `Core.initializeGUI` to split two parts and define `initializeGUIimpl` function which can be called from Test code.  

## Pull request type

-  Other
refactor

## Which ticket is resolved?


## What does this PR change?

- Define `initializeGUIimpl`
- Separate a save thread initialization
- TestCoreInitializer calls `initializeGUIimpl` when environment is not headless, not a ConsoleWindow.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
