### PR TITLE
feat: extend entry with state final

### DIFF
--- a/src/org/omegat/core/data/ParseEntry.java
+++ b/src/org/omegat/core/data/ParseEntry.java
@@ -47,8 +47,8 @@ import org.omegat.util.StringUtil;
 /**
  * Process one entry on parse source file.
  *
- * This class caches segments for one file, then flushes they. It required to ability to link prev/next
- * segments.
+ * This class caches segments for one file, then flushes they. It required to
+ * ability to link prev/next segments.
  *
  * @author Maxym Mykhalchuk
  * @author Henry Pijffers
@@ -73,9 +73,9 @@ public abstract class ParseEntry implements IParseCallback {
          * Flush queue.
          */
         for (ParseEntryQueueItem item : parseQueue) {
-            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts, item.segmentTranslation,
-                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path,
-                    item.isFinal);
+            addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts,
+                    item.segmentTranslation, item.segmentTranslationFuzzy, item.props, item.prevSegment,
+                    item.nextSegment, item.path, item.isFinal);
         }
 
         /*
@@ -107,7 +107,8 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      *
      * @param id
      *            ID of entry, if format supports it
@@ -116,16 +117,21 @@ public abstract class ParseEntry implements IParseCallback {
      * @param translation
      *            translation of the source string, if format supports it
      * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
      *            reference during translation.
      * @param props
-     *            a staggered array of non-uniquely-identifying key=value properties (metadata) for the entry.
-     *            If property is org.omegat.core.data.SegmentProperties.REFERENCE, the entire segment is added only to
-     *            the generated 'reference' TMX, a special TMX that is used as extra reference during translation.
-     *            The segment is not added to the list of translatable segments.
-     *            Property can also be org.omegat.core.data.SegmentProperties.COMMENT, which shown in the comment panel.
-     *            Other properties are possible, but have no special meaning in OmegaT.
+     *            a staggered array of non-uniquely-identifying key=value
+     *            properties (metadata) for the entry. If property is
+     *            org.omegat.core.data.SegmentProperties.REFERENCE, the entire
+     *            segment is added only to the generated 'reference' TMX, a
+     *            special TMX that is used as extra reference during
+     *            translation. The segment is not added to the list of
+     *            translatable segments. Property can also be
+     *            org.omegat.core.data.SegmentProperties.COMMENT, which shown in
+     *            the comment panel. Other properties are possible, but have no
+     *            special meaning in OmegaT.
      * @param path
      *            path of entry in file
      * @param filter
@@ -134,8 +140,9 @@ public abstract class ParseEntry implements IParseCallback {
      *            protected parts
      */
     @Override
-    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-            String path, IFilter filter, List<ProtectedPart> protectedParts, boolean isFinal) {
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts,
+            boolean isFinal) {
         if (StringUtil.isEmpty(source)) {
             // empty string - not need to save
             return;
@@ -182,24 +189,28 @@ public abstract class ParseEntry implements IParseCallback {
                     String onesrc = segments.get(i);
                     List<ProtectedPart> segmentProtectedParts = ProtectedPart.extractFor(protectedParts,
                             onesrc);
-                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts, isFinal);
+                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts,
+                            isFinal);
                 }
             }
         } else {
-            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts, isFinal);
+            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts,
+                    isFinal);
         }
     }
 
     @Override
-    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-                                       String path, IFilter filter, List<ProtectedPart> protectedParts) {
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
         addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts, false);
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      * <p>
-     * Old call for filters that only support extracting a "comment" property. Kept for compatibility.
+     * Old call for filters that only support extracting a "comment" property.
+     * Kept for compatibility.
      */
     @Override
     public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
@@ -209,9 +220,11 @@ public abstract class ParseEntry implements IParseCallback {
     }
 
     /**
-     * This method is called by filters to add new entry in OmegaT after read it from source file.
+     * This method is called by filters to add new entry in OmegaT after read it
+     * from source file.
      * <p>
-     * Old call without path, for compatibility. Comment is converted to a property.
+     * Old call without path, for compatibility. Comment is converted to a
+     * property.
      *
      * @param id
      *            ID of entry, if format supports it
@@ -220,8 +233,9 @@ public abstract class ParseEntry implements IParseCallback {
      * @param translation
      *            translation of the source string, if format supports it
      * @param isFuzzy
-     *            flag for fuzzy translation. If a translation is fuzzy, it is not added to the projects TMX,
-     *            but it is added to the generated 'reference' TMX, a special TMX that is used as extra
+     *            flag for fuzzy translation. If a translation is fuzzy, it is
+     *            not added to the projects TMX, but it is added to the
+     *            generated 'reference' TMX, a special TMX that is used as extra
      *            reference during translation.
      * @param comment
      *            entry's comment, if format supports it
@@ -237,9 +251,9 @@ public abstract class ParseEntry implements IParseCallback {
     /**
      * Add segment to queue because we possible need to link prev/next segments.
      */
