### PR TITLE
refactor: avoid usage of direct LT language class

### DIFF
--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -38,10 +38,7 @@ import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 import org.languagetool.JLanguageTool;
-import org.languagetool.language.AmericanEnglish;
-import org.languagetool.language.CanadianEnglish;
-import org.languagetool.language.English;
-import org.languagetool.language.French;
+import org.languagetool.Languages;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.PatternRule;
 import org.languagetool.server.HTTPServer;
@@ -65,7 +62,7 @@ public class LanguageToolTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testExecuteLanguageToolCheck() throws Exception {
-        JLanguageTool lt = new JLanguageTool(new org.languagetool.language.Belarusian());
+        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForShortCode("be"));
 
         // The test string is Belarusian; originally it was actual UTF-8,
         // but that causes the test to fail when environment encodings aren't set
@@ -77,7 +74,7 @@ public class LanguageToolTest {
 
     @Test
     public void testFrench() throws Exception {
-        JLanguageTool lt = new JLanguageTool(new French());
+        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForShortCode("fr"));
 
         // example from https://github.com/languagetool-org/languagetool/issues/2852
         List<RuleMatch> matches = lt.check("Il est par cons\u00E9quent perdue.");
@@ -87,7 +84,7 @@ public class LanguageToolTest {
 
     @Test
     public void testEnglish() throws Exception {
-        JLanguageTool lt = new JLanguageTool(new AmericanEnglish());
+        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForLocale(new Locale("en", "US")));
 
         List<RuleMatch> matches = lt.check("Check test");
         assertEquals(0, matches.size());
@@ -152,29 +149,29 @@ public class LanguageToolTest {
     public void testLanguageMapping() {
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-US"));
-            assertEquals(AmericanEnglish.class, lang.getClass());
+            assertEquals(Languages.getLanguageForLocale(new Locale("en", "US")).getClass(), lang.getClass());
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-CA"));
-            assertEquals(CanadianEnglish.class, lang.getClass());
+            assertEquals(Languages.getLanguageForLocale(new Locale("en", "CA")).getClass(), lang.getClass());
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("en"));
-            assertEquals(English.class, lang.getClass());
+            assertEquals(Languages.getLanguageForShortCode("en").getClass(), lang.getClass());
         }
         {
             // Unknown region--fall back to generic class
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-JA"));
-            assertEquals(English.class, lang.getClass());
+            assertEquals(Languages.getLanguageForShortCode("en").getClass(), lang.getClass());
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("be-BY"));
-            assertEquals(org.languagetool.language.Belarusian.class, lang.getClass());
+            assertEquals(Languages.getLanguageForShortCode("be").getClass(), lang.getClass());
         }
         {
             // Belarusian is offered in be-BY only; ensure hit with just "be"
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("be"));
-            assertEquals(org.languagetool.language.Belarusian.class, lang.getClass());
+            assertEquals(Languages.getLanguageForShortCode("be").getClass(), lang.getClass());
         }
         {
             org.languagetool.Language lang = LanguageToolNativeBridge.getLTLanguage(new Language("xyz"));

--- a/test/src/org/omegat/languagetools/LuceneGosenCompatibilityTest.java
+++ b/test/src/org/omegat/languagetools/LuceneGosenCompatibilityTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.Objects;
 
 import net.java.sen.SenFactory;
 import net.java.sen.StringTagger;
@@ -37,7 +38,7 @@ import net.java.sen.StringTagger;
 import org.junit.Test;
 
 import org.languagetool.JLanguageTool;
-import org.languagetool.language.Japanese;
+import org.languagetool.Languages;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.PatternRule;
 
@@ -45,7 +46,8 @@ public class LuceneGosenCompatibilityTest {
 
     /**
      * Regression test for bugs#1204.
-     * https://sourceforge.net/p/omegat/bugs/1204/
+     * <a href="https://sourceforge.net/p/omegat/bugs/1204/">
+     * LanguageTool6 lucene-gosen-ipadic from omegat project is incompatible</a>
      */
     @Test
     public void testLuceneGosenGetStringTagger6() {
@@ -55,7 +57,7 @@ public class LuceneGosenCompatibilityTest {
 
     @Test
     public void testJapanese() throws Exception {
-        JLanguageTool lt = new JLanguageTool(new Japanese());
+        JLanguageTool lt = new JLanguageTool(Objects.requireNonNull(Languages.getLanguageForName("Japanese")));
         List<RuleMatch> matches = lt.check("そんじゃそこらのやつらとは違う");
         assertEquals(1, matches.size());
         assertTrue(matches.get(0).getRule() instanceof PatternRule);


### PR DESCRIPTION
- Avoid direct reference of LT language classes.
- We can use LT utility methods; Languages.getLanguageByName getLanguageByShortCode getLanguageByLocale

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
