### PR TITLE
[RFE#1736] feat: Alternative translation highlight

### DIFF
--- a/Plugins.properties
+++ b/Plugins.properties
@@ -95,6 +95,7 @@ tokenizer=org.omegat.tokenizer.DefaultTokenizer \
     org.omegat.tokenizer.LuceneSwedishTokenizer \
     org.omegat.tokenizer.LuceneThaiTokenizer \
     org.omegat.tokenizer.LuceneTurkishTokenizer
+marker=org.omegat.gui.editor.mark.AltTranslationsMarker
 plugin.desc.dictionary=Bundled dictionary files connectors. There are two bundled connectors. LingvoDSL, connector \
   \ for .dsl, .dsl.dz, .dsl.gz and StarDict, connector for .ifo, *.dict
 plugin.desc.misc=Bundled misc plugins

--- a/Plugins.properties
+++ b/Plugins.properties
@@ -48,6 +48,7 @@ plugin=org.omegat.filters3.xml.xliff.XLIFFFilter \
     org.omegat.filters4.xml.xliff.SdlProject \
     org.omegat.tokenizer.LuceneEnglishTokenizer \
     org.omegat.tokenizer.HunspellTokenizer \
+    org.omegat.gui.editor.mark.AltTranslationsMarker \
     org.omegat.gui.scripting.ScriptingWindow \
     org.omegat.externalfinder.ExternalFinder \
     org.omegat.gui.theme.DefaultFlatTheme \
@@ -95,7 +96,6 @@ tokenizer=org.omegat.tokenizer.DefaultTokenizer \
     org.omegat.tokenizer.LuceneSwedishTokenizer \
     org.omegat.tokenizer.LuceneThaiTokenizer \
     org.omegat.tokenizer.LuceneTurkishTokenizer
-marker=org.omegat.gui.editor.mark.AltTranslationsMarker
 plugin.desc.dictionary=Bundled dictionary files connectors. There are two bundled connectors. LingvoDSL, connector \
   \ for .dsl, .dsl.dz, .dsl.gz and StarDict, connector for .ifo, *.dict
 plugin.desc.misc=Bundled misc plugins

--- a/Plugins.properties
+++ b/Plugins.properties
@@ -48,7 +48,6 @@ plugin=org.omegat.filters3.xml.xliff.XLIFFFilter \
     org.omegat.filters4.xml.xliff.SdlProject \
     org.omegat.tokenizer.LuceneEnglishTokenizer \
     org.omegat.tokenizer.HunspellTokenizer \
-    org.omegat.gui.editor.mark.AltTranslationsMarker \
     org.omegat.gui.scripting.ScriptingWindow \
     org.omegat.externalfinder.ExternalFinder \
     org.omegat.gui.theme.DefaultFlatTheme \

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -101,7 +101,7 @@
     <suppress files="(BidiUtils|Java8Compat|MagicComment|JnaLoader)\.java" checks="HideUtilityClassConstructor"/>
     <suppress files="JTextPaneLinkifier\.java" checks="EmptyBlock"/>
     <suppress files="RepositoriesMappingController\.java:" checks="MethodLength"/>
-    <suppress files="EditorSettings\.java" checks="ParameterNumber" lines="497"/>
+    <suppress files="EditorSettings\.java" checks="ParameterNumber" lines="525"/>
     <suppress files="(IssuesPanel|PreferencesWindow)Controller\.java" checks="MethodLength"/>
     <suppress files="MatchesVarExpansion\.java" checks="InnerAssignment"/>
     <suppress files="EditorTextArea3\.java" checks="MethodLength"/>

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -1,13 +1,16 @@
 ----------------------------------------------------------------------
  OmegaT 6.1.0
 ----------------------------------------------------------------------
-  44 Enhancement
+  45 Enhancement
   69 Bug fixes
    5 Localisation updates
 ----------------------------------------------------------------------
 6.1.0 vs 6.0.0
 
   Implemented requests:
+
+  - Alternative translation highlight
+  https://sourceforge.net/p/omegat/feature-requests/1736/
 
   - Support for Stardict's Pango content type
   https://sourceforge.net/p/omegat/feature-requests/1727/

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -425,6 +425,7 @@ MW_VIEW_MENU_MARK_WHITESPACE=Displa&y Whitespace
 MW_VIEW_MENU_MARK_BIDI=Display &Bidi Control Characters
 
 MW_VIEW_MENU_MARK_AUTOPOPULATED=Highlight &Auto-Populated Segments
+MW_VIEW_MENU_MARK_ALT_TRANSLATIONS=Highlight Segments with Alternative Translation
 
 MW_VIEW_GLOSSARY_MARK=Mark Gl&ossary Matches
 LT_OPTIONS_MENU_ENABLED=Mark &Language Checker Issues
@@ -2562,6 +2563,7 @@ COLOR_ALIGNER_NEEDSREVIEW=Aligner \"Needs Review\" group
 COLOR_ALIGNER_HIGHLIGHT=Aligner highlight
 COLOR_ALIGNER_TABLE_ROW_HIGHLIGHT=Aligner table row highlight
 COLOR_MACHINETRANSLATE_SELECTED_HIGHLIGHT=Machine translate highlight
+COLOR_MARK_ALT_TRANSLATION=Alternative translation highlight
 GUI_COLORS_COLOR=Item:
 GUI_COLORS_RESET_COLOR=&Reset Colour
 PREFS_TITLE_COLORS=Colours

--- a/src/org/omegat/ColorScheme_dark.properties
+++ b/src/org/omegat/ColorScheme_dark.properties
@@ -42,3 +42,4 @@ OmegaT.searchFieldErrorText=#7f0000
 OmegaT.searchDimmedBackground=#80808080
 OmegaT.searchResultBorder=#EED20080
 OmegaT.machinetranslateSelectedHighlight=#ffcc00
+OmegaT.markAltTranslations=#006666

--- a/src/org/omegat/ColorScheme_light.properties
+++ b/src/org/omegat/ColorScheme_light.properties
@@ -42,3 +42,4 @@ OmegaT.searchFieldErrorText=#ff0000
 OmegaT.searchDimmedBackground=#80808080
 OmegaT.searchResultBorder=#EED20080
 OmegaT.machinetranslateSelectedHighlight=#ffff00
+OmegaT.markAltTranslations=#33ffff

--- a/src/org/omegat/gui/editor/EditorSettings.java
+++ b/src/org/omegat/gui/editor/EditorSettings.java
@@ -62,6 +62,7 @@ public class EditorSettings implements IEditorSettings {
     private boolean markWhitespace;
     private boolean markParagraphDelimitations;
     private boolean markBidi;
+    private boolean markAltTranslations;
     private String displayModificationInfo;
     private boolean autoSpellChecking;
     private boolean viewSourceBold;
@@ -91,6 +92,7 @@ public class EditorSettings implements IEditorSettings {
         markNonUniqueSegments = Preferences.isPreferenceDefault(Preferences.MARK_NON_UNIQUE_SEGMENTS,
                MARK_NON_UNIQUE_SEGMENTS_DEFAULT);
         markNoted = Preferences.isPreference(Preferences.MARK_NOTED_SEGMENTS);
+        markAltTranslations = Preferences.isPreference(Preferences.MARK_ALT_TRANSLATIONS);
         markNBSP  = Preferences.isPreference(Preferences.MARK_NBSP);
         markParagraphDelimitations = Preferences.isPreferenceDefault(Preferences.MARK_PARA_DELIMITATIONS,
                 MARK_PARA_DELIMITATIONS_DEFAULT);
@@ -226,6 +228,10 @@ public class EditorSettings implements IEditorSettings {
         return markBidi;
     }
 
+    public boolean isMarkAltTranslations() {
+        return markAltTranslations;
+    }
+
     public boolean isDoFontFallback() {
         return doFontFallback;
     }
@@ -330,6 +336,21 @@ public class EditorSettings implements IEditorSettings {
             parent.activateEntry();
         }
     }
+
+    public void setMarkAltTranslations(boolean markAltTranslations) {
+        UIThreadsUtil.mustBeSwingThread();
+
+        parent.commitAndDeactivate();
+
+        this.markAltTranslations = markAltTranslations;
+        Preferences.setPreference(Preferences.MARK_ALT_TRANSLATIONS, markAltTranslations);
+
+        if (Core.getProject().isProjectLoaded()) {
+            parent.loadDocument();
+            parent.activateEntry();
+        }
+    }
+
 
     public void setDoFontFallback(boolean doFontFalback) {
         UIThreadsUtil.mustBeSwingThread();

--- a/src/org/omegat/gui/editor/EditorSettings.java
+++ b/src/org/omegat/gui/editor/EditorSettings.java
@@ -84,20 +84,20 @@ public class EditorSettings implements IEditorSettings {
     protected EditorSettings(final EditorController parent) {
         this.parent = parent;
 
-        //options from menu 'view'
+        // options from menu 'view'
         useTabForAdvance = Preferences.isPreference(Preferences.USE_TAB_TO_ADVANCE);
         markTranslated = Preferences.isPreference(Preferences.MARK_TRANSLATED_SEGMENTS);
         markUntranslated = Preferences.isPreference(Preferences.MARK_UNTRANSLATED_SEGMENTS);
         displaySegmentSources = Preferences.isPreference(Preferences.DISPLAY_SEGMENT_SOURCES);
         markNonUniqueSegments = Preferences.isPreferenceDefault(Preferences.MARK_NON_UNIQUE_SEGMENTS,
-               MARK_NON_UNIQUE_SEGMENTS_DEFAULT);
+                MARK_NON_UNIQUE_SEGMENTS_DEFAULT);
         markNoted = Preferences.isPreference(Preferences.MARK_NOTED_SEGMENTS);
         markAltTranslations = Preferences.isPreference(Preferences.MARK_ALT_TRANSLATIONS);
-        markNBSP  = Preferences.isPreference(Preferences.MARK_NBSP);
+        markNBSP = Preferences.isPreference(Preferences.MARK_NBSP);
         markParagraphDelimitations = Preferences.isPreferenceDefault(Preferences.MARK_PARA_DELIMITATIONS,
                 MARK_PARA_DELIMITATIONS_DEFAULT);
-        markWhitespace  = Preferences.isPreference(Preferences.MARK_WHITESPACE);
-        markBidi  = Preferences.isPreference(Preferences.MARK_BIDI);
+        markWhitespace = Preferences.isPreference(Preferences.MARK_WHITESPACE);
+        markBidi = Preferences.isPreference(Preferences.MARK_BIDI);
         displayModificationInfo = Preferences.getPreferenceDefault(Preferences.DISPLAY_MODIFICATION_INFO,
                 DISPLAY_MODIFICATION_INFO_SELECTED);
         autoSpellChecking = Preferences.isPreference(Preferences.ALLOW_AUTO_SPELLCHECKING);
@@ -213,15 +213,19 @@ public class EditorSettings implements IEditorSettings {
     public boolean isMarkNBSP() {
         return markNBSP;
     }
+
     /**
      * mark whitespace?
+     * 
      * @return true when set, false otherwise
      */
     public boolean isMarkWhitespace() {
         return markWhitespace;
     }
+
     /**
      * mark Bidirectional control characters
+     * 
      * @return true when set, false otherwise
      */
     public boolean isMarkBidi() {
@@ -291,6 +295,7 @@ public class EditorSettings implements IEditorSettings {
             parent.activateEntry();
         }
     }
+
     public void setMarkWhitespace(boolean markWhitespace) {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -304,7 +309,7 @@ public class EditorSettings implements IEditorSettings {
             parent.activateEntry();
         }
     }
-    
+
     public void setMarkParagraphDelimitations(boolean delimitations) {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -350,7 +355,6 @@ public class EditorSettings implements IEditorSettings {
             parent.activateEntry();
         }
     }
-
 
     public void setDoFontFallback(boolean doFontFalback) {
         UIThreadsUtil.mustBeSwingThread();
@@ -458,15 +462,15 @@ public class EditorSettings implements IEditorSettings {
     }
 
     /**
-     * repaint segments in editor according to new view options. Use when options change to make them effective
-     * immediately.
+     * repaint segments in editor according to new view options. Use when
+     * options change to make them effective immediately.
      */
     public void updateViewPreferences() {
         UIThreadsUtil.mustBeSwingThread();
 
         parent.commitAndDeactivate();
 
-        //update variables
+        // update variables
         viewSourceBold = Preferences.isPreference(Preferences.VIEW_OPTION_SOURCE_ALL_BOLD);
         viewActiveSourceBold = Preferences.isPreference(Preferences.VIEW_OPTION_SOURCE_ACTIVE_BOLD);
         markFirstNonUnique = Preferences.isPreference(Preferences.VIEW_OPTION_UNIQUE_FIRST);
@@ -478,15 +482,16 @@ public class EditorSettings implements IEditorSettings {
     }
 
     /**
-     * repaint segments in editor according to new view tag validation options. Use when options change to make them
-     * effective immediately.
+     * repaint segments in editor according to new view tag validation options.
+     * Use when options change to make them effective immediately.
      */
     public void updateTagValidationPreferences() {
         UIThreadsUtil.mustBeSwingThread();
 
         parent.commitAndDeactivate();
 
-        // nothing special to do: tags/placeholders are determined by segment builder and info is passed as argument to
+        // nothing special to do: tags/placeholders are determined by segment
+        // builder and info is passed as argument to
         // getattributeSet.
 
         if (Core.getProject().isProjectLoaded()) {
@@ -501,12 +506,14 @@ public class EditorSettings implements IEditorSettings {
      * @param isSource
      *            is it a source segment or a target segment
      * @param isPlaceholder
-     *            is it for a placeholder (OmegaT tag or sprintf-variable etc.) or regular text inside the segment?
+     *            is it for a placeholder (OmegaT tag or sprintf-variable etc.)
+     *            or regular text inside the segment?
      * @param isRemoveText
      *            is it text that should be removed from translation?
      * @param duplicate
-     *            is the sourceTextEntry a duplicate or not? values: DUPLICATE.NONE, DUPLICATE.FIRST or DUPLICATE.NEXT.
-     *            See sourceTextEntryste.getDuplicate()
+     *            is the sourceTextEntry a duplicate or not? values:
+     *            DUPLICATE.NONE, DUPLICATE.FIRST or DUPLICATE.NEXT. See
+     *            sourceTextEntryste.getDuplicate()
      * @param active
      *            is it an active segment?
      * @param translationExists
@@ -565,7 +572,7 @@ public class EditorSettings implements IEditorSettings {
             fg = Styles.EditorColor.COLOR_REMOVETEXT_TARGET.getColor();
         }
 
-        //determine background color
+        // determine background color
         Color bg = null;
         if (active) {
             if (isSource) {
@@ -606,11 +613,12 @@ public class EditorSettings implements IEditorSettings {
                 break;
             }
         }
-        if (isNBSP && isMarkNBSP()) { //overwrite others, because space is smallest.
+        if (isNBSP && isMarkNBSP()) { // overwrite others, because space is
+                                      // smallest.
             bg = Styles.EditorColor.COLOR_NBSP.getColor();
         }
 
-        //determine bold
+        // determine bold
         Boolean bold = false;
         if (isSource) {
             if (viewSourceBold || (active && viewActiveSourceBold)) {
@@ -618,7 +626,7 @@ public class EditorSettings implements IEditorSettings {
             }
         }
 
-        //determine italic
+        // determine italic
         Boolean italic = false;
         if (isRemoveText && isSource) {
             italic = true;
@@ -629,15 +637,17 @@ public class EditorSettings implements IEditorSettings {
 
     /**
      * Returns font attributes for paragraph start
+     * 
      * @return
      */
     public AttributeSet getParagraphStartAttributeSet() {
-        return Styles.createAttributeSet(Styles.EditorColor.COLOR_PARAGRAPH_START.getColor(),
-                null, false, true);
+        return Styles.createAttributeSet(Styles.EditorColor.COLOR_PARAGRAPH_START.getColor(), null, false,
+                true);
     }
 
     /**
      * Returns font attributes for the modification info line.
+     * 
      * @return
      */
     public AttributeSet getModificationInfoAttributeSet() {

--- a/src/org/omegat/gui/editor/IEditorSettings.java
+++ b/src/org/omegat/gui/editor/IEditorSettings.java
@@ -75,6 +75,10 @@ public interface IEditorSettings {
 
     void setMarkBidi(boolean markBidi);
 
+    boolean isMarkAltTranslations();
+
+    void setMarkAltTranslations(boolean markAltTranslations);
+
     boolean isAutoSpellChecking();
 
     void setAutoSpellChecking(boolean isNeedToSpell);

--- a/src/org/omegat/gui/editor/IEditorSettings.java
+++ b/src/org/omegat/gui/editor/IEditorSettings.java
@@ -66,9 +66,9 @@ public interface IEditorSettings {
     boolean isMarkWhitespace();
 
     void setMarkWhitespace(boolean markWhitespace);
-    
+
     void setMarkParagraphDelimitations(boolean mark);
-    
+
     boolean isMarkParagraphDelimitations();
 
     boolean isMarkBidi();

--- a/src/org/omegat/gui/editor/IEditorSettings.java
+++ b/src/org/omegat/gui/editor/IEditorSettings.java
@@ -75,10 +75,6 @@ public interface IEditorSettings {
 
     void setMarkBidi(boolean markBidi);
 
-    boolean isMarkAltTranslations();
-
-    void setMarkAltTranslations(boolean markAltTranslations);
-
     boolean isAutoSpellChecking();
 
     void setAutoSpellChecking(boolean isNeedToSpell);

--- a/src/org/omegat/gui/editor/MarkerController.java
+++ b/src/org/omegat/gui/editor/MarkerController.java
@@ -40,7 +40,6 @@ import javax.swing.text.Position;
 import org.omegat.core.Core;
 import org.omegat.core.spellchecker.SpellCheckerMarker;
 import org.omegat.filters2.master.PluginUtils;
-import org.omegat.gui.editor.mark.AltTranslationsMarker;
 import org.omegat.gui.editor.mark.BidiMarkers;
 import org.omegat.gui.editor.mark.CalcMarkersThread;
 import org.omegat.gui.editor.mark.ComesFromAutoTMMarker;

--- a/src/org/omegat/gui/editor/MarkerController.java
+++ b/src/org/omegat/gui/editor/MarkerController.java
@@ -87,6 +87,7 @@ public class MarkerController {
         Core.registerMarker(new ComesFromMTMarker());
         Core.registerMarker(new FontFallbackMarker());
         Core.registerMarker(new SpellCheckerMarker());
+        Core.registerMarker(new AltTranslationsMarker());
     }
 
 

--- a/src/org/omegat/gui/editor/MarkerController.java
+++ b/src/org/omegat/gui/editor/MarkerController.java
@@ -88,7 +88,6 @@ public class MarkerController {
         Core.registerMarker(new ComesFromMTMarker());
         Core.registerMarker(new FontFallbackMarker());
         Core.registerMarker(new SpellCheckerMarker());
-        Core.registerMarker(new AltTranslationsMarker());
     }
 
 

--- a/src/org/omegat/gui/editor/MarkerController.java
+++ b/src/org/omegat/gui/editor/MarkerController.java
@@ -40,6 +40,7 @@ import javax.swing.text.Position;
 import org.omegat.core.Core;
 import org.omegat.core.spellchecker.SpellCheckerMarker;
 import org.omegat.filters2.master.PluginUtils;
+import org.omegat.gui.editor.mark.AltTranslationsMarker;
 import org.omegat.gui.editor.mark.BidiMarkers;
 import org.omegat.gui.editor.mark.CalcMarkersThread;
 import org.omegat.gui.editor.mark.ComesFromAutoTMMarker;

--- a/src/org/omegat/gui/editor/MarkerController.java
+++ b/src/org/omegat/gui/editor/MarkerController.java
@@ -40,6 +40,7 @@ import javax.swing.text.Position;
 import org.omegat.core.Core;
 import org.omegat.core.spellchecker.SpellCheckerMarker;
 import org.omegat.filters2.master.PluginUtils;
+import org.omegat.gui.editor.mark.AltTranslationsMarker;
 import org.omegat.gui.editor.mark.BidiMarkers;
 import org.omegat.gui.editor.mark.CalcMarkersThread;
 import org.omegat.gui.editor.mark.ComesFromAutoTMMarker;
@@ -87,6 +88,7 @@ public class MarkerController {
         Core.registerMarker(new ComesFromMTMarker());
         Core.registerMarker(new FontFallbackMarker());
         Core.registerMarker(new SpellCheckerMarker());
+        Core.registerMarker(new AltTranslationsMarker());
     }
 
 

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 public class AltTranslationsMarker extends AbstractMarker {
 
-    protected static final Highlighter.HighlightPainter PAINTER = new TransparentHighlightPainter(
+    private final Highlighter.HighlightPainter painter = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
 
     public static void loadPlugins() {
@@ -62,7 +62,7 @@ public class AltTranslationsMarker extends AbstractMarker {
 
         if (!Core.getProject().getTranslationInfo(ste).defaultTranslation) {
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
-            m.painter = PAINTER;
+            m.painter = painter;
             return Collections.singletonList(m);
         }
 

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -1,3 +1,28 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Lev Abashkin
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
 package org.omegat.gui.editor.mark;
 
 import org.omegat.core.Core;

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -48,7 +48,8 @@ public class AltTranslationsMarker extends AbstractMarker {
     }
 
     @Override
-    public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive) throws Exception {
+    public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
+            boolean isActive) throws Exception {
         if (!isEnabled()) {
             return null;
         }

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -27,7 +27,6 @@ package org.omegat.gui.editor.mark;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.gui.editor.EditorSettings;
 import org.omegat.util.gui.Styles;
 
 import javax.swing.text.Highlighter;
@@ -39,19 +38,13 @@ public class AltTranslationsMarker extends AbstractMarker {
     private final Highlighter.HighlightPainter painter = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
 
-    public static void loadPlugins() {
-        Core.registerMarkerClass(AltTranslationsMarker.class);
-    }
-    public static void unloadPlugins() {
-    }
-
     public AltTranslationsMarker() throws Exception {
         super();
     }
 
     @Override
     protected boolean isEnabled() {
-        return ((EditorSettings) Core.getEditor().getSettings()).isMarkAltTranslations();
+        return Core.getEditor().getSettings().isMarkAltTranslations();
     }
 
     @Override

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -1,0 +1,39 @@
+package org.omegat.gui.editor.mark;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.util.gui.Styles;
+
+import javax.swing.text.Highlighter;
+import java.util.Collections;
+import java.util.List;
+
+public class AltTranslationsMarker extends AbstractMarker {
+
+    protected static final Highlighter.HighlightPainter PAINTER = new TransparentHighlightPainter(
+            Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
+
+    public AltTranslationsMarker() throws Exception {
+        super();
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return Core.getEditor().getSettings().isMarkAltTranslations();
+    }
+
+    @Override
+    public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive) throws Exception {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        if (!Core.getProject().getTranslationInfo(ste).defaultTranslation) {
+            Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
+            m.painter = PAINTER;
+            return Collections.singletonList(m);
+        }
+
+        return null;
+    }
+}

--- a/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -2,6 +2,7 @@ package org.omegat.gui.editor.mark;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.editor.EditorSettings;
 import org.omegat.util.gui.Styles;
 
 import javax.swing.text.Highlighter;
@@ -13,13 +14,19 @@ public class AltTranslationsMarker extends AbstractMarker {
     protected static final Highlighter.HighlightPainter PAINTER = new TransparentHighlightPainter(
             Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
 
+    public static void loadPlugins() {
+        Core.registerMarkerClass(AltTranslationsMarker.class);
+    }
+    public static void unloadPlugins() {
+    }
+
     public AltTranslationsMarker() throws Exception {
         super();
     }
 
     @Override
     protected boolean isEnabled() {
-        return Core.getEditor().getSettings().isMarkAltTranslations();
+        return ((EditorSettings) Core.getEditor().getSettings()).isMarkAltTranslations();
     }
 
     @Override

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -334,6 +334,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 "MW_VIEW_MENU_DISPLAY_SEGMENT_SOURCES");
         viewMarkNonUniqueSegmentsCheckBoxMenuItem = createCheckboxMenuItem(
                 "MW_VIEW_MENU_MARK_NON_UNIQUE_SEGMENTS");
+        viewMarkAlternativeTranslationsCheckBoxMenuItem = createCheckboxMenuItem(
+                "MW_VIEW_MENU_MARK_ALT_TRANSLATIONS");
         viewMarkNotedSegmentsCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NOTED_SEGMENTS");
         viewMarkNBSPCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_NBSP");
         viewMarkWhitespaceCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_WHITESPACE");
@@ -362,6 +364,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 .setIcon(MainMenuIcons.newTextIcon(Styles.EditorColor.COLOR_NON_UNIQUE.getColor(), 'M'));
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_NOTED.getColor()));
+        viewMarkAlternativeTranslationsCheckBoxMenuItem
+                .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor()));
         viewMarkNBSPCheckBoxMenuItem
                 .setIcon(MainMenuIcons.newColorIcon(Styles.EditorColor.COLOR_NBSP.getColor()));
         viewMarkWhitespaceCheckBoxMenuItem
@@ -551,6 +555,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMenu.add(viewMarkParagraphStartCheckBoxMenuItem);
         viewMenu.add(viewDisplaySegmentSourceCheckBoxMenuItem);
         viewMenu.add(viewMarkNonUniqueSegmentsCheckBoxMenuItem);
+        viewMenu.add(viewMarkAlternativeTranslationsCheckBoxMenuItem);
         viewMenu.add(viewMarkNotedSegmentsCheckBoxMenuItem);
         viewMenu.add(viewMarkNBSPCheckBoxMenuItem);
         viewMenu.add(viewMarkWhitespaceCheckBoxMenuItem);
@@ -892,6 +897,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
                 .setSelected(Core.getEditor().getSettings().isMarkNonUniqueSegments());
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkNotedSegments());
+        viewMarkAlternativeTranslationsCheckBoxMenuItem
+                .setSelected(Core.getEditor().getSettings().isMarkAltTranslations());
         viewMarkNBSPCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkNBSP());
         viewMarkWhitespaceCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkWhitespace());
         viewMarkBidiCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkBidi());
@@ -1112,6 +1119,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     JMenuItem upperCaseMenuItem;
     JCheckBoxMenuItem viewDisplaySegmentSourceCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkNonUniqueSegmentsCheckBoxMenuItem;
+    JCheckBoxMenuItem viewMarkAlternativeTranslationsCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkNotedSegmentsCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkNBSPCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkWhitespaceCheckBoxMenuItem;

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -898,7 +898,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkNotedSegments());
         viewMarkAlternativeTranslationsCheckBoxMenuItem
-                .setSelected(Core.getEditor().getSettings().isMarkAltTranslations());
+                .setSelected(((EditorSettings) Core.getEditor().getSettings()).isMarkAltTranslations());
         viewMarkNBSPCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkNBSP());
         viewMarkWhitespaceCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkWhitespace());
         viewMarkBidiCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkBidi());

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -898,7 +898,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMarkNotedSegmentsCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkNotedSegments());
         viewMarkAlternativeTranslationsCheckBoxMenuItem
-                .setSelected(((EditorSettings) Core.getEditor().getSettings()).isMarkAltTranslations());
+                .setSelected(Core.getEditor().getSettings().isMarkAltTranslations());
         viewMarkNBSPCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkNBSP());
         viewMarkWhitespaceCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkWhitespace());
         viewMarkBidiCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkBidi());

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -696,10 +696,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     public void viewMarkAlternativeTranslationsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
-                .setMarkAltTranslations(
-                        mainWindow.menu.viewMarkAlternativeTranslationsCheckBoxMenuItem.isSelected());
+        Core.getEditor().getSettings().setMarkAltTranslations(
+                mainWindow.menu.viewMarkAlternativeTranslationsCheckBoxMenuItem.isSelected());
     }
 
     public void viewMarkAutoPopulatedCheckBoxMenuItemActionPerformed() {
@@ -752,7 +750,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     /**
-     * Identify all the placeholders in the source text and automatically inserts them into the target text.
+     * Identify all the placeholders in the source text and automatically
+     * inserts them into the target text.
      */
     public void editTagPainterMenuItemActionPerformed() {
         // insert tags
@@ -818,7 +817,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     /**
-     * Displays the filters setup dialog to allow customizing file filters in detail.
+     * Displays the filters setup dialog to allow customizing file filters in
+     * detail.
      */
     public void optionsSetupFileFiltersMenuItemActionPerformed() {
         new PreferencesWindowController().show(Core.getMainWindow().getApplicationFrame(),
@@ -826,7 +826,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     /**
-     * Displays the segmentation setup dialog to allow customizing the segmentation rules in detail.
+     * Displays the segmentation setup dialog to allow customizing the
+     * segmentation rules in detail.
      */
     public void optionsSentsegMenuItemActionPerformed() {
         new PreferencesWindowController().show(Core.getMainWindow().getApplicationFrame(),
@@ -835,7 +836,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     /**
-     * Displays the workflow setup dialog to allow customizing the diverse workflow options.
+     * Displays the workflow setup dialog to allow customizing the diverse
+     * workflow options.
      */
     public void optionsWorkflowMenuItemActionPerformed() {
         new PreferencesWindowController().show(Core.getMainWindow().getApplicationFrame(),
@@ -843,8 +845,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     /**
-     * Restores defaults for all dockable parts. May be expanded in the future to reset the entire GUI to its
-     * defaults.
+     * Restores defaults for all dockable parts. May be expanded in the future
+     * to reset the entire GUI to its defaults.
      */
     public void viewRestoreGUIMenuItemActionPerformed() {
         Core.getMainWindow().resetDesktopLayout();

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -695,6 +695,13 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         Core.getEditor().getSettings().setMarkBidi(mainWindow.menu.viewMarkBidiCheckBoxMenuItem.isSelected());
     }
 
+    public void viewMarkAlternativeTranslationsCheckBoxMenuItemActionPerformed() {
+        Core.getEditor()
+                .getSettings()
+                .setMarkAltTranslations(
+                        mainWindow.menu.viewMarkAlternativeTranslationsCheckBoxMenuItem.isSelected());
+    }
+
     public void viewMarkAutoPopulatedCheckBoxMenuItemActionPerformed() {
         Core.getEditor().getSettings()
                 .setMarkAutoPopulated(mainWindow.menu.viewMarkAutoPopulatedCheckBoxMenuItem.isSelected());

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -696,8 +696,7 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     public void viewMarkAlternativeTranslationsCheckBoxMenuItemActionPerformed() {
-        Core.getEditor()
-                .getSettings()
+        ((EditorSettings) Core.getEditor().getSettings())
                 .setMarkAltTranslations(
                         mainWindow.menu.viewMarkAlternativeTranslationsCheckBoxMenuItem.isSelected());
     }

--- a/src/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -696,7 +696,8 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     public void viewMarkAlternativeTranslationsCheckBoxMenuItemActionPerformed() {
-        ((EditorSettings) Core.getEditor().getSettings())
+        Core.getEditor()
+                .getSettings()
                 .setMarkAltTranslations(
                         mainWindow.menu.viewMarkAlternativeTranslationsCheckBoxMenuItem.isSelected());
     }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -187,6 +187,8 @@ public final class Preferences {
     public static final String MARK_WHITESPACE = "mark_whitespace";
     /** Mark Bidi controls as symbols */
     public static final String MARK_BIDI = "mark_bidi";
+    /** Mark alternative translations */
+    public static final String MARK_ALT_TRANSLATIONS = "mark_alt_translations";
     /** Do aggressive font fallback */
     public static final String FONT_FALLBACK = "font_fallback";
 

--- a/src/org/omegat/util/gui/MenuExtender.java
+++ b/src/org/omegat/util/gui/MenuExtender.java
@@ -54,7 +54,7 @@ public final class MenuExtender {
         /**
          * View menu.
          */
-        VIEW("view", 13),
+        VIEW("view", 14),
         /**
          * Tools menu.
          */

--- a/src/org/omegat/util/gui/Styles.java
+++ b/src/org/omegat/util/gui/Styles.java
@@ -120,6 +120,8 @@ public final class Styles {
 
         COLOR_MARK_COMES_FROM_TM_XENFORCED(UIManager.getColor("OmegaT.markComesFromTmXenforced")),
 
+        COLOR_MARK_ALT_TRANSLATION(UIManager.getColor("OmegaT.markAltTranslations")),
+
         COLOR_REPLACE(UIManager.getColor("OmegaT.replace")),
 
         COLOR_LANGUAGE_TOOLS(UIManager.getColor("OmegaT.languageTools")),

--- a/test/data/mark/alternative.tmx
+++ b/test/data/mark/alternative.tmx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx11.dtd">
+<tmx version="1.1">
+    <header srclang="en" />
+    <body>
+        <tu>
+            <tuv lang="en">
+                <seg>Edit</seg>
+            </tuv>
+            <tuv lang="fr">
+                <seg>default</seg>
+            </tuv>
+        </tu>
+        <tu>
+            <prop type="file">file1</prop>
+            <prop type="id">1_1</prop>
+            <prop type="prev">prev1</prop>
+            <prop type="next">next1</prop>
+            <tuv lang="en">
+                <seg>Edit</seg>
+            </tuv>
+            <tuv lang="fr">
+                <seg>alternative</seg>
+            </tuv>
+        </tu>
+    </body>
+</tmx>

--- a/test/fixtures/org/omegat/core/TestCore.java
+++ b/test/fixtures/org/omegat/core/TestCore.java
@@ -387,6 +387,15 @@ public abstract class TestCore {
             }
 
             @Override
+            public boolean isMarkAltTranslations() {
+                return false;
+            }
+
+            @Override
+            public void setMarkAltTranslations(final boolean markAltTranslations) {
+            }
+
+            @Override
             public boolean isAutoSpellChecking() {
                 return false;
             }

--- a/test/src/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
+++ b/test/src/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Lev Abashkin
+               2024 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.editor.mark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.util.Language;
+
+public class AltTranslationsMarkerTest  extends MarkerTestBase {
+
+    private ProjectTMX projectTMX;
+
+    @Before
+    public void preUp() throws Exception {
+        TestCoreInitializer.initEditor(editor);
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        projectTMX = new ProjectTMX(new Language("en"), new Language("fr"), true,
+                Paths.get("test/data/mark/alternative.tmx").toFile(), null);
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return true;
+            }
+
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return new ProjectProperties() {
+                    @Override
+                    public Language getSourceLanguage() {
+                        return new Language("en");
+                    }
+
+                    @Override
+                    public Language getTargetLanguage() {
+                        return new Language("fr");
+                    }
+                };
+            }
+
+            @Override
+            public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+                if (ste == null || projectTMX == null) {
+                    return EMPTY_TRANSLATION;
+                }
+                TMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
+                if (r == null) {
+                    r = projectTMX.getDefaultTranslation(ste.getSrcText());
+                }
+                if (r == null) {
+                    r = EMPTY_TRANSLATION;
+                }
+                return r;
+            }
+
+        });
+    }
+
+    @Test
+    public void testAltTranslationsMarker() throws Exception {
+        IMarker marker = new AltTranslationsMarker();
+        Core.getEditor().getSettings().setMarkAltTranslations(true);
+        String sourceText = "Edit";
+        String translationText = "default";
+        // default entry: file and
+        EntryKey key0 = new EntryKey("file0", sourceText, "1_0", "prev0", "next0", "path");
+        SourceTextEntry ste0 = new SourceTextEntry(key0, 1, new String[0], sourceText,
+                Collections.emptyList());
+        List<Mark> result = marker.getMarksForEntry(ste0, sourceText, translationText, true);
+        assertNull(result);
+        // alternative entry: file and 1_0
+        translationText = "alternative";
+        EntryKey key1 = new EntryKey("file1", sourceText, "1_1", "prev1", "next1", null);
+        SourceTextEntry ste1 = new SourceTextEntry(key1, 1, new String[0], sourceText,
+                Collections.emptyList());
+        result = marker.getMarksForEntry(ste1, sourceText, translationText, true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        // TODO: further checks
+    }
+}

--- a/test/src/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
+++ b/test/src/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
@@ -48,7 +48,7 @@ import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.util.Language;
 
-public class AltTranslationsMarkerTest  extends MarkerTestBase {
+public class AltTranslationsMarkerTest extends MarkerTestBase {
 
     private ProjectTMX projectTMX;
 

--- a/test/src/org/omegat/gui/editor/mark/MarkerTestBase.java
+++ b/test/src/org/omegat/gui/editor/mark/MarkerTestBase.java
@@ -63,6 +63,7 @@ public class MarkerTestBase extends TestCore {
         private boolean markGlossaryMatches;
         private boolean markLanguageChecker;
         private boolean doFontFallback;
+        private boolean markAlt;
 
         @Override
         public boolean isUseTabForAdvance() {
@@ -162,6 +163,16 @@ public class MarkerTestBase extends TestCore {
         @Override
         public void setMarkBidi(boolean markBidi) {
             this.markBidi = markBidi;
+        }
+
+        @Override
+        public boolean isMarkAltTranslations() {
+            return markAlt;
+        }
+
+        @Override
+        public void setMarkAltTranslations(final boolean markAltTranslations) {
+            markAlt = markAltTranslations;
         }
 
         @Override


### PR DESCRIPTION
Re-working on the proposal from @chelobaka 

I have reverted some changes from my review comment, because we now understand mark is not perfect to be a plugin.

I tweak several places to fix test errors which is caused by the proposed changes.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Alternative translation highlight
  * https://sourceforge.net/p/omegat/feature-requests/1736/
 
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- This PR implements new highlighter for marking segments with an alternative translation.
- GUI bits one might expect for a highlighter like changing color in settings and default color values for light/dark themes.

## Other information

Re-submit PR to modify #950