### PR TITLE
made CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE log message better readable…

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1734,7 +1734,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Default
 CORE_SRX_RULES_FORMATTING_TEXT=Text files segmentation
 CORE_SRX_RULES_FORMATTING_HTML=HTML, XHTML, ODF and Infix segmentation
 
-CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unknown language code {0} specified
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unknown language code '{0}' specified
 
 # org.omegat.core.spellchecker.SpellCheckerManager
 CORE_SPELLCHECKER_NO_ENGINE=No active spell checker engine found

--- a/src/org/omegat/Bundle_de.properties
+++ b/src/org/omegat/Bundle_de.properties
@@ -1545,6 +1545,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Standard
 CORE_SRX_RULES_FORMATTING_TEXT=Segmentierung von Textdateien
 CORE_SRX_RULES_FORMATTING_HTML=Segmentierung von HTML-, XHTML-, ODF- und Infix-Dateien
 
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Unbekannter Sprachcode '{0}' spezifiziert
 
 # org.omegat.segmentation.SegmentationCustomizer
 

--- a/src/org/omegat/Bundle_it.properties
+++ b/src/org/omegat/Bundle_it.properties
@@ -1555,7 +1555,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Predefinito
 CORE_SRX_RULES_FORMATTING_TEXT=Segmentazione file di testo
 CORE_SRX_RULES_FORMATTING_HTML=Segmentazione HTML, XHTML, ODF e Infix
 
-CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Il codice di lingua {0} specificato \u00e8 sconosciuto
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Il codice di lingua '{0}' specificato \u00e8 sconosciuto
 
 # org.omegat.core.spellchecker.SpellCheckerManager
 CORE_SPELLCHECKER_NO_ENGINE=Non \u00e8 stato trovato alcun motore attivo per il correttore ortografico

--- a/src/org/omegat/Bundle_nl.properties
+++ b/src/org/omegat/Bundle_nl.properties
@@ -1555,7 +1555,7 @@ CORE_SRX_RULES_LANG_DEFAULT=Standaard
 CORE_SRX_RULES_FORMATTING_TEXT=Segmentatie van tekstbestanden
 CORE_SRX_RULES_FORMATTING_HTML=segmentatie voor HTML, XHTML, ODF en Infix
 
-CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Onbekende taalcode {0} gespecificeerd
+CORE_SRX_RULES_UNKNOWN_LANGUAGE_CODE=Onbekende taalcode '{0}' gespecificeerd
 
 # org.omegat.core.spellchecker.SpellCheckerManager
 CORE_SPELLCHECKER_NO_ENGINE=Geen actief programma voor spellingscontrole gevonden


### PR DESCRIPTION
… by surrounding the faulty language code with quotes.

this only touches localized variants of the string, no code changes at all.

this is how it looked prior to the change with the example faulty language code 'Segmentierung der Textdateien'
<img width="868" alt="Bildschirmfoto 2024-10-11 um 15 25 30" src="https://github.com/user-attachments/assets/26e50825-d44e-4f7a-a8fa-6c5ab1bb1319">
