### PR TITLE
refactor: FindMatches to split looong method into multiple private method, use lambda, and relax suppression of checkstyle

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -136,7 +136,8 @@
          lines="90,91,92,96,100,104,105,107,264,275,276,284,286,293,294,308,309,359,361,449,495,605,674,710"/>
 
     <!-- matching -->
-    <suppress files="NearString\.java" checks="(ParameterNumber|TypeName)" lines="49,55-120"/>
+    <suppress files="NearString\.java" checks="TypeName" lines="51-55"/>
+    <suppress files="NearString\.java" checks="ParameterNumber" lines="85-150"/>
     <suppress files="LevenshteinDistance\.java" checks="LocalVariableName" lines="147,159"/>
 
     <!-- Aligner, AlignFilePickerController, AlignPanelController -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -78,8 +78,6 @@
     <suppress files="Platform\.java" checks="ConstantName" lines="61-80"/>
     <!-- util/Preferences -->
     <suppress files="Preferences\.java" checks="LineLength" lines="197"/>
-    <!-- core/statistics, ignore private FindMatches#addNearString -->
-    <suppress checks="ParameterNumber" files="FindMatches\.java" lines="410-440"/>
     <!-- util/xml -->
     <suppress checks="(EmptyBlock|MethodLength)" files="XMLStreamReader\.java"/>
     <!-- util -->
@@ -138,7 +136,7 @@
          lines="90,91,92,96,100,104,105,107,264,275,276,284,286,293,294,308,309,359,361,449,495,605,674,710"/>
 
     <!-- matching -->
-    <suppress files="NearString\.java" checks="(ParameterNumber|TypeName)" lines="49,53,57,76"/>
+    <suppress files="NearString\.java" checks="(ParameterNumber|TypeName)" lines="49,55-120"/>
     <suppress files="LevenshteinDistance\.java" checks="LocalVariableName" lines="147,159"/>
 
     <!-- Aligner, AlignFilePickerController, AlignPanelController -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -78,8 +78,8 @@
     <suppress files="Platform\.java" checks="ConstantName" lines="61-80"/>
     <!-- util/Preferences -->
     <suppress files="Preferences\.java" checks="LineLength" lines="197"/>
-    <!-- core/stat -->
-    <suppress checks="(ParameterNumber|MethodLength)" files="FindMatches\.java" lines="164,350,459"/>
+    <!-- core/statistics, ignore private FindMatches#addNearString -->
+    <suppress checks="ParameterNumber" files="FindMatches\.java" lines="410-440"/>
     <!-- util/xml -->
     <suppress checks="(EmptyBlock|MethodLength)" files="XMLStreamReader\.java"/>
     <!-- util -->

--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -57,29 +57,22 @@ public class NearString {
     }
 
     public NearString(EntryKey key, ITMXEntry entry, MATCH_SOURCE comesFrom, boolean fuzzyMark,
-                      Scores scores,
-                      byte[] nearData, String projName) {
+                      Scores scores, byte[] nearData, String projName) {
         this(key, entry.getSourceText(), entry.getTranslationText(), comesFrom, fuzzyMark, scores,
                 nearData, projName, entry.getCreator(), entry.getCreationDate(), entry.getChanger(),
                 entry.getChangeDate(), entry.getProperties());
     }
 
-    public NearString(EntryKey key, String source, String translation, MATCH_SOURCE comesFrom,
-            boolean fuzzyMark, int nearScore, int nearScoreNoStem, int adjustedScore,
-            byte[] nearData, String projName, String creator, long creationDate,
-            String changer, long changedDate, List<TMXProp> props) {
-        this(key, source, translation, comesFrom, fuzzyMark, new Scores(nearScore, nearScoreNoStem,
-                adjustedScore), nearData, projName, creator, creationDate, changer, changedDate, props);
-    }
-
     /**
-     * Constructor, keep backward compatibility.
+     * Constructor, backward compatible.
      * @param key entry key
      * @param source source text
      * @param translation translation text
      * @param comesFrom origin
      * @param fuzzyMark fuzzy or not
-     * @param scores fuzzy similarity score
+     * @param nearScore
+     * @param nearScoreNoStem
+     * @param adjustedScore
      * @param nearData similarity data.
      * @param projName project name.
      * @param creator creator name
@@ -88,7 +81,16 @@ public class NearString {
      * @param changedDate changer date
      * @param props properties of entry.
      */
