### PR TITLE
chore: Some tokenizer as language module

### DIFF
--- a/Plugins.properties
+++ b/Plugins.properties
@@ -82,15 +82,12 @@ tokenizer=org.omegat.tokenizer.DefaultTokenizer \
     org.omegat.tokenizer.LuceneIndonesianTokenizer \
     org.omegat.tokenizer.LuceneIrishTokenizer \
     org.omegat.tokenizer.LuceneItalianTokenizer \
-    org.omegat.tokenizer.LuceneJapaneseTokenizer \
     org.omegat.tokenizer.LuceneLatvianTokenizer \
     org.omegat.tokenizer.LuceneNorwegianTokenizer \
     org.omegat.tokenizer.LucenePersianTokenizer \
-    org.omegat.tokenizer.LucenePolishTokenizer \
     org.omegat.tokenizer.LucenePortugueseTokenizer \
     org.omegat.tokenizer.LuceneRomanianTokenizer \
     org.omegat.tokenizer.LuceneRussianTokenizer \
-    org.omegat.tokenizer.LuceneSmartChineseTokenizer \
     org.omegat.tokenizer.LuceneSpanishTokenizer \
     org.omegat.tokenizer.LuceneSwedishTokenizer \
     org.omegat.tokenizer.LuceneThaiTokenizer \

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,7 +180,7 @@ fifesoft = ["fifesoft-rsyntaxtextarea", "fifesoft-autocomplete", "fifesoft-langu
 caffeine = ["caffeine", "caffeine-jcache"]
 languagetool-tests = ["languagetool-server", "languagetool-be", "languagetool-fr", "languagetool-en",
     "languagetool-ja", "languagetool-pl"]
-lucene = ["lucene-core", "lucene-analyzers-common", "lucene-analyzers-kuromoji", "lucene-analyzers-smartcn", "lucene-analyzers-stempel"]
+lucene = ["lucene-core", "lucene-analyzers-common"]
 jgit = ["jgit", "jgit-agent", "jgit-http", "jgit-ssh"]
 dictionary = ["trie4j", "dsl4j", "stardict4j", "jsoup"]
 xmlunit = ["xmlunit-core", "xmlunit-assertj", "assertj"]

--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -25,6 +25,9 @@ dependencies {
             exclude module: 'icu4j'
         }
         implementation(dependencies.variantOf(libs.lucene.gosen) { classifier("ipadic") })
+        compileOnly(libs.lucene.analyzers.common)
+        compileOnly(libs.lucene.core)
+        implementation(libs.lucene.analyzers.kuromoji)
         implementation(libs.icj4j)
     }
 

--- a/language-modules/ja/src/main/java/org/omegat/languages/ja/JapanesePlugin.java
+++ b/language-modules/ja/src/main/java/org/omegat/languages/ja/JapanesePlugin.java
@@ -25,6 +25,7 @@
 
 package org.omegat.languages.ja;
 
