### PR TITLE
[6.0] chore: backport win build shell util

### DIFF
--- a/ci/iscc
+++ b/ci/iscc
@@ -12,12 +12,17 @@ bindpaths() {
     done
 }
 
+# set TMPDIR for context creation
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TMPDIR=$( dirname ${SCRIPT_DIR} )/build/tmp
+
 # workaround for build failure on CI env.
 # see https://sourceforge.net/p/omegat/bugs/1228/
 PUID=`id -u`
 PGID=`id -g`
 IMAGE=omegatorg/innosetup:innosetup6
-CONTEXT=`mktemp -d`
+CONTEXT=${TMPDIR}/iscc
+mkdir -p $CONTEXT
 
 cat << __EOF__  > $CONTEXT/Dockerfile
 FROM docker.io/amake/innosetup:innosetup6-buster
@@ -32,13 +37,16 @@ WORKDIR /work
 ENTRYPOINT ["iscc"]
 __EOF__
 
-CMD="$(type -p docker)" || [[ -e $CMD ]] && $CMD info >/dev/null 2>1 || CMD="$(type -p nerdctl)"
-echo select container CLI: $CMD
-$CMD info || false
+CMD="$(type -p docker)" && $CMD info >/dev/null 2>&1 || CMD="$(type -p nerdctl)" && $CMD info > /dev/null || false
+echo Select container CLI: $CMD
 
-if ! $CMD build -t $IMAGE $CONTEXT ; then
-  echo Container build error for ISCC, abort...
-  exit 1
+IMAGEID=$($CMD images -q $IMAGE)
+if [[ -z "$IMAGEID" ]]; then
+  echo Now build custom image
+  if ! $CMD build -t $IMAGE $CONTEXT ; then
+    echo Container build error for ISCC, abort...
+    exit 1
+  fi
 fi
 exec $CMD run -i --rm  \
    -u `id -u`:`id -g` \

--- a/ci/osslsigncode
+++ b/ci/osslsigncode
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This accept environment variable USBDEV which is smartcard device
+# USBDEV="--device /dev/bus/usb/004/004"
+
 relpaths() {
     for arg in "$@"; do printf -- "%s\n" "${arg#$PWD/}"; done
 }
@@ -12,8 +15,30 @@ bindpaths() {
     done
 }
 
-exec docker run --rm -i \
-    -v "$PWD":/work $(bindpaths "$@") \
-    --entrypoint osslsigncode \
-    amake/innosetup:innosetup6 \
-    $(relpaths "$@")
+CMD="$(type -p docker)" && $CMD info >/dev/null 2>1 || CMD="$(type -p nerdctl)" && $CMD info >/dev/null || false
+echo Select container CLI: $CMD
+
+# build container image
+CTX=$(mktemp -d)
+cat <<__EOF__ > $CTX/Dockerfile
+FROM debian:bookworm-slim
+LABEL authors="miurahr"
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends osslsigncode && rm -rf /var/lib/apt/lists/*
+WORKDIR /work
+__EOF__
+$CMD build -t omegatorg/osslsigncode $CTX
+
+if [[ -z "${USBDEV}" ]]; then
+  exec $CMD run --rm -i \
+      -v "$PWD":/work $(bindpaths "$@") \
+      --pull=never omegatorg/osslsigncode \
+      osslsigncode $@
+else
+  exec $CMD run --rm -i \
+      -v "$PWD":/work $(bindpaths "$@") \
+      --privileged --device $USBDEV \
+      --pull=never omegatorg/osslsigncode \
+      osslsigncode $@
+fi
+


### PR DESCRIPTION

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- Backport ci/iscc and ci/osslsigncode from master branch
- These supports recent container execution environments

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
