### PR TITLE
chore: fix buid from source distribution

### DIFF
--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -5,12 +5,16 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
-                                                              '**/maligna-*.jar', '**/supertmxmerge-*.jar',
-                                                              '**/slf4j*'])
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
+            '**/slf4j*.jar', '**/supertmxmerge-*.jar'])
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/maligna-*.jar'])
     } else {
         // Aligner
-        implementation(libs.loomchild.maligna)
+        implementation(libs.loomchild.maligna) {
+            exclude module: 'jaxb-api'
+            exclude module: 'jaxb-core'
+            exclude module: 'jaxb-impl'
+        }
         compileOnly(libs.madlonkay.supertmxmerge)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.commons.io)

--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -6,15 +6,16 @@ dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
-            '**/slf4j*.jar', '**/supertmxmerge-*.jar'])
+            '**/slf4j*.jar', '**/supertmxmerge-*.jar', '**/jaxb-api*.jar'])
         compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/maligna-*.jar'])
     } else {
         // Aligner
         implementation(libs.loomchild.maligna) {
             exclude module: 'jaxb-api'
             exclude module: 'jaxb-core'
-            exclude module: 'jaxb-impl'
+            exclude module: 'jaxb-runtime'
         }
+        compileOnly(libs.jaxb.api)
         compileOnly(libs.madlonkay.supertmxmerge)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.commons.io)

--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
                                                               '**/maligna-*.jar', '**/supertmxmerge-*.jar',
                                                               '**/slf4j*'])
     } else {

--- a/build.gradle
+++ b/build.gradle
@@ -272,13 +272,6 @@ dependencies {
         }
         implementation(libs.language.detector)
 
-        runtimeOnly(libs.languagetool.all) {
-            // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen'
-            exclude module: 'language-detector'
-        }
-        runtimeOnly 'org.omegat.lucene:lucene-gosen:5.5.1:ipadic'
-
         // Lucene for tokenizers
         implementation(libs.bundles.lucene)
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ ext {
             }
         }
     }
-    providedLibsDir = file('lib/provided')
+    providedCoreLibsDir = file('lib/provided/core')
+    providedModuleLibsDir = file('lib/provided/module')
 }
 def omtFlavor = omtVersion.beta.empty ? 'standard' : 'latest'
 def omtWebsite = 'https://omegat.org'
@@ -223,14 +224,11 @@ configurations {
     genMac
 }
 
