### PR TITLE
refactor: simplify IParseCallback#addEntry

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/Aligner.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Aligner.java
@@ -262,14 +262,14 @@ public class Aligner {
                     @Override
                     public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
                             String path, IFilter filter, List<ProtectedPart> protectedParts) {
-                        process(source, id != null ? id : path != null ? path : null);
+                        process(source, id != null ? id : path);
                     }
 
                     @Override
                     public void addEntryWithProperties(String id, String source, String translation,
                             boolean isFuzzy, String[] props, String path, IFilter filter,
                             List<ProtectedPart> protectedParts) {
-                        process(source, id != null ? id : path != null ? path : null);
+                        process(source, id != null ? id : path);
 
                     }
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -70,8 +70,8 @@
     <suppress files="PluginInformation\.java" checks="NeedBraces" lines="167-192"/>
     <!-- core/data/* -->
     <suppress checks="ParameterNumber" files="PluginInformation\.java" lines="60"/>
-    <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="136,198,233,277"/>
-    <suppress checks="ParameterNumber" files="ExternalTMFactory\.java" lines="256,263"/>
+    <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="130-150,200-277"/>
+    <suppress checks="ParameterNumber" files="ExternalTMFactory\.java" lines="240-260"/>
     <suppress checks="(ParameterNumber|FileLength)" files="RealProject\.java"/>
 
     <!-- util/Platform -->

--- a/src/org/omegat/core/data/ExternalTMFactory.java
+++ b/src/org/omegat/core/data/ExternalTMFactory.java
@@ -248,12 +248,6 @@ public final class ExternalTMFactory {
 
                         @Override
                         public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                                String comment, IFilter filter) {
-                            process(source, translation, id, comment, null, null);
-                        }
-
-                        @Override
-                        public void addEntry(String id, String source, String translation, boolean isFuzzy,
                                 String comment, String path, IFilter filter,
                                 List<ProtectedPart> protectedParts) {
                             process(source, translation, id, comment, path, null);

--- a/src/org/omegat/core/data/ParseEntry.java
+++ b/src/org/omegat/core/data/ParseEntry.java
@@ -47,8 +47,8 @@ import org.omegat.util.StringUtil;
 /**
  * Process one entry on parse source file.
  *
- * This class caches segments for one file, then flushes they. It required to ability to link prev/next
- * segments.
+ * This class caches segments for one file, then flushes they. It required to
+ * ability to link prev/next segments.
  *
  * @author Maxym Mykhalchuk
  * @author Henry Pijffers
@@ -59,7 +59,7 @@ public abstract class ParseEntry implements IParseCallback {
     private final ProjectProperties config;
 
     /** Cached segments. */
-    private List<ParseEntryQueueItem> parseQueue = new ArrayList<ParseEntryQueueItem>();
+    private final List<ParseEntryQueueItem> parseQueue = new ArrayList<>();
 
     public ParseEntry(final ProjectProperties conf) {
         this.config = conf;
@@ -73,8 +73,9 @@ public abstract class ParseEntry implements IParseCallback {
          * Flush queue.
          */
         for (ParseEntryQueueItem item : parseQueue) {
-            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts, item.segmentTranslation,
-                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path);
+            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts,
+                    item.segmentTranslation, item.segmentTranslationFuzzy, item.props, item.prevSegment,
+                    item.nextSegment, item.path);
         }
 
         /*
@@ -106,7 +107,8 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      *
      * @param id
      *            ID of entry, if format supports it
@@ -115,16 +117,21 @@ public abstract class ParseEntry implements IParseCallback {
      * @param translation
      *            translation of the source string, if format supports it
      * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
      *            reference during translation.
      * @param props
-     *            a staggered array of non-uniquely-identifying key=value properties (metadata) for the entry.
-     *            If property is org.omegat.core.data.SegmentProperties.REFERENCE, the entire segment is added only to
-     *            the generated 'reference' TMX, a special TMX that is used as extra reference during translation.
-     *            The segment is not added to the list of translatable segments.
-     *            Property can also be org.omegat.core.data.SegmentProperties.COMMENT, which shown in the comment panel.
-     *            Other properties are possible, but have no special meaning in OmegaT.
+     *            a staggered array of non-uniquely-identifying key=value
+     *            properties (metadata) for the entry. If property is
+     *            org.omegat.core.data.SegmentProperties.REFERENCE, the entire
+     *            segment is added only to the generated 'reference' TMX, a
+     *            special TMX that is used as extra reference during
+     *            translation. The segment is not added to the list of
+     *            translatable segments. Property can also be
+     *            org.omegat.core.data.SegmentProperties.COMMENT, which shown in
+     *            the comment panel. Other properties are possible, but have no
+     *            special meaning in OmegaT.
      * @param path
      *            path of entry in file
      * @param filter
@@ -133,8 +140,8 @@ public abstract class ParseEntry implements IParseCallback {
      *            protected parts
      */
     @Override