-    private void internalAddSegment(String id, short segmentIndex, String segmentSource, String segmentTranslation,
-            boolean segmentTranslationFuzzy, String[] props, String path, List<ProtectedPart> protectedParts,
-                                    boolean isFinal) {
+    private void internalAddSegment(String id, short segmentIndex, String segmentSource,
+            String segmentTranslation, boolean segmentTranslationFuzzy, String[] props, String path,
+            List<ProtectedPart> protectedParts, boolean isFinal) {
         if (segmentSource.trim().isEmpty()) {
             // skip empty segments
             return;
@@ -283,14 +297,13 @@ public abstract class ParseEntry implements IParseCallback {
      * @param path
      *            path of segment
      * @param isFinal
-     *           (since 6.1.0) translation is final state.
+     *            (since 6.1.0) translation is final state.
      */
     protected void addSegment(String id, short segmentIndex, String segmentSource,
-                              List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
-                              String[] props, String prevSegment, String nextSegment, String path,
-                              boolean isFinal) {
-        addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
-                props, prevSegment, nextSegment, path);
+            List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
+            String[] props, String prevSegment, String nextSegment, String path, boolean isFinal) {
+        addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation,
+                segmentTranslationFuzzy, props, prevSegment, nextSegment, path);
     }
 
     /**

--- a/src/org/omegat/core/data/ParseEntry.java
+++ b/src/org/omegat/core/data/ParseEntry.java
@@ -74,7 +74,8 @@ public abstract class ParseEntry implements IParseCallback {
          */
         for (ParseEntryQueueItem item : parseQueue) {
             addSegment(item.id, item.segmentIndex, item.segmentSource, item.protectedParts, item.segmentTranslation,
-                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path);
+                    item.segmentTranslationFuzzy, item.props, item.prevSegment, item.nextSegment, item.path,
+                    item.isFinal);
         }
 
         /*
@@ -134,7 +135,7 @@ public abstract class ParseEntry implements IParseCallback {
      */
     @Override
     public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-            String path, IFilter filter, List<ProtectedPart> protectedParts) {
+            String path, IFilter filter, List<ProtectedPart> protectedParts, boolean isFinal) {
         if (StringUtil.isEmpty(source)) {
             // empty string - not need to save
             return;
@@ -175,18 +176,24 @@ public abstract class ParseEntry implements IParseCallback {
             List<String> segments = Core.getSegmenter().segment(sourceLang, source, spaces, brules);
             if (segments.size() == 1) {
                 internalAddSegment(id, (short) 0, segments.get(0), translation, isFuzzy, props, path,
-                        protectedParts);
+                        protectedParts, isFinal);
             } else {
                 for (short i = 0; i < segments.size(); i++) {
                     String onesrc = segments.get(i);
                     List<ProtectedPart> segmentProtectedParts = ProtectedPart.extractFor(protectedParts,
                             onesrc);
-                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts);
+                    internalAddSegment(id, i, onesrc, null, false, props, path, segmentProtectedParts, isFinal);
                 }
             }
         } else {
-            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts);
+            internalAddSegment(id, (short) 0, source, translation, isFuzzy, props, path, protectedParts, isFinal);
         }
