### PR TITLE
fix: spell: look for LT bundle spelling/ folder

### DIFF
--- a/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/MorfologikSpellchecker.java
+++ b/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/MorfologikSpellchecker.java
@@ -93,16 +93,28 @@ public class MorfologikSpellchecker extends AbstractSpellChecker implements ISpe
         return Optional.empty();
     }
 
+    private String findDictionaryFolderInLTJar(String language) {
+        final String[] folders = new String[] {"/hunspell/", "/spelling/"};
+        for (String folder : folders) {
+            String path = "/" + new Language(language).getLanguageCode() + folder + language;
+            if (JLanguageTool.getDataBroker().resourceExists(path + SC_DICT_EXTENSION)) {
+                return path;
+            }
+        }
+        return null;
+    }
+
     /**
      * If there is a Morfologik dictionary for the current target language
      * bundled with LanguageTool, install it.
      */
     private void installLTBundledDictionary(String dictionaryDir, String language) {
-        String resPath = "/" + new Language(language).getLanguageCode() + "/hunspell/" + language + SC_DICT_EXTENSION;
-        String infoPath = "/" + new Language(language).getLanguageCode() + "/hunspell/" + language + SC_INFO_EXTENSION;
-        if (!JLanguageTool.getDataBroker().resourceExists(resPath)) {
+        String path = findDictionaryFolderInLTJar(language);
+        if (path == null) {
             return;
         }
+        String resPath = path + SC_DICT_EXTENSION;
+        String infoPath = path + SC_INFO_EXTENSION;
         try {
             try (InputStream dictStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(resPath);
                  FileOutputStream fos = new FileOutputStream(

--- a/src/org/omegat/languagetools/LanguageManager.java
+++ b/src/org/omegat/languagetools/LanguageManager.java
@@ -65,7 +65,7 @@ public final class LanguageManager {
             return null;
         }
         // search for language-country code.
-        String fqcn = LT_LANGUAGE_CLASSES.get(lang.getLanguage());
+        String fqcn = LT_LANGUAGE_CLASSES.get(lang.getLanguage().replace("_", "-"));
         if (fqcn != null) {
             result = Languages.getOrAddLanguageByClassName(fqcn);
         }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]


## Which ticket is resolved?

- Speller: morfologik: LT bundled dictionary not found in Dutch
- https://sourceforge.net/p/omegat/bugs/1271/

## What does this PR change?

- Looking for `spelling/` folder in addition to `hunspell/` in resources
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and
-after screenshots -->