+import org.omegat.core.Core;
 import org.omegat.languagetools.LanguageManager;
 
 public final class JapanesePlugin {
@@ -36,6 +37,7 @@ public final class JapanesePlugin {
 
     public static void loadPlugins() {
         LanguageManager.registerLTLanguage("ja-JP", JAPANESE);
+        Core.registerTokenizerClass(LuceneJapaneseTokenizer.class);
     }
 
     public static void unloadPlugins() {

--- a/language-modules/ja/src/main/java/org/omegat/languages/ja/LuceneJapaneseTokenizer.java
+++ b/language-modules/ja/src/main/java/org/omegat/languages/ja/LuceneJapaneseTokenizer.java
@@ -22,7 +22,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
-package org.omegat.tokenizer;
+package org.omegat.languages.ja;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -40,6 +40,9 @@ import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.util.CharArraySet;
+
+import org.omegat.tokenizer.BaseTokenizer;
+import org.omegat.tokenizer.Tokenizer;
 import org.omegat.util.PatternConsts;
 
 /**

--- a/language-modules/ja/src/test/java/org/omegat/languages/ja/TokenizerTest.java
+++ b/language-modules/ja/src/test/java/org/omegat/languages/ja/TokenizerTest.java
@@ -1,0 +1,86 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2015 Aaron Madlon-Kay
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.languages.ja;
+
+import org.junit.Test;
+
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.ITokenizer.StemmingMode;
+import org.omegat.tokenizer.TokenizerTestBase;
+
+public class TokenizerTest extends TokenizerTestBase {
+
+    /**
+     * LuceneJapaneseTokenizer includes two customizations that warrant testing:
+     * <ol>
+     * <li>Special removal of tags (e.g. &lt;x0/>) when stemming
+     * <li>Re-joining of tags when doing verbatim or non-stemming tokenizing
+     * </ol>
+     */
+    @Test
+    public void testJapanese() {
+        ITokenizer tok = new LuceneJapaneseTokenizer();
+        String orig = "\u6211\u3005\u306E\u3059\u3079\u3066\u306F\u540C\u3058\uFF11\u500B\u306E\u60D1"
+                + "\u661F\uFF08\u82F1\uFF1A\u300Ca planet\u300D\uFF09\u306B\u4F4F\u307F\u3001\u6211"
+                + "\u3005\u306E\u3059\u3079\u3066\u306F\u305D\u306E\u751F\u7269\u570F\u306E1.5\u90E8"
+                + "\u3067\u3042\u308B<x0/>\u3002";
+        assertVerbatim(new String[] { "\u6211\u3005", "\u306E", "\u3059\u3079\u3066", "\u306F",
+                "\u540C\u3058", "\uFF11", "\u500B", "\u306E", "\u60D1\u661F", "\uFF08", "\u82F1", "\uFF1A",
+                "\u300C", "a", " ", "planet", "\u300D", "\uFF09", "\u306B", "\u4F4F\u307F", "\u3001",
+                "\u6211\u3005", "\u306E", "\u3059\u3079\u3066", "\u306F", "\u305D\u306E", "\u751F\u7269",
+                "\u570F", "\u306E", "1", ".", "5", "\u90E8", "\u3067", "\u3042\u308B", "<x0/>", "\u3002" },
+                tok.tokenizeVerbatimToStrings(orig), tok.tokenizeVerbatim(orig), orig);
+        assertResult(
+                new String[] { "\u6211\u3005", "\u306E", "\u3059\u3079\u3066", "\u306F", "\u540C\u3058",
+                        "\u500B", "\u306E", "\u60D1\u661F", "\uFF08", "\u82F1", "\uFF1A", "\u300C", "a",
+                        "planet", "\u300D", "\uFF09", "\u306B", "\u4F4F\u307F", "\u3001", "\u6211\u3005",
+                        "\u306E", "\u3059\u3079\u3066", "\u306F", "\u305D\u306E", "\u751F\u7269", "\u570F",
+                        "\u306E", ".", "\u90E8", "\u3067", "\u3042\u308B", "\u3002" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.NONE));
+        assertResult(
+                new String[] { "\u6211\u3005", "\u306E", "\u3059\u3079\u3066", "\u306F", "\u540C\u3058", "1",
+                        "\uFF11", "\u500B", "\u306E", "\u60D1\u661F", "\u82F1", "a", "planet", "\u306B",
+                        "\u4F4F\u3080", "\u4F4F\u307F", "\u6211\u3005", "\u306E", "\u3059\u3079\u3066",
+                        "\u306F", "\u305D\u306E", "\u751F\u7269", "\u570F", "\u306E", "1", "5", "\u90E8",
+                        "\u3060", "\u3067", "\u3042\u308B" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.GLOSSARY));
+        assertResult(
+                new String[] { "\u6211\u3005", "\u3059\u3079\u3066", "\u540C\u3058", "\u500B", "\u60D1\u661F",
+                        "\u82F1", "a", "planet", "\u4F4F\u3080", "\u4F4F\u307F", "\u6211\u3005",
+                        "\u3059\u3079\u3066", "\u751F\u7269", "\u570F", "\u90E8" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.MATCHING));
+
+        // Check for TagJoiningFilter
+        orig = "<x0/>\u3042</x0>\u300C<x1/>\u300D<x2/>\u3002<foo bar 123";
+        assertVerbatim(
+                new String[] { "<x0/>", "\u3042", "</x0>", "\u300C", "<x1/>", "\u300D", "<x2/>", "\u3002",
+                        "<", "foo", " ", "bar", " ", "123" },
+                tok.tokenizeVerbatimToStrings(orig), tok.tokenizeVerbatim(orig), orig);
+        // Check for tag removal
+        assertResult(new String[] { "\u3042", "foo", "bar" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.MATCHING));
+    }
+}

--- a/language-modules/pl/build.gradle
+++ b/language-modules/pl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
             exclude module: 'jackson-databind'
             exclude group: 'org.jetbrains'
         }
+        implementation(libs.lucene.analyzers.stempel)
         implementation(libs.languagetool.pl) {
             exclude module: 'languagetool-core'
         }

--- a/language-modules/pl/src/main/java/org/omegat/languages/pl/LucenePolishTokenizer.java
+++ b/language-modules/pl/src/main/java/org/omegat/languages/pl/LucenePolishTokenizer.java
@@ -24,7 +24,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
-package org.omegat.tokenizer;
+package org.omegat.languages.pl;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -32,6 +32,9 @@ import java.io.StringReader;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.pl.PolishAnalyzer;
 import org.apache.lucene.analysis.util.CharArraySet;
+
+import org.omegat.tokenizer.BaseTokenizer;
+import org.omegat.tokenizer.Tokenizer;
 
 /**
  * @author Alex Buloichik (alex73mail@gmail.com)

--- a/language-modules/pl/src/main/java/org/omegat/languages/pl/PolishPlugin.java
+++ b/language-modules/pl/src/main/java/org/omegat/languages/pl/PolishPlugin.java
@@ -25,6 +25,7 @@
 
 package org.omegat.languages.pl;
 
+import org.omegat.core.Core;
 import org.omegat.languagetools.LanguageManager;
 
 public final class PolishPlugin {
@@ -36,6 +37,7 @@ public final class PolishPlugin {
 
     public static void loadPlugins() {
         LanguageManager.registerLTLanguage("pl-PL", POLISH);
+        Core.registerTokenizerClass(LucenePolishTokenizer.class);
     }
 
     public static void unloadPlugins() {

--- a/language-modules/zh/build.gradle
+++ b/language-modules/zh/build.gradle
@@ -18,6 +18,7 @@ dependencies {
             exclude module: 'jackson-databind'
             exclude group: 'org.jetbrains'
         }
+        implementation(libs.lucene.analyzers.smartcn)
         implementation(libs.languagetool.zh) {
             exclude module: 'languagetool-core'
         }

--- a/language-modules/zh/src/main/java/org/omegat/languages/zh/ChinesePlugin.java
+++ b/language-modules/zh/src/main/java/org/omegat/languages/zh/ChinesePlugin.java
@@ -25,6 +25,7 @@
 
 package org.omegat.languages.zh;
 
+import org.omegat.core.Core;
 import org.omegat.languagetools.LanguageManager;
 
 public final class ChinesePlugin {
@@ -36,6 +37,7 @@ public final class ChinesePlugin {
 
     public static void loadPlugins() {
         LanguageManager.registerLTLanguage("zh-CH", CHINESE);
+        Core.registerTokenizerClass(LuceneSmartChineseTokenizer.class);
     }
 
     public static void unloadPlugins() {

--- a/language-modules/zh/src/main/java/org/omegat/languages/zh/LuceneSmartChineseTokenizer.java
+++ b/language-modules/zh/src/main/java/org/omegat/languages/zh/LuceneSmartChineseTokenizer.java
@@ -23,7 +23,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
-package org.omegat.tokenizer;
+package org.omegat.languages.zh;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -31,6 +31,9 @@ import java.io.StringReader;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.cn.smart.HMMChineseTokenizer;
 import org.apache.lucene.analysis.cn.smart.SmartChineseAnalyzer;
+
+import org.omegat.tokenizer.BaseTokenizer;
+import org.omegat.tokenizer.Tokenizer;
 import org.omegat.util.Token;
 
 /**

--- a/language-modules/zh/src/test/java/org/omegat/languages/zh/TokenizerTest.java
+++ b/language-modules/zh/src/test/java/org/omegat/languages/zh/TokenizerTest.java
@@ -1,0 +1,126 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2015 Aaron Madlon-Kay
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.languages.zh;
+
+import org.junit.Test;
+
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.ITokenizer.StemmingMode;
+import org.omegat.tokenizer.LuceneGermanTokenizer;
+import org.omegat.tokenizer.TokenizerTestBase;
+
+public class TokenizerTest extends TokenizerTestBase {
+
+    /**
+     * Chinese tends to have very few character boundaries breakable by
+     * BreakIterator, so LuceneSmartChineseTokenizer tokenizes by code point for
+     * verbatim tokenizing.
+     * <p>
+     * Text from https://zh.wikipedia.org/wiki/%E6%B1%89%E8%AF%AD
+     */
+    @Test
+    public void testChinese() {
+        ITokenizer tok = new LuceneSmartChineseTokenizer();
+        String orig = "\u6F22\u8A9E\u7684\u6587\u5B57\u7CFB\u7D71\u2014\u2014\u6F22\u5B57\u662F"
+                + "\u4E00\u7A2E\u610F\u97F3\u8A9E\u8A00\uFF0C\u8868\u610F\u7684\u540C\u6642\u4E5F"
+                + "\u5177\u4E00\u5B9A\u7684\u8868\u97F3\u529F\u80FD\u3002";
+        assertVerbatim(new String[] { "\u6F22", "\u8A9E", "\u7684", "\u6587", "\u5B57", "\u7CFB", "\u7D71",
+                "\u2014", "\u2014", "\u6F22", "\u5B57", "\u662F", "\u4E00", "\u7A2E", "\u610F", "\u97F3",
+                "\u8A9E", "\u8A00", "\uFF0C", "\u8868", "\u610F", "\u7684", "\u540C", "\u6642", "\u4E5F",
+                "\u5177", "\u4E00", "\u5B9A", "\u7684", "\u8868", "\u97F3", "\u529F", "\u80FD", "\u3002" },
+                tok.tokenizeVerbatimToStrings(orig), tok.tokenizeVerbatim(orig), orig);
+        assertResult(
+                new String[] { "\u6F22", "\u8A9E", "\u7684", "\u6587\u5B57", "\u7CFB", "\u7D71", ",", ",",
+                        "\u6F22", "\u5B57", "\u662F", "\u4E00", "\u7A2E", "\u610F", "\u97F3", "\u8A9E",
+                        "\u8A00", ",", "\u8868\u610F", "\u7684", "\u540C", "\u6642", "\u4E5F", "\u5177",
+                        "\u4E00\u5B9A", "\u7684", "\u8868\u97F3", "\u529F\u80FD", "," },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.NONE));
+        assertResult(new String[] { "\u6F22", "\u8A9E", "\u7684", "\u6587\u5B57", "\u7CFB", "\u7D71", ",",
+                "\u2014", ",", "\u2014", "\u6F22", "\u5B57", "\u662F", "\u4E00", "\u7A2E", "\u610F", "\u97F3",
+                "\u8A9E", "\u8A00", ",", "\uFF0C", "\u8868\u610F", "\u7684", "\u540C", "\u6642", "\u4E5F",
+                "\u5177", "\u4E00\u5B9A", "\u7684", "\u8868\u97F3", "\u529F\u80FD", ",", "\u3002" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.GLOSSARY));
+        assertResult(
+                new String[] { "\u6F22", "\u8A9E", "\u7684", "\u6587\u5B57", "\u7CFB", "\u7D71", "\u6F22",
+                        "\u5B57", "\u662F", "\u4E00", "\u7A2E", "\u610F", "\u97F3", "\u8A9E", "\u8A00",
+                        "\u8868\u610F", "\u7684", "\u540C", "\u6642", "\u4E5F", "\u5177", "\u4E00\u5B9A",
+                        "\u7684", "\u8868\u97F3", "\u529F\u80FD" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.MATCHING));
+    }
+
+    /**
+     * The behavior of the Lucene GermanAnalyzer was better for our purposes in
+     * Lucene 3.0, so we implement a custom analyzer that recreates that
+     * behavior.
+     *
+     * @see <a href=
+     *      "https://groups.yahoo.com/neo/groups/OmegaT/conversations/messages/28395">
+     *      User group discussion</a>
+     * @see <a href=
+     *      "https://sourceforge.net/p/omegat/mailman/message/36839317/">Sourceforge
+     *      archive</a>
+     */
+    @Test
+    public void testGerman() {
+        ITokenizer tok = new LuceneGermanTokenizer();
+        assertResult(new String[] { "prasentier", "pr\u00e4sentierte" },
+                tok.tokenizeWordsToStrings("pr\u00e4sentierte", StemmingMode.GLOSSARY));
+        assertResult(new String[] { "prasentier", "pr\u00e4sentieren" },
+                tok.tokenizeWordsToStrings("pr\u00e4sentieren", StemmingMode.GLOSSARY));
+    }
+
+    /**
+     * The DefaultTokenizer has a completely different implementation from the
+     * Lucene-base tokenizers (the latter were originally an external plugin,
+     * for licensing reasons). It's based on Java's BreakIterator. It warrants
+     * testing so that it doesn't get overlooked when changes are made to the
+     * other tokenizers.
+     */
+    @Test
+    public void testDefault() {
+        ITokenizer tok = new DefaultTokenizer();
+        String orig = "The quick, brown <x0/> jumped over 1 \"lazy\" \u0130stanbul. "
+                + "\u65E5\u672C\u8A9E\u3042\u3044\u3046\u3048\u304A\u3002";
+        assertVerbatim(
+                new String[] { "The", " ", "quick", ",", " ", "brown", " ", "<x0/>", " ", "jumped", " ",
+                        "over", " ", "1", " ", "\"", "lazy", "\"", " ", "\u0130stanbul", ".", " ",
+                        "\u65E5\u672C\u8A9E", "\u3042\u3044\u3046\u3048\u304A", "\u3002" },
+                tok.tokenizeVerbatimToStrings(orig), tok.tokenizeVerbatim(orig), orig);
+        assertResult(
+                new String[] { "The", "quick", "brown", "jumped", "over", "lazy", "\u0130stanbul",
+                        "\u65E5\u672C\u8A9E", "\u3042\u3044\u3046\u3048\u304A" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.NONE));
+        assertResult(
+                new String[] { "The", "quick", "brown", "jumped", "over", "lazy", "\u0130stanbul",
+                        "\u65E5\u672C\u8A9E", "\u3042\u3044\u3046\u3048\u304A" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.GLOSSARY));
+        assertResult(
+                new String[] { "The", "quick", "brown", "jumped", "over", "lazy", "\u0130stanbul",
+                        "\u65E5\u672C\u8A9E", "\u3042\u3044\u3046\u3048\u304A" },
+                tok.tokenizeWordsToStrings(orig, StemmingMode.MATCHING));
+    }
+}

