### PR TITLE
[6.0.1] fix: NPE when team with glossary outside

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1049,7 +1049,6 @@ public class RealProject implements IProject {
         if (processGlossary) {
             final String glossaryPath = config.getWritableGlossaryFile().getUnderRoot();
             final File glossaryFile = config.getWritableGlossaryFile().getAsFile();
-            new File(config.getProjectRootDir(), glossaryPath);
             if (glossaryPath != null && remoteRepositoryProvider.isUnderMapping(glossaryPath)) {
                 final List<GlossaryEntry> glossaryEntries;
                 if (glossaryFile.exists()) {


### PR DESCRIPTION
Cherry-pick ecfec4c

fix the case that OmegaT raises NPE when the writable glossary file is out of project root

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

## What does this PR change?

- Backport PR #574 
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
