### PR TITLE
chore(ci): upload with recursively

### DIFF
--- a/ci/azure-pipelines/publish_manual_snapshot.yml
+++ b/ci/azure-pipelines/publish_manual_snapshot.yml
@@ -13,4 +13,4 @@ steps:
         dest=$(SOURCEFORGE_FILE_USER)@frs.sourceforge.net
         destdir=/home/project-web/omegat/htdocs/manual-snapshot/
         echo "mkdir $destdir" | SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e sftp -oStrictHostKeyChecking=no $dest || true
-        SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e scp -s -oStrictHostKeyChecking=no $srcdir/* $dest:$destdir
+        SSHPASS=$(SOURCEFORGE_FILE_PASS) sshpass -e scp -r -s -oStrictHostKeyChecking=no $srcdir/* $dest:$destdir


### PR DESCRIPTION
Last CI build is failed because upload of snapshot manual is failed.
It is because command line scp does not have a "recursive" option.

## Pull request type

- Build and release changes -> [build/release]


## Which ticket is resolved?

## What does this PR change?

- Use "scp -r -s" for uploading manual contents


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
