### PR TITLE
feat: update tmx writer, escaper, and unit test

### DIFF
--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -30,6 +30,7 @@ package org.omegat.util;
 
 import static com.ctc.wstx.api.WstxOutputProperties.P_OUTPUT_ESCAPE_CR;
 import static org.codehaus.stax2.XMLOutputFactory2.P_AUTOMATIC_EMPTY_ELEMENTS;
+import static org.codehaus.stax2.XMLOutputFactory2.P_TEXT_ESCAPER;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -109,6 +110,7 @@ public class TMXWriter2 implements AutoCloseable {
         factory = XMLOutputFactory.newInstance();
         factory.setProperty(P_OUTPUT_ESCAPE_CR, false);
         factory.setProperty(P_AUTOMATIC_EMPTY_ELEMENTS, true);
+        factory.setProperty(P_TEXT_ESCAPER, new TmxEscapingWriterFactory());
 
         out = new BufferedOutputStream(Files.newOutputStream(file.toPath()));
         xml = factory.createXMLStreamWriter(out, StandardCharsets.UTF_8.name());

--- a/src/org/omegat/util/TmxEscapingWriterFactory.java
+++ b/src/org/omegat/util/TmxEscapingWriterFactory.java
@@ -1,0 +1,123 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Hiroshi Miura
+ Home page: https://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.codehaus.stax2.io.EscapingWriterFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class TmxEscapingWriterFactory implements EscapingWriterFactory {
+
+    @Override
+    public Writer createEscapingWriterFor(final Writer writer, final String s)
+            throws UnsupportedEncodingException {
+        return new EscapeWriter(writer);
+    }
+
+    @Override
+    public Writer createEscapingWriterFor(final OutputStream outputStream, final String s)
+            throws UnsupportedEncodingException {
+        return new EscapeWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+    }
+
+    public static class EscapeWriter extends Writer {
+
+        // Copy from woodstox:com.ctc.wstx.sw.BufferingXmlWriter
+        private static final int[] QUOTABLE_TEXT_CHARS;
+        private static final int HIGH_ENC = 0xFFFE;
+
+        static {
+            int[] q = new int[4096];
+            Arrays.fill(q, 0, 32, 1);
+            Arrays.fill(q, 127, 160, 1);
+            q['\t'] = 0;
+            q['\n'] = 0;
+            q['<'] = 1;
+            q['>'] = 1;
+            q['&'] = 1;
+            QUOTABLE_TEXT_CHARS = q;
+        }
+
+        private final Writer delegate;
+
+        public EscapeWriter(@NotNull Writer delegate) {
+            this.delegate = delegate;
+        }
+
+        /**
+         * Wrap Writer and escape characters.
+         *
+         * @param cbuf Array of characters
+         * @param off  Offset from which to start writing characters
+         * @param len  Number of characters to write
+         * @throws IOException
+         */
+        @Override
+        public void write(@NotNull final char[] cbuf, final int off, final int len) throws IOException {
+            StringBuilder escaped = new StringBuilder();
+            for (int i = off; i < off + len; i++) {
+                char c = cbuf[i];
+                if (c < 4096 && QUOTABLE_TEXT_CHARS[c] != 0) {
+                    switch (c) {
+                    case '<':
+                        escaped.append("&lt;");
+                        break;
+                        case '>':
+                            escaped.append("&gt;");
+                            break;
+                        case '&':
+                            escaped.append("&amp;");
+                            break;
+                        default:
+                            escaped.append(String.format("&#x%02x;", (int) c));
+                    }
+                } else if (c >= HIGH_ENC) {
+                    escaped.append(String.format("&#x%04x;", (int) c));
+                } else {
+                    escaped.append(c);
+                }
+            }
+            delegate.write(escaped.toString());
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/src/org/omegat/util/TmxEscapingWriterFactory.java
+++ b/src/org/omegat/util/TmxEscapingWriterFactory.java
@@ -62,6 +62,7 @@ public class TmxEscapingWriterFactory implements EscapingWriterFactory {
             q['<'] = 1;
             q['>'] = 1;
             q['&'] = 1;
+            q['\r'] = (byte) (Platform.isWindows ? 0 : 1);
             QUOTABLE_TEXT_CHARS = q;
         }
 

--- a/src/org/omegat/util/TmxEscapingWriterFactory.java
+++ b/src/org/omegat/util/TmxEscapingWriterFactory.java
@@ -1,27 +1,27 @@
-/**************************************************************************
- OmegaT - Computer Assisted Translation (CAT) tool
- with fuzzy matching, translation memory, keyword search,
- glossaries, and translation leveraging into updated projects.
-
- Copyright (C) 2024 Hiroshi Miura
- Home page: https://www.omegat.org/
- Support center: https://omegat.org/support
-
- This file is part of OmegaT.
-
- OmegaT is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- OmegaT is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+/*
+ * OmegaT - Computer Assisted Translation (CAT) tool
+ *          with fuzzy matching, translation memory, keyword search,
+ *          glossaries, and translation leveraging into updated projects.
+ *
+ * Copyright (C) 2024 Hiroshi Miura
+ *          Home page: https://www.omegat.org/
+ *          Support center: https://omegat.org/support
+ *
+ * This file is part of OmegaT.
+ *
+ * OmegaT is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OmegaT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 package org.omegat.util;
 

--- a/test/data/tmx/test-save-tmx14.tmx
+++ b/test/data/tmx/test-save-tmx14.tmx
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE tmx SYSTEM "tmx14.dtd">
 <tmx version="1.4">
-<header  datatype="plaintext" srclang="en-US" adminlang="EN-US" o-tmf="OmegaT TMX" segtype="paragraph" creationtoolversion="test" creationtool="test"/>
+  <header  datatype="plaintext" srclang="en-US" adminlang="EN-US" o-tmf="OmegaT TMX" segtype="paragraph"
+ creationtoolversion="test" creationtool="test"/>
   <body>
     <tu>
-        <tuv xml:lang="en-US">
-            <seg>source</seg>
-        </tuv>
-        <tuv xml:lang="be-BY">
-            <seg>target</seg>
-        </tuv>
+      <tuv xml:lang="en-US">
+        <seg>source</seg>
+      </tuv>
+      <tuv xml:lang="be-BY">
+        <seg>target</seg>
+      </tuv>
     </tu>
-    
     <tu>
       <tuv xml:lang="en-US">
-        <seg>1<ph x='1'>&lt;a1/&gt;</ph>2</seg>
+        <seg>1<ph x="1">&lt;a1/&gt;</ph>2</seg>
       </tuv>
       <tuv xml:lang="be-BY">
         <seg>zz</seg>
@@ -22,7 +22,7 @@
     </tu>
     <tu>
       <tuv xml:lang="en-US">
-        <seg>3<bpt i='1' x='1'>&lt;a1&gt;</bpt>4<ept i='1'>&lt;/a1&gt;</ept>5</seg>
+        <seg>3<bpt i="1" x="1">&lt;a1&gt;</bpt>4<ept i="1">&lt;/a1&gt;</ept>5</seg>
       </tuv>
       <tuv xml:lang="be-BY">
         <seg>zz</seg>
@@ -30,12 +30,11 @@
     </tu>
     <tu>
       <tuv xml:lang="en-US">
-        <seg>6<it pos='begin' x='1'>&lt;a1&gt;</it>7</seg>
+        <seg>6<it pos="begin" x="1">&lt;a1&gt;</it>7</seg>
       </tuv>
       <tuv xml:lang="be-BY">
         <seg>zz</seg>
       </tuv>
     </tu>
-    
   </body>
 </tmx>

--- a/test/src/org/omegat/util/TMXWriterTest.java
+++ b/test/src/org/omegat/util/TMXWriterTest.java
@@ -24,6 +24,7 @@
  **************************************************************************/
 package org.omegat.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -178,7 +179,7 @@ public class TMXWriterTest extends TestFilterBase {
                 text.append(buffer, 0, len);
             }
         }
-        assertTrue(text.toString().contains("tar" + eol + "get"));
+        assertThat(text.toString()).as("Preserve EOL mark in text.").contains("tar" + eol + "get");
 
         final List<String> trs = new ArrayList<>();
         load(null, trs, true, false);

--- a/test/src/org/omegat/util/TmxEscapingWriterTest.java
+++ b/test/src/org/omegat/util/TmxEscapingWriterTest.java
@@ -48,6 +48,11 @@ public class TmxEscapingWriterTest {
         writer = factory.createEscapingWriterFor(outputStream, null);
     }
 
+    /**
+     * Test basic characters, as-is.
+     *
+     * @throws IOException I/O error happened.
+     */
     @Test
     public void escapeBasic() throws IOException {
         writer.write("Hello world!\n");
@@ -55,24 +60,69 @@ public class TmxEscapingWriterTest {
         assertThat(outputStream.toString()).isEqualTo("Hello world!\n");
     }
 
+    /**
+     * Test signs to be escaped.
+     * @throws IOException I/O error happened.
+     */
     @Test
     public void escapeToEntities() throws IOException {
-        writer.write("\"<escape>\"");
+        writer.write("'<escape>\"");
         writer.flush();
-        assertThat(outputStream.toString()).isEqualTo("\"&lt;escape&gt;\"");
+        assertThat(outputStream.toString())
+                .as("Check escape of < & and > signs and as-is for single/double quote")
+                .isEqualTo("'&lt;escape&gt;\"");
     }
 
+    /**
+     * Test escape of NBSP, no-escape.
+     * @throws IOException I/O error happened.
+     */
+    @Test
+    public void testNBSP() throws IOException {
+        writer.write("\u00a0");
+        writer.flush();
+        assertThat(outputStream.toString())
+                .as("Check NBSP is not escaped.")
+                .isEqualTo("\u00a0");
+    }
+
+    /**
+     * Test Control character No-Break-Here, escape.
+     *
+     * @throws IOException I/O error happened.
+     */
+    @Test
+    public void testNBH() throws IOException {
+        writer.write("\u0083");
+        writer.flush();
+        assertThat(outputStream.toString())
+                .as("Check NO_BREAK_HERE control character to be escaped")
+                .isEqualTo("&#x83;");
+    }
+
+    /**
+     * Test emoji and flag, surrogate pair, escape.
+     * @throws IOException I/O error happened.
+     */
     @Test
     public void testSurrogatePair() throws IOException {
         writer.write("\uD83D\uDE00");
         writer.flush();
-        assertThat(outputStream.toString()).isEqualTo("\uD83D\uDE00");
+        assertThat(outputStream.toString())
+                .as("Check emoji and flag that requires surrogate pair for encode.")
+                .isEqualTo("\uD83D\uDE00");
     }
 
+    /**
+     * Test Invalid character, BOM flag, escape.
+     * @throws IOException I/O error happened.
+     */
     @Test
     public void testInvalidChar() throws IOException {
         writer.write((char) 0xFFFE);
         writer.flush();
-        assertThat(outputStream.toString()).isEqualToIgnoringCase("&#xfffe;");
+        assertThat(outputStream.toString())
+                .as("check BOM mark to be escaped when appeared in TEXT.")
+                .isEqualToIgnoringCase("&#xfffe;");
     }
 }

--- a/test/src/org/omegat/util/TmxEscapingWriterTest.java
+++ b/test/src/org/omegat/util/TmxEscapingWriterTest.java
@@ -79,11 +79,11 @@ public class TmxEscapingWriterTest {
      */
     @Test
     public void testNBSP() throws IOException {
-        writer.write("\u00a0");
+        writer.write("[\u00A0]");
         writer.flush();
         assertThat(outputStream.toString())
                 .as("Check NBSP is not escaped.")
-                .isEqualTo("\u00a0");
+                .isEqualTo("[\u00A0]");
     }
 
     /**
@@ -106,11 +106,11 @@ public class TmxEscapingWriterTest {
      */
     @Test
     public void testSurrogatePair() throws IOException {
-        writer.write("\uD83D\uDE00");
+        writer.write("[😀]");
         writer.flush();
         assertThat(outputStream.toString())
                 .as("Check emoji and flag that requires surrogate pair for encode.")
-                .isEqualTo("\uD83D\uDE00");
+                .isEqualTo("[😀]");
     }
 
     /**

--- a/test/src/org/omegat/util/TmxEscapingWriterTest.java
+++ b/test/src/org/omegat/util/TmxEscapingWriterTest.java
@@ -1,0 +1,78 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Hiroshi Miura
+ Home page: https://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TmxEscapingWriterTest {
+
+    private OutputStream outputStream;
+    private Writer writer;
+
+    @Before
+    public void setUp() throws UnsupportedEncodingException {
+        outputStream = new ByteArrayOutputStream();
+        var factory = new TmxEscapingWriterFactory();
+        writer = factory.createEscapingWriterFor(outputStream, null);
+    }
+
+    @Test
+    public void escapeBasic() throws IOException {
+        writer.write("Hello world!\n");
+        writer.flush();
+        assertThat(outputStream.toString()).isEqualTo("Hello world!\n");
+    }
+
+    @Test
+    public void escapeToEntities() throws IOException {
+        writer.write("\"<escape>\"");
+        writer.flush();
+        assertThat(outputStream.toString()).isEqualTo("\"&lt;escape&gt;\"");
+    }
+
+    @Test
+    public void testSurrogatePair() throws IOException {
+        writer.write("\uD83D\uDE00");
+        writer.flush();
+        assertThat(outputStream.toString()).isEqualTo("\uD83D\uDE00");
+    }
+
+    @Test
+    public void testInvalidChar() throws IOException {
+        writer.write((char) 0xFFFE);
+        writer.flush();
+        assertThat(outputStream.toString()).isEqualToIgnoringCase("&#xfffe;");
+    }
+}

--- a/test/src/org/omegat/util/TmxEscapingWriterTest.java
+++ b/test/src/org/omegat/util/TmxEscapingWriterTest.java
@@ -29,16 +29,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Test;
 
 public class TmxEscapingWriterTest {
 
-    private OutputStream outputStream;
+    private ByteArrayOutputStream outputStream;
     private Writer writer;
 
     @Before
@@ -46,6 +46,10 @@ public class TmxEscapingWriterTest {
         outputStream = new ByteArrayOutputStream();
         var factory = new TmxEscapingWriterFactory();
         writer = factory.createEscapingWriterFor(outputStream, null);
+    }
+
+    private String result() {
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
     /**
@@ -57,7 +61,7 @@ public class TmxEscapingWriterTest {
     public void escapeBasic() throws IOException {
         writer.write("Hello world!\n");
         writer.flush();
-        assertThat(outputStream.toString()).isEqualTo("Hello world!\n");
+        assertThat(result()).isEqualTo("Hello world!\n");
     }
 
     /**
@@ -68,7 +72,7 @@ public class TmxEscapingWriterTest {
     public void escapeToEntities() throws IOException {
         writer.write("'<escape>\"");
         writer.flush();
-        assertThat(outputStream.toString())
+        assertThat(result())
                 .as("Check escape of < & and > signs and as-is for single/double quote")
                 .isEqualTo("'&lt;escape&gt;\"");
     }
@@ -81,7 +85,7 @@ public class TmxEscapingWriterTest {
     public void testNBSP() throws IOException {
         writer.write("[\u00A0]");
         writer.flush();
-        assertThat(outputStream.toString())
+        assertThat(result())
                 .as("Check NBSP is not escaped.")
                 .isEqualTo("[\u00A0]");
     }
@@ -95,7 +99,7 @@ public class TmxEscapingWriterTest {
     public void testNBH() throws IOException {
         writer.write("\u0083");
         writer.flush();
-        assertThat(outputStream.toString())
+        assertThat(result())
                 .as("Check NO_BREAK_HERE control character to be escaped")
                 .isEqualTo("&#x83;");
     }
@@ -108,7 +112,7 @@ public class TmxEscapingWriterTest {
     public void testSurrogatePair() throws IOException {
         writer.write("[😀]");
         writer.flush();
-        assertThat(outputStream.toString())
+        assertThat(result())
                 .as("Check emoji and flag that requires surrogate pair for encode.")
                 .isEqualTo("[😀]");
     }
@@ -121,7 +125,7 @@ public class TmxEscapingWriterTest {
     public void testInvalidChar() throws IOException {
         writer.write((char) 0xFFFE);
         writer.flush();
-        assertThat(outputStream.toString())
+        assertThat(result())
                 .as("check BOM mark to be escaped when appeared in TEXT.")
                 .isEqualToIgnoringCase("&#xfffe;");
     }

--- a/test/src/org/omegat/util/TmxEscapingWriterTest.java
+++ b/test/src/org/omegat/util/TmxEscapingWriterTest.java
@@ -1,27 +1,27 @@
-/**************************************************************************
- OmegaT - Computer Assisted Translation (CAT) tool
- with fuzzy matching, translation memory, keyword search,
- glossaries, and translation leveraging into updated projects.
-
- Copyright (C) 2024 Hiroshi Miura
- Home page: https://www.omegat.org/
- Support center: https://omegat.org/support
-
- This file is part of OmegaT.
-
- OmegaT is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- OmegaT is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+/*
+ * OmegaT - Computer Assisted Translation (CAT) tool
+ *          with fuzzy matching, translation memory, keyword search,
+ *          glossaries, and translation leveraging into updated projects.
+ *
+ * Copyright (C) 2024 Hiroshi Miura
+ *          Home page: https://www.omegat.org/
+ *          Support center: https://omegat.org/support
+ *
+ * This file is part of OmegaT.
+ *
+ * OmegaT is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OmegaT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 package org.omegat.util;
 


### PR DESCRIPTION
## Pull request type


- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- TMX writer output in 6.1 should be the same as in 6.0
  * https://sourceforge.net/p/omegat/feature-requests/1749/

## What does this PR change?

- update TMX test expectation for level2 write
    - use double quote for attribute
    - format indentation and empty line
- Add TmxEscapingWriterFactory class and unit test with ordinary string, "< & >", Surrogate Pair and invalid one.
- Use TmxEscapingWriterFactory in TMXWriter2 for TEXT writer

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->

`com.sun.xml.bind.marshaller#escape` which is ultimately OmegaT 6.0 and before use is as follows;
```java
public void escape(char[] ch, int start, int length, boolean isAttVal, Writer out) throws IOException {
        int limit = start + length;

        for(int i = start; i < limit; ++i) {
            char c = ch[i];
            if (c == '&' || c == '<' || c == '>' || c == '\r' || c == '\n' && isAttVal || c == '"' && isAttVal) {
                if (i != start) {
                    out.write(ch, start, i - start);
                }

                start = i + 1;
                switch (ch[i]) {
                    case '\n':
                    case '\r':
                        out.write("&#");
                        out.write(Integer.toString(c));
                        out.write(59);
                        break;
                    case '"':
                        out.write("&quot;");
                        break;
                    case '&':
                        out.write("&amp;");
                        break;
                    case '<':
                        out.write("&lt;");
                        break;
                    case '>':
                        out.write("&gt;");
                        break;
                    default:
                        throw new IllegalArgumentException("Cannot escape: '" + c + "'");
                }
            }
        }

        if (start != limit) {
            out.write(ch, start, limit - start);
        }

    }

```

