### PR TITLE
Feat: Improve supporting LanguageTool local server

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2060,7 +2060,7 @@ GUI_SPELLCHECKER_SOURCE_LABEL=&Source (segment {0}):
 # LanguageTool
 
 LT_SERVER_STARTED=LanguageTool server started
-
+LT_SERVER_LOG=LanguageTool server: {0}
 LT_SERVER_TERMINATED=LanguageTool server terminated
 
 LT_API_VERSION_MISMATCH=LanguageTool API version mismatch

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2121,6 +2121,9 @@ GUI_LANGUAGETOOL_RULES_UNAVAILABLE_ERROR=There was an error initializing Languag
 
 GUI_LANGUAGETOOL_RULES_UNAVAILABLE_NO_PROJECT=Load a project to configure rules for that project\'s languages.
 
+GUI_LANGUAGETOOL_MODEL_PATH=LanguageTool ngrams model
+GUI_LANGUAGETOOL_MODEL_CHOOSE_BUTTON=Choose ngram dir
+
 PREFS_TITLE_LANGUAGETOOL=LanguageTool
 
 # org.omegat.gui.dialogs.DictionaryInstallerDialog

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2085,6 +2085,7 @@ LT_ERROR_ON_CHECK=LanguageTool: An error occurred during check. LanguageTool wil
 GUI_LANGUAGETOOL_DIALOG_TITLE=LanguageTool settings
 
 GUI_LANGUAGETOOL_FILE_CHOOSER_TITLE=Select languagetool-server.jar
+GUI_LANGUAGETOOL_DIRECTORY_CHOOSER_TITLE=Select ngrams folder
 
 GUI_LANGUAGETOOL_JAR_FILE_FILTER=JAR files
 

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
@@ -120,6 +120,7 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
         panel.bridgeLocalRadioButton.addActionListener(e -> handleBridgeTypeChange(BridgeType.LOCAL_INSTALLATION));
         panel.bridgeRemoteRadioButton.addActionListener(e -> handleBridgeTypeChange(BridgeType.REMOTE_URL));
         panel.directoryChooseButton.addActionListener(e -> chooseLocalInstallation());
+        panel.modelDirectoryChooseButton.addActionListener(e -> chooseLanguageModel());
         panel.addRuleButton.addActionListener(e -> addRule());
         panel.deleteRuleButton.addActionListener(e -> deleteRules());
         if (Core.getProject().isProjectLoaded()) {
@@ -145,6 +146,19 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
         if (result == JFileChooser.APPROVE_OPTION) {
             File file = fileChooser.getSelectedFile();
             panel.localServerJarPathTextField.setText(file.getAbsolutePath());
+        }
+    }
+
+    private void chooseLanguageModel() {
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        fileChooser.setDialogTitle(OStrings.getString("GUI_LANGUAGETOOL_DIRECTORY_CHOOSER_TITLE"));
+        String modelPath = LanguageToolPrefs.getLanguageModelDefaultPath();
+        fileChooser.setCurrentDirectory(new File(modelPath));
+        int result = fileChooser.showOpenDialog(panel);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File file = fileChooser.getSelectedFile();
+            panel.modelDirectoryTextField.setText(file.getAbsolutePath());
         }
     }
 

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
@@ -426,16 +426,22 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
             panel.localServerJarPathTextField.setEnabled(false);
             panel.directoryChooseButton.setEnabled(false);
             panel.urlTextField.setEnabled(false);
+            panel.modelDirectoryTextField.setEnabled(false);
+            panel.modelDirectoryChooseButton.setEnabled(false);
             break;
         case REMOTE_URL:
             panel.localServerJarPathTextField.setEnabled(false);
             panel.directoryChooseButton.setEnabled(false);
             panel.urlTextField.setEnabled(true);
+            panel.modelDirectoryTextField.setEnabled(false);
+            panel.modelDirectoryChooseButton.setEnabled(false);
             break;
         case LOCAL_INSTALLATION:
             panel.localServerJarPathTextField.setEnabled(true);
             panel.directoryChooseButton.setEnabled(true);
             panel.urlTextField.setEnabled(false);
