### PR TITLE
chore: add unescape diff tool

### DIFF
--- a/config/git/udiff.sh
+++ b/config/git/udiff.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Unescape Unicode sequences in a properties file
+unescape() {
+    perl -CSD -Mopen=':std,:utf8' -pe 's/\\u([0-9a-fA-F]{4})/chr(hex($1))/eg' "$1"
+}
+
+# Create temporary files for the unescaped content
+LOCAL=$(mktemp)
+REMOTE=$(mktemp)
+
+# Perform the unescaping
+unescape "$1" > "$LOCAL"
+unescape "$2" > "$REMOTE"
+
+# Run diff with unescaped content
+diff --unified=3 --ignore-case --color=always "$LOCAL" "$REMOTE" | less --raw-control-chars
+
+# Clean up temporary files
+rm -f "$LOCAL" "$REMOTE"
+


### PR DESCRIPTION
Developers can use the unescape diff tool by configurae git like

```bash
git config difftool.udiff.cmd 'config/git/udiff.sh $LOCAL $REMOTE'
git config alias.udiff 'difftool --tool=udiff'
```

then developers can run like

```bash
git udiff src/org/omegat/Bundles_(lang).properties
```

## Pull request type

 Other (describe below)
developers configuration

## Other information

Developers need to have "bash", "perl", "diff" and "less" commands on the environment to use.
