### PR TITLE
fix(test): avoid NPE when aborting long running thread

### DIFF
--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -375,18 +375,24 @@ public class CalcMatchStatisticsTest {
                 "RowMatch85", "RowMatch75", "RowMatch50", "RowNoMatch", "Total" };
 
         private MatchStatCounts result;
+        private final IStatsConsumer callback;
 
         CalcMatchStatisticsMock(IStatsConsumer callback) {
             super(callback, false);
+            this.callback = callback;
         }
 
         @Override
         public void run() {
             entriesToProcess = Core.getProject().getAllEntries().size();
             result = calcTotal(false);
+            callback.finishData();
         }
 
         public String[][] getTable() {
+            if (result == null) {
+                return null;
+            }
             return result.calcTable(rowsTotal, i -> i != 1);
         }
     }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix of test

## Which ticket is resolved?
N.A.

## What does this PR change?

- Check result is not null. It can be null when the execution thread is intercepted.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