+            panel.modelDirectoryTextField.setEnabled(true);
+            panel.modelDirectoryChooseButton.setEnabled(true);
             break;
         }
     }
@@ -457,6 +463,7 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
 
         panel.urlTextField.setText(LanguageToolPrefs.getRemoteUrl());
         panel.localServerJarPathTextField.setText(LanguageToolPrefs.getLocalServerJarPath());
+        panel.modelDirectoryTextField.setText(LanguageToolPrefs.getLanguageModelPath());
 
         if (targetLanguageCode != null) {
             disabledCategories = LanguageToolPrefs.getDisabledCategories(targetLanguageCode);
@@ -474,6 +481,7 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
         panel.bridgeNativeRadioButton.setSelected(true);
         panel.urlTextField.setText("");
         panel.localServerJarPathTextField.setText("");
+        panel.modelDirectoryTextField.setText("");
 
         if (targetLanguageCode != null) {
             disabledCategories = LanguageToolPrefs.getDefaultDisabledCategories();
@@ -491,6 +499,7 @@ public class LanguageToolConfigurationController extends BasePreferencesControll
         LanguageToolPrefs.setBridgeType(selectedBridgeType);
         LanguageToolPrefs.setRemoteUrl(panel.urlTextField.getText());
         LanguageToolPrefs.setLocalServerJarPath(panel.localServerJarPathTextField.getText());
+        LanguageToolPrefs.setLanguageModelPath(panel.modelDirectoryTextField.getText());
 
         if (targetLanguageCode != null) {
             LanguageToolPrefs.setDisabledCategories(disabledCategories, targetLanguageCode);

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.form
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.form
@@ -36,7 +36,7 @@
                 <EmptyBorder bottom="5" left="0" right="0" top="0"/>
               </Border>
               <Border PropertyName="inside" info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-                <TitledBorder title="Service type">
+                <TitledBorder title="&lt;GUI_LANGUAGETOOL_BRIDGE_TYPE&gt;">
                   <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_BRIDGE_TYPE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                 </TitledBorder>
               </Border>
@@ -223,6 +223,9 @@
                   <Properties>
                     <Property name="toolTipText" type="java.lang.String" value=""/>
                   </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="localServerJarPathTextFieldActionPerformed"/>
+                  </Events>
                   <AuxValues>
                     <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
                   </AuxValues>
@@ -250,6 +253,66 @@
                 </Component>
               </SubComponents>
             </Container>
+            <Container class="javax.swing.JPanel" name="jPanel1">
+              <Properties>
+                <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                  <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
+                    <EmptyBorder bottom="0" left="25" right="0" top="5"/>
+                  </Border>
+                </Property>
+              </Properties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                  <BorderConstraints direction="Last"/>
+                </Constraint>
+              </Constraints>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="modelDirectoryLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODEL_PATH&quot;)" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="North"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JTextField" name="modelDirectoryTextField">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODEL_PATH&quot;)" type="code"/>
+                    </Property>
+                  </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                  </AuxValues>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="Center"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JButton" name="modelDirectoryChooseButton">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODELCHOOSE_BUTTON&quot;)" type="code"/>
+                    </Property>
+                  </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                  </AuxValues>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+                      <BorderConstraints direction="East"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+              </SubComponents>
+            </Container>
           </SubComponents>
         </Container>
       </SubComponents>
@@ -258,7 +321,7 @@
       <Properties>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-            <TitledBorder title="Rules">
+            <TitledBorder title="&lt;GUI_LANGUAGETOOL_RULES&gt;">
               <ResourceString PropertyName="titleX" bundle="org/omegat/Bundle.properties" key="GUI_LANGUAGETOOL_RULES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
             </TitledBorder>
           </Border>

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.form
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.form
@@ -282,11 +282,6 @@
                   </Constraints>
                 </Component>
                 <Component class="javax.swing.JTextField" name="modelDirectoryTextField">
-                  <Properties>
-                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODEL_PATH&quot;)" type="code"/>
-                    </Property>
-                  </Properties>
                   <AuxValues>
                     <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
                   </AuxValues>
@@ -299,7 +294,7 @@
                 <Component class="javax.swing.JButton" name="modelDirectoryChooseButton">
                   <Properties>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODELCHOOSE_BUTTON&quot;)" type="code"/>
+                      <Connection code="OStrings.getString(&quot;GUI_LANGUAGETOOL_MODEL_CHOOSE_BUTTON&quot;)" type="code"/>
                     </Property>
                   </Properties>
                   <AuxValues>

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
@@ -143,11 +143,9 @@ public class LanguageToolConfigurationPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(modelDirectoryLabel, OStrings.getString("GUI_LANGUAGETOOL_MODEL_PATH"));
         jPanel1.add(modelDirectoryLabel, java.awt.BorderLayout.NORTH);
-
-        modelDirectoryTextField.setText(OStrings.getString("GUI_LANGUAGETOOL_MODEL_PATH"));
         jPanel1.add(modelDirectoryTextField, java.awt.BorderLayout.CENTER);
 
-        org.openide.awt.Mnemonics.setLocalizedText(modelDirectoryChooseButton, OStrings.getString("GUI_LANGUAGETOOL_MODELCHOOSE_BUTTON"));
+        org.openide.awt.Mnemonics.setLocalizedText(modelDirectoryChooseButton, OStrings.getString("GUI_LANGUAGETOOL_MODEL_CHOOSE_BUTTON"));
         jPanel1.add(modelDirectoryChooseButton, java.awt.BorderLayout.EAST);
 
         localPanel.add(jPanel1, java.awt.BorderLayout.PAGE_END);

--- a/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
+++ b/src/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
@@ -61,6 +61,10 @@ public class LanguageToolConfigurationPanel extends javax.swing.JPanel {
         localPathLabel = new javax.swing.JLabel();
         localServerJarPathTextField = new javax.swing.JTextField();
         directoryChooseButton = new javax.swing.JButton();
+        jPanel1 = new javax.swing.JPanel();
+        modelDirectoryLabel = new javax.swing.JLabel();
+        modelDirectoryTextField = new javax.swing.JTextField();
+        modelDirectoryChooseButton = new javax.swing.JButton();
         rulesPanel = new javax.swing.JPanel();
         rulesMessagePanel = new javax.swing.JPanel();
         rulesMessageLabel = new javax.swing.JLabel();
@@ -122,12 +126,31 @@ public class LanguageToolConfigurationPanel extends javax.swing.JPanel {
         directoryPanel.add(localPathLabel, java.awt.BorderLayout.NORTH);
 
         localServerJarPathTextField.setToolTipText("");
+        localServerJarPathTextField.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                localServerJarPathTextFieldActionPerformed(evt);
+            }
+        });
         directoryPanel.add(localServerJarPathTextField, java.awt.BorderLayout.CENTER);
 
         org.openide.awt.Mnemonics.setLocalizedText(directoryChooseButton, OStrings.getString("GUI_LANGUAGETOOL_CHOOSE_BUTTON")); // NOI18N
         directoryPanel.add(directoryChooseButton, java.awt.BorderLayout.EAST);
 
         localPanel.add(directoryPanel, java.awt.BorderLayout.CENTER);
