### PR TITLE
refactor: add IMainWindow#resetDesktopLayout

### DIFF
--- a/src/org/omegat/gui/main/ConsoleWindow.java
+++ b/src/org/omegat/gui/main/ConsoleWindow.java
@@ -142,6 +142,10 @@ public class ConsoleWindow implements IMainWindow {
         return null;
     }
 
+    @Override
+    public void resetDesktopLayout() {
+    }
+
     public Cursor getCursor() {
         return Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR);
     }

--- a/src/org/omegat/gui/main/IMainWindow.java
+++ b/src/org/omegat/gui/main/IMainWindow.java
@@ -204,4 +204,9 @@ public interface IMainWindow {
      * Retrieve main docking desktop.
      */
     DockingDesktop getDesktop();
+
+    /**
+     * Restores the main window layout to the default values.
+     */
+    default void resetDesktopLayout() {}
 }

--- a/src/org/omegat/gui/main/MainWindow.java
+++ b/src/org/omegat/gui/main/MainWindow.java
@@ -176,6 +176,13 @@ public class MainWindow implements IMainWindow {
         });
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public void resetDesktopLayout() {
+       MainWindowUI.resetDesktopLayout(this);
+    }
+
     @SuppressWarnings("unchecked")
     private void initMainMenu() {
         MainWindowMenuHandler mainWindowMenuHandler = new MainWindowMenuHandler(this);

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -988,7 +988,7 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
      * defaults.
      */
     public void viewRestoreGUIMenuItemActionPerformed() {
-        MainWindowUI.resetDesktopLayout(mainWindow);
+        Core.getMainWindow().resetDesktopLayout();
     }
 
     public void optionsAccessConfigDirMenuItemActionPerformed() {

--- a/src/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/org/omegat/gui/preferences/view/AppearanceController.java
@@ -40,8 +40,6 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
-import org.omegat.gui.main.MainWindow;
-import org.omegat.gui.main.MainWindowUI;
 import org.omegat.gui.preferences.BasePreferencesController;
 import org.omegat.gui.preferences.IMenuPreferece;
 import org.omegat.gui.preferences.MainMenuUI;
@@ -188,7 +186,7 @@ public class AppearanceController extends BasePreferencesController {
 
     private void initListeners() {
         panel.restoreWindowButton
-                .addActionListener(e -> MainWindowUI.resetDesktopLayout((MainWindow) Core.getMainWindow()));
+                .addActionListener(e -> Core.getMainWindow().resetDesktopLayout());
         panel.cbLightThemeSelect.addActionListener(e -> setRestartRequired(isModified()));
         panel.cbDarkThemeSelect.addActionListener(e -> setRestartRequired(isModified()));
         panel.useDarkThemeRB.addActionListener(e -> setRestartRequired(isModified()));

--- a/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
@@ -291,4 +291,8 @@ class TestMainWindow implements IMainWindow {
         return desktop;
     }
 
+    @Override
+    public void resetDesktopLayout() {
+    }
+
 }

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -678,6 +678,10 @@ public final class TestTeamIntegrationChild {
             return null;
         }
 
+        @Override
+        public void resetDesktopLayout() {
+        }
+
         public Cursor getCursor() {
             return null;
         }

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -274,6 +274,10 @@ public abstract class TestCore {
                 return null;
             }
 
+            @Override
+            public void resetDesktopLayout() {
+            }
+
             public Cursor getCursor() {
                 return null;
             }


### PR DESCRIPTION
extend IMainWindow API to add `resetDesktopLayout` to help menu handler to avoid direct dependency for raw MainWindow object to help test code mocking it.
 
## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

- Extend IMainWindow API
- Remove dependency to "raw" mainWindow from MainWindowMenuHandler
- Update test codes according to API


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
