### PR TITLE
improve test robustness against network reachability

### DIFF
--- a/test/src/org/omegat/filters/TestFilterBase.java
+++ b/test/src/org/omegat/filters/TestFilterBase.java
@@ -50,6 +50,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.w3c.dom.Document;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 import org.omegat.core.Core;
 import org.omegat.core.TestCore;
@@ -72,8 +74,6 @@ import org.omegat.filters2.master.FilterMaster;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.util.Language;
 import org.omegat.util.TMXReader2;
-import org.xmlunit.diff.DefaultNodeMatcher;
-import org.xmlunit.diff.ElementSelectors;
 
 /**
  * Base class for testing filter parsing.
@@ -421,6 +421,11 @@ public abstract class TestFilterBase extends TestCore {
     protected void compareTMX(File f1, File f2) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+        factory.setValidating(false);
+        factory.setFeature("http://xml.org/sax/features/namespaces", true);
+        factory.setFeature("http://xml.org/sax/features/validation", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         builder.setEntityResolver(TMXReader2.TMX_DTD_RESOLVER);
 
@@ -440,6 +445,12 @@ public abstract class TestFilterBase extends TestCore {
 
     protected void compareXML(URL f1, URL f2) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(false);
+        factory.setValidating(false);
+        factory.setFeature("http://xml.org/sax/features/namespaces", false);
+        factory.setFeature("http://xml.org/sax/features/validation", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         var doc1 = builder.parse(f1.toExternalForm());
         var doc2 = builder.parse(f2.toExternalForm());


### PR DESCRIPTION
There are some test case that requires network reachability and TCP port availability on OS.
These tests are failed when some network issue exists.
This is the improvement of test case to be robust against network connectivity.

## Pull request type

- Other (describe below)
test improvement

## Which ticket is resolved?

N.A.

## What does this PR change?

- Select TCP port which is not used for LanguageTool Server test case
- Configure JAXB parser not to download DTD and validate in XML test case.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
