### PR TITLE
refactor: reduce direct reference to real MainWindow object from MenuHandler

### DIFF
--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -409,7 +409,7 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         // RFE 1302358
         // Add Yes/No Warning before OmegaT quits
         if (projectModified || Preferences.isPreference(Preferences.ALWAYS_CONFIRM_QUIT)) {
-            if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(mainWindow.getApplicationFrame(),
+            if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
                     OStrings.getString("MW_QUIT_CONFIRM"), OStrings.getString("CONFIRM_DIALOG_TITLE"),
                     JOptionPane.YES_NO_OPTION)) {
                 return;


### PR DESCRIPTION

It is required to decouple MenuHandler with real MainWindow object reference to allow mocking MainWindow in Acceptance Test. This changes a reference to mainWindow field of MainWindowMenuHandler to get application frame when exit application.

## Pull request type
- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

- Change reference `mainWindow` to `Core.getMainWindow()` in `prepareForExit` method.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