--- a/test/fixtures/org/omegat/tokenizer/TokenizerTestBase.java
+++ b/test/fixtures/org/omegat/tokenizer/TokenizerTestBase.java
@@ -28,6 +28,7 @@ package org.omegat.tokenizer;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 
 import org.omegat.util.Token;
 
@@ -35,7 +36,7 @@ public class TokenizerTestBase {
 
     protected void assertVerbatim(String[] expected, String[] test, Token[] testTok, String origString) {
         assertResult(expected, test);
-        assertEquals(StringUtils.join(expected), StringUtils.join(test));
+        Assert.assertEquals(StringUtils.join(expected), StringUtils.join(test));
         assertEquals(expected.length, testTok.length);
         for (int i = 0; i < expected.length; i++) {
             assertEquals(expected[i], testTok[i].getTextFromString(origString));

--- a/test/src/org/omegat/core/data/TokenTest.java
+++ b/test/src/org/omegat/core/data/TokenTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 import org.omegat.core.TestCore;
 import org.omegat.tokenizer.ITokenizer;
-import org.omegat.tokenizer.LuceneJapaneseTokenizer;
+import org.omegat.tokenizer.LuceneCJKTokenizer;
 import org.omegat.util.Token;
 
 public class TokenTest extends TestCore {
@@ -45,7 +45,7 @@ public class TokenTest extends TestCore {
      */
     @Test
     public void testGlossaryTokenEqualityEnglish() {
-        ITokenizer tok = new LuceneJapaneseTokenizer();
+        ITokenizer tok = new LuceneCJKTokenizer();
         String str = "source and target";
         String glos = "target";
         Token[] strTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);
@@ -63,7 +63,7 @@ public class TokenTest extends TestCore {
      */
     @Test(expected = AssertionError.class)
     public void testGlossaryTokenEqualityJapanese() {
-        ITokenizer tok = new LuceneJapaneseTokenizer();
+        ITokenizer tok = new LuceneCJKTokenizer();
         String str = "\u5834\u6240";
         String glos = "\u5857\u5E03";
         Token[] strTokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.GLOSSARY);

--- a/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -45,7 +45,6 @@ import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneCJKTokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
-import org.omegat.tokenizer.LuceneJapaneseTokenizer;
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
@@ -103,7 +102,7 @@ public class GlossarySearcherTest extends TestCore {
         String sourceText = "場所";
         String translationText = "translation";
         String commentText = "comment";
-        ITokenizer tok = new LuceneJapaneseTokenizer();
+        ITokenizer tok = new LuceneCJKTokenizer();
         Language language = new Language("ja");
         Language trLang = new Language("en");
         setupProject(language);
@@ -122,7 +121,7 @@ public class GlossarySearcherTest extends TestCore {
         Language language = new Language("ja");
         Language trLang = new Language("en");
         setupProject(language);
-        ITokenizer tok = new LuceneJapaneseTokenizer();
+        ITokenizer tok = new LuceneCJKTokenizer();
         List<GlossaryEntry> entries = Arrays
                 .asList(new GlossaryEntry("\u5857\u5E03", "wrong", "", true, "origin"));
         List<GlossaryEntry> result = glossarySearcherCommon(sourceText, tok, language, trLang, entries);
@@ -134,7 +133,7 @@ public class GlossarySearcherTest extends TestCore {
         Language language = new Language("ja");
         Language trLang = new Language("en");
         setupProject(language);
-        ITokenizer tok = new LuceneJapaneseTokenizer();
+        ITokenizer tok = new LuceneCJKTokenizer();
         List<GlossaryEntry> entries = Arrays.asList(
                 new GlossaryEntry("\u307E\u3050\u308D", "tuna", "", true, ""),
                 new GlossaryEntry("\u7FFB\u8A33", "translation", "", true, ""),


### PR DESCRIPTION
Tokenizer is used for the project in which the source or target language is the same as the provided one.
It is feasible to move tokenizers to the corresponding language module.

## Pull request type

- Build/release
- refactoring

## Which ticket is resolved?

## What does this PR change?

- Move Japanese, Chinese and Polish tokenizers to the corresponding language module.
- There are derived from 3rd party analyzer library, that are not mandatory for other languages.
-

## Other information

Depends on #1183