### PR TITLE
Chore: Fix test-integration docker configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,8 +16,8 @@ services:
       context: test-integration/docker/client
       args:
         JAVA: 17
-        JDKVER: jdk_17.0.8.1.0+1
-        GRADLE: 8.4
+        JDKVER: jdk_17.0.11.0.0+9
+        GRADLE: 8.8
     depends_on:
       - server
     volumes:

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -3,7 +3,7 @@
 #           with fuzzy matching, translation memory, keyword search,
 #           glossaries, and translation leveraging into updated projects.
 #
-#  Copyright (C) 2022,2023 Hiroshi Miura
+#  Copyright (C) 2022-2024 Hiroshi Miura
 #                Home page: https://www.omegat.org/
 #                Support center: https://omegat.org/support
 #
@@ -24,13 +24,13 @@
 #  **************************************************************************/
 #
 
-FROM debian:bullseye-slim
-ARG CAVER=1.0.2-1
+FROM debian:bookworm-slim
+ARG CAVER=1.0.3-1
 ARG JAVA=11
-ARG JDKVER=jdk_11.0.20.1.0+1
-ARG GRADLE=8.4
+ARG JDKVER=jdk_11.0.23.0.0+9
+ARG GRADLE=8.8
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git inotify-tools curl subversion unzip rsync  \
- java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit
+ java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit openjdk-17-jdk
 RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh
 RUN chown -R omegat.omegat /home/omegat
 COPY --chown=omegat ssh_config /home/omegat/.ssh/config


### PR DESCRIPTION
Now OmegaT project is configured with Gradle 8.8 and its feature,
integration test's docker compose does not reflect it.

This PR fix the issue in integration test. 
integ-test failure lead a failure of weekly publish of packages.

## Pull request type
- Build and release changes -> [build/release]


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
