### PR TITLE
feat: filter(po): plural as comment in japanese

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2257,6 +2257,7 @@ POFILTER_TRANSLATOR_COMMENTS=Translator comments:
 POFILTER_EXTRACTED_COMMENTS=Extracted comments:
 POFILTER_REFERENCES=References:
 POFILTER_PLURAL_FORM_COMMENT=Translate this plural as a plural form #{0}.
+POFILTER_SINGULAR_COMMENT=Corresponding plural source:
 
 # HTML-Filter
 HTMLFILTER_TAG=Tag:

--- a/src/org/omegat/filters2/po/PoFilter.java
+++ b/src/org/omegat/filters2/po/PoFilter.java
@@ -10,7 +10,7 @@
                2011 Didier Briel
                2013-1014 Alex Buloichik, Enrique Estevez
                2017 Didier Briel
-               2023 Hiroshi Miura
+               2023-2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -313,7 +313,10 @@ public class PoFilter extends AbstractFilter {
     }
 
     private StringBuilder[] sources, targets;
-    private StringBuilder translatorComments, extractedComments, references, sourceFuzzyTrue;
+    private StringBuilder translatorComments;
+    private StringBuilder extractedComments;
+    private StringBuilder references;
+    private StringBuilder sourceFuzzyTrue;
     private int plurals = 2;
     private String path;
     private boolean nowrap, fuzzy, fuzzyTrue;
@@ -610,33 +613,39 @@ public class PoFilter extends AbstractFilter {
 
     protected void parseOrAlign(int pair) {
         String pathSuffix;
-        String s;
-        String c = "";
+        String source;
+        StringBuilder sb = new StringBuilder();
         if (pair > 0) {
-            s = unescape(sources[1].toString());
+            source = unescape(sources[1].toString());
             pathSuffix = "[" + pair + "]";
-            c += StringUtil.format(OStrings.getString("POFILTER_PLURAL_FORM_COMMENT"), pair) + "\n";
+            sb.append(StringUtil.format(OStrings.getString("POFILTER_PLURAL_FORM_COMMENT"), pair)).append("\n");
         } else {
-            s = unescape(sources[pair].toString());
+            source = unescape(sources[0].toString());
             pathSuffix = "";
+            String s1 = unescape(sources[1].toString());
+            if (!StringUtil.isEmpty(s1)) {
+                sb.append(OStrings.getString("POFILTER_SINGULAR_COMMENT")).append("\n").append(s1).append("\n\n");
+            }
         }
-        String t = unescape(targets[pair].toString());
+        String translate = unescape(targets[pair].toString());
 
         if (translatorComments.length() > 0) {
-            c += OStrings.getString("POFILTER_TRANSLATOR_COMMENTS") + "\n"
-                    + unescape(translatorComments.toString() + "\n");
+            sb.append(OStrings.getString("POFILTER_TRANSLATOR_COMMENTS")).append("\n").append(unescape(
+                    translatorComments.toString())).append("\n");
         }
         if (extractedComments.length() > 0) {
-            c += OStrings.getString("POFILTER_EXTRACTED_COMMENTS") + "\n"
-                    + unescape(extractedComments.toString() + "\n");
+            sb.append(OStrings.getString("POFILTER_EXTRACTED_COMMENTS")).append("\n").append(unescape(
+                    extractedComments.toString())).append("\n");
         }
         if (references.length() > 0) {
-            c += OStrings.getString("POFILTER_REFERENCES") + "\n" + unescape(references.toString() + "\n");
+            sb.append(OStrings.getString("POFILTER_REFERENCES")).append("\n").append(unescape(references
+                            .toString())).append("\n");
         }
-        if (c.isEmpty()) {
-            c = null;
+        String comments = sb.toString();
+        if (comments.isEmpty()) {
+            comments = null;
         }
-        parseOrAlign(s, t, c, pathSuffix);
+        parseOrAlign(source, translate, comments, pathSuffix);
     }
 
     /**


### PR DESCRIPTION
Japanese is nplural=1 language.
When there is no marker in singular msgid, translator can not see plural form of msgid when translate in OmegaT panes. This add plural form of msgid as a comment of a segment which is a singular form.

## Pull request type


- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- N.A.
- https://sourceforge.net/p/omegat/feature-requests/

## What does this PR change?

- Add plural form of msgid string as comment when singular msgid is a source

## Other information

ref: discussion on https://sourceforge.net/p/omegat/bugs/1269/