+    @Deprecated
     public NearString(EntryKey key, String source, String translation, MATCH_SOURCE comesFrom,
+            boolean fuzzyMark, int nearScore, int nearScoreNoStem, int adjustedScore,
+            byte[] nearData, String projName, String creator, long creationDate,
+            String changer, long changedDate, List<TMXProp> props) {
+        this(key, source, translation, comesFrom, fuzzyMark, new Scores(nearScore, nearScoreNoStem,
+                adjustedScore), nearData, projName, creator, creationDate, changer, changedDate, props);
+    }
+
+    private NearString(EntryKey key, String source, String translation, MATCH_SOURCE comesFrom,
                       boolean fuzzyMark, Scores scores, byte[] nearData, String projName, String creator,
                       long creationDate, String changer, long changedDate, List<TMXProp> props) {
         this.key = key;
@@ -188,7 +190,7 @@ public class NearString {
     public String[] projs;
 
     /** matching attributes of near strEntry */
-    public final byte[] attr;
+    public byte[] attr;
 
     public final List<TMXProp> props;
     public final String creator;

--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -7,6 +7,7 @@
                2009 Alex Buloichik
                2012 Thomas Cordonnier
                2013-2014 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -34,6 +35,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ITMXEntry;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TMXProp;
 
@@ -54,16 +56,47 @@ public class NearString {
         SCORE, SCORE_NO_STEM, ADJUSTED_SCORE
     }
 
-    public NearString(final EntryKey key, final String source, final String translation, MATCH_SOURCE comesFrom,
-            final boolean fuzzyMark, final int nearScore, final int nearScoreNoStem, final int adjustedScore,
-            final byte[] nearData, final String projName, final String creator, final long creationDate,
-            final String changer, final long changedDate, final List<TMXProp> props) {
+    public NearString(EntryKey key, ITMXEntry entry, MATCH_SOURCE comesFrom, boolean fuzzyMark,
+                      Scores scores,
+                      byte[] nearData, String projName) {
+        this(key, entry.getSourceText(), entry.getTranslationText(), comesFrom, fuzzyMark, scores,
+                nearData, projName, entry.getCreator(), entry.getCreationDate(), entry.getChanger(),
+                entry.getChangeDate(), entry.getProperties());
+    }
+
+    public NearString(EntryKey key, String source, String translation, MATCH_SOURCE comesFrom,
+            boolean fuzzyMark, int nearScore, int nearScoreNoStem, int adjustedScore,
+            byte[] nearData, String projName, String creator, long creationDate,
+            String changer, long changedDate, List<TMXProp> props) {
+        this(key, source, translation, comesFrom, fuzzyMark, new Scores(nearScore, nearScoreNoStem,
+                adjustedScore), nearData, projName, creator, creationDate, changer, changedDate, props);
+    }
+
+    /**
+     * Constructor, keep backward compatibility.
+     * @param key entry key
+     * @param source source text
+     * @param translation translation text
+     * @param comesFrom origin
+     * @param fuzzyMark fuzzy or not
+     * @param scores fuzzy similarity score
+     * @param nearData similarity data.
+     * @param projName project name.
+     * @param creator creator name
+     * @param creationDate creation date
+     * @param changer changer name
+     * @param changedDate changer date
+     * @param props properties of entry.
+     */
+    public NearString(EntryKey key, String source, String translation, MATCH_SOURCE comesFrom,
+                      boolean fuzzyMark, Scores scores, byte[] nearData, String projName, String creator,
+                      long creationDate, String changer, long changedDate, List<TMXProp> props) {
         this.key = key;
         this.source = source;
         this.translation = translation;
         this.comesFrom = comesFrom;
         this.fuzzyMark = fuzzyMark;
-        this.scores = new Scores[] { new Scores(nearScore, nearScoreNoStem, adjustedScore) };
+        this.scores = new Scores[] { scores };
         this.attr = nearData;
         this.projs = new String[] { projName == null ? "" : projName };
         this.props = props;
@@ -73,31 +106,69 @@ public class NearString {
         this.changedDate = changedDate;
     }
 
+    /**
+     * Merge NearString object.
+     * @param ns NearString to merge.
+     * @param key entry key.
+     * @param entry TMXEntry entry
+     * @param comesFrom origin
+     * @param fuzzyMark fuzzy or not
+     * @param scores similarity score
+     * @param nearData similarity data
+     * @param projName project name
+     * @return NearString merged.
+     */
+    public static NearString merge(NearString ns, EntryKey key, ITMXEntry entry, MATCH_SOURCE comesFrom,
+                                   boolean fuzzyMark, Scores scores, byte[] nearData, String projName) {
+
+        List<String> projs = new ArrayList<>();
+        List<Scores> mergedScores = new ArrayList<>();
+        projs.addAll(Arrays.asList(ns.projs));
+        mergedScores.addAll(Arrays.asList(ns.scores));
+
+        NearString merged;
+        if (scores.score > ns.scores[0].score) {
+            merged = new NearString(key, entry, comesFrom, fuzzyMark, scores, nearData, null);
+            projs.add(0, projName);
+            mergedScores.add(0, merged.scores[0]);
+        } else {
+            merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark,
+                    scores, ns.attr, null, ns.creator, ns.creationDate, ns.changer,
+                    ns.changedDate, ns.props);
+            projs.add(projName);
+            mergedScores.add(merged.scores[0]);
+        }
+        merged.projs = projs.toArray(new String[projs.size()]);
+        merged.scores = mergedScores.toArray(new Scores[mergedScores.size()]);
+        return merged;
+    }
+
+    @Deprecated
     public static NearString merge(NearString ns, final EntryKey key, final String source, final String translation,
             MATCH_SOURCE comesFrom, final boolean fuzzyMark, final int nearScore, final int nearScoreNoStem,
             final int adjustedScore, final byte[] nearData, final String projName, final String creator,
             final long creationDate, final String changer, final long changedDate, final List<TMXProp> props) {
 
         List<String> projs = new ArrayList<>();
-        List<Scores> scores = new ArrayList<>();
+        List<Scores> mergedScores = new ArrayList<>();
         projs.addAll(Arrays.asList(ns.projs));
-        scores.addAll(Arrays.asList(ns.scores));
+        mergedScores.addAll(Arrays.asList(ns.scores));
 
         NearString merged;
         if (nearScore > ns.scores[0].score) {
             merged = new NearString(key, source, translation, comesFrom, fuzzyMark, nearScore,
                     nearScoreNoStem, adjustedScore, nearData, null, creator, creationDate, changer, changedDate, props);
             projs.add(0, projName);
-            scores.add(0, merged.scores[0]);
+            mergedScores.add(0, merged.scores[0]);
         } else {
             merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark, nearScore,
                     nearScoreNoStem, adjustedScore, ns.attr, null, ns.creator, ns.creationDate, ns.changer,
                     ns.changedDate, ns.props);
             projs.add(projName);
-            scores.add(merged.scores[0]);
+            mergedScores.add(merged.scores[0]);
         }
         merged.projs = projs.toArray(new String[projs.size()]);
-        merged.scores = scores.toArray(new Scores[scores.size()]);
+        merged.scores = mergedScores.toArray(new Scores[mergedScores.size()]);
         return merged;
     }
 
@@ -114,15 +185,16 @@ public class NearString {
     public boolean fuzzyMark;
 
     public Scores[] scores;
+    public String[] projs;
 
     /** matching attributes of near strEntry */
-    public byte[] attr;
-    public String[] projs;
-    public List<TMXProp> props;
-    public String creator;
-    public long creationDate;
-    public String changer;
-    public long changedDate;
+    public final byte[] attr;
+
+    public final List<TMXProp> props;
+    public final String creator;
+    public final long creationDate;
+    public final String changer;
+    public final long changedDate;
 
     public static class Scores {
         public final int score;

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -42,11 +42,9 @@ import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ExternalTMFactory;
 import org.omegat.core.data.ExternalTMX;
 import org.omegat.core.data.IProject;
-import org.omegat.core.data.IProject.DefaultTranslationsIterator;
-import org.omegat.core.data.IProject.MultipleTranslationsIterator;
 import org.omegat.core.data.ITMXEntry;
+import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
 import org.omegat.core.matching.FuzzyMatcher;
 import org.omegat.core.matching.ISimilarityCalculator;
@@ -59,7 +57,6 @@ import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
-import org.omegat.util.TMXProp;
 import org.omegat.util.Token;
 
 /**
@@ -87,8 +84,9 @@ import org.omegat.util.Token;
 public class FindMatches {
 
     /**
-     * According to gettext source code, PO fuzzies are created above 60%
-     * https://sourceforge.net/p/omegat/feature-requests/1258/
+     * According to gettext source code, PO fuzzy entries are created above 60%
+     * <a href=
+     * "https://sourceforge.net/p/omegat/feature-requests/1258/">RFE#1258</a>
      */
     static final int PENALTY_FOR_FUZZY = 40;
     private static final int PENALTY_FOR_REMOVED = 5;
@@ -164,10 +162,8 @@ public class FindMatches {
     public List<NearString> search(String searchText, boolean requiresTranslation, boolean fillSimilarityData,
             IStopped stop) throws StoppedException {
         result = new ArrayList<>(OConsts.MAX_NEAR_STRINGS + 1);
-
         srcText = searchText;
         removedText = "";
-
         // remove part that is to be removed according to user settings.
         // Rationale: it might be a big string influencing the 'editing
         // distance', while it is not really part
@@ -181,36 +177,16 @@ public class FindMatches {
             srcText = removeMatcher.replaceAll("");
             removedText = removedBuffer.toString();
         }
-
-        // get tokens for original string
+        // get tokens for original string which includes non-word tokens
         strTokensStem = tokenizeStem(srcText);
         strTokensNoStem = tokenizeNoStem(srcText);
         strTokensAll = tokenizeAll(srcText);
-        /* HP: includes non - word tokens */
 
         // travel by project entries, including orphaned
         if (project.getProjectProperties().isSupportDefaultTranslations()) {
-            project.iterateByDefaultTranslations(new DefaultTranslationsIterator() {
-                public void iterate(String source, TMXEntry trans) {
-                    checkStopped(stop);
-                    if (!searchExactlyTheSame && source.equals(searchText)) {
-                        // skip original==original entry comparison
-                        return;
-                    }
-                    if (requiresTranslation && trans.translation == null) {
-                        return;
-                    }
-                    String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
-                    processEntry(null, source, trans.translation, NearString.MATCH_SOURCE.MEMORY, false, 0,
-                            fileName, trans.creator, trans.creationDate, trans.changer, trans.changeDate,
-                            null);
-                }
-            });
-        }
-        project.iterateByMultipleTranslations(new MultipleTranslationsIterator() {
-            public void iterate(EntryKey source, TMXEntry trans) {
+            project.iterateByDefaultTranslations((source, trans) -> {
                 checkStopped(stop);
-                if (!searchExactlyTheSame && source.sourceText.equals(searchText)) {
+                if (!searchExactlyTheSame && source.equals(searchText)) {
                     // skip original==original entry comparison
                     return;
                 }
@@ -218,19 +194,31 @@ public class FindMatches {
                     return;
                 }
                 String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
-                processEntry(source, source.sourceText, trans.translation, NearString.MATCH_SOURCE.MEMORY,
-                        false, 0, fileName, trans.creator, trans.creationDate, trans.changer,
-                        trans.changeDate, null);
+                PrepareTMXEntry entry = new PrepareTMXEntry(trans);
+                entry.source = source;
+                processEntry(null, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0);
+            });
+        }
+        project.iterateByMultipleTranslations((source, trans) -> {
+            checkStopped(stop);
+            if (!searchExactlyTheSame && source.sourceText.equals(searchText)) {
+                // skip original==original entry comparison
+                return;
             }
+            if (requiresTranslation && trans.translation == null) {
+                return;
+            }
+            String fileName = project.isOrphaned(source) ? ORPHANED_FILE_NAME : null;
+            PrepareTMXEntry entry = new PrepareTMXEntry(trans);
+            entry.source = source.sourceText;
+            processEntry(source, entry, fileName, NearString.MATCH_SOURCE.MEMORY, false, 0);
         });
-
         /*
          * Penalty applied for fuzzy matches in another language (if no match in
          * the target language was found).
          */
         int foreignPenalty = Preferences.getPreferenceDefault(Preferences.PENALTY_FOR_FOREIGN_MATCHES,
                 Preferences.PENALTY_FOR_FOREIGN_MATCHES_DEFAULT);
-
         // travel by translation memories
         for (Map.Entry<String, ExternalTMX> en : project.getTransMemories().entrySet()) {
             int penalty = 0;
@@ -248,44 +236,42 @@ public class FindMatches {
                 if (requiresTranslation && tmen.getTranslationText() == null) {
                     continue;
                 }
-
                 int tmenPenalty = penalty;
                 if (tmen.hasPropValue(ExternalTMFactory.TMXLoader.PROP_FOREIGN_MATCH, "true")) {
                     tmenPenalty += foreignPenalty;
                 }
-
-                processEntry(null, tmen.getSourceText(), tmen.getTranslationText(),
-                        NearString.MATCH_SOURCE.TM, false, tmenPenalty, en.getKey(), tmen.getCreator(),
-                        tmen.getCreationDate(), tmen.getChanger(), tmen.getChangeDate(), tmen.getProperties());
+                processEntry(null, tmen, en.getKey(), NearString.MATCH_SOURCE.TM, false, tmenPenalty);
             }
         }
-
         // travel by all entries for check source file translations
         for (SourceTextEntry ste : project.getAllEntries()) {
             checkStopped(stop);
             if (ste.getSourceTranslation() != null) {
-                processEntry(ste.getKey(), ste.getSrcText(), ste.getSourceTranslation(),
-                        NearString.MATCH_SOURCE.MEMORY, ste.isSourceTranslationFuzzy(), 0, ste.getKey().file,
-                        "", 0, "", 0, null);
+                PrepareTMXEntry entry = new PrepareTMXEntry();
+                entry.source = ste.getSrcText();
+                entry.translation = ste.getSourceTranslation();
+                entry.creator = "";
+                entry.changer = "";
+                entry.creationDate = 0;
+                entry.changeDate = 0;
+                processEntry(ste.getKey(), entry, ste.getKey().file, NearString.MATCH_SOURCE.MEMORY,
+                        ste.isSourceTranslationFuzzy(), 0);
             }
         }
-
         if (separateSegmentMatcher != null) {
             // split paragraph even when segmentation disabled, then find
             // matches for every segment
-            List<StringBuilder> spaces = new ArrayList<StringBuilder>();
-            List<Rule> brules = new ArrayList<Rule>();
+            List<StringBuilder> spaces = new ArrayList<>();
+            List<Rule> brules = new ArrayList<>();
             Language sourceLang = project.getProjectProperties().getSourceLanguage();
             Language targetLang = project.getProjectProperties().getTargetLanguage();
             List<String> segments = Core.getSegmenter().segment(sourceLang, srcText, spaces, brules);
             if (segments.size() > 1) {
-                List<String> fsrc = new ArrayList<String>(segments.size());
-                List<String> ftrans = new ArrayList<String>(segments.size());
+                List<String> fsrc = new ArrayList<>(segments.size());
+                List<String> ftrans = new ArrayList<>(segments.size());
                 // multiple segments
-                for (short i = 0; i < segments.size(); i++) {
-                    String onesrc = segments.get(i);
-
-                    // find match for separate segment
+                for (String onesrc : segments) {
+                    // find match for a separate segment
                     List<NearString> segmentMatch = separateSegmentMatcher.search(onesrc, requiresTranslation,
                             false, stop);
                     if (!segmentMatch.isEmpty()
@@ -297,37 +283,33 @@ public class FindMatches {
                         ftrans.add("");
                     }
                 }
-                // glue found sources
-                String foundSrc = Core.getSegmenter().glue(sourceLang, sourceLang, fsrc, spaces, brules);
-                // glue found translations
-                String foundTrans = Core.getSegmenter().glue(sourceLang, targetLang, ftrans, spaces, brules);
-                processEntry(null, foundSrc, foundTrans, NearString.MATCH_SOURCE.TM, false, 0, "", "", 0, "",
-                        0, null);
+                // glue found sources and translations
+                PrepareTMXEntry entry = new PrepareTMXEntry();
+                entry.source = Core.getSegmenter().glue(sourceLang, sourceLang, fsrc, spaces, brules);
+                entry.translation = Core.getSegmenter().glue(sourceLang, targetLang, ftrans, spaces, brules);
+                entry.creator = "";
+                entry.changer = "";
+                entry.creationDate = 0;
+                entry.changeDate = 0;
+                processEntry(null, entry, "", NearString.MATCH_SOURCE.TM, false, 0);
             }
         }
-
+        // fill similarity data only for a result
         if (fillSimilarityData) {
-            // fill similarity data only for result
             for (NearString near : result) {
-                // fix for bug 1586397
-                byte[] similarityData = FuzzyMatcher.buildSimilarityData(strTokensAll,
-                        tokenizeAll(near.source));
-                near.attr = similarityData;
+                near.attr = FuzzyMatcher.buildSimilarityData(strTokensAll, tokenizeAll(near.source));
             }
         }
-
         return result;
     }
 
     /**
-     * Compare one entry with original entry.
+     * Compare one entry with the original entry.
      *
      * @param key
      *            entry to compare
-     * @param source
-     *            source text
-     * @param translation
-     *            translation text
+     * @param entry
+     *            PrepareTMXEntry entry to process.
      * @param comesFrom
      *            match source
      * @param fuzzy
@@ -336,22 +318,11 @@ public class FindMatches {
      *            penalty score
      * @param tmxName
      *            tmx name
-     * @param creator
-     *            translation creator
-     * @param creationDate
-     *            creation date of translation
-     * @param changer
-     *            last editor name
-     * @param changedDate
-     *            last change date
-     * @param props
-     *            TMX properties
      */
-    protected void processEntry(EntryKey key, String source, String translation,
-            NearString.MATCH_SOURCE comesFrom, boolean fuzzy, int penalty, String tmxName, String creator,
-            long creationDate, String changer, long changedDate, List<TMXProp> props) {
+    public void processEntry(EntryKey key, ITMXEntry entry, String tmxName,
+                              NearString.MATCH_SOURCE comesFrom, boolean fuzzy, int penalty) {
         // remove part that is to be removed prior to tokenize
-        String realSource = source;
+        String realSource = entry.getSourceText();
         int realPenaltyForRemoved = 0;
         if (removePattern != null) {
             StringBuilder entryRemovedText = new StringBuilder();
@@ -380,8 +351,8 @@ public class FindMatches {
         }
         similarityStem -= realPenaltyForRemoved;
 
-        // check if we have chance by first percentage only
-        if (!haveChanceToAdd(similarityStem, Integer.MAX_VALUE, Integer.MAX_VALUE)) {
+        // check if we have a chance by first percentage only
+        if (noChanceToAdd(similarityStem, Integer.MAX_VALUE, Integer.MAX_VALUE)) {
             return;
         }
 
@@ -395,8 +366,8 @@ public class FindMatches {
         }
         similarityNoStem -= realPenaltyForRemoved;
 
-        // check if we have chance by first and second percentages
-        if (!haveChanceToAdd(similarityStem, similarityNoStem, Integer.MAX_VALUE)) {
+        // check if we have a chance by first and second percentages
+        if (noChanceToAdd(similarityStem, similarityNoStem, Integer.MAX_VALUE)) {
             return;
         }
 
@@ -411,7 +382,7 @@ public class FindMatches {
         simAdjusted -= realPenaltyForRemoved;
 
         // check if we have chance by first, second and third percentages
-        if (!haveChanceToAdd(similarityStem, similarityNoStem, simAdjusted)) {
+        if (noChanceToAdd(similarityStem, similarityNoStem, simAdjusted)) {
             return;
         }
 
@@ -421,13 +392,12 @@ public class FindMatches {
             return;
         }
 
-        addNearString(key, source, translation, comesFrom, fuzzy, similarityStem, similarityNoStem,
-                simAdjusted, null, tmxName, creator, creationDate, changer, changedDate, props);
+        addNearString(key, entry, comesFrom, fuzzy, similarityStem, similarityNoStem, simAdjusted, tmxName);
     }
 
     /**
-     * Check if entry have a chance to be added to result list. If no, there is
-     * no sense to calculate other parameters.
+     * Check if entries have a chance to be added to a result list. If true,
+     * there is no sense to calculate other parameters.
      *
      * @param simStem
      *            similarity with stemming
@@ -435,11 +405,11 @@ public class FindMatches {
      *            similarity without stemming
      * @param simExactly
      *            exactly similarity
-     * @return true if we have chance
+     * @return true if we have no chance.
      */
-    protected boolean haveChanceToAdd(final int simStem, final int simNoStem, final int simExactly) {
+    private boolean noChanceToAdd(int simStem, int simNoStem, int simExactly) {
         if (result.size() < maxCount) {
-            return true;
+            return false;
         }
         NearString st = result.get(result.size() - 1);
         int chance = Integer.compare(st.scores[0].score, simStem);
@@ -449,30 +419,29 @@ public class FindMatches {
         if (chance == 0) {
             chance = Integer.compare(st.scores[0].adjustedScore, simExactly);
         }
-        return chance != 1;
+        return chance == 1;
     }
 
     /**
-     * Add near string into result list. Near strings sorted by
-     * "similarity,simAdjusted"
+     * Add near string into the result list. Near strings sorted by "similarity,
+     * simAdjusted"
      */
-    protected void addNearString(final EntryKey key, final String source, final String translation,
-            NearString.MATCH_SOURCE comesFrom, final boolean fuzzy, final int similarity,
-            final int similarityNoStem, final int simAdjusted, final byte[] similarityData,
-            final String tmxName, final String creator, final long creationDate, final String changer,
-            final long changedDate, final List<TMXProp> tuProperties) {
+    private void addNearString(EntryKey key, ITMXEntry entry, NearString.MATCH_SOURCE comesFrom, boolean fuzzy,
+                               int similarity, int similarityNoStem, int simAdjusted, String tmxName) {
+        final String source = entry.getSourceText();
+        final String translation = entry.getTranslationText();
         // find position for new data
         int pos = 0;
         for (int i = 0; i < result.size(); i++) {
             NearString st = result.get(i);
             if (source.equals(st.source) && Objects.equals(translation, st.translation)) {
                 // Consolidate identical matches from different sources into a
-                // single NearString with
-                // multiple project entries.
+                // single NearString with multiple project entries.
                 result.set(i,
                         NearString.merge(st, key, source, translation, comesFrom, fuzzy, similarity,
-                                similarityNoStem, simAdjusted, similarityData, tmxName, creator, creationDate,
-                                changer, changedDate, tuProperties));
+                                similarityNoStem, simAdjusted, null, tmxName,
+                                entry.getCreator(), entry.getCreationDate(), entry.getChanger(),
+                                entry.getChangeDate(), entry.getProperties()));
                 return;
             }
             if (st.scores[0].score < similarity) {
@@ -497,9 +466,9 @@ public class FindMatches {
         }
 
         result.add(pos,
-                new NearString(key, source, translation, comesFrom, fuzzy, similarity, similarityNoStem,
-                        simAdjusted, similarityData, tmxName, creator, creationDate, changer, changedDate,
-                        tuProperties));
+                new NearString(key, source, translation, comesFrom, fuzzy, similarity, similarityNoStem, simAdjusted,
+                        null, tmxName, entry.getCreator(), entry.getCreationDate(), entry.getChanger(),
+                        entry.getChangeDate(), entry.getProperties()));
         if (result.size() > maxCount) {
             result.remove(result.size() - 1);
         }
@@ -508,11 +477,11 @@ public class FindMatches {
     /*
      * Methods for tokenize strings with caching.
      */
-    Map<String, Token[]> tokenizeStemCache = new HashMap<String, Token[]>();
-    Map<String, Token[]> tokenizeNoStemCache = new HashMap<String, Token[]>();
-    Map<String, Token[]> tokenizeAllCache = new HashMap<String, Token[]>();
+    Map<String, Token[]> tokenizeStemCache = new HashMap<>();
+    Map<String, Token[]> tokenizeNoStemCache = new HashMap<>();
+    Map<String, Token[]> tokenizeAllCache = new HashMap<>();
 
-    public Token[] tokenizeStem(String str) {
+    Token[] tokenizeStem(String str) {
         Token[] tokens = tokenizeStemCache.get(str);
         if (tokens == null) {
             tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.MATCHING);
@@ -521,7 +490,7 @@ public class FindMatches {
         return tokens;
     }
 
-    public Token[] tokenizeNoStem(String str) {
+    Token[] tokenizeNoStem(String str) {
         // No-stemming token comparisons are intentionally case-insensitive
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
@@ -533,7 +502,7 @@ public class FindMatches {
         return tokens;
     }
 
-    public Token[] tokenizeAll(String str) {
+    Token[] tokenizeAll(String str) {
         // Verbatim token comparisons are intentionally case-insensitive.
         // for matching purposes.
         str = str.toLowerCase(srcLocale);
@@ -545,17 +514,29 @@ public class FindMatches {
         return tokens;
     }
 
-    protected void checkStopped(IStopped stop) throws StoppedException {
+    private void checkStopped(IStopped stop) throws StoppedException {
         if (stop.isStopped()) {
             throw new StoppedException();
         }
     }
 
     /**
-     * Process will throw this exception if it stopped.All callers must catch it
-     * and just skip.
+     * The Process will throw this exception if it stopped. All callers must
+     * catch it and just skip.
      */
     @SuppressWarnings("serial")
     public static class StoppedException extends RuntimeException {
+    }
+
+    static class Similarity {
+        int similarity;
+        int similarityNoStem;
+        int simAdjusted;
+
+        Similarity(int sim, int simNoStem, int simAdj) {
+            similarity = sim;
+            similarityNoStem = simNoStem;
+            simAdjusted = simAdj;
+        }
     }
 }

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -73,7 +73,9 @@ public class CalcMatchStatisticsTest {
         IStatsConsumer callback = new TestStatsConsumer();
         CalcMatchStatisticsMock calcMatchStatistics = new CalcMatchStatisticsMock(callback);
         calcMatchStatistics.start();
-        while (calcMatchStatistics.isAlive()) {
+        try {
+            calcMatchStatistics.join();
+        } catch (InterruptedException e) {
             calcMatchStatistics.checkInterrupted();
         }
         String[][] result = calcMatchStatistics.getTable();
@@ -133,7 +135,9 @@ public class CalcMatchStatisticsTest {
         //
         calcMatchStatistics = new CalcMatchStatisticsMock(callback);
         calcMatchStatistics.start();
-        while (calcMatchStatistics.isAlive()) {
+        try {
+            calcMatchStatistics.join();
+        } catch (InterruptedException e) {
             calcMatchStatistics.checkInterrupted();
         }
         result = calcMatchStatistics.getTable();

--- a/test/src/org/omegat/gui/editor/mark/ComesFromMTMarkerTest.java
+++ b/test/src/org/omegat/gui/editor/mark/ComesFromMTMarkerTest.java
@@ -41,6 +41,7 @@ import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.DataUtils;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
@@ -147,15 +148,18 @@ public class ComesFromMTMarkerTest extends MarkerTestBase {
 
     @Test
     public void testNearString() {
-        final String sourceText = "source";
-        final String targetText = "target";
-        final String user = "translator";
+        PrepareTMXEntry entry = new PrepareTMXEntry();
+        entry.source = "source";
+        entry.translation = "target";
+        entry.changer = "translator";
+        entry.creator = "translator";
+        entry.changeDate = 10000L;
+        entry.creationDate = 10000L;
         final int score = 75;
         final byte[] nearData = null;
-        final long date = 10000L;
-        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
-        NearString near = new NearString(key, sourceText, targetText, NearString.MATCH_SOURCE.TM, false,
-                score, score, score, nearData, project.toString(), user, date, user, date, Collections.emptyList());
+        EntryKey key = new EntryKey("file", entry.getSourceText(), "id", "prev", "next", "path");
+        NearString near = new NearString(key, entry, NearString.MATCH_SOURCE.TM, false,
+                new NearString.Scores(score, score, score), nearData, project.toString());
         assertThat(DataUtils.isFromMTMemory(near)).isTrue();
     }
 }

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -208,7 +208,7 @@ public class MatchesVarExpansionTest {
         entry.changeDate = 20020523;
         entry.otherProperties = testProps;
         NearString.Scores scores = new NearString.Scores(20, 40, 60);
-        return new NearString(null, entry, null, false, scores, null, null);
+        return new NearString(null, entry, null, false, scores, null, "mock testing project");
     };
 
     private void setupProject(Language sourceLanguage, Language targetLanguage) {

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -36,10 +36,12 @@ import java.util.Locale;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.omegat.core.Core;
 import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.matching.NearString;
@@ -197,9 +199,16 @@ public class MatchesVarExpansionTest {
         List<TMXProp> testProps = new ArrayList<>();
         testProps.add(new TMXProp("sourceLanguage", "mock source language"));
         testProps.add(new TMXProp("targetLanguage", "mock target language"));
-
-        return new NearString(null, "mock source text", "mock target text", null, false, 20, 40, 60, null,
-                "mock testing project", "mock creator", 20020523, "mock modifier", 20020523, testProps);
+        PrepareTMXEntry entry = new PrepareTMXEntry();
+        entry.source = "mock source text";
+        entry.translation = "mock target text";
+        entry.creator = "mock creator";
+        entry.creationDate = 20020523;
+        entry.changer = "mock modifier";
+        entry.changeDate = 20020523;
+        entry.otherProperties = testProps;
+        NearString.Scores scores = new NearString.Scores(20, 40, 60);
+        return new NearString(null, entry, null, false, scores, null, null);
     };
 
     private void setupProject(Language sourceLanguage, Language targetLanguage) {


### PR DESCRIPTION
FindMatches class has been introduced in 2013 and there are several place to improve coding styles.

## Pull request type

- refactoring

## Which ticket is resolved?


## What does this PR change?

- Update javadoc contents
- style: remove final from arguments
- revert haveChanceToAdd logic to noChanceToAdd because all conditions are negated
- Replace inline ` new DefaultTranslationsIterator()` and `new MultiTranslationsIterator()` to lambda expression
- Add  NearString and FindMatches ctors with small number of arguments, with PrepareTMXEntries and NearString.Scores data classes.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
