### PR TITLE
[RFE#1763] feat: localize dialogs for extra locales

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,6 +266,8 @@ dependencies {
 
         // macOS integration
         implementation(libs.madlonkay.desktopsupport)
+        // extra locales
+        implementation(libs.swing.extra.locales)
 
         // stax
         implementation(libs.stax2.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ flatlaf="3.5.1"
 assertj_swing_junit = "4.0.0-beta-1"
 morfologik = "2.1.9"
 jaxb = "2.3.0"
+swing_extra_locales = "0.3.0"
 
 [libraries]
 slf4j-api = {group = "org.slf4j", name = "slf4j-api",  version.ref = "slf4j"}
@@ -169,6 +170,7 @@ language-detector = {group = "org.omegat", name = "language-detector", version.r
 assertj_swing_junit = {group = "tokyo.northside", name = "assertj-swing-junit", version.ref = "assertj_swing_junit"}
 morfologik-stemming = { group = "org.carrot2", name = "morfologik-stemming", version.ref = "morfologik" }
 morfologik-speller = { group = "org.carrot2", name = "morfologik-speller", version.ref = "morfologik" }
+swing-extra-locales = { group = "org.omegat", name = "swing-extra-locales", version.ref = "swing_extra_locales"}
 
 [bundles]
 groovy = ["groovy-jsr223", "groovy-dateutil", "groovy-json", "groovy-xml", "groovy-swing", "groovy-templates", "ivy"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ flatlaf="3.5.1"
 assertj_swing_junit = "4.0.0-beta-1"
 morfologik = "2.1.9"
 jaxb = "2.3.0"
-swing_extra_locales = "0.3.0"
+swing_extra_locales = "0.3.2"
 
 [libraries]
 slf4j-api = {group = "org.slf4j", name = "slf4j-api",  version.ref = "slf4j"}

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -70,8 +70,6 @@ import javax.swing.UIManager;
 
 import org.apache.commons.lang3.StringUtils;
 import org.languagetool.JLanguageTool;
-import org.omegat.languagetools.LanguageClassBroker;
-import org.omegat.languagetools.LanguageDataBroker;
 import tokyo.northside.logging.ILogger;
 
 import org.omegat.CLIParameters.PSEUDO_TRANSLATE_TYPE;
@@ -95,6 +93,9 @@ import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.scripting.ConsoleBindings;
 import org.omegat.gui.scripting.ScriptItem;
 import org.omegat.gui.scripting.ScriptRunner;
+import org.omegat.languagetools.LanguageClassBroker;
+import org.omegat.languagetools.LanguageDataBroker;
+import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;

--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -95,7 +95,6 @@ import org.omegat.gui.scripting.ScriptItem;
 import org.omegat.gui.scripting.ScriptRunner;
 import org.omegat.languagetools.LanguageClassBroker;
 import org.omegat.languagetools.LanguageDataBroker;
-import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;

--- a/src/org/omegat/gui/theme/DefaultClassicTheme.java
+++ b/src/org/omegat/gui/theme/DefaultClassicTheme.java
@@ -76,7 +76,7 @@ public class DefaultClassicTheme extends DelegatingLookAndFeel {
     }
 
     public UIDefaults getDefaults() {
-        return setDefaults(systemLookAndFeel.getDefaults());
+        return setDefaults(super.getDefaults());
     }
 
     /**

--- a/src/org/omegat/gui/theme/DefaultClassicTheme.java
+++ b/src/org/omegat/gui/theme/DefaultClassicTheme.java
@@ -39,6 +39,7 @@ import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.border.MatteBorder;
 
+import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.UIDesignManager;
@@ -76,7 +77,7 @@ public class DefaultClassicTheme extends DelegatingLookAndFeel {
     }
 
     public UIDefaults getDefaults() {
-        return setDefaults(super.getDefaults());
+        return setDefaults(systemLookAndFeel.getDefaults());
     }
 
     /**
@@ -88,6 +89,7 @@ public class DefaultClassicTheme extends DelegatingLookAndFeel {
      * @return the modified {@link UIDefaults} object
      */
     public static UIDefaults setDefaults(UIDefaults defaults) {
+        ExtraLocales.setDefaults(defaults);
         defaults.put("OmegaTStatusArea.border", new MatteBorder(1, 1, 1, 1, Color.BLACK));
 
         try {

--- a/src/org/omegat/gui/theme/DefaultFlatTheme.java
+++ b/src/org/omegat/gui/theme/DefaultFlatTheme.java
@@ -84,7 +84,7 @@ public class DefaultFlatTheme extends DelegatingLookAndFeel {
     @Override
     public UIDefaults getDefaults() {
         // Use system LAF ID because we use the ID to see if it's e.g. Windows
-        return setDefaults(systemLookAndFeel.getDefaults(), systemLookAndFeel.getID());
+        return setDefaults(super.getDefaults(), getSystemLafID());
     }
 
     /**

--- a/src/org/omegat/gui/theme/DefaultFlatTheme.java
+++ b/src/org/omegat/gui/theme/DefaultFlatTheme.java
@@ -42,6 +42,7 @@ import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 
+import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Platform;
@@ -84,7 +85,7 @@ public class DefaultFlatTheme extends DelegatingLookAndFeel {
     @Override
     public UIDefaults getDefaults() {
         // Use system LAF ID because we use the ID to see if it's e.g. Windows
-        return setDefaults(super.getDefaults(), getSystemLafID());
+        return setDefaults(systemLookAndFeel.getDefaults(), systemLookAndFeel.getID());
     }
 
     /**
@@ -98,6 +99,9 @@ public class DefaultFlatTheme extends DelegatingLookAndFeel {
      * @return the modified {@link UIDefaults} object
      */
     public static UIDefaults setDefaults(UIDefaults defaults, String lafId) {
+        // load extra locales
+        ExtraLocales.setDefaults(defaults);
+
         // Colors
         // #EEEEEE on Metal & OS X LAF
         Color standardBgColor = defaults.getColor("Panel.background");

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -33,14 +33,12 @@ import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.LayoutStyle;
 import javax.swing.LookAndFeel;
-import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.plaf.basic.BasicLookAndFeel;
 
 import org.madlonkay.desktopsupport.DesktopSupport;
 
-import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.gui.ResourcesUtil;
 
 /**
@@ -126,14 +124,5 @@ public abstract class DelegatingLookAndFeel extends BasicLookAndFeel {
     @Override
     public void uninitialize() {
         systemLookAndFeel.uninitialize();
-    }
-
-    public String getSystemLafID() {
-        return systemLookAndFeel.getID();
-    }
-
-    @Override
-    public UIDefaults getDefaults() {
-        return ExtraLocales.setDefaults(systemLookAndFeel.getDefaults());
     }
 }

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -39,6 +39,8 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.plaf.basic.BasicLookAndFeel;
 
 import org.madlonkay.desktopsupport.DesktopSupport;
+
+import org.omegat.swing.extra.ExtraLocales;
 import org.omegat.util.gui.ResourcesUtil;
 
 /**
@@ -128,6 +130,6 @@ public abstract class DelegatingLookAndFeel extends BasicLookAndFeel {
 
     @Override
     public UIDefaults getDefaults() {
-        return systemLookAndFeel.getDefaults();
+        return ExtraLocales.setDefaults(systemLookAndFeel.getDefaults());
     }
 }

--- a/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -128,6 +128,10 @@ public abstract class DelegatingLookAndFeel extends BasicLookAndFeel {
         systemLookAndFeel.uninitialize();
     }
 
+    public String getSystemLafID() {
+        return systemLookAndFeel.getID();
+    }
+
     @Override
     public UIDefaults getDefaults() {
         return ExtraLocales.setDefaults(systemLookAndFeel.getDefaults());

--- a/theme/src/main/java/org/omegat/gui/theme/DefaultFlatDarkTheme.java
+++ b/theme/src/main/java/org/omegat/gui/theme/DefaultFlatDarkTheme.java
@@ -93,6 +93,7 @@ public class DefaultFlatDarkTheme extends FlatLaf {
     @Override
     public UIDefaults getDefaults() {
         UIDefaults original = parent.getDefaults();
+        // get omegat defaults
         UIDefaults defaults = DefaultFlatTheme.setDefaults(original, ID);
         UIDefaults custom = setDarkDefaults(defaults);
         UIManager.put("DockViewTitleBar.border", new MatteBorder(1, 1, 1, 1, custom.getColor("border")));

--- a/theme/src/main/java/org/omegat/gui/theme/DefaultFlatLightTheme.java
+++ b/theme/src/main/java/org/omegat/gui/theme/DefaultFlatLightTheme.java
@@ -58,9 +58,8 @@ public class DefaultFlatLightTheme extends FlatLaf {
     @Override
     public UIDefaults getDefaults() {
         UIDefaults origin = new FlatLightLaf().getDefaults();
-        UIDefaults defaults = DefaultFlatTheme.setDefaults(origin, ID); // get
-                                                                        // omegat
-                                                                        // defaults
+        // get omegat defaults
+        UIDefaults defaults = DefaultFlatTheme.setDefaults(origin, ID);
         UIDefaults custom = setLightDefaults(defaults);
         UIManager.put("DockViewTitleBar.border", new MatteBorder(1, 1, 1, 1, custom.getColor("borderColor")));
         DefaultFlatDarkTheme.setupDecoration();


### PR DESCRIPTION
Java runtime only supports 11 languages for standard dialogs such as Open, Save, and Color Chooser.
This uses swing-extra-locales library to enhance these dialogs with translations in Russian, Ukrainian, Arabic and Catalan.


## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Localize UI for genuine dialogs in various languages
- https://sourceforge.net/p/omegat/feature-requests/1763/

## What does this PR change?

- Add dependency `swing-extra-locales` and initialize the library

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