-    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-            String path, IFilter filter, List<ProtectedPart> protectedParts) {
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
         if (StringUtil.isEmpty(source)) {
             // empty string - not need to save
             return;
@@ -190,9 +197,11 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      * <p>
-     * Old call for filters that only support extracting a "comment" property. Kept for compatibility.
+     * Old call for filters that only support extracting a "comment" property.
+     * Kept for compatibility.
      */
     @Override
     public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
@@ -202,36 +211,11 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
-     * <p>
-     * Old call without path, for compatibility. Comment is converted to a property.
-     *
-     * @param id
-     *            ID of entry, if format supports it
-     * @param source
-     *            Translatable source string
-     * @param translation
-     *            translation of the source string, if format supports it
-     * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
-     *            reference during translation.
-     * @param comment
-     *            entry's comment, if format supports it
-     * @param filter
-     *            filter which produces entry
-     */
-    @Override
-    public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-            IFilter filter) {
-        addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
-    }
-
-    /**
      * Add segment to queue because we possible need to link prev/next segments.
      */
-    private void internalAddSegment(String id, short segmentIndex, String segmentSource, String segmentTranslation,
-            boolean segmentTranslationFuzzy, String[] props, String path, List<ProtectedPart> protectedParts) {
+    private void internalAddSegment(String id, short segmentIndex, String segmentSource,
+            String segmentTranslation, boolean segmentTranslationFuzzy, String[] props, String path,
+            List<ProtectedPart> protectedParts) {
         if (segmentSource.trim().isEmpty()) {
             // skip empty segments
             return;

--- a/src/org/omegat/filters2/IParseCallback.java
+++ b/src/org/omegat/filters2/IParseCallback.java
@@ -38,10 +38,10 @@ import org.omegat.core.data.ProtectedPart;
  */
 public interface IParseCallback {
     /**
-     * Read entry from source file, with arbitrary (optional) properties
+     * Read entry from a source file, with arbitrary (optional) properties
      *
      * @param id
-     *            ID in source file, or null if ID not supported by format
+     *            ID in a source file, or null if ID not supported by format
      * @param source
      *            source entry text
      * @param translation
@@ -55,24 +55,46 @@ public interface IParseCallback {
      * @param filter
      *            filter which produces entry
      * @param protectedParts
-     *            (since 3.0.6) protected parts
+     *            protected parts
      */
     void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
             String path, IFilter filter, List<ProtectedPart> protectedParts);
 
     /**
-     * Read entry from source file, with single "comment" property. Convenience
-     * method for
+     * Read entry from a source file, with single "comment" property.
+     * Convenience method for
      * {@link #addEntryWithProperties(String, String, String, boolean, String[], String, IFilter, List)}.
      */
     void addEntry(String id, String source, String translation, boolean isFuzzy, String comment, String path,
             IFilter filter, List<ProtectedPart> protectedParts);
 
     /**
-     * Old call without path, for compatibility with OmegaT &lt; 2.5.0
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from a source file.
+     * <p>
+     * Old call without a path, for compatibility. Comment is converted to a
+     * property.
+     *
+     * @param id
+     *            ID of entry, if a format supports it
+     * @param source
+     *            Translatable source string
+     * @param translation
+     *            translation of the source string, if a format supports it
+     * @param isFuzzy
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
+     *            reference during translation.
+     * @param comment
+     *            entry's comment, if format supports it
+     * @param filter
+     *            filter which produces entry
      */
-    void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-            IFilter filter);
+    default void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
+            IFilter filter) {
+        addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
+    }
 
     /**
      * This method can be called from any filter on the end of file processing.

--- a/src/org/omegat/filters2/text/ilias/ILIASFilter.java
+++ b/src/org/omegat/filters2/text/ilias/ILIASFilter.java
@@ -103,15 +103,15 @@ public class ILIASFilter extends AbstractFilter {
      * @param outfile
      */
     @Override
-    public void processFile(BufferedReader reader, BufferedWriter outfile, FilterContext fc) throws IOException {
-        LinebreakPreservingReader lbpr = new LinebreakPreservingReader(reader); // fix
-                                                                                // for
-                                                                                // bug
-                                                                                // 1462566
+    public void processFile(BufferedReader reader, BufferedWriter outfile, FilterContext fc)
+            throws IOException {
+        // fix for bug 1462566
+        LinebreakPreservingReader lbpr = new LinebreakPreservingReader(reader);
         String line;
         /*
-         * ILIAS strings look like module_name#:#identifier#:#string to translate
-         * The file usually begins from some text that does not match the pattern
+         * ILIAS strings look like module_name#:#identifier#:#string to
+         * translate The file usually begins from some text that does not match
+         * the pattern
          */
 
         while ((line = lbpr.readLine()) != null) {
@@ -132,7 +132,8 @@ public class ILIASFilter extends AbstractFilter {
             String key = mat.group(1) + "#:#" + mat.group(2);
             String value = mat.group(3);
 
-            if (value.isEmpty()) { // If original text is empty, the translated is empty too
+            if (value.isEmpty()) { // If original text is empty, the translated
+                                   // is empty too
                 outfile.write(line + lbpr.getLinebreak());
                 continue;
             }
@@ -207,7 +208,7 @@ public class ILIASFilter extends AbstractFilter {
      */
     private String process(String key, String value) {
         if (entryParseCallback != null) {
-            entryParseCallback.addEntry(key, value, null, false, null, this);
+            entryParseCallback.addEntry(key, value, null, false, null, null, this, null);
             return value;
         } else if (entryTranslateCallback != null) {
             String trans = entryTranslateCallback.getTranslation(key, value);

--- a/src/org/omegat/filters2/text/magento/MagentoFilter.java
+++ b/src/org/omegat/filters2/text/magento/MagentoFilter.java
@@ -43,8 +43,8 @@ import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 
 /**
- * Filter to support Files for Magento CE locale. The files are a kind of CSV that looks like
- * "string in code","string to display in a locale"
+ * Filter to support Files for Magento CE locale. The files are a kind of CSV
+ * that looks like "string in code", "string to display in a locale"
  *
  * @author Michael Zakharov <trapman.hunt@gmail.com>
  */
@@ -79,11 +79,13 @@ public class MagentoFilter extends AbstractFilter {
 
     /**
      * Doing the processing of the file...
+     * 
      * @param reader
      * @param outfile
      */
     @Override
-    public void processFile(BufferedReader reader, BufferedWriter outfile, FilterContext fc) throws IOException {
+    public void processFile(BufferedReader reader, BufferedWriter outfile, FilterContext fc)
+            throws IOException {
         LinebreakPreservingReader lbpr = new LinebreakPreservingReader(reader); // fix
                                                                                 // for
                                                                                 // bug
@@ -92,21 +94,19 @@ public class MagentoFilter extends AbstractFilter {
         /*
          * Magento CSV looks like "string in the code","translation to display"
          * The pattern below successfully handles cases like:
-         * "Use "",""",""","" will be used"
-         * The string will be displayed as: Use ","
-         * or, after translation: "," will be used
-         * The pattern splits it like
-         * "Use "",""" (key for translation) and ""","" will be used" (value for translation)
+         * "Use "",""",""","" will be used" The string will be displayed as: Use
+         * "," or, after translation: "," will be used The pattern splits it
+         * like "Use "",""" (key for translation) and ""","" will be used"
+         * (value for translation)
          */
         Pattern splitter = Pattern.compile(",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))");
 
         while ((line = lbpr.readLine()) != null) {
 
             /**
-             * Some lines in Magento locale CSV may look like:
-             * "first, second
-             * third","first, second, third"
-             * It is unknown, if these lines are valid or not, so I inserted a quick workaround.
+             * Some lines in Magento locale CSV may look like: "first, second
+             * third","first, second, third" It is unknown, if these lines are
+             * valid or not, so I inserted a quick workaround.
              */
             String contLine;
             // Continue reading until the line ends with ", or end of file
@@ -171,7 +171,7 @@ public class MagentoFilter extends AbstractFilter {
      */
     private String process(String key, String value) {
         if (entryParseCallback != null) {
-            entryParseCallback.addEntry(key, value, null, false, null, this);
+            entryParseCallback.addEntry(key, value, null, false, null, null, this, null);
             return value;
         } else if (entryTranslateCallback != null) {
             String trans = entryTranslateCallback.getTranslation(key, value);

--- a/test/src/org/omegat/core/data/TmxComplianceBase.java
+++ b/test/src/org/omegat/core/data/TmxComplianceBase.java
@@ -153,6 +153,7 @@ public abstract class TmxComplianceBase {
                 assertNotNull(e);
                 return e.translation;
             }
+
             @Override
             String getCurrentFile() {
                 return fileTextIn;
@@ -168,20 +169,16 @@ public abstract class TmxComplianceBase {
         final List<String> result = new ArrayList<String>();
 
         IParseCallback callback = new IParseCallback() {
+            @Override
             public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                    String comment, IFilter filter) {
-            }
-
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
             @Override
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 result.addAll(Core.getSegmenter().segment(context.getSourceLang(), source, null, null));
             }
 

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -359,12 +359,6 @@ public class CalcMatchStatisticsTest {
         }
 
         @Override
-        public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                IFilter filter) {
-            addEntry(id, source, translation, isFuzzy, comment, null, filter, Collections.emptyList());
-        }
-
-        @Override
         public void linkPrevNextSegments() {
         }
     }

--- a/test/src/org/omegat/filters/TestFilterBase.java
+++ b/test/src/org/omegat/filters/TestFilterBase.java
@@ -50,6 +50,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.w3c.dom.Document;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
@@ -72,8 +74,6 @@ import org.omegat.filters2.master.FilterMaster;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.util.Language;
 import org.omegat.util.TMXReader2;
-import org.xmlunit.diff.DefaultNodeMatcher;
-import org.xmlunit.diff.ElementSelectors;
 
 /**
  * Base class for testing filter parsing.
@@ -114,11 +114,6 @@ public abstract class TestFilterBase extends TestCore {
         final List<String> result = new ArrayList<String>();
 
         filter.parseFile(new File(filename), Collections.emptyMap(), context, new IParseCallback() {
-            public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                    String comment, IFilter filter) {
-                addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
-            }
-
             public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
                     String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
@@ -157,20 +152,16 @@ public abstract class TestFilterBase extends TestCore {
         final List<String> result = new ArrayList<String>();
 
         filter.parseFile(new File(filename), options, context, new IParseCallback() {
+            @Override
             public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                    String comment, IFilter filter) {
-                addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
-            }
-
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            @Override
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 if (!source.isEmpty()) {
                     result.add(source);
                 }
@@ -202,21 +193,16 @@ public abstract class TestFilterBase extends TestCore {
             final Map<String, String> result, final Map<String, String> legacyTMX) throws Exception {
 
         filter.parseFile(new File(filename), Collections.emptyMap(), context, new IParseCallback() {
+            @Override
             public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                    String comment, IFilter filter) {
-                addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
-            }
-
-            public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                    String path, IFilter filter, List<ProtectedPart> protectedParts) {
+                    String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
                 addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
             }
 
             @Override
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String segTranslation = isFuzzy ? null : translation;
                 result.put(source, segTranslation);
                 if (translation != null) {
@@ -236,24 +222,27 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the parseFile method of a given filter using some options;
-     * returns a list of ParsedEntry with the
-     * attributes that the filter-under-test finds in the given file and returns to the IParseCallback.addEntry method.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param options the filter options/config to use
+     * Helper function for testing the parseFile method of a given filter using
+     * some options; returns a list of ParsedEntry with the attributes that the
+     * filter-under-test finds in the given file and returns to the
+     * IParseCallback.addEntry method.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param options
+     *            the filter options/config to use
      * @return list of found information
-     * @throws Exception when the filter throws an exception on parseFile.
+     * @throws Exception
+     *             when the filter throws an exception on parseFile.
      */
     protected List<ParsedEntry> parse3(AbstractFilter filter, String filename, Map<String, String> options)
             throws Exception {
         final List<ParsedEntry> result = new ArrayList<>();
 
         filter.parseFile(new File(filename), options, context, new IParseCallback() {
-            public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                    String comment, IFilter filter) {
-                addEntry(id, source, translation, isFuzzy, comment, null, filter, null);
-            }
+            @Override
             public void addEntry(String id, String source, String translation, boolean isFuzzy,
                     String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 String[] props = comment == null ? null : new String[] { SegmentProperties.COMMENT, comment };
@@ -261,9 +250,8 @@ public abstract class TestFilterBase extends TestCore {
             }
 
             @Override
-            public void addEntryWithProperties(String id, String source, String translation,
-                    boolean isFuzzy, String[] props, String path,
-                    IFilter filter, List<ProtectedPart> protectedParts) {
+            public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                    String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                 if (source.isEmpty()) {
                     return;
                 }
@@ -285,11 +273,16 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Helper function for testing the translateFile method of a filter. Translation equals the source.
-     * Translation is written to {@link #outFile}.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @throws Exception when the filter throws an exception
+     * Helper function for testing the translateFile method of a filter.
+     * Translation equals the source. Translation is written to
+     * {@link #outFile}.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @throws Exception
+     *             when the filter throws an exception
      */
     protected void translate(AbstractFilter filter, String filename) throws Exception {
         translate(filter, filename, Collections.emptyMap());
@@ -297,63 +290,83 @@ public abstract class TestFilterBase extends TestCore {
 
     /**
      * Helper function for testing the translateFile method of a filter.
-     * Translation equals the source when monolingual filter.
-     * Translation is written to {@link #outFile}.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param config the filter options/config to use
-     * @throws Exception when the filter throws an exception
+     * Translation equals the source when monolingual filter. Translation is
+     * written to {@link #outFile}.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param config
+     *            the filter options/config to use
+     * @throws Exception
+     *             when the filter throws an exception
      */
-    protected void translate(AbstractFilter filter, String filename, Map<String, String> config) throws Exception {
+    protected void translate(AbstractFilter filter, String filename, Map<String, String> config)
+            throws Exception {
         translate(filter, filename, config, Collections.emptyMap());
     }
 
     /**
      * Helper function for testing the translateFile method of a filter.
-     * Translation equals the source when monolingual filter when no translation is found.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param config the filter options/config to use
-     * @param translations expected translations.
-     * @throws Exception when the filter throws an exception
+     * Translation equals the source when monolingual filter when no translation
+     * is found.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param config
+     *            the filter options/config to use
+     * @param translations
+     *            expected translations.
+     * @throws Exception
+     *             when the filter throws an exception
      */
     protected void translate(AbstractFilter filter, String filename, Map<String, String> config,
-                             Map<String, String> translations) throws Exception {
+            Map<String, String> translations) throws Exception {
         translate(filter, filename, config, translations, filter.isBilingual());
     }
 
     /**
      * Helper function for testing the translateFile method of a filter.
-     * Translation equals the source when allowBlank is false and translation is not found.
-     * @param filter the filter to test
-     * @param filename the file to use as input for the filter
-     * @param config the filter options/config to use
-     * @param translations expected translations.
-     * @param allowBlank return null as translation when translation is not found.
-     * @throws Exception when the filter throws an exception
+     * Translation equals the source when allowBlank is false and translation is
+     * not found.
+     * 
+     * @param filter
+     *            the filter to test
+     * @param filename
+     *            the file to use as input for the filter
+     * @param config
+     *            the filter options/config to use
+     * @param translations
+     *            expected translations.
+     * @param allowBlank
+     *            return null as translation when translation is not found.
+     * @throws Exception
+     *             when the filter throws an exception
      */
     protected void translate(AbstractFilter filter, String filename, Map<String, String> config,
-                           Map<String, String> translations, boolean allowBlank) throws Exception {
-        filter.translateFile(new File(filename), outFile, config, context,
-                new ITranslateCallback() {
-                    public String getTranslation(String id, String source, String path) {
-                        String translation = translations.get(source);
-                        if (translation == null && !allowBlank) {
-                            return source;
-                        }
-                        return translation;
-                    }
+            Map<String, String> translations, boolean allowBlank) throws Exception {
+        filter.translateFile(new File(filename), outFile, config, context, new ITranslateCallback() {
+            public String getTranslation(String id, String source, String path) {
+                String translation = translations.get(source);
+                if (translation == null && !allowBlank) {
+                    return source;
+                }
+                return translation;
+            }
 
-                    public String getTranslation(String id, String source) {
-                        return getTranslation(id, source, null);
-                    }
+            public String getTranslation(String id, String source) {
+                return getTranslation(id, source, null);
+            }
 
-                    public void linkPrevNextSegments() {
-                    }
+            public void linkPrevNextSegments() {
+            }
 
-                    public void setPass(int pass) {
-                    }
-                });
+            public void setPass(int pass) {
+            }
+        });
     }
 
     protected void align(IFilter filter, String in, String out, IAlignCallback callback) throws Exception {
@@ -363,37 +376,50 @@ public abstract class TestFilterBase extends TestCore {
     }
 
     /**
-     * Asserts if the filter translateFile method produces a binary identical file from the given file, when no
-     * filter options/config given.
+     * Asserts if the filter translateFile method produces a binary identical
+     * file from the given file, when no filter options/config given.
      *
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @throws Exception when the filter throws an exception.
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @throws Exception
+     *             when the filter throws an exception.
      */
     protected void translateText(AbstractFilter filter, String filename) throws Exception {
         translateText(filter, filename, Collections.emptyMap());
     }
+
     /**
-     * Asserts if the filter translateFile method produces a binary identical file from the given file under the given
-     * filter options/config.
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @param config  the filter options/config
-     * @throws Exception when the filter throws an exception.
+     * Asserts if the filter translateFile method produces a binary identical
+     * file from the given file under the given filter options/config.
+     * 
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @param config
+     *            the filter options/config
+     * @throws Exception
+     *             when the filter throws an exception.
      */
 
-    protected void translateText(AbstractFilter filter, String filename, Map<String, String> config) throws Exception {
+    protected void translateText(AbstractFilter filter, String filename, Map<String, String> config)
+            throws Exception {
         translate(filter, filename, config);
         compareBinary(new File(filename), outFile);
     }
 
     /**
-     * Tests if the filter translateFile method produces an identical XML file from the given file, when no
-     * filter options/config given.
+     * Tests if the filter translateFile method produces an identical XML file
+     * from the given file, when no filter options/config given.
      *
-     * @param filter The filter to test
-     * @param filename the file to translate during the test
-     * @throws Exception when the filter throws an exception.
+     * @param filter
+     *            The filter to test
+     * @param filename
+     *            the file to translate during the test
+     * @throws Exception
+     *             when the filter throws an exception.
      */
     protected void translateXML(AbstractFilter filter, String filename) throws Exception {
         translate(filter, filename);
@@ -426,12 +452,10 @@ public abstract class TestFilterBase extends TestCore {
 
         Document doc1 = builder.parse(f1);
         Document doc2 = builder.parse(f2);
-        assertThat(doc1).and(doc2)
-                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
-                .withAttributeFilter(attr ->
-                        !("creationtoolversion".equals(attr.getName()) || "creationtool".equals(attr.getName())))
-                .ignoreWhitespace()
-                .areIdentical();
+        assertThat(doc1).and(doc2).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+                .withAttributeFilter(attr -> !("creationtoolversion".equals(attr.getName())
+                        || "creationtool".equals(attr.getName())))
+                .ignoreWhitespace().areIdentical();
     }
 
     protected void compareXML(File f1, File f2) throws Exception {
@@ -443,8 +467,7 @@ public abstract class TestFilterBase extends TestCore {
         DocumentBuilder builder = factory.newDocumentBuilder();
         var doc1 = builder.parse(f1.toExternalForm());
         var doc2 = builder.parse(f2.toExternalForm());
-        assertThat(doc1).and(doc2)
-                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+        assertThat(doc1).and(doc2).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
                 .areIdentical();
     }
 
@@ -486,7 +509,8 @@ public abstract class TestFilterBase extends TestCore {
 
     protected void checkMulti(String sourceText, String id, String path, String prev, String next,
             String comment) {
-        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path), fi.entries.get(fiCount).getKey());
+        assertEquals(new EntryKey(fi.filePath, sourceText, id, prev, next, path),
+                fi.entries.get(fiCount).getKey());
         assertEquals(comment, fi.entries.get(fiCount).getComment());
         fiCount++;
     }
@@ -507,7 +531,8 @@ public abstract class TestFilterBase extends TestCore {
         fiCount++;
     }
 
-    protected SourceTextEntry checkMultiNoPrevNext(String sourceText, String id, String path, String comment) {
+    protected SourceTextEntry checkMultiNoPrevNext(String sourceText, String id, String path,
+            String comment) {
         SourceTextEntry ste = fi.entries.get(fiCount);
         assertEquals(path, ste.getKey().path);
         assertEquals(id, ste.getKey().id);
@@ -548,7 +573,8 @@ public abstract class TestFilterBase extends TestCore {
             Set<EntryKey> existKeys = new HashSet<EntryKey>();
             Map<String, ExternalTMX> transMemories = new HashMap<>();
 
-            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys, transMemories);
+            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys,
+                    transMemories);
 
             TestFileInfo fi = new TestFileInfo();
             fi.filePath = file;
@@ -604,8 +630,8 @@ public abstract class TestFilterBase extends TestCore {
     protected static class TestAlignCallback implements IAlignCallback {
         public List<AlignedEntry> entries = new ArrayList<AlignedEntry>();
 
-        public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                String path, IFilter filter) {
+        public void addTranslation(String id, String source, String translation, boolean isFuzzy, String path,
+                IFilter filter) {
             AlignedEntry en = new AlignedEntry();
             en.id = id;
             en.source = source;

--- a/test/src/org/omegat/filters2/master/FilterMasterTest.java
+++ b/test/src/org/omegat/filters2/master/FilterMasterTest.java
@@ -163,12 +163,6 @@ public class FilterMasterTest {
                     }
 
                     @Override
-                    public void addEntry(String id, String source, String translation, boolean isFuzzy,
-                            String comment, IFilter filter) {
-                        /* empty */
-                    }
-
-                    @Override
                     public void linkPrevNextSegments() {
                         /* empty */
                     }


### PR DESCRIPTION
Use default for old addEntry method signature to reduce code duplications.

## Pull request type

- Other (describe below)
refactor

## What does this PR change?


- Update IParseCallback#addEntry to be default
- Remove overrides of it
- Update ILIASFilter and MagentoFilter to use new one


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