+    }
+
+    @Override
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
+                                       String path, IFilter filter, List<ProtectedPart> protectedParts) {
+        addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts, false);
     }
 
     /**
@@ -231,7 +238,8 @@ public abstract class ParseEntry implements IParseCallback {
      * Add segment to queue because we possible need to link prev/next segments.
      */
     private void internalAddSegment(String id, short segmentIndex, String segmentSource, String segmentTranslation,
-            boolean segmentTranslationFuzzy, String[] props, String path, List<ProtectedPart> protectedParts) {
+            boolean segmentTranslationFuzzy, String[] props, String path, List<ProtectedPart> protectedParts,
+                                    boolean isFinal) {
         if (segmentSource.trim().isEmpty()) {
             // skip empty segments
             return;
@@ -245,11 +253,48 @@ public abstract class ParseEntry implements IParseCallback {
         item.segmentTranslationFuzzy = segmentTranslationFuzzy;
         item.props = props;
         item.path = path;
+        item.isFinal = isFinal;
         parseQueue.add(item);
     }
 
     /**
-     * Adds a segment to the project. If a translation is given, it it added to
+     * Adds a segment to the project. If a translation is given, it is added to
+     * the projects TMX.
+     *
+     * @param id
+     *            ID of entry, if format supports it
+     * @param segmentIndex
+     *            Number of the segment-part of the original source string.
+     * @param segmentSource
+     *            Translatable source string
+     * @param protectedParts
+     *            protected parts
+     * @param segmentTranslation
+     *            translation of the source string, if format supports it
+     * @param segmentTranslationFuzzy
+     *            fuzzy flag of translation of the source string, if format
+     *            supports it
+     * @param props
+     *            entry's properties, like comments, if format supports it
+     * @param prevSegment
+     *            previous segment's text
+     * @param nextSegment
+     *            next segment's text
+     * @param path
+     *            path of segment
+     * @param isFinal
+     *           (since 6.1.0) translation is final state.
+     */
+    protected void addSegment(String id, short segmentIndex, String segmentSource,
+                              List<ProtectedPart> protectedParts, String segmentTranslation, boolean segmentTranslationFuzzy,
+                              String[] props, String prevSegment, String nextSegment, String path,
+                              boolean isFinal) {
+        addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
+                props, prevSegment, nextSegment, path);
+    }
+
+    /**
+     * Adds a segment to the project. If a translation is given, it is added to
      * the projects TMX.
      *
      * @param id
@@ -371,5 +416,6 @@ public abstract class ParseEntry implements IParseCallback {
         String prevSegment;
         String nextSegment;
         String path;
+        boolean isFinal;
     }
 }

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1053,8 +1053,9 @@ public class RealProject implements IProject {
 
                         @Override
                         public void reload(File file) throws Exception {
-                            ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
-                                    config.isSentenceSegmentingEnabled(), file, null);
+                            ProjectTMX newTMX = new ProjectTMX(config.getSourceLanguage(),
+                                    config.getTargetLanguage(), config.isSentenceSegmentingEnabled(), file,
+                                    null);
                             projectTMX.replaceContent(newTMX);
                         }
 
@@ -1077,8 +1078,8 @@ public class RealProject implements IProject {
                 final List<GlossaryEntry> glossaryEntries;
                 if (glossaryFile.exists()) {
                     glossaryEntries = GlossaryReaderTSV.read(glossaryFile, true);
-                    logger.atDebug().setMessage("Read {0} glossaries from {1}").addArgument(glossaryEntries.size())
-                            .addArgument(glossaryFile).log();
+                    logger.atDebug().setMessage("Read {0} glossaries from {1}")
+                            .addArgument(glossaryEntries.size()).addArgument(glossaryFile).log();
                 } else {
                     glossaryEntries = Collections.emptyList();
                 }
@@ -1091,8 +1092,7 @@ public class RealProject implements IProject {
                                 if (file.exists()) {
                                     baseGlossaryEntries = GlossaryReaderTSV.read(file, true);
                                     logger.atDebug().setMessage("read {0} entries from local glossary.txt")
-                                            .addArgument(baseGlossaryEntries.size())
-                                            .log();
+                                            .addArgument(baseGlossaryEntries.size()).log();
                                 } else {
                                     baseGlossaryEntries = new ArrayList<>();
                                 }
@@ -1102,10 +1102,8 @@ public class RealProject implements IProject {
                             public void parseHeadFile(File file) throws Exception {
                                 if (file.exists()) {
                                     headGlossaryEntries = GlossaryReaderTSV.read(file, true);
-                                    logger.atDebug()
-                                            .setMessage("read {0} entries from remote glossaries")
-                                            .addArgument(headGlossaryEntries.size())
-                                            .log();
+                                    logger.atDebug().setMessage("read {0} entries from remote glossaries")
+                                            .addArgument(headGlossaryEntries.size()).log();
                                 } else {
                                     headGlossaryEntries = new ArrayList<>();
                                 }
@@ -1131,7 +1129,8 @@ public class RealProject implements IProject {
 
                             @Override
                             public void reload(final File file) {
-                                logger.atDebug().setMessage("Reloading glossary file {0}").addArgument(file).log();
+                                logger.atDebug().setMessage("Reloading glossary file {0}").addArgument(file)
+                                        .log();
                                 notifyGlossaryManagerFileChanged(file);
                             }
 
@@ -1888,11 +1887,11 @@ public class RealProject implements IProject {
         }
 
         protected void addSegment(String id, short segmentIndex, String segmentSource,
-                                  List<ProtectedPart> protectedParts, String segmentTranslation,
-                                  boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
-                                  String path) {
-            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
-                    props, prevSegment, nextSegment, path, false);
+                List<ProtectedPart> protectedParts, String segmentTranslation,
+                boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
+                String path) {
+            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation,
+                    segmentTranslationFuzzy, props, prevSegment, nextSegment, path, false);
         }
 
         protected void addSegment(String id, short segmentIndex, String segmentSource,

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1887,13 +1887,18 @@ public class RealProject implements IProject {
             tmBuilder = null;
         }
 
-        /**
-         * {@inheritDoc}
-         */
+        protected void addSegment(String id, short segmentIndex, String segmentSource,
+                                  List<ProtectedPart> protectedParts, String segmentTranslation,
+                                  boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
+                                  String path) {
+            addSegment(id, segmentIndex, segmentSource, protectedParts, segmentTranslation, segmentTranslationFuzzy,
+                    props, prevSegment, nextSegment, path, false);
+        }
+
         protected void addSegment(String id, short segmentIndex, String segmentSource,
                 List<ProtectedPart> protectedParts, String segmentTranslation,
                 boolean segmentTranslationFuzzy, String[] props, String prevSegment, String nextSegment,
-                String path) {
+                String path, boolean isFinal) {
             // if the source string is empty, don't add it to TM
             if (segmentSource.trim().isEmpty()) {
                 throw new RuntimeException("Segment must not be empty");
@@ -1910,7 +1915,7 @@ public class RealProject implements IProject {
                 segmentTranslation = null;
             }
             SourceTextEntry srcTextEntry = new SourceTextEntry(ek, allProjectEntries.size() + 1, props,
-                    segmentTranslation, protectedParts, segmentIndex == 0);
+                    segmentTranslation, protectedParts, segmentIndex == 0, isFinal);
             srcTextEntry.setSourceTranslationFuzzy(segmentTranslationFuzzy);
 
             if (SegmentProperties.isReferenceEntry(props)) {

--- a/src/org/omegat/filters2/IParseCallback.java
+++ b/src/org/omegat/filters2/IParseCallback.java
@@ -61,9 +61,9 @@ public interface IParseCallback {
      *            true if translation state is final
      * @since 6.1.0
      */
-    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
-                                        String path, IFilter filter, List<ProtectedPart> protectedParts,
-                                        boolean isFinal) {
+    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+            String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts,
+            boolean isFinal) {
         addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
     }
 

--- a/src/org/omegat/filters2/IParseCallback.java
+++ b/src/org/omegat/filters2/IParseCallback.java
@@ -37,6 +37,7 @@ import org.omegat.core.data.ProtectedPart;
  * @author Aaron Madlon-Kay
  */
 public interface IParseCallback {
+
     /**
      * Read entry from source file, with arbitrary (optional) properties
      *
@@ -55,7 +56,36 @@ public interface IParseCallback {
      * @param filter
      *            filter which produces entry
      * @param protectedParts
-     *            (since 3.0.6) protected parts
+     *            protected parts
+     * @param isFinal
+     *            true if translation state is final
+     * @since 6.1.0
+     */
+    default void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
+                                        String path, IFilter filter, List<ProtectedPart> protectedParts,
+                                        boolean isFinal) {
+        addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
+    }
+
+    /**
+     * Read entry from source file, with arbitrary (optional) properties
+     *
+     * @param id
+     *            ID in source file, or null if ID not supported by format
+     * @param source
+     *            source entry text
+     * @param translation
+     *            exist translation text
+     * @param isFuzzy
+     *            true if translation is fuzzy
+     * @param props
+     *            an array of key=value metadata properties for the entry
+     * @param path
+     *            path of segment
+     * @param filter
+     *            filter which produces entry
+     * @param protectedParts
+     *            protected parts
      */
     void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy, String[] props,
             String path, IFilter filter, List<ProtectedPart> protectedParts);


### PR DESCRIPTION
Extend STE to hold final state.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->
- Title
  * URL

<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- It extends `SourceTextEntry` to have field `finalState` and method `isFinalState`
- It extends `IParserCallback#addEntryWithProperties` to accept boolean `isFinal`
- It extends `ParseEntry` to call `addSegment` with `isFinal`
- It extends `RealProject.LoadFilesCallback#addSegment` to accept boolean `isFinal`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
TODO

- [ ] implement marker
- [ ] write test
