### PR TITLE
refactor: clean todo comments

### DIFF
--- a/src/org/omegat/CLIParameters.java
+++ b/src/org/omegat/CLIParameters.java
@@ -85,9 +85,7 @@ public final class CLIParameters {
      * CLI parameter to specify target tokenizer
      */
     public static final String TOKENIZER_TARGET = "ITokenizerTarget";
-    // TODO: Document this; see RealProject.patchFileNameForEntryKey()
     public static final String ALTERNATE_FILENAME_FROM = "alternate-filename-from";
-    // TODO: Document this; see RealProject.patchFileNameForEntryKey()
     public static final String ALTERNATE_FILENAME_TO = "alternate-filename-to";
 
     // Non-GUI modes only

--- a/src/org/omegat/core/data/ProjectFactory.java
+++ b/src/org/omegat/core/data/ProjectFactory.java
@@ -34,8 +34,6 @@ import org.omegat.core.events.IProjectEventListener;
 /**
  * Factory for load project, create project, and create "not-loaded" project.
  *
- * TODO: change exception handling
- *
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public final class ProjectFactory {
@@ -48,7 +46,7 @@ public final class ProjectFactory {
     }
 
     /**
-     * Create new project.
+     * Create a new project.
      */
     public static void createProject(ProjectProperties newProps) {
         RealProject p = new RealProject(newProps);

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1264,24 +1264,13 @@ public class RealProject implements IProject {
                 loadFilesCallback.fileFinished();
 
                 if (filter != null && !fi.entries.isEmpty()) {
-                    fi.filterClass = filter.getClass(); // Don't store the
-                                                        // instance, because
-                                                        // every file gets an
-                                                        // instance and
-                                                        // then we consume a lot
-                                                        // of memory for all
-                                                        // instances.
-                                                        // See also IFilter
-                                                        // "TODO: each filter
-                                                        // should be stateless"
+                    fi.filterClass = filter.getClass();
+                    // Don't store the instance, because
+                    // every file gets an instance and
+                    // then we consume a lot of memory for all
+                    // instances. See also IFilter
                     fi.filterFileFormatName = filter.getFileFormatName();
-                    try {
-                        fi.fileEncoding = filter.getInEncodingLastParsedFile();
-                    } catch (Error e) { // In case a filter doesn't have
-                                        // getInEncodingLastParsedFile() (e.g.,
-                                        // Okapi plugin)
-                        fi.fileEncoding = "";
-                    }
+                    fi.fileEncoding = filter.getInEncodingLastParsedFile();
                     projectFilesList.add(fi);
                 }
             } catch (TranslationException e) {

--- a/src/org/omegat/filters2/IFilter.java
+++ b/src/org/omegat/filters2/IFilter.java
@@ -32,12 +32,10 @@ import java.util.Map;
 
 /**
  * Interface for filters declaration.
- *
- * TODO: each filter should be stateless, i.e. options shouldn't be stored in
+ * <p>
+ * Note: each filter should be stateless, i.e., options shouldn't be stored in
  * filter, but should be sent to filter on each parse, align, or translate
- * operation.
- *
- * Filters shouldn't use Core, but use Context instead.
+ * operation through context. Filters shouldn't use Core, but use Context.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
@@ -61,7 +59,7 @@ public interface IFilter {
     /**
      * The default list of filter instances that this filter class has. One
      * filter class may have different filter instances, different by source
-     * file mask, encoding of the source file etc.
+     * file mask, encoding of the source file, etc.
      * <p>
      * Note that the user may change the instances freely.
      *
@@ -75,7 +73,7 @@ public interface IFilter {
      * True means that OmegaT should handle all the encoding mess.
      * <p>
      * Return false to state that your filter doesn't need encoding management
-     * provided by OmegaT, because it either autodetects the encoding based on
+     * provided by OmegaT, because it either autodetect the encoding based on
      * file contents (like HTML filter does) or the encoding is fixed (like in
      * OpenOffice files).
      *

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -462,11 +462,10 @@ public class LatexFilter extends AbstractFilter {
 
                 par = sb.toString();
             } catch (java.util.regex.PatternSyntaxException e) {
-                // TODO: understand the exceptions
-                Log.log("LaTeX PatternSyntaxException: " + e.getMessage());
-                Log.log(command);
+                Log.getLogger(LatexFilter.class).atDebug()
+                        .setMessage("LaTeX command \"{}\" cause PatternSyntaxException: {}")
+                        .addArgument(command).addArgument(e.getMessage()).log();
             }
-
         }
         return par;
     }

--- a/src/org/omegat/filters3/xml/Translator.java
+++ b/src/org/omegat/filters3/xml/Translator.java
@@ -33,9 +33,10 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
+import org.xml.sax.Attributes;
+
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.util.Language;
-import org.xml.sax.Attributes;
 
 /**
  * The interface to specify the method a Handler can use to translate text.
@@ -44,7 +45,7 @@ import org.xml.sax.Attributes;
  * @author Didier Briel
  * @author Alex Buloichik
  */
-interface Translator {
+public interface Translator {
     /**
      * The method the Handler would call to pass translatable content to OmegaT
      * core and receive translation.
@@ -56,15 +57,15 @@ interface Translator {
      *
      * @param inFile
      *            The source file.
-     * @param outEncoding
+     * @param inEncoding
      *            Encoding of the source file, if the filter supports it.
-     *            Otherwise null.
+     *            Otherwise, it should be null.
      * @return The reader of the source file.
      *
      * @throws UnsupportedEncodingException
      *             Thrown if JVM doesn't support the specified inEncoding.
      * @throws IOException
-     *             If any I/O Error occurs upon reader creation.
+     *             If I/O Error occurs upon reader creation.
      */
     BufferedReader createReader(File inFile, String inEncoding) throws UnsupportedEncodingException,
             IOException;
@@ -76,7 +77,7 @@ interface Translator {
      *            The target file.
      * @param outEncoding
      *            Encoding of the target file, if the filter supports it.
-     *            Otherwise null.
+     *            Otherwise, it should be null.
      * @return The writer for the target file.
      *
      * @throws UnsupportedEncodingException
@@ -116,7 +117,7 @@ interface Translator {
     void text(String text);
 
     /**
-     * Returns true if current section should be ignored by parser.
+     * Returns true if the current section should be ignored by parser.
      */
     boolean isInIgnored();
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -2146,6 +2146,35 @@ public class EditorController implements IEditor {
         editor.autoCompleter.setVisible(false);
     }
 
+    @Override
+    public CaretPosition getCurrentPositionInEntryTranslationInEditor() {
+        int selectionEnd = getCurrentPositionInEntryTranslation();
+        String selection = getSelectedText();
+        String translation = getCurrentTranslation();
+
+        if (StringUtil.isEmpty(translation) || StringUtil.isEmpty(selection)) {
+            // no translation or no selection
+            return new CaretPosition(selectionEnd);
+        } else {
+            // get selected range
+            int selectionStart = selectionEnd;
+            int pos = 0;
+            do {
+                pos = translation.indexOf(selection, pos);
+                if (pos == selectionEnd) {
+                    selectionStart = pos;
+                    selectionEnd = pos + selection.length();
+                    break;
+                } else if ((pos + selection.length()) == selectionEnd) {
+                    selectionStart = pos;
+                    break;
+                }
+                pos++;
+            } while (pos > 0);
+            return new CaretPosition(selectionStart, selectionEnd);
+        }
+    }
+
     /**
      * Class for checking if alternative translation exist.
      */

--- a/src/org/omegat/gui/editor/IEditor.java
+++ b/src/org/omegat/gui/editor/IEditor.java
@@ -499,4 +499,12 @@ public interface IEditor {
     default boolean isOrientationAllLtr() {
         return true;
     }
+
+    /**
+     * Get the current position in the entity translation in the editor
+     * @return caret position.
+     */
+    default CaretPosition getCurrentPositionInEntryTranslationInEditor() {
+        return CaretPosition.startOfEntry();
+    }
 }

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -795,8 +795,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     }
 
     /**
-     * Set 'actionCommand' for all menu items. TODO: change to key from resource
-     * bundle values
+     * Set 'actionCommand' for all menu items.
      */
     protected void setActionCommands() {
         try {

--- a/src/org/omegat/gui/preferences/view/SpellcheckerConfigurationController.java
+++ b/src/org/omegat/gui/preferences/view/SpellcheckerConfigurationController.java
@@ -176,7 +176,9 @@ public class SpellcheckerConfigurationController extends BasePreferencesControll
             }
         }
 
-        // TODO: We shouldn't be persisting anything here.
+        // Note: When we realize spellchecker dictionary as an extension plugin,
+        // We should remove the URL preference.
+        // See also SpellcheckerConfigurationController#initFromPrefs.
         Preferences.setPreference(Preferences.SPELLCHECKER_DICTIONARY_URL, panel.dictionaryUrlTextField.getText());
 
         try {

--- a/src/org/omegat/gui/search/SearchWindowController.java
+++ b/src/org/omegat/gui/search/SearchWindowController.java
@@ -74,7 +74,6 @@ import org.omegat.core.search.SearchMode;
 import org.omegat.core.search.Searcher;
 import org.omegat.core.threads.SearchThread;
 import org.omegat.gui.editor.EditorController;
-import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.editor.IEditor.CaretPosition;
 import org.omegat.gui.editor.IEditorFilter;
 import org.omegat.gui.editor.filter.ReplaceFilter;
@@ -123,7 +122,7 @@ public class SearchWindowController {
 
         this.mode = mode;
         initialEntry = Core.getEditor().getCurrentEntryNumber();
-        initialCaret = getCurrentPositionInEntryTranslationInEditor(Core.getEditor());
+        initialCaret = Core.getEditor().getCurrentPositionInEntryTranslationInEditor();
 
         if (Platform.isMacOSX()) {
             OSXIntegration.enableFullScreen(form);
@@ -1162,43 +1161,6 @@ public class SearchWindowController {
             if (c instanceof Container) {
                 setEnabled((Container) c, enabled);
             }
-        }
-    }
-
-    /*
-     * TODO: This should be a method on EditorController exposed via IEditor,
-     * NOT here.
-     */
-    private CaretPosition getCurrentPositionInEntryTranslationInEditor(IEditor editor) {
-        if (editor instanceof EditorController) {
-            EditorController c = (EditorController) editor;
-            int selectionEnd = c.getCurrentPositionInEntryTranslation();
-            String selection = c.getSelectedText();
-            String translation = c.getCurrentTranslation();
-
-            if (StringUtil.isEmpty(translation) || StringUtil.isEmpty(selection)) {
-                // no translation or no selection
-                return new CaretPosition(selectionEnd);
-            } else {
-                // get selected range
-                int selectionStart = selectionEnd;
-                int pos = 0;
-                do {
-                    pos = translation.indexOf(selection, pos);
-                    if (pos == selectionEnd) {
-                        selectionStart = pos;
-                        selectionEnd = pos + selection.length();
-                        break;
-                    } else if ((pos + selection.length()) == selectionEnd) {
-                        selectionStart = pos;
-                        break;
-                    }
-                    pos++;
-                } while (pos > 0);
-                return new CaretPosition(selectionStart, selectionEnd);
-            }
-        } else {
-            return CaretPosition.startOfEntry();
         }
     }
 

--- a/src/org/omegat/tokenizer/HunspellTokenizer.java
+++ b/src/org/omegat/tokenizer/HunspellTokenizer.java
@@ -38,9 +38,43 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.ar.ArabicAnalyzer;
+import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
+import org.apache.lucene.analysis.br.BrazilianAnalyzer;
+import org.apache.lucene.analysis.ca.CatalanAnalyzer;
+import org.apache.lucene.analysis.cjk.CJKAnalyzer;
+import org.apache.lucene.analysis.core.StopFilter;
+import org.apache.lucene.analysis.cz.CzechAnalyzer;
+import org.apache.lucene.analysis.da.DanishAnalyzer;
+import org.apache.lucene.analysis.de.GermanAnalyzer;
+import org.apache.lucene.analysis.el.GreekAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.es.SpanishAnalyzer;
+import org.apache.lucene.analysis.eu.BasqueAnalyzer;
+import org.apache.lucene.analysis.fa.PersianAnalyzer;
+import org.apache.lucene.analysis.fi.FinnishAnalyzer;
+import org.apache.lucene.analysis.fr.FrenchAnalyzer;
+import org.apache.lucene.analysis.ga.IrishAnalyzer;
+import org.apache.lucene.analysis.gl.GalicianAnalyzer;
+import org.apache.lucene.analysis.hi.HindiAnalyzer;
+import org.apache.lucene.analysis.hu.HungarianAnalyzer;
 import org.apache.lucene.analysis.hunspell.Dictionary;
 import org.apache.lucene.analysis.hunspell.HunspellStemFilter;
+import org.apache.lucene.analysis.hy.ArmenianAnalyzer;
+import org.apache.lucene.analysis.id.IndonesianAnalyzer;
+import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.lv.LatvianAnalyzer;
+import org.apache.lucene.analysis.nl.DutchAnalyzer;
+import org.apache.lucene.analysis.no.NorwegianAnalyzer;
+import org.apache.lucene.analysis.pl.PolishAnalyzer;
+import org.apache.lucene.analysis.ro.RomanianAnalyzer;
+import org.apache.lucene.analysis.ru.RussianAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.sv.SwedishAnalyzer;
+import org.apache.lucene.analysis.th.ThaiAnalyzer;
+import org.apache.lucene.analysis.tr.TurkishAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
+
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.events.IProjectEventListener.PROJECT_CHANGE_TYPE;
@@ -65,7 +99,7 @@ public class HunspellTokenizer extends BaseTokenizer {
     private volatile Dictionary dict;
     private volatile boolean failedToLoadDict;
 
-    private Dictionary getDict() {
+    protected Dictionary getDict() {
         if (failedToLoadDict) {
             return null;
         }
@@ -95,10 +129,13 @@ public class HunspellTokenizer extends BaseTokenizer {
             if (dictionary == null) {
                 return tokenizer;
             }
-
-            return new HunspellStemFilter(tokenizer, dictionary);
-
-            /// TODO: implement stop words checks
+            CharArraySet stopWords;
+            if (stopWordsAllowed) {
+                stopWords = getEffectiveStopWordSet();
+            } else {
+                stopWords = CharArraySet.EMPTY_SET;
+            }
+            return new StopFilter(new HunspellStemFilter(tokenizer, dictionary), stopWords);
         } else {
             return tokenizer;
         }
@@ -127,7 +164,12 @@ public class HunspellTokenizer extends BaseTokenizer {
             return;
         }
 
-        for (File file : dictionaryDir.listFiles()) {
+        var fileList = dictionaryDir.listFiles();
+        if (fileList == null) {
+            return;
+        }
+
+        for (File file : fileList) {
             String name = file.getName();
             if (name.endsWith(OConsts.SC_AFFIX_EXTENSION)) {
                 Language lang = new Language(name.substring(0, name.lastIndexOf(OConsts.SC_AFFIX_EXTENSION)));
@@ -173,7 +215,7 @@ public class HunspellTokenizer extends BaseTokenizer {
             result.add(lang.getLanguage().toLowerCase(Locale.ENGLISH));
             result.add(lang.getLanguageCode().toLowerCase(Locale.ENGLISH));
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     private static synchronized void reset() {
@@ -192,5 +234,80 @@ public class HunspellTokenizer extends BaseTokenizer {
     }
 
     public static void unloadPlugins() {
+    }
+
+    private CharArraySet getEffectiveStopWordSet() {
+        String language = getEffectiveLanguage().getLanguageCode();
+        String country = getEffectiveLanguage().getCountryCode();
+        switch (language) {
+            case "ar":
+                return ArabicAnalyzer.getDefaultStopSet();
+            case "hy":
+                return ArmenianAnalyzer.getDefaultStopSet();
+            case "eu":
+                return BasqueAnalyzer.getDefaultStopSet();
+            case "es":
+                if (country.equals("BR")) {
+                    return BrazilianAnalyzer.getDefaultStopSet();
+                } else {
+                    return SpanishAnalyzer.getDefaultStopSet();
+                }
+            case "bg":
+                return BulgarianAnalyzer.getDefaultStopSet();
+            case "ca":
+                return CatalanAnalyzer.getDefaultStopSet();
+            case "ja":
+            case "ko":
+            case "zh":
+                return CJKAnalyzer.getDefaultStopSet();
+            case "cs":
+                return CzechAnalyzer.getDefaultStopSet();
+            case "da":
+                return DanishAnalyzer.getDefaultStopSet();
+            case "nl":
+                return DutchAnalyzer.getDefaultStopSet();
+            case "en":
+                return EnglishAnalyzer.getDefaultStopSet();
+            case "fi":
+                return FinnishAnalyzer.getDefaultStopSet();
+            case "fr":
+                return FrenchAnalyzer.getDefaultStopSet();
+            case "gl":
+                return GalicianAnalyzer.getDefaultStopSet();
+            case "de":
+                return GermanAnalyzer.getDefaultStopSet();
+            case "el":
+                return GreekAnalyzer.getDefaultStopSet();
+            case "hi":
+                return HindiAnalyzer.getDefaultStopSet();
+            case "hu":
+                return HungarianAnalyzer.getDefaultStopSet();
+            case "id":
+                return IndonesianAnalyzer.getDefaultStopSet();
+            case "ga":
+                return IrishAnalyzer.getDefaultStopSet();
+            case "it":
+                return ItalianAnalyzer.getDefaultStopSet();
+            case "lv":
+                return LatvianAnalyzer.getDefaultStopSet();
+            case "nb":
+                return NorwegianAnalyzer.getDefaultStopSet();
+            case "fa":
+                return PersianAnalyzer.getDefaultStopSet();
+            case "pl":
+                return PolishAnalyzer.getDefaultStopSet();
+            case "ro":
+                return RomanianAnalyzer.getDefaultStopSet();
+            case "ru":
+                return RussianAnalyzer.getDefaultStopSet();
+            case "sv":
+                return SwedishAnalyzer.getDefaultStopSet();
+            case "th":
+                return ThaiAnalyzer.getDefaultStopSet();
+            case "tr":
+                return TurkishAnalyzer.getDefaultStopSet();
+            default:
+                return CharArraySet.EMPTY_SET;
+        }
     }
 }


### PR DESCRIPTION
There are a couple of TODO comments in the OmegaT source.
This PR is to clean it up with updating comments, put it to issue ticket, or update javadoc.

## Pull request type
Please mark github LABEL of the type of change your PR introduces:
- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

- CLIParameters: put it on document issue
- IFilter: Explicitly explains the limitation in JavaDoc
- LatexFilter: refactor logging as debug log
- ProjectFactory: update comments
- RealProject: explains in IFilter javadoc, so leave the pointer to IFilter in the comment.
- Translator: make it public and update comment typos.
- BaseMainWindowMenu: it is original implementer's idea to load menu from a resource bundle. remove it.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