-ext {
-    providedLibsDir = file('lib/provided')
-}
 
 dependencies {
     // Libs are provided in the "source" distribution only
-    if (providedLibsDir.directory) {
-        implementation fileTree(dir: providedLibsDir, include: '**/*.jar', excludes: ['**/slf4j-api-1.*.jar'])
+    if (providedCoreLibsDir.directory) {
+        implementation fileTree(dir: providedCoreLibsDir, include: '**/*.jar', excludes: ['**/slf4j-api-1.*.jar'])
     } else {
         implementation(libs.commons.io)
         implementation(libs.commons.lang3)
@@ -735,9 +733,11 @@ distributions {
             from(processResources) {
                 into('src')
             }
-            into('lib/provided') {
-                // collect project runtime dependencies in all subprojects and sourceSets
+            into('lib/provided/core') {
                 from configurations.runtimeClasspath
+            }
+            into('lib/provided/module') {
+                // collect project runtime dependencies in all subprojects and sourceSets
                 from {subprojects.findAll { it.getSubprojects().isEmpty()}
                         .collect { it.configurations.matching { it.name.endsWith('untimeClasspath')
                                 && !it.name.startsWith('test') && !it.name.startsWith('jaxb')

--- a/build.gradle
+++ b/build.gradle
@@ -739,7 +739,7 @@ distributions {
                         'docs_devel/**', 'scripts/**',
                         'gradle/**', 'gradle*', 'build.gradle', 'settings.gradle', 'README.md', '*.properties',
                         'tipoftheday/**', 'machinetranslators/**', 'scriptengine/**', 'LICENSE', 'compose.yml',
-                        'aligner/**', 'language-modules/**', 'spellchecker/**', '.checkstyle'
+                        'aligner/**', 'language-modules/**', 'spellchecker/**', 'theme/**', '.checkstyle'
                 exclude '**/build/**', 'doc_src/**/pdf/**', 'doc_src/**/xhtml5/**', 'local.properties', '**/out/**'
             }
             from(processResources) {

--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,12 @@ configurations {
 dependencies {
     // Libs are provided in the "source" distribution only
     if (providedCoreLibsDir.directory) {
-        implementation fileTree(dir: providedCoreLibsDir, include: '**/*.jar', excludes: ['**/slf4j-api-1.*.jar'])
+        api fileTree(dir: providedCoreLibsDir, includes: ['**/slf4j-api-*.jar', '**/jaxb-api-*.jar'])
+        implementation fileTree(dir: providedCoreLibsDir, include: '**/*.jar', excludes: ['**/slf4j-api-*.jar',
+            '**/slf4j-jdk14-*.jar', 'language-detector-*.jar', '**/hunspell-*.jar',
+                '**/groovy*.jar', '**/jaxb-runtime-*.jar'])
+        runtimeOnly fileTree(dir: providedCoreLibsDir, includes: ['**/slf4j-jdk14-*.jar',
+            '**/language-detector-*.jar', '**/hunspell-*.jar', '**/groovy*.jar', '**/jaxb-runtime-*.jar'])
     } else {
         implementation(libs.commons.io)
         implementation(libs.commons.lang3)
@@ -237,12 +242,17 @@ dependencies {
         implementation(libs.slf4j.format.jdk14)
         runtimeOnly(libs.slf4j.jdk14)
 
+        // jaxb gen compilation
+        implementation(libs.jaxb.api)
+        runtimeOnly(libs.jaxb.core)
+        runtimeOnly(libs.jaxb.runtime)
+
         // macOS integration
         implementation(libs.madlonkay.desktopsupport)
 
         // stax
         implementation(libs.stax2.api)
-        runtimeOnly(libs.woodstox.core)
+        implementation(libs.woodstox.core)
 
         // Data: inline data URL handler
         implementation(libs.url.protocol.handler)
@@ -267,8 +277,10 @@ dependencies {
             exclude module: 'guava'
             exclude module: 'language-detector'
             exclude group: 'com.google.android'
+            exclude module: 'hunspell'
         }
-        implementation(libs.language.detector)
+        runtimeOnly(libs.language.detector)
+        runtimeOnly(libs.dumont.hunspell)
 
         // Lucene for tokenizers
         implementation(libs.bundles.lucene)

--- a/build.gradle
+++ b/build.gradle
@@ -725,10 +725,11 @@ distributions {
         contents {
             from(rootDir) {
                 include 'config/**', 'ci/iscc', 'ci/osslsigncode', 'images/**', 'lib/**', 'release/**',
-                    'src/**/*.java', 'test/**', 'test-integration/**', 'doc_src/**', 'docs_devel/**', 'scripts/**',
-                    'gradle/**', 'gradle*', 'build.gradle', 'settings.gradle', 'README.md', '*.properties',
-                    'tipoftheday/**', 'machinetranslators/**', 'scriptengine/**', 'LICENSE', 'compose.yml',
-                    '.checkstyle'
+                        'src/**/*.java', 'test/**','test-acceptance/**', 'test-integration/**', 'doc_src/**',
+                        'docs_devel/**', 'scripts/**',
+                        'gradle/**', 'gradle*', 'build.gradle', 'settings.gradle', 'README.md', '*.properties',
+                        'tipoftheday/**', 'machinetranslators/**', 'scriptengine/**', 'LICENSE', 'compose.yml',
+                        'aligner/**', 'language-modules/**', 'spellchecker/**', '.checkstyle'
                 exclude '**/build/**', 'doc_src/**/pdf/**', 'doc_src/**/xhtml5/**', 'local.properties', '**/out/**'
             }
             from(processResources) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,13 +45,14 @@ stardict4j = "1.1.0"
 juniversalchardet = "2.5.0"
 mnemonics = "1.2"
 hunspell = "2.1.2"
-xjc = "2.3.4"
+xjc = "2.3.9"
 jna = "5.13.0"
 jfa = "1.2.0"
 tipoftheday = "0.4.4"
 flatlaf="3.5.1"
 assertj_swing_junit = "4.0.0-beta-1"
 morfologik = "2.1.9"
+jaxb = "2.3.0"
 
 [libraries]
 slf4j-api = {group = "org.slf4j", name = "slf4j-api",  version.ref = "slf4j"}
@@ -156,7 +157,10 @@ stardict4j = {group = "tokyo.northside", name = "stardict4j", version.ref = "sta
 juniversal-chardet = {group = "com.github.albfernandez", name = "juniversalchardet", version.ref = "juniversalchardet"}
 omegat-mnemonics = {group = "org.omegat", name = "lib-mnemonics", version.ref = "mnemonics"}
 dumont-hunspell = {group = "com.gitlab.dumonts", name = "hunspell", version.ref = "hunspell"}
-jaxb-xjc = {group = "org.grassfish.jaxb", name = "jaxb-xjc", version.ref = "xjc"}
+jaxb-api = {group = "javax.xml.bind", name = "jaxb-api", version.ref = "jaxb"}
+jaxb-xjc = {group = "org.glassfish.jaxb", name = "jaxb-xjc", version.ref = "xjc"}
+jaxb-core = {group = "org.glassfish.jaxb", name = "jaxb-core", version.ref = "jaxb"}
+jaxb-runtime = {group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb"}
 tipoftheday = {group = "tokyo.northside", name = "tipoftheday", version.ref = "tipoftheday"}
 jna = {group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna"}
 jfa = {group = "de.jangassen", name = "jfa", version.ref = "jfa"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,7 +167,7 @@ jfa = {group = "de.jangassen", name = "jfa", version.ref = "jfa"}
 flatlaf = {group = "com.formdev", name = "flatlaf", version.ref = "flatlaf"}
 language-detector = {group = "org.omegat", name = "language-detector", version.ref = "languagedetector"}
 assertj_swing_junit = {group = "tokyo.northside", name = "assertj-swing-junit", version.ref = "assertj_swing_junit"}
-morfologik = { group = "org.carrot2", name = "morfologik-stemming", version.ref = "morfologik" }
+morfologik-stemming = { group = "org.carrot2", name = "morfologik-stemming", version.ref = "morfologik" }
 morfologik-speller = { group = "org.carrot2", name = "morfologik-speller", version.ref = "morfologik" }
 
 [bundles]
@@ -182,7 +182,6 @@ lucene = ["lucene-core", "lucene-analyzers-common", "lucene-analyzers-kuromoji",
 jgit = ["jgit", "jgit-agent", "jgit-http", "jgit-ssh"]
 dictionary = ["trie4j", "dsl4j", "stardict4j", "jsoup"]
 xmlunit = ["xmlunit-core", "xmlunit-assertj", "assertj"]
-morfologik = ['morfologik', 'morfologik-speller']
 
 [plugins]
 spotbugs = {id = "com.github.spotbugs", version = "6.0.19"}

--- a/language-modules/build.gradle
+++ b/language-modules/build.gradle
@@ -40,18 +40,61 @@ plugins.forEach { args ->
     dependencies.add("${name}CompileOnly", libs.languagetool.core) {
         exclude module: "hunspell"
     }
-    if (name.equals("ja")) {
-        dependencies.jaImplementation(libs.languagetool.ja) {
-            // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-            exclude module: 'lucene-gosen'
-            exclude module: 'languagetool-core'
-            exclude module: 'icu4j'
+    // when build from sourceZip
+    if (providedModuleLibsDir.directory) {
+        dependencies.add("${name}Implementation", fileTree(dir: providedModuleLibsDir,
+                include: "**/language-${name}-*.jar"))
+        if (name.equals("ja")) {
+            dependencies.jaImplementation(fileTree(dir: providedModuleLibsDir,
+                    includes: ['**/lucene-gosen-*.jar', '**/icu4j-*.jar']))
+        } else if (name.equals("en")) {
+            dependencies.add("enRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    includes: ['**/opennlp-*.jar']))
+        } else if (name.equals("ca")) {
+            dependencies.add("caRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/catalan-pos-dict-*.jar'))
+        } else if (name.equals("de")) {
+            dependencies.add("deRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    includes: ['**/commons-lang3-*.jar', '**/jwordsplitter-*.jar', '**/german-*.jar', '**/openregex-*.jar']))
+        } else if (name.equals("el")) {
+            dependencies.add("elRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/morphology-el-*.jar'))
+        } else if (name.equals("es")) {
+            dependencies.add("esRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/spanish-pos-dict-*.jar'))
+        } else if (name.equals("fr")) {
+            dependencies.add("frRuntimeOnly", fileTree(dir: providedModuleLibsDir, include: '**/french-*.jar'))
+        } else if (name.equals("ga")) {
+            dependencies.add("gaRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/languagetool-ga-dicts-*.jar'))
+        } else if (name.equals('pt')) {
+            dependencies.add("ptRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/portuguese-pos-dict-*.jar'))
+        } else if (name.equals("ru")) {
+            dependencies.add("ruRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/openregex-*.jar'))
+        } else if (name.equals("uk")) {
+            dependencies.add("ukRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/morfologik-ukrainian-*.jar'))
+        } else if (name.equals("zh")) {
+            dependencies.add("zhRuntimeOnly", fileTree(dir: providedModuleLibsDir,
+                    include: '**/hanlp-portable-*.jar'))
         }
-        dependencies.jaImplementation(dependencies.variantOf(libs.lucene.gosen){ classifier("ipadic") })
-        dependencies.jaImplementation(libs.icj4j)
     } else {
-        dependencies.add("${name}Implementation", libs.languagetool.getAt(name)) {
-            exclude module: 'languagetool-core'
+        // build from project git repository
+        if (name.equals("ja")) {
+            dependencies.jaImplementation(libs.languagetool.ja) {
+                // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
+                exclude module: 'lucene-gosen'
+                exclude module: 'languagetool-core'
+                exclude module: 'icu4j'
+            }
+            dependencies.jaImplementation(dependencies.variantOf(libs.lucene.gosen) { classifier("ipadic") })
+            dependencies.jaImplementation(libs.icj4j)
+        } else {
+            dependencies.add("${name}Implementation", libs.languagetool.getAt(name)) {
+                exclude module: 'languagetool-core'
+            }
         }
     }
     configurations.getByName("${name}RuntimeClasspath").exclude(module: 'languagetool-core')

--- a/language-modules/build.gradle
+++ b/language-modules/build.gradle
@@ -43,8 +43,10 @@ plugins.forEach { args ->
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
             exclude module: 'lucene-gosen'
             exclude module: 'languagetool-core'
+            exclude module: 'icu4j'
         }
         dependencies.jaImplementation(dependencies.variantOf(libs.lucene.gosen){ classifier("ipadic") })
+        dependencies.jaImplementation(libs.icj4j)
     } else {
         dependencies.add("${name}Implementation", libs.languagetool.getAt(name)) {
             exclude module: 'languagetool-core'

--- a/language-modules/build.gradle
+++ b/language-modules/build.gradle
@@ -37,7 +37,9 @@ plugins.forEach { args ->
     def pluginClass = "org.omegat.languages.${name}.${lang}Plugin"
     sourceSets.create(name)
     dependencies.add("${name}CompileOnly", project.rootProject)
-    dependencies.add("${name}CompileOnly", libs.languagetool.core)
+    dependencies.add("${name}CompileOnly", libs.languagetool.core) {
+        exclude module: "hunspell"
+    }
     if (name.equals("ja")) {
         dependencies.jaImplementation(libs.languagetool.ja) {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                  '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                  '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/deepl/build.gradle
+++ b/machinetranslators/deepl/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/deepl/build.gradle
+++ b/machinetranslators/deepl/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/deepl/build.gradle
+++ b/machinetranslators/deepl/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                    '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                  '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                  '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                  '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -8,8 +8,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/jackson*.jar'])
+        compileOnly fileTree(dir: providedLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -8,8 +8,9 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar', '**/jackson*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/*commons-*.jar', '**/slf4j*.jar',
+                                                                    '**/jackson*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.commons.text)

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -16,6 +16,8 @@ dependencies {
         implementation(libs.dumont.hunspell)
         compileOnly(libs.languagetool.core) {
             exclude module: 'guava'
+            exclude module: 'language-detector'
+            exclude group: 'com.google.android'
             exclude module: 'jackson-databind'
             exclude group: 'org.jetbrains'
         }
@@ -25,6 +27,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
     testRuntimeOnly(libs.languagetool.en)
+    testRuntimeOnly(libs.languagetool.de)
 }
 
 jar {

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -4,16 +4,14 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-io-*.jar',
-                                                              '**/lib-mnemonics-*.jar',
-                                                              '**/slf4j-format-jdk14-*.jar'])
-        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/hunspell-*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/languagetool-core-*.jar',
+                '**/commons-io-*.jar', '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar',
+                '**/hunspell-*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.slf4j.format.jdk14)
-        implementation(libs.dumont.hunspell)
         compileOnly(libs.languagetool.core) {
             exclude module: 'guava'
             exclude module: 'language-detector'
@@ -21,6 +19,9 @@ dependencies {
             exclude module: 'jackson-databind'
             exclude group: 'org.jetbrains'
         }
+        // hunspell is in dependency of languagetool-core
+        // and usable in OmegaT-core libraries
+        // implementation(libs.dumont.hunspell)
     }
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/commons-io-*.jar',
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-io-*.jar',
                                                               '**/lib-mnemonics-*.jar',
                                                               '**/slf4j-format-jdk14-*.jar'])
-        implementation fileTree(dir: providedLibsDir, includes: ['**/hunspell-*.jar'])
+        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/hunspell-*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.omegat.mnemonics)

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -5,9 +5,8 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar',
-                                                              '**/lib-mnemonics-*.jar',
-                                                              '**/slf4j-format-jdk14-*.jar'])
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar', '**/languagetool-core-*.jar',
+                                                                  '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar'])
         implementation fileTree(dir: providedModuleLibsDir, includes: ['**/morfologik-*.jar'])
     } else {
         implementation(libs.bundles.morfologik)

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-io-*.jar',
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar',
                                                               '**/lib-mnemonics-*.jar',
                                                               '**/slf4j-format-jdk14-*.jar'])
         implementation fileTree(dir: providedModuleLibsDir, includes: ['**/morfologik-*.jar'])
@@ -18,6 +18,7 @@ dependencies {
             exclude module: 'guava'
             exclude module: 'jackson-databind'
             exclude module: 'language-detector'
+            exclude module: 'hunspell'
             exclude group: 'com.google.android'
             exclude group: 'org.jetbrains'
         }

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -10,20 +10,24 @@ dependencies {
                                                               '**/slf4j-format-jdk14-*.jar'])
         implementation fileTree(dir: providedLibsDir, includes: ['**/morfologik-*.jar'])
     } else {
+        implementation(libs.bundles.morfologik)
         compileOnly(libs.commons.io)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.slf4j.format.jdk14)
         compileOnly(libs.languagetool.core) {
             exclude module: 'guava'
             exclude module: 'jackson-databind'
+            exclude module: 'language-detector'
+            exclude group: 'com.google.android'
             exclude group: 'org.jetbrains'
         }
-        implementation(libs.bundles.morfologik)
     }
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
+    testRuntimeOnly(libs.languagetool.en)
+    testRuntimeOnly(libs.languagetool.de)
 }
 
 jar {

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -5,11 +5,13 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar', '**/languagetool-core-*.jar',
-                                                                  '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar'])
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-*.jar', '**/languagetool-core-*.jar',
+                                       '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar', '**/morfologik-*.jar'])
         implementation fileTree(dir: providedModuleLibsDir, includes: ['**/morfologik-*.jar'])
     } else {
-        implementation(libs.bundles.morfologik)
+        // morfologik stemming and speller are dependency of languagetool-core
+        compileOnly(libs.morfologik.stemming)
+        compileOnly(libs.morfologik.speller)
         compileOnly(libs.commons.io)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.slf4j.format.jdk14)
@@ -20,6 +22,7 @@ dependencies {
             exclude module: 'hunspell'
             exclude group: 'com.google.android'
             exclude group: 'org.jetbrains'
+            exclude module: 'morfologik-fsa'
         }
     }
     testImplementation(libs.junit4)

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/commons-io-*.jar',
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/commons-io-*.jar',
                                                               '**/lib-mnemonics-*.jar',
                                                               '**/slf4j-format-jdk14-*.jar'])
-        implementation fileTree(dir: providedLibsDir, includes: ['**/morfologik-*.jar'])
+        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/morfologik-*.jar'])
     } else {
         implementation(libs.bundles.morfologik)
         compileOnly(libs.commons.io)

--- a/theme/build.gradle
+++ b/theme/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, include: '**/flatlaf*.jar')
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, include: '**/flatlaf*.jar')
     } else {
         // platform independent dark theme
         implementation(libs.flatlaf)

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -18,9 +18,9 @@ sourceSets {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedLibsDir.directory) {
-        compileOnly fileTree(dir: providedLibsDir, includes: ['**/jackson*.jar'])
-        implementation fileTree(dir: providedLibsDir, includes: ['**/tipoftheday-*.jar'])
+    if (providedModuleLibsDir.directory) {
+        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/jackson*.jar'])
+        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/tipoftheday-*.jar', '**/icu4j-72*.jar'])
     } else {
         // runtime dependencies should be in main project
         implementation(libs.tipoftheday)

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -18,16 +18,21 @@ sourceSets {
 
 dependencies {
     compileOnly(project.rootProject)
-    if (providedModuleLibsDir.directory) {
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/jackson*.jar'])
-        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/tipoftheday-*.jar', '**/icu4j-72*.jar'])
+    if (providedCoreLibsDir.directory) {
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-lang3-*.jar', '**/jackson*.jar',
+                                                                  '**/icu4j-*.jar'])
+        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/tipoftheday-*.jar'])
     } else {
         // runtime dependencies should be in main project
-        implementation(libs.tipoftheday)
+        implementation(libs.tipoftheday) {
+            exclude module: 'commons-lang3'
+        }
+        compileOnly(libs.commons.lang3)
         constraints {
             implementation(libs.icj4j)
         }
-        implementation(libs.jackson.yaml)
+        // jackson-databind-yaml is dependency of languagetool-core
+        compileOnly(libs.jackson.yaml)
     }
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -26,6 +26,7 @@ dependencies {
         // runtime dependencies should be in main project
         implementation(libs.tipoftheday) {
             exclude module: 'commons-lang3'
+            exclude module: 'commons-io'
         }
         compileOnly(libs.commons.lang3)
         constraints {


### PR DESCRIPTION
We should guarantee to build from source distribution without any remote resources.
There often happens that a remote library removed and the project build is not possible.

To guarantee old OmegaT revisions building, we bundles all dependency libraries.

Now we use modular architecture, it is important to guarantee it also for modules.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?
- Fix a Build failure from sourceDistZip
- It is because missing dependency from `lib/provided`
- Also update removal of unused dependency


## Other information

TODO

- [x] When building from source Zip distribution, it should also be produced same distribution as original
