### PR TITLE
chore: test-integ: fix spawn with Java 17

### DIFF
--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +73,7 @@ import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.util.Language;
 import org.omegat.util.ProjectFileStorage;
+import org.omegat.util.StaticUtils;
 import org.omegat.util.TMXWriter2;
 import org.omegat.util.TestPreferencesInitializer;
 
@@ -409,8 +411,10 @@ public final class TestTeamIntegration {
             if (!new File(DIR + "/" + source + "/omegat/").mkdirs()) {
                 throw new Exception("Impossible to create test dir");
             }
+            // Get `java` command path from java.home
+            Path javaBin = Paths.get(System.getProperty("java.home")).resolve("bin/java");
             List<String> cmd = new ArrayList<>();
-            cmd.add("java");
+            cmd.add(javaBin.toString());
             cmd.add("-Duser.name=" + source);
             if (logConfig != null) {
                 cmd.add("-Djava.util.logging.config.file=" + logConfig);

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -73,7 +73,6 @@ import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.util.Language;
 import org.omegat.util.ProjectFileStorage;
-import org.omegat.util.StaticUtils;
 import org.omegat.util.TMXWriter2;
 import org.omegat.util.TestPreferencesInitializer;
 


### PR DESCRIPTION
Java 13 and later change launch mechanism on linux https://bugs.openjdk.org/browse/JDK-8213192
This fixes a child process spawn error on Java 17

## Pull request type

- Bug fix -> [bug]
- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Update TestIntegration class to launch child process
- change "java" with full path of java command

## Other information

ref https://stackoverflow.com/questions/61301818/java-failed-to-exec-spawn-helper-error-since-moving-to-java-14-on-linux