+
+        jPanel1.setBorder(javax.swing.BorderFactory.createEmptyBorder(5, 25, 0, 0));
+        jPanel1.setLayout(new java.awt.BorderLayout());
+
+        org.openide.awt.Mnemonics.setLocalizedText(modelDirectoryLabel, OStrings.getString("GUI_LANGUAGETOOL_MODEL_PATH"));
+        jPanel1.add(modelDirectoryLabel, java.awt.BorderLayout.NORTH);
+
+        modelDirectoryTextField.setText(OStrings.getString("GUI_LANGUAGETOOL_MODEL_PATH"));
+        jPanel1.add(modelDirectoryTextField, java.awt.BorderLayout.CENTER);
+
+        org.openide.awt.Mnemonics.setLocalizedText(modelDirectoryChooseButton, OStrings.getString("GUI_LANGUAGETOOL_MODELCHOOSE_BUTTON"));
+        jPanel1.add(modelDirectoryChooseButton, java.awt.BorderLayout.EAST);
+
+        localPanel.add(jPanel1, java.awt.BorderLayout.PAGE_END);
 
         externalOptionsPanel.add(localPanel);
 
@@ -169,6 +192,10 @@ public class LanguageToolConfigurationPanel extends javax.swing.JPanel {
         add(rulesPanel, java.awt.BorderLayout.CENTER);
     }// </editor-fold>//GEN-END:initComponents
 
