### PR TITLE
fix: o.o.g.p.v.CustomColor setRestartRequired when selection changed

### DIFF
--- a/src/org/omegat/gui/preferences/view/CustomColorSelectionController.java
+++ b/src/org/omegat/gui/preferences/view/CustomColorSelectionController.java
@@ -176,6 +176,9 @@ public class CustomColorSelectionController extends BasePreferencesController {
             Color color = temporaryPreferences.getOrDefault(style, style.getColor());
             setColorChooserWithoutNotifying(color);
         });
+        if (enabled) {
+            setRestartRequired(hasChanges());
+        }
     }
 
     private void resetCurrentColor() {


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Preferences/CutomColorSelector don't show notification immediately when modifying color  
- https://sourceforge.net/p/omegat/bugs/1273/

## What does this PR change?

- check the change when the selection changed

## Other information

This can be backported to releases/6.0 branch
