### PR TITLE
fix: write startup log into file

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -70,7 +70,6 @@ import javax.swing.UIManager;
 
 import org.apache.commons.lang3.StringUtils;
 import tokyo.northside.logging.ILogger;
-import tokyo.northside.logging.LoggerFactory;
 
 import org.omegat.CLIParameters.PSEUDO_TRANSLATE_TYPE;
 import org.omegat.CLIParameters.TAG_VALIDATION_MODE;

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -50,9 +50,11 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,6 +68,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
+import org.apache.commons.lang3.StringUtils;
 import tokyo.northside.logging.ILogger;
 import tokyo.northside.logging.LoggerFactory;
 
@@ -117,12 +120,11 @@ import com.vlsolutions.swing.docking.DockingDesktop;
  * @author Hiroshi Miura
  */
 public final class Main {
-    private static final ILogger LOGGER = LoggerFactory.getLogger(Main.class, OStrings.getResourceBundle());
 
     private Main() {
     }
 
-    /** Project location for load on startup. */
+    /** Project location for a load on startup. */
     protected static File projectLocation = null;
 
     /** Remote project location. */
@@ -183,13 +185,20 @@ public final class Main {
         if (PARAMS.containsKey(CLIParameters.DISABLE_LOCATION_SAVE)) {
             RuntimePreferences.setLocationSaveEnabled(false);
         }
-        LOGGER.atInfo().log(
-                "\n===================================================================\n"
-                        + "{0} ({1}) Locale {2}",
-                OStrings.getNameAndVersion(), DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-                        .withLocale(Locale.getDefault()).format(ZonedDateTime.now()),
-                Locale.getDefault().getDisplayName());
-        LOGGER.atInfo().logRB("LOG_STARTUP_INFO", System.getProperty("java.vendor"),
+
+        // initialize logging backend and loading configuration.
+        ILogger logger = Log.getLogger(Main.class);
+
+        logger.atInfo()
+                .setMessage("\n{0}\n{1} (started on {2} {3}) Locale {4}")
+                .addArgument(StringUtils.repeat('=', 120))
+                .addArgument(OStrings.getNameAndVersion())
+                .addArgument(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                        .withLocale(Locale.getDefault()).format(ZonedDateTime.now()))
+                .addArgument(ZoneId.systemDefault().getDisplayName(TextStyle.SHORT, Locale.getDefault()))
+                .addArgument(Locale.getDefault().toLanguageTag())
+                .log();
+        logger.atInfo().logRB("LOG_STARTUP_INFO", System.getProperty("java.vendor"),
                 System.getProperty("java.version"), System.getProperty("java.home"));
 
         System.setProperty("http.agent", OStrings.getDisplayNameAndVersion());

--- a/src/org/omegat/logger.properties
+++ b/src/org/omegat/logger.properties
@@ -8,10 +8,10 @@ org.omegat.level = ALL
 java.util.logging.ConsoleHandler.level = ALL
 org.omegat.util.logging.OmegaTFileHandler.level = ALL
 
-org.omegat.util.logging.OmegaTLogFormatter.mask=$mark: $level: $text $key
+org.omegat.util.logging.OmegaTLogFormatter.mask=$time: $level: $text $key
 #org.omegat.util.logging.OmegaTLogFormatter.mask=$time: $threadName [$level] $key $text
 
-#org.omegat.util.logging.OmegaTLogFormatter.timeFormat=HH:mm:ss,SSSS
+org.omegat.util.logging.OmegaTLogFormatter.timeFormat=HH:mm:ss,SSSS
 
 java.util.logging.ConsoleHandler.formatter = org.omegat.util.logging.OmegaTLogFormatter
 

--- a/src/org/omegat/util/Log.java
+++ b/src/org/omegat/util/Log.java
@@ -56,19 +56,24 @@ import org.omegat.util.logging.OmegaTFileHandler;
  */
 public final class Log {
 
-    private static final ILogger LOGGER = LoggerFactory.getLogger(ILogger.ROOT_LOGGER_NAME,
-            OStrings.getResourceBundle());
+    private static final ILogger LOGGER;
 
     private Log() {
     }
 
     static {
+        LOGGER = LoggerFactory.getLogger(ILogger.ROOT_LOGGER_NAME,
+                OStrings.getResourceBundle());
+        init();
+    }
+
+    private static void init() {
         boolean loaded = false;
 
         // Ask slf4j-format-jdk14 to append (KEY) to log message.
         // When you switch to backend other than slf4j-jdk14(aka. JUL),
         // you should set to false. Otherwise, you may get duplicated key
-        // in message.
+        // in a message.
         System.setProperty(LoggerDecorator.LOCALISATION_KEY_APPENDER, "true");
 
         String customLogConfig = System.getProperty("java.util.logging.config.file");


### PR DESCRIPTION

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- OmegaT 6.1 does not write startup message in log file
- https://sourceforge.net/p/omegat/bugs/1262/

## What does this PR change?

- refactor: Log static initialization
- changed: logger configuration to show time in log file
- changed: update start up message with timezone


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