+    private void localServerJarPathTextFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_localServerJarPathTextFieldActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_localServerJarPathTextFieldActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     javax.swing.JButton addRuleButton;
     javax.swing.JRadioButton bridgeLocalRadioButton;
@@ -179,9 +206,13 @@ public class LanguageToolConfigurationPanel extends javax.swing.JPanel {
     javax.swing.JButton directoryChooseButton;
     private javax.swing.JPanel directoryPanel;
     private javax.swing.JPanel externalOptionsPanel;
+    private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel localPanel;
     private javax.swing.JLabel localPathLabel;
     javax.swing.JTextField localServerJarPathTextField;
+    javax.swing.JButton modelDirectoryChooseButton;
+    private javax.swing.JLabel modelDirectoryLabel;
+    javax.swing.JTextField modelDirectoryTextField;
     private javax.swing.JPanel nativePanel;
     private javax.swing.JPanel remotePanel;
     javax.swing.JPanel rulesButtonsPanel;

--- a/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
@@ -127,13 +127,15 @@ public class LanguageToolNetworkBridge extends BaseLanguageToolBridge {
         // Run the server
         if (useModel) {
             Path config = prepareConfig();
-            ProcessBuilder pb = new ProcessBuilder("java", "-cp", serverJar.getAbsolutePath(), SERVER_CLASS_NAME,
-                    "--port", Integer.toString(port), "--config", config.toString());
+            ProcessBuilder pb = new ProcessBuilder("java", "-Xms256m", "-Xmx512m",
+                    "-cp", serverJar.getAbsolutePath(), SERVER_CLASS_NAME,
+                    "--port", Integer.toString(port), "--public", "--config", config.toString(), "--allow-origin");
             pb.redirectErrorStream(true);
             server = pb.start();
         } else {
-            ProcessBuilder pb = new ProcessBuilder("java", "-cp", serverJar.getAbsolutePath(), SERVER_CLASS_NAME,
-                    "--port", Integer.toString(port));
+            ProcessBuilder pb = new ProcessBuilder("java", "-Xms256m", "-Xmx512m",
+                    "-cp", serverJar.getAbsolutePath(), SERVER_CLASS_NAME,
+                    "--port", Integer.toString(port), "--public", "--allow-origin");
             pb.redirectErrorStream(true);
             server = pb.start();
         }

--- a/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNetworkBridge.java
@@ -157,7 +157,7 @@ public class LanguageToolNetworkBridge extends BaseLanguageToolBridge {
         List<String> commands = new ArrayList<>();
         commands.add("java");
         commands.add("-Xms256m");
-        commands.add("-Xmx512m");
+        commands.add("-Xmx768m");
         commands.add("-cp");
         commands.add(classPath);
         commands.add(SERVER_CLASS_NAME);

--- a/src/org/omegat/languagetools/LanguageToolPrefs.java
+++ b/src/org/omegat/languagetools/LanguageToolPrefs.java
@@ -88,6 +88,14 @@ public final class LanguageToolPrefs {
         return Preferences.getPreference(Preferences.LANGUAGETOOL_LOCAL_SERVER_JAR_PATH);
     }
 
+    public static void setLanguageModelPath(String path) {
+        Preferences.setPreference(Preferences.LANGUAGETOOL_LANGUAGE_MODEL_PATH, path);
+    }
+
+    public static String getLanguageModelPath() {
+        return Preferences.getPreference(Preferences.LANGUAGETOOL_LANGUAGE_MODEL_PATH);
+    }
+
     public static void setDisabledRules(Set<String> rules, String languageCode) {
         setLanguageSpecificPreference(rules,
                 Preferences.LANGUAGETOOL_DISABLED_RULES_PREFIX, languageCode);

--- a/src/org/omegat/languagetools/LanguageToolPrefs.java
+++ b/src/org/omegat/languagetools/LanguageToolPrefs.java
@@ -192,7 +192,7 @@ public final class LanguageToolPrefs {
             String path = "Library/Application Support/" + APPLICATION_ID;
             directory = Paths.get(userHome).resolve(path);
         } else if (Platform.isLinux()) {
-            // Path: /home/<YourUserName>/.local/LanguageTool/ngrams
+            // Path: /home/<YourUserName>/.local/share/LanguageTool/ngrams
             Path appDataDir = null;
             try {
                 String xdgConfigHome = System.getenv("XDG_CONFIG_HOME");
@@ -208,7 +208,7 @@ public final class LanguageToolPrefs {
                 String path = APPLICATION_ID + "/ngrams";
                 directory = appDataDir.resolve(path);
             } else {
-                String path = ".local/" + APPLICATION_ID + "/ngrams";
+                String path = ".local/share/" + APPLICATION_ID + "/ngrams";
                 directory = Paths.get(userHome).resolve(path);
             }
         } else {

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -182,6 +182,9 @@ public final class LanguageToolWrapper {
             case LOCAL_INSTALLATION:
                 String localServerJarPath = LanguageToolPrefs.getLocalServerJarPath();
                 String languageModelPath = LanguageToolPrefs.getLanguageModelPath();
+                if (languageModelPath == null) {
+                    languageModelPath = LanguageToolPrefs.getLanguageModelDefaultPath();
+                }
                 bridge = new LanguageToolNetworkBridge(sourceLang, targetLang, localServerJarPath, 8081,
                         languageModelPath);
                 break;
@@ -201,4 +204,5 @@ public final class LanguageToolWrapper {
         LanguageToolPrefs.applyRules(bridge, targetLang.getLanguageCode());
         return bridge;
     }
+
 }

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -181,7 +181,9 @@ public final class LanguageToolWrapper {
             switch (type) {
             case LOCAL_INSTALLATION:
                 String localServerJarPath = LanguageToolPrefs.getLocalServerJarPath();
-                bridge = new LanguageToolNetworkBridge(sourceLang, targetLang, localServerJarPath, 8081);
+                String languageModelPath = LanguageToolPrefs.getLanguageModelPath();
+                bridge = new LanguageToolNetworkBridge(sourceLang, targetLang, localServerJarPath, 8081,
+                        languageModelPath);
                 break;
             case REMOTE_URL:
                 String remoteUrl = LanguageToolPrefs.getRemoteUrl();

--- a/src/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/org/omegat/languagetools/LanguageToolWrapper.java
@@ -27,6 +27,8 @@
 
 package org.omegat.languagetools;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -185,7 +187,8 @@ public final class LanguageToolWrapper {
                 if (languageModelPath == null) {
                     languageModelPath = LanguageToolPrefs.getLanguageModelDefaultPath();
                 }
-                bridge = new LanguageToolNetworkBridge(sourceLang, targetLang, localServerJarPath, 8081,
+                int port = getFreePort();
+                bridge = new LanguageToolNetworkBridge(sourceLang, targetLang, localServerJarPath, port,
                         languageModelPath);
                 break;
             case REMOTE_URL:
@@ -203,6 +206,18 @@ public final class LanguageToolWrapper {
 
         LanguageToolPrefs.applyRules(bridge, targetLang.getLanguageCode());
         return bridge;
+    }
+
+    private static final int[] FREE_PORT_RANGE = {8081, 10080, 10081, 10082, 10083, 10084, 10085, 10086};
+
+    private static int getFreePort() {
+        for (int p : FREE_PORT_RANGE) {
+            try (ServerSocket serverSocket = new ServerSocket(p)) {
+                return serverSocket.getLocalPort();
+            } catch (IOException ignored) {
+            }
+        }
+        return -1;
     }
 
 }

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -297,6 +297,8 @@ public final class Preferences {
     public static final String LANGUAGETOOL_REMOTE_URL = "lt_remoteURL";
     /** Local path to LanguageTool server jar file */
     public static final String LANGUAGETOOL_LOCAL_SERVER_JAR_PATH = "lt_localServerJarPath";
+    /** Local path to LanguageTool ngram model files */
+    public static final String LANGUAGETOOL_LANGUAGE_MODEL_PATH = "lt_languageModelPath";
     /** Disabled categories */
     public static final String LANGUAGETOOL_DISABLED_CATEGORIES_PREFIX = "lt_disabledCategories";
     /** Disabled rules prefix */

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -251,27 +251,7 @@ public final class StaticUtils {
             return configDir;
         }
 
-        String home; // user home directory
-
-        // get os and user home properties
-        try {
-            // get the user's home directory
-            home = System.getProperty("user.home");
-        } catch (SecurityException e) {
-            // access to the os/user home properties is restricted,
-            // the location of the config dir cannot be determined,
-            // set the config dir to the current working dir
-            configDir = new File(".").getAbsolutePath() + File.separator;
-
-            // log the exception, only do this after the config dir
-            // has been set to the current working dir, otherwise
-            // the log method will probably fail
-            Log.logErrorRB("SU_USERHOME_PROP_ACCESS_ERROR");
-            Log.log(e.toString());
-
-            return configDir;
-        }
-
+        String home = getHomeDir();
         // if os or user home is null or empty, we cannot reliably determine
         // the config dir, so we use the current working dir (= empty string)
         if (StringUtil.isEmpty(home)) {
@@ -357,6 +337,23 @@ public final class StaticUtils {
 
         // we should have a correct, existing config dir now
         return configDir;
+    }
+
+    public static String getHomeDir() {
+        String home; // user home directory
+        // get os and user home properties
+        try {
+            // get the user's home directory
+            home = System.getProperty("user.home");
+        } catch (SecurityException e) {
+            // log the exception, only do this after the config dir
+            // has been set to the current working dir, otherwise
+            // the log method will probably fail
+            Log.logErrorRB("SU_USERHOME_PROP_ACCESS_ERROR");
+            Log.log(e.toString());
+            return null;
+        }
+        return home;
     }
 
     public static String getScriptDir() {


### PR DESCRIPTION
A code to launch local LanguageTool server from OmegaT has not been maintained in many years.
This improves handling of local LanguageTool server launcher, to add necessary arguments, catch connection error.

Also allow specifying ngram files for LT server.

## Pull request type

- Feature enhancement -> [enhancement]


## Which ticket is resolved?

- Support ngrams for local LT server jar launcher
- https://sourceforge.net/p/omegat/feature-requests/1764/


## What does this PR change?

- Update Preferences > LanguageTool > Local Server Jar to accept folder path that have language model files 
- Catch HTTP connection error and handling the error properly, instead of dumping stacks
- Put heap memory option to java
- Put `--public` to LT server
- Put `--allow-origin`  to LT server (Handle CORS)
- Automatically select an unused port instead of default 8081 only
- Default language model (ngram) paths
    - windows:  `\\user\<YourUserName>\AppData\Roaming\languagetool.org\LanguageTool\ngrams`
    - Linux: `$HOME/.local/share/LanguageTool/ngrams`
    - macOS: `/Library/Application-Support/LanguageTool/ngrams`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
