### PR TITLE
refactor: PluginUtils to handle theme plugins

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -332,15 +332,7 @@ public final class Main {
      * Execute standard GUI.
      */
     protected static int runGUI() {
-        ClassLoader cl = ClassLoader.getSystemClassLoader();
-        MainClassLoader mainClassLoader;
-        if (cl instanceof MainClassLoader) {
-            mainClassLoader = (MainClassLoader) cl;
-        } else {
-            mainClassLoader = new MainClassLoader(cl);
-        }
-        PluginUtils.getThemePluginJars().forEach(mainClassLoader::addJarToClasspath);
-        UIManager.put("ClassLoader", mainClassLoader);
+        UIManager.put("ClassLoader",  PluginUtils.getThemeClassLoader());
 
         // macOS-specific - they must be set BEFORE any GUI calls
         if (Platform.isMacOSX()) {

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -272,6 +272,10 @@ public final class PluginUtils {
      * @throws ClassNotFoundException
      *             when specified plugin is not found.
      */
+    public static void loadPluginFromProperties(Properties props) throws ClassNotFoundException {
+        ClassLoader pluginsClassLoader = PluginUtils.class.getClassLoader();
+        loadFromProperties(props, pluginsClassLoader);
+    }
 
     /**
      * This method creates a list of plugins to load. It tries to only take the

--- a/test-acceptance/src/org/omegat/TestMainInitializer.java
+++ b/test-acceptance/src/org/omegat/TestMainInitializer.java
@@ -2,16 +2,15 @@ package org.omegat;
 
 import javax.swing.UIManager;
 
+import org.omegat.filters2.master.PluginUtils;
+
 public final class TestMainInitializer {
 
     private TestMainInitializer() {
     }
 
     public static void initClassloader() {
-        ClassLoader cl = ClassLoader.getSystemClassLoader();
-        MainClassLoader mainClassLoader = (cl instanceof MainClassLoader) ? (MainClassLoader) cl
-                : new MainClassLoader(cl);
-        UIManager.put("ClassLoader", mainClassLoader);
+        UIManager.put("ClassLoader", PluginUtils.getThemeClassLoader());
     }
 
 }


### PR DESCRIPTION
This defines URLClassLoader class loader named THEME_CLASSLOADER that can be add URLs dynamically. It loads theme modules and plugins. Main class set the ClassLoader as UI class loader and Java Swing subsystem can find LaF classes.



<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

dev-ML
https://sourceforge.net/p/omegat/mailman/omegat-development/thread/a2d24fed-49c2-4ea4-9ee6-3cf49c207ba6%40northside.tokyo/#msg58797265


## What does this PR change?

- Define THEME_CLASSLOADER in PluginUtils
- THEME_CLASSLOADER is MainClassLoader object
- Load theme plugins with THEME_CLASSLOADER

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
