### PR TITLE
fix: LTmod's IllegalArgument on en-AU

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -353,16 +353,9 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.bundles.xmlunit)
-    // LanguageTool unit tests exercise these languages
-    testImplementation(libs.bundles.languagetool.tests) {
-        exclude group: 'org.slf4j'
-        exclude module: 'guava'
-        exclude module: 'language-detector'
-        exclude group: 'ch.qos.logback'
-        // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
-        exclude module: 'lucene-gosen'
-    }
-    testImplementation(variantOf(libs.lucene.gosen){ classifier("ipadic") })
+
+    testImplementation(project(":language-modules"))
+    testImplementation(libs.languagetool.server)
     testRuntimeOnly(libs.slf4j.jdk14)
 
     // JAXB codegen only

--- a/language-modules/build.gradle
+++ b/language-modules/build.gradle
@@ -1,4 +1,4 @@
-def plugins = [
+def moduleList = [
         [ code: 'ar', lang: 'Arabic'],
         [ code: 'ast', lang: 'Asturian'],
         [ code: 'be', lang: 'Belarusian'],
@@ -31,7 +31,7 @@ def plugins = [
         [ code: 'zh', lang: 'Chinese']
 ]
 
-plugins.forEach { args ->
+moduleList.forEach { args ->
     def name = args.get('code')
     def lang = args.get('lang')
     def pluginClass = "org.omegat.languages.${name}.${lang}Plugin"
@@ -129,4 +129,23 @@ plugins.forEach { args ->
         group = 'other'
     }
     tasks.getByName("checkstyleMain").dependsOn tasks.named("checkstyle${capitalName}")
+}
+
+dependencies {
+    testImplementation(libs.junit4)
+    testRuntimeOnly(libs.slf4j.jdk14)
+    testImplementation(project.rootProject)
+
+    testCompileOnly(dependencies.variantOf(libs.lucene.gosen) { classifier("ipadic") })
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'language-all'
+    }
+    testRuntimeOnly(libs.languagetool.ja) {
+        // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
+        exclude module: 'lucene-gosen'
+        exclude module: 'languagetool-core'
+        exclude module: 'icu4j'
+    }
+    testRuntimeOnly(dependencies.variantOf(libs.lucene.gosen) { classifier("ipadic") })
+    testRuntimeOnly(libs.icj4j)
 }

--- a/language-modules/src/test/java/org/omegat/languages/test/LuceneGosenCompatibilityTest.java
+++ b/language-modules/src/test/java/org/omegat/languages/test/LuceneGosenCompatibilityTest.java
@@ -23,7 +23,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.omegat.languagetools;
+package org.omegat.languages.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -34,15 +34,27 @@ import java.util.Objects;
 
 import net.java.sen.SenFactory;
 import net.java.sen.StringTagger;
-
+import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.languagetool.JLanguageTool;
-import org.languagetool.Languages;
+import org.languagetool.Language;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.PatternRule;
 
+import org.omegat.languagetools.LanguageDataBroker;
+import org.omegat.languagetools.LanguageManager;
+
 public class LuceneGosenCompatibilityTest {
+
+    private static final String JAPANESE = "org.languagetool.language.Japanese";
+
+    @BeforeClass
+    public static void setUpClass() {
+        // We don't use plugin loader in a test context
+        // JLanguageTool.setClassBrokerBroker(new LanguageClassBroker());
+        JLanguageTool.setDataBroker(new LanguageDataBroker());
+        LanguageManager.registerLTLanguage("ja-JP", JAPANESE);
+    }
 
     /**
      * Regression test for bugs#1204.
@@ -57,7 +69,8 @@ public class LuceneGosenCompatibilityTest {
 
     @Test
     public void testJapanese() throws Exception {
-        JLanguageTool lt = new JLanguageTool(Objects.requireNonNull(Languages.getLanguageForName("Japanese")));
+        Language lang = LanguageManager.getLTLanguage(new org.omegat.util.Language("ja-JP"));
+        JLanguageTool lt = new JLanguageTool(Objects.requireNonNull(lang));
         List<RuleMatch> matches = lt.check("そんじゃそこらのやつらとは違う");
         assertEquals(1, matches.size());
         assertTrue(matches.get(0).getRule() instanceof PatternRule);

--- a/src/org/omegat/languagetools/LanguageManager.java
+++ b/src/org/omegat/languagetools/LanguageManager.java
@@ -44,18 +44,39 @@ public final class LanguageManager {
         LT_LANGUAGE_CLASSES.put(lang, fqcn);
     }
 
+    /**
+     * Get LanguageTool language.
+     * <p>
+     *     This code made side effect to load LT modules eventually.
+     *     It loads a specified language-country.
+     *     It also loads a variant of countries, such as "en-US" for "en-AU".
+     *     And also it loads language code module such as "en".
+     *     It is because sone language definition depends on another language,
+     *     for example, en-AU depends on en-US.
+     *     When loading only en-AU language module class, it failed to load
+     *     with an error, not-found "en-US".
+     * </p>
+     * @param lang OmegaT language code.
+     * @return LanguageTool's Language object.
+     */
     static Language getLTLanguage(org.omegat.util.Language lang) {
+        Language result = null;
         if (lang == null) {
             return null;
         }
+        // search for language-country code.
         String fqcn = LT_LANGUAGE_CLASSES.get(lang.getLanguage());
         if (fqcn != null) {
-            return Languages.getOrAddLanguageByClassName(fqcn);
+            result = Languages.getOrAddLanguageByClassName(fqcn);
         }
         // Search for language code
         fqcn = LT_LANGUAGE_CLASSES.get(lang.getLanguageCode());
         if (fqcn != null) {
-            return Languages.getOrAddLanguageByClassName(fqcn);
+            // when exists, load it.
+            Language language = Languages.getOrAddLanguageByClassName(fqcn);
+            if (result == null) {
+                result = language;
+            }
         }
         // Search for just language code match but allow country difference
         String languageCode;
@@ -66,10 +87,14 @@ public final class LanguageManager {
                 languageCode = entry.getKey();
             }
             if (languageCode.equals(lang.getLanguageCode())) {
-                return Languages.getOrAddLanguageByClassName(entry.getValue());
+                // when exists, load it.
+                Language language = Languages.getOrAddLanguageByClassName(entry.getValue());
+                if (result == null) {
+                    result = language;
+                }
             }
         }
-        return null;
+        return result;
     }
 
     static Language getLTLanguage() {

--- a/src/org/omegat/languagetools/LanguageManager.java
+++ b/src/org/omegat/languagetools/LanguageManager.java
@@ -51,7 +51,7 @@ public final class LanguageManager {
      *     It loads a specified language-country.
      *     It also loads a variant of countries, such as "en-US" for "en-AU".
      *     And also it loads language code module such as "en".
-     *     It is because sone language definition depends on another language,
+     *     It is because some language definition depends on another language,
      *     for example, en-AU depends on en-US.
      *     When loading only en-AU language module class, it failed to load
      *     with an error, not-found "en-US".
@@ -59,7 +59,7 @@ public final class LanguageManager {
      * @param lang OmegaT language code.
      * @return LanguageTool's Language object.
      */
-    static Language getLTLanguage(org.omegat.util.Language lang) {
+    public static Language getLTLanguage(org.omegat.util.Language lang) {
         Language result = null;
         if (lang == null) {
             return null;


### PR DESCRIPTION
- When loading "en-AU" LT language, it failed with IllegalArgumentException because of missing "en-US".

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Failed to load "en-AU" LT language by IllegalArgumentException
- https://sourceforge.net/p/omegat/bugs/1265/

## What does this PR change?

- LanguageManager#getLTLanguage loads not only specified language, such as "en-AU" also loads variants such as "en-US", "en-GB" and "en"

## Other information

- [x] write test case with "en-AU"