### PR TITLE
[Bug#sf1258] http git repo erroneously set to svn

### DIFF
--- a/src/org/omegat/core/team2/RemoteRepositoryFactory.java
+++ b/src/org/omegat/core/team2/RemoteRepositoryFactory.java
@@ -75,6 +75,10 @@ public final class RemoteRepositoryFactory {
             return "svn";
         } else if (url.startsWith("git")) {
             return "git";
+        } else if (url.startsWith("https://git")) {
+            return "git";
+        } else if (url.endsWith(".git")) {
+            return "git";
         } else {
             if (GITRemoteRepository2.isGitRepository(url)) {
                 return "git";

--- a/test/src/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
+++ b/test/src/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
@@ -31,28 +31,28 @@ import org.junit.Test;
 
 public final class RemoteRepositoryFactoryTest {
 
-	@Test
-	public void testDetectRepositoryType_svnPrefix() {
-		String url = "svn://example.com/repo";
-		assertEquals("svn", RemoteRepositoryFactory.detectRepositoryType(url));
-	}
+    @Test
+    public void testDetectRepositoryType_svnPrefix() {
+        String url = "svn://example.com/repo";
+        assertEquals("svn", RemoteRepositoryFactory.detectRepositoryType(url));
+    }
 
-	@Test
-	public void testDetectRepositoryType_gitPrefix() {
-		String url = "git://example.com/repo";
-		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
-	}
+    @Test
+    public void testDetectRepositoryType_gitPrefix() {
+        String url = "git://example.com/repo";
+        assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+    }
 
-	@Test
-	public void testDetectRepositoryType_httpsGitPrefix() {
-		String url = "https://git.example.com/repo";
-		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
-	}
+    @Test
+    public void testDetectRepositoryType_httpsGitPrefix() {
+        String url = "https://git.example.com/repo";
+        assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+    }
 
-	@Test
-	public void testDetectRepositoryType_gitSuffix() {
-		String url = "https://example.com/repo.git";
-		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
-	}
+    @Test
+    public void testDetectRepositoryType_gitSuffix() {
+        String url = "https://example.com/repo.git";
+        assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+    }
 
 }

--- a/test/src/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
+++ b/test/src/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
@@ -1,0 +1,58 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Damien Rembert
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class RemoteRepositoryFactoryTest {
+
+	@Test
+	public void testDetectRepositoryType_svnPrefix() {
+		String url = "svn://example.com/repo";
+		assertEquals("svn", RemoteRepositoryFactory.detectRepositoryType(url));
+	}
+
+	@Test
+	public void testDetectRepositoryType_gitPrefix() {
+		String url = "git://example.com/repo";
+		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+	}
+
+	@Test
+	public void testDetectRepositoryType_httpsGitPrefix() {
+		String url = "https://git.example.com/repo";
+		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+	}
+
+	@Test
+	public void testDetectRepositoryType_gitSuffix() {
+		String url = "https://example.com/repo.git";
+		assertEquals("git", RemoteRepositoryFactory.detectRepositoryType(url));
+	}
+
+}


### PR DESCRIPTION
## Which ticket is resolved?

- Fix behaviour where git repos would be recognised as SVN
  * https://sourceforge.net/p/omegat/bugs/1258/

## What does this PR change?

This PR implements changes recommended on the bug report:
- Assume that url that start with `https://git` are git repos
- Assume that url that end with `.git` are git repos
