### PR TITLE
Add FindMatches class test with segmented

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -71,7 +71,7 @@
     <!-- core/data/* -->
     <suppress checks="ParameterNumber" files="PluginInformation\.java" lines="60"/>
     <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="130-150,200-277"/>
-    <suppress checks="ParameterNumber" files="ExternalTMFactory\.java" lines="240-260"/>
+    <suppress checks="ParameterNumber" files="ExternalTMFactory\.java" lines="270-290"/>
     <suppress checks="(ParameterNumber|FileLength)" files="RealProject\.java"/>
 
     <!-- util/Platform -->

--- a/src/org/omegat/core/data/ExternalTMFactory.java
+++ b/src/org/omegat/core/data/ExternalTMFactory.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2017 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -33,6 +34,7 @@ import java.util.Locale;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.ParseEntry.ParseEntryResult;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.IFilter;
 import org.omegat.filters2.IParseCallback;
@@ -48,6 +50,7 @@ import org.omegat.util.TMXReader2;
  * Common utility class for external TMs.
  *
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  *
  */
 public final class ExternalTMFactory {
@@ -60,17 +63,22 @@ public final class ExternalTMFactory {
     }
 
     public static ExternalTMX load(File file) throws Exception {
-        ProjectProperties props = Core.getProject().getProjectProperties();
+        return load(file, Core.getProject().getProjectProperties(), Core.getSegmenter(),
+                Core.getFilterMaster());
+    }
+
+    public static ExternalTMX load(File file, ProjectProperties props, Segmenter segmenter,
+                                   FilterMaster filterMaster) throws Exception {
         if (TMXLoader.isSupported(file)) {
-            return new TMXLoader(file)
+            return new TMXLoader(file, segmenter)
                     .setExtTmxLevel2(Preferences.isPreference(Preferences.EXT_TMX_SHOW_LEVEL2))
                     .setUseSlash(Preferences.isPreference(Preferences.EXT_TMX_USE_SLASH))
                     .setDoSegmenting(props.isSentenceSegmentingEnabled())
                     .setKeepForeignMatches(Preferences.isPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH))
                     .load(props.getSourceLanguage(), props.getTargetLanguage());
-        } else if (BifileLoader.isSupported(file)) {
-            return new BifileLoader(file).setRemoveTags(props.isRemoveTags())
-                    .setRemoveSpaces(Core.getFilterMaster().getConfig().isRemoveSpacesNonseg())
+        } else if (BifileLoader.isSupported(file, filterMaster)) {
+            return new BifileLoader(file, segmenter, filterMaster).setRemoveTags(props.isRemoveTags())
+                    .setRemoveSpaces(filterMaster.getConfig().isRemoveSpacesNonseg())
                     .setDoSegmenting(props.isSentenceSegmentingEnabled())
                     .load(props.getSourceLanguage(), props.getTargetLanguage());
         } else {
@@ -94,9 +102,15 @@ public final class ExternalTMFactory {
         private boolean useSlash;
         private boolean doSegmenting;
         private boolean keepForeignMatches;
+        private final Segmenter segmenter;
 
         public TMXLoader(File file) {
+            this(file, Core.getSegmenter());
+        }
+
+        public TMXLoader(File file, Segmenter segmenter) {
             this.file = file;
+            this.segmenter = segmenter;
         }
 
         public TMXLoader setExtTmxLevel2(boolean extTmxLevel2) {
@@ -167,7 +181,7 @@ public final class ExternalTMFactory {
 
                     List<String> sources = new ArrayList<String>();
                     List<String> targets = new ArrayList<String>();
-                    Core.getSegmenter().segmentEntries(doSegmenting && isParagraphSegtype, sourceLang,
+                    segmenter.segmentEntries(doSegmenting && isParagraphSegtype, sourceLang,
                             tuvSource.text, targetLang, tuvTarget.text, sources, targets);
 
                     for (int i = 0; i < sources.size(); i++) {
@@ -199,8 +213,13 @@ public final class ExternalTMFactory {
     }
 
     public static final class BifileLoader {
+
         public static boolean isSupported(File file) {
             FilterMaster fm = Core.getFilterMaster();
+            return isSupported(file, fm);
+        }
+
+        public static boolean isSupported(File file, FilterMaster fm) {
             try {
                 return fm.isFileSupported(file, true) && fm.isBilingualFile(file);
             } catch (Exception e) {
@@ -212,9 +231,17 @@ public final class ExternalTMFactory {
         private boolean removeTags;
         private boolean removeSpaces;
         private boolean doSegmenting;
+        private final Segmenter segmenter;
+        private final FilterMaster filterMaster;
 
         public BifileLoader(File file) {
+            this(file, Core.getSegmenter(), Core.getFilterMaster());
+        }
+
+        public BifileLoader(File file, Segmenter segmenter, FilterMaster filterMaster) {
             this.file = file;
+            this.segmenter = segmenter;
+            this.filterMaster = filterMaster;
         }
 
         public BifileLoader setRemoveTags(boolean removeTags) {
@@ -239,7 +266,7 @@ public final class ExternalTMFactory {
         private List<PrepareTMXEntry> loadImpl(Language sourceLang, Language targetLang) throws Exception {
             List<PrepareTMXEntry> entries = new ArrayList<>();
             ParseEntryResult throwaway = new ParseEntryResult();
-            Core.getFilterMaster().loadFile(file.getPath(),
+            filterMaster.loadFile(file.getPath(),
                     new FilterContext(sourceLang, targetLang, true).setRemoveAllTags(removeTags),
                     new IParseCallback() {
                         @Override
@@ -273,7 +300,7 @@ public final class ExternalTMFactory {
 
                             List<String> sources = new ArrayList<>();
                             List<String> targets = new ArrayList<>();
-                            Core.getSegmenter().segmentEntries(doSegmenting, sourceLang, source, targetLang,
+                            segmenter.segmentEntries(doSegmenting, sourceLang, source, targetLang,
                                     target, sources, targets);
 
                             if (sources.size() == targets.size()) {

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -74,14 +74,14 @@ public class ProjectTMX {
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<String, TMXEntry> defaults;
+    protected Map<String, TMXEntry> defaults;
 
     /**
      * Storage for alternative translations for current project.
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<EntryKey, TMXEntry> alternatives;
+    protected Map<EntryKey, TMXEntry> alternatives;
 
     final CheckOrphanedCallback checkOrphanedCallback;
 

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -5,6 +5,7 @@
 
  Copyright (C) 2012 Alex Buloichik
                2013-2014 Aaron Madlon-Kay, Alex Buloichik
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.omegat.core.Core;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
@@ -87,9 +89,15 @@ public class ProjectTMX {
 
     public ProjectTMX(Language sourceLanguage, Language targetLanguage, boolean isSentenceSegmentingEnabled,
             File file, CheckOrphanedCallback callback) throws Exception {
+        this(sourceLanguage, targetLanguage, isSentenceSegmentingEnabled, file, callback,
+                Core.getSegmenter());
+    }
+
+    public ProjectTMX(Language sourceLanguage, Language targetLanguage, boolean isSentenceSegmentingEnabled,
+                      File file, CheckOrphanedCallback callback, Segmenter segmenter) throws Exception {
         this.checkOrphanedCallback = callback;
-        alternatives = new HashMap<EntryKey, TMXEntry>();
-        defaults = new HashMap<String, TMXEntry>();
+        alternatives = new HashMap<>();
+        defaults = new HashMap<>();
 
         if (file == null || !file.exists()) {
             // file not exist - new project
@@ -104,7 +112,7 @@ public class ProjectTMX {
                 false,
                 true,
                 Preferences.isPreference(Preferences.EXT_TMX_USE_SLASH),
-                new Loader(sourceLanguage, targetLanguage, isSentenceSegmentingEnabled));
+                new Loader(sourceLanguage, targetLanguage, segmenter, isSentenceSegmentingEnabled));
     }
 
     /**
@@ -285,11 +293,14 @@ public class ProjectTMX {
     private class Loader implements TMXReader2.LoadCallback {
         private final Language sourceLang;
         private final Language targetLang;
+        private final Segmenter segmenter;
         private final boolean sentenceSegmentingEnabled;
 
-        Loader(Language sourceLang, Language targetLang, boolean sentenceSegmentingEnabled) {
+        Loader(Language sourceLang, Language targetLang,
+               Segmenter segmenter, boolean sentenceSegmentingEnabled) {
             this.sourceLang = sourceLang;
             this.targetLang = targetLang;
+            this.segmenter = segmenter;
             this.sentenceSegmentingEnabled = sentenceSegmentingEnabled;
         }
 
@@ -317,7 +328,7 @@ public class ProjectTMX {
 
             List<String> sources = new ArrayList<String>();
             List<String> targets = new ArrayList<String>();
-            Core.getSegmenter().segmentEntries(sentenceSegmentingEnabled && isParagraphSegtype, sourceLang,
+            segmenter.segmentEntries(sentenceSegmentingEnabled && isParagraphSegtype, sourceLang,
                     tuvSource.text, targetLang, translation, sources, targets);
 
             synchronized (this) {

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -7,6 +7,7 @@
                2012 Thomas Cordonnier
                2013 Alex Buloichik
                2015 Aaron Madlon-Kay
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -101,7 +102,8 @@ public class CalcMatchStatistics extends LongProcessThread {
     private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal
             .withInitial(LevenshteinDistance::new);
     private final ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
-            () -> new FindMatches(Core.getProject(), OConsts.MAX_NEAR_STRINGS, true, false, false));
+            () -> new FindMatches(Core.getProject(), Core.getSegmenter(), OConsts.MAX_NEAR_STRINGS, true,
+                    false, false));
     private final StringBuilder textForLog = new StringBuilder();
 
     public CalcMatchStatistics(IStatsConsumer callback, boolean perFile) {

--- a/src/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -45,11 +45,13 @@ import org.omegat.core.matching.FuzzyMatcher;
 import org.omegat.core.matching.ISimilarityCalculator;
 import org.omegat.core.matching.LevenshteinDistance;
 import org.omegat.core.matching.NearString;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.statistics.FindMatches.StoppedException;
 import org.omegat.core.threads.LongProcessInterruptedException;
 import org.omegat.core.threads.LongProcessThread;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.Token;
 import org.omegat.util.gui.TextUtil;
@@ -101,23 +103,33 @@ public class CalcMatchStatistics extends LongProcessThread {
 
     private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal
             .withInitial(LevenshteinDistance::new);
-    private final ThreadLocal<FindMatches> finder = ThreadLocal.withInitial(
-            () -> new FindMatches(Core.getProject(), Core.getSegmenter(), OConsts.MAX_NEAR_STRINGS, true,
-                    false, false));
+    private final ThreadLocal<FindMatches> finder;
     private final StringBuilder textForLog = new StringBuilder();
+    private final IProject project;
 
     public CalcMatchStatistics(IStatsConsumer callback, boolean perFile) {
+        this(Core.getProject(), Core.getSegmenter(), callback, perFile,
+                Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                OConsts.FUZZY_MATCH_THRESHOLD));
+    }
+
+    public CalcMatchStatistics(IProject project, Segmenter segmenter, IStatsConsumer callback,
+                               boolean perFile, int threshold) {
+        this.project = project;
         this.callback = callback;
         this.perFile = perFile;
+        finder = ThreadLocal.withInitial(
+                () -> new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, true,
+                        false, false, threshold));
     }
 
     @Override
     public void run() {
         if (perFile) {
-            entriesToProcess = Core.getProject().getAllEntries().size() * 2;
+            entriesToProcess = project.getAllEntries().size() * 2;
             calcPerFile();
         } else {
-            entriesToProcess = Core.getProject().getAllEntries().size();
+            entriesToProcess = project.getAllEntries().size();
             calcTotal(true);
         }
         callback.finishData();
@@ -144,7 +156,7 @@ public class CalcMatchStatistics extends LongProcessThread {
 
     void calcPerFile() {
         int fileNumber = 0;
-        for (IProject.FileInfo fi : Core.getProject().getProjectFiles()) {
+        for (IProject.FileInfo fi : project.getProjectFiles()) {
             fileNumber++;
 
             MatchStatCounts perFileCounts = forFile(fi);
@@ -168,7 +180,7 @@ public class CalcMatchStatistics extends LongProcessThread {
         appendText(outText + "\n");
         appendTable(title, table);
 
-        String fn = Core.getProject().getProjectProperties().getProjectInternal()
+        String fn = project.getProjectProperties().getProjectInternal()
                 + OConsts.STATS_MATCH_PER_FILE_FILENAME;
         Statistics.writeStat(fn, textForLog.toString());
         callback.setDataFile(fn);
@@ -181,11 +193,11 @@ public class CalcMatchStatistics extends LongProcessThread {
         final List<SourceTextEntry> untranslatedEntries = new ArrayList<SourceTextEntry>();
 
         // We should iterate all segments from all files in project.
-        for (SourceTextEntry ste : Core.getProject().getAllEntries()) {
+        for (SourceTextEntry ste : project.getAllEntries()) {
             checkInterrupted();
             StatCount count = new StatCount(ste);
             boolean isFirst = alreadyProcessedInProject.add(ste.getSrcText());
-            if (Core.getProject().getTranslationInfo(ste).isTranslated()) {
+            if (project.getTranslationInfo(ste).isTranslated()) {
                 // segment has translation - should be calculated as "Exact
                 // matched"
                 result.addExact(count);
@@ -214,7 +226,7 @@ public class CalcMatchStatistics extends LongProcessThread {
             String outText = TextUtil.showTextTable(header, table, align);
             showText(outText);
             showTable(table);
-            String fn = Core.getProject().getProjectProperties().getProjectInternal()
+            String fn = project.getProjectProperties().getProjectInternal()
                     + OConsts.STATS_MATCH_FILENAME;
             Statistics.writeStat(fn, outText);
             callback.setDataFile(fn);
@@ -235,7 +247,7 @@ public class CalcMatchStatistics extends LongProcessThread {
             StatCount count = new StatCount(ste);
             boolean existInFile = alreadyProcessedInFile.contains(ste.getSrcText());
             boolean existInPreviousFiles = alreadyProcessedInProject.contains(ste.getSrcText());
-            if (Core.getProject().getTranslationInfo(ste).isTranslated()) {
+            if (project.getTranslationInfo(ste).isTranslated()) {
                 // segment has translation - should be calculated as
                 // "Exact matched"
                 result.addExact(count);

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -52,6 +52,7 @@ import org.omegat.core.matching.ISimilarityCalculator;
 import org.omegat.core.matching.LevenshteinDistance;
 import org.omegat.core.matching.NearString;
 import org.omegat.core.segmentation.Rule;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.util.Language;
 import org.omegat.util.OConsts;
@@ -133,6 +134,8 @@ public class FindMatches {
 
     private final boolean applyThreshold;
 
+    private final Segmenter segmenter;
+
     /**
      * @param searchExactlyTheSame
      *            allows to search similarities with the same text as source
@@ -142,12 +145,13 @@ public class FindMatches {
      */
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
             boolean searchExactlyTheSame) {
-        this(project, maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, true);
+        this(project, Core.getSegmenter(), maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, true);
     }
 
-    public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
+    public FindMatches(IProject project, Segmenter segmenter, int maxCount, boolean allowSeparateSegmentMatch,
             boolean searchExactlyTheSame, boolean applyThreshold) {
         this.project = project;
+        this.segmenter = segmenter;
         this.tok = project.getSourceTokenizer();
         this.srcLocale = project.getProjectProperties().getSourceLanguage().getLocale();
         this.maxCount = maxCount;
@@ -262,7 +266,7 @@ public class FindMatches {
             List<Rule> brules = new ArrayList<>();
             Language sourceLang = project.getProjectProperties().getSourceLanguage();
             Language targetLang = project.getProjectProperties().getTargetLanguage();
-            List<String> segments = Core.getSegmenter().segment(sourceLang, srcText, spaces, brules);
+            List<String> segments = segmenter.segment(sourceLang, srcText, spaces, brules);
             if (segments.size() > 1) {
                 List<String> fsrc = new ArrayList<>(segments.size());
                 List<String> ftrans = new ArrayList<>(segments.size());
@@ -282,8 +286,8 @@ public class FindMatches {
                 }
                 // glue found sources and translations
                 PrepareTMXEntry entry = new PrepareTMXEntry();
-                entry.source = Core.getSegmenter().glue(sourceLang, sourceLang, fsrc, spaces, brules);
-                entry.translation = Core.getSegmenter().glue(sourceLang, targetLang, ftrans, spaces, brules);
+                entry.source = segmenter.glue(sourceLang, sourceLang, fsrc, spaces, brules);
+                entry.translation = segmenter.glue(sourceLang, targetLang, ftrans, spaces, brules);
                 processEntry(null, entry, "", NearString.MATCH_SOURCE.TM, false, 0);
             }
         }

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -145,11 +145,13 @@ public class FindMatches {
      */
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
             boolean searchExactlyTheSame) {
-        this(project, Core.getSegmenter(), maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, true);
+        this(project, Core.getSegmenter(), maxCount, allowSeparateSegmentMatch, searchExactlyTheSame, true,
+                Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
+                        OConsts.FUZZY_MATCH_THRESHOLD));
     }
 
     public FindMatches(IProject project, Segmenter segmenter, int maxCount, boolean allowSeparateSegmentMatch,
-            boolean searchExactlyTheSame, boolean applyThreshold) {
+            boolean searchExactlyTheSame, boolean applyThreshold, int threshold) {
         this.project = project;
         this.segmenter = segmenter;
         this.tok = project.getSourceTokenizer();
@@ -157,10 +159,9 @@ public class FindMatches {
         this.maxCount = maxCount;
         this.searchExactlyTheSame = searchExactlyTheSame;
         if (allowSeparateSegmentMatch && !project.getProjectProperties().isSentenceSegmentingEnabled()) {
-            separateSegmentMatcher = new FindMatches(project, 1, false, true);
+            separateSegmentMatcher = new FindMatches(project, segmenter, 1, false, true, true, threshold);
         }
-        this.fuzzyMatchThreshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
-                OConsts.FUZZY_MATCH_THRESHOLD);
+        this.fuzzyMatchThreshold = threshold;
         this.applyThreshold = applyThreshold;
     }
 

--- a/test/data/tmx/test-match-stat-en-ca.tmx
+++ b/test/data/tmx/test-match-stat-en-ca.tmx
@@ -1499,30 +1499,26 @@
     </tu>
     <tu>
       <tuv xml:lang="en">
-        <seg>This badge is granted when you’ve invited 5 people who subsequently spent enough time on the site to become full members. Wow! Thanks for expanding the diversity of our community with new members!
-</seg>
+        <seg>This badge is granted when you’ve invited 5 people who subsequently spent enough time on the site to become full members.</seg>
       </tuv>
       <tuv xml:lang="ca">
-        <seg>Aquesta insígnia es concedeix quan heu convidat 5 persones que posteriorment han passat prou temps en el lloc web per a convertir-se en membres plens. Bé! Gràcies per ampliar la diversitat de la comunitat amb nous membres.
-</seg>
+        <seg>Aquesta insígnia es concedeix quan heu convidat 5 persones que posteriorment han passat prou temps en ellloc web per a convertir-se en membres plens.</seg>
       </tuv>
     </tu>
     <tu>
       <tuv xml:lang="en">
-        <seg>Champion</seg>
+        <seg>Wow!</seg>
       </tuv>
       <tuv xml:lang="ca">
-        <seg>Campió</seg>
+        <seg>Bé!</seg>
       </tuv>
     </tu>
     <tu>
       <tuv xml:lang="en">
-        <seg>This badge is granted when you use all %{max_likes_per_day} of your daily likes for 20 days. Wow! You’re a role model for encouraging your fellow community members!
-</seg>
+        <seg>Thanks for expanding the diversity of our community with new members!</seg>
       </tuv>
       <tuv xml:lang="ca">
-        <seg>Aquesta insígnia es concedeix quan utilitzeu tots els vostres %{max_likes_per_day} 'm'agrada' diaris durant vint dies. Oh! Sou un model per a animar els companys de comunitat!
-</seg>
+        <seg>Gràcies per ampliar la diversitat de la comunitat amb nous membres.</seg>
       </tuv>
     </tu>
     <tu>

--- a/test/src/org/omegat/core/segmentation/SegmenterTest.java
+++ b/test/src/org/omegat/core/segmentation/SegmenterTest.java
@@ -40,7 +40,7 @@ import org.omegat.util.Language;
  */
 public class SegmenterTest {
 
-    private Segmenter segmenter = new Segmenter(SRX.getDefault());
+    private final Segmenter segmenter = new Segmenter(SRX.getDefault());
 
     /**
      * Test of segment method, of class org.omegat.core.segmentation.Segmenter.

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -48,7 +48,6 @@ import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
-import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.IFilter;
@@ -59,19 +58,19 @@ import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.util.Language;
-import org.omegat.util.OConsts;
+import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 import org.omegat.util.TestPreferencesInitializer;
 
 public class CalcMatchStatisticsTest {
 
     @Test
-    public void testCalcMatchStatics() {
-        int threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
-                OConsts.FUZZY_MATCH_THRESHOLD);
-        Assert.assertEquals(30, threshold);
+    public void testCalcMatchStatics() throws Exception {
+        TestProject project = new TestProject(new ProjectPropertiesTest());
         IStatsConsumer callback = new TestStatsConsumer();
-        CalcMatchStatisticsMock calcMatchStatistics = new CalcMatchStatisticsMock(callback);
+        Segmenter segmenter = new Segmenter(Preferences.getSRX());
+        CalcMatchStatisticsMock calcMatchStatistics = new CalcMatchStatisticsMock(project, segmenter,
+                callback, 30);
         calcMatchStatistics.start();
         try {
             calcMatchStatistics.join();
@@ -122,18 +121,9 @@ public class CalcMatchStatisticsTest {
         Assert.assertEquals("938", result[7][2]);
         Assert.assertEquals("4894", result[7][3]);
         Assert.assertEquals("5699", result[7][4]);
-        // double check condition
-        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
-                OConsts.FUZZY_MATCH_THRESHOLD);
-        Assert.assertEquals(30, threshold);
 
         // change threshold
-        Preferences.setPreference(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD, 70);
-        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
-                OConsts.FUZZY_MATCH_THRESHOLD);
-        Assert.assertEquals(70, threshold);
-        //
-        calcMatchStatistics = new CalcMatchStatisticsMock(callback);
+        calcMatchStatistics = new CalcMatchStatisticsMock(project, segmenter, callback, 70);
         calcMatchStatistics.start();
         try {
             calcMatchStatistics.join();
@@ -184,10 +174,6 @@ public class CalcMatchStatisticsTest {
         Assert.assertEquals("938", result[7][2]);
         Assert.assertEquals("4894", result[7][3]);
         Assert.assertEquals("5699", result[7][4]);
-        // double check condition
-        threshold = Preferences.getPreferenceDefault(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD,
-                OConsts.FUZZY_MATCH_THRESHOLD);
-        Assert.assertEquals(70, threshold);
     }
 
     /*
@@ -199,8 +185,6 @@ public class CalcMatchStatisticsTest {
         Core.initializeConsole(Collections.emptyMap());
         TestPreferencesInitializer.init();
         Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
-        Core.setSegmenter(new Segmenter(SRX.getDefault()));
-        Core.setProject(new TestProject(new ProjectPropertiesTest()));
     }
 
     protected static class ProjectPropertiesTest extends ProjectProperties {
@@ -219,12 +203,14 @@ public class CalcMatchStatisticsTest {
 
         private final ProjectTMX projectTMX;
         private Map<String, ExternalTMX> transMemories;
+        private final Segmenter segmenter;
 
         TestProject(ProjectProperties prop) throws Exception {
             super();
             this.prop = prop;
+            segmenter = new Segmenter(Preferences.getSRX());
             projectTMX = new ProjectTMX(new Language("en"), new Language("ca"), true,
-                    Paths.get("test/data/tmx/empty.tmx").toFile(), null);
+                    Paths.get("test/data/tmx/empty.tmx").toFile(), null, segmenter);
         }
 
         @Override
@@ -257,7 +243,7 @@ public class CalcMatchStatisticsTest {
             try {
                 filter.parseFile(testSource.toFile(), Collections.emptyMap(), context, testCallback);
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.log(e);
             }
             return ste;
         }
@@ -308,7 +294,7 @@ public class CalcMatchStatisticsTest {
                     try {
                         ExternalTMX newTMX;
                         Path testTmx = Paths.get("test/data/tmx/test-match-stat-en-ca.tmx");
-                        newTMX = ExternalTMFactory.load(testTmx.toFile());
+                        newTMX = ExternalTMFactory.load(testTmx.toFile(), prop, segmenter, null);
                         transMemories.put(testTmx.toString(), newTMX);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
@@ -372,17 +358,20 @@ public class CalcMatchStatisticsTest {
         private final String[] rowsTotal = new String[] { "RowRepetitions", "RowExactMatch", "RowMatch95",
                 "RowMatch85", "RowMatch75", "RowMatch50", "RowNoMatch", "Total" };
 
+        private final IProject project;
         private MatchStatCounts result;
         private final IStatsConsumer callback;
 
-        CalcMatchStatisticsMock(IStatsConsumer callback) {
-            super(callback, false);
+        CalcMatchStatisticsMock(IProject project, Segmenter segmenter, IStatsConsumer callback,
+                                int threshold) {
+            super(project, segmenter, callback, false, threshold);
+            this.project = project;
             this.callback = callback;
         }
 
         @Override
         public void run() {
-            entriesToProcess = Core.getProject().getAllEntries().size();
+            entriesToProcess = project.getAllEntries().size();
             result = calcTotal(false);
             callback.finishData();
         }

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -26,21 +26,18 @@
 package org.omegat.core.statistics;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,8 +51,10 @@ import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
 import org.omegat.core.events.IStopped;
 import org.omegat.core.matching.NearString;
+import org.omegat.core.segmentation.Rule;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.tokenizer.DefaultTokenizer;
@@ -69,6 +68,7 @@ import org.omegat.util.TestPreferencesInitializer;
 
 public class FindMatchesTest {
 
+    private static final File TMX_MATCH_EN_CA = new File("test/data/tmx/test-match-stat-en-ca.tmx");
     private static final File TMX_EN_US_SR = new File("test/data/tmx/en-US_sr.tmx");
     private static final File TMX_EN_US_GB_SR = new File("test/data/tmx/en-US_en-GB_fr_sr.tmx");
     private static Path tmpDir;
@@ -76,18 +76,19 @@ public class FindMatchesTest {
     /**
      * Reproduce and test for RFE#1578.
      * <p>
-     * When external TM has different target language, and
-     * source has country code such as "en-US", and
-     * project source is only language code such as "en",
-     * and set preference to use other target language,
-     * OmegaT show the source of "en-US" as reference.
+     * When external TM has different target language, and a source has country
+     * code such as "en-US", and a project source is only language code such as
+     * "en", and set preference to use another target language, OmegaT shows the
+     * source of "en-US" as reference.
      *
      * test conditions:
-     *   header adminlang=en
-     *   header srclang=en-US
-     *   header segtype=sentence
-     *   1st tuv: en-US  value: XXX
-     *   2nd tuv: sr     value: YYY
+     * <ul>
+     *   <li>header adminlang=en</li>
+     *   <li>header srclang=en-US</li>
+     *   <li>header segtype=sentence</li>
+     *   <li>1st tuv: en-US  value: XXX</li>
+     *   <li>2nd tuv: sr     value: YYY</li>
+     * </ul>
      */
     @Test
     public void testSearchRFE1578() throws Exception {
@@ -96,9 +97,10 @@ public class FindMatchesTest {
         prop.setTargetLanguage("cnr");
         prop.setSupportDefaultTranslations(true);
         prop.setSentenceSegmentingEnabled(false);
-        IProject project = new TestProject(prop, TMX_EN_US_SR);
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        IProject project = new TestProject(prop, null, TMX_EN_US_SR, new LuceneEnglishTokenizer(),
+                new DefaultTokenizer());
         Core.setProject(project);
-        Core.setSegmenter(new Segmenter(new SRX()));
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, OConsts.MAX_NEAR_STRINGS, true, false);
         List<NearString> result = finder.search("XXX", true, true, iStopped);
@@ -112,17 +114,20 @@ public class FindMatchesTest {
      * Test with tmx file with en-US, en-GB, fr and sr.
      * <p>
      * test conditions:
-     *   header adminlang=en
-     *   header srclang=en-US
-     *   header segtype=sentence
-     *   1st tuv: en-US  value: XXx
-     *   2nd tuv: en-GB  value: XXX
-     *   3rd tuv: fr     value: YYY
-     *   4th tuv: sr     value: ZZZ
+     * <ul>
+     *   <li>header adminlang=en</li>
+     *   <li>header srclang=en-US</li>
+     *   <li>header segtype=sentence</li>
+     *   <li>1st tuv: en-US  value: XXx</li>
+     *   <li>2nd tuv: en-GB  value: XXX</li>
+     *   <li>3rd tuv: fr     value: YYY</li>
+     *   <li>4th tuv: sr     value: ZZZ</li>
+     * </ul>
      * project properties:
-     *   source: en
-     *   target: cnr
-     *
+     * <ul>
+     *   <li>source: en</li>
+     *   <li>target: cnr</li>
+     * </ul>
      */
     @Test
     public void testSearchRFE1578_2() throws Exception {
@@ -131,15 +136,16 @@ public class FindMatchesTest {
         prop.setTargetLanguage("cnr");
         prop.setSupportDefaultTranslations(true);
         prop.setSentenceSegmentingEnabled(false);
-        IProject project = new TestProject(prop, TMX_EN_US_GB_SR);
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        IProject project = new TestProject(prop, null, TMX_EN_US_GB_SR, new LuceneEnglishTokenizer(),
+                new DefaultTokenizer());
         Core.setProject(project);
-        Core.setSegmenter(new Segmenter(new SRX()));
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, OConsts.MAX_NEAR_STRINGS, true, false);
         // Search source "XXx" in en-US
         List<NearString> result = finder.search("XXX", true, true, iStopped);
         // There should be three entries.
-        assertEquals("XXx", result.get(0).source);  // should be en-US.
+        assertEquals("XXx", result.get(0).source); // should be en-US.
         assertEquals("XXX", result.get(0).translation); // should be en-GB
         assertEquals("YYY", result.get(1).translation); // fr
         assertEquals("ZZZ", result.get(2).translation); // sr
@@ -159,17 +165,75 @@ public class FindMatchesTest {
         Preferences.setPreference(Preferences.EXT_TMX_SHOW_LEVEL2, false);
         Preferences.setPreference(Preferences.EXT_TMX_USE_SLASH, false);
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, true);
+        Preferences.setPreference(Preferences.PENALTY_FOR_FOREIGN_MATCHES, 15);
         Core.registerTokenizerClass(DefaultTokenizer.class);
         Core.registerTokenizerClass(LuceneEnglishTokenizer.class);
     }
 
     static class TestProject extends NotLoadedProject implements IProject {
-        private ProjectProperties prop;
-        private File testTmx;
+        private final ProjectProperties prop;
+        private ProjectTMXMock projectTMX;
+        private final File externalTmx;
+        private final ITokenizer sourceTokenizer;
+        private final ITokenizer targetTokenizer;
 
-        TestProject(final ProjectProperties prop, final File testTmx) {
+        final ProjectTMX.CheckOrphanedCallback checkOrphanedCallback = new ProjectTMX.CheckOrphanedCallback() {
+            public boolean existSourceInProject(String src) {
+                return false;
+            }
+            public boolean existEntryInProject(EntryKey key) {
+                return false;
+            }
+        };
+
+        TestProject(final ProjectProperties prop, File testTmx, File externalTmx,
+                    ITokenizer sourceTokenizer,
+                    ITokenizer targetTokenizer) {
             this.prop = prop;
-            this.testTmx = testTmx;
+            this.sourceTokenizer = sourceTokenizer;
+            this.targetTokenizer = targetTokenizer;
+            this.externalTmx = externalTmx;
+            projectTMX = null;
+            if (testTmx != null) {
+                try {
+                    projectTMX = new ProjectTMXMock(prop.getSourceLanguage(), prop.getTargetLanguage(),
+                            prop.isSentenceSegmentingEnabled(), testTmx, checkOrphanedCallback);
+                } catch (Exception ignored) {
+                }
+            }
+       }
+
+        public void iterateByDefaultTranslations(DefaultTranslationsIterator it) {
+            if (projectTMX == null) {
+                return;
+            }
+            Map.Entry<String, TMXEntry>[] entries;
+            synchronized (checkOrphanedCallback) {
+                entries = entrySetToArray(projectTMX.getDefaultsMap().entrySet());
+            }
+            for (Map.Entry<String, TMXEntry> en : entries) {
+                it.iterate(en.getKey(), en.getValue());
+            }
+        }
+
+        public void iterateByMultipleTranslations(MultipleTranslationsIterator it) {
+            if (projectTMX == null) {
+                return;
+            }
+            Map.Entry<EntryKey, TMXEntry>[] entries;
+            synchronized (checkOrphanedCallback) {
+                entries = entrySetToArray(projectTMX.getAlternativesMap().entrySet());
+            }
+            for (Map.Entry<EntryKey, TMXEntry> en : entries) {
+                it.iterate(en.getKey(), en.getValue());
+            }
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private <K, V> Map.Entry<K, V>[] entrySetToArray(Set<Map.Entry<K, V>> set) {
+            // Assign to variable to facilitate suppressing the rawtypes warning
+            Map.Entry[] a = new Map.Entry[set.size()];
+            return set.toArray(a);
         }
 
         @Override
@@ -181,18 +245,33 @@ public class FindMatchesTest {
         public List<SourceTextEntry> getAllEntries() {
             List<SourceTextEntry> ste = new ArrayList<>();
             ste.add(new SourceTextEntry(new EntryKey("source.txt", "XXX", null, "", "", null),
-                    1, null, null, new ArrayList<>()));
+                    1, null, null, Collections.emptyList()));
             return ste;
         }
 
         @Override
         public ITokenizer getSourceTokenizer() {
-            return new LuceneEnglishTokenizer();
+            return sourceTokenizer;
         };
 
         @Override
         public ITokenizer getTargetTokenizer() {
-            return new DefaultTokenizer();
+            return targetTokenizer;
+        }
+
+        @Override
+        public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+            if (projectTMX == null) {
+                return null;
+            }
+            TMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
+            if (r == null) {
+                r = projectTMX.getDefaultTranslation(ste.getSrcText());
+            }
+            if (r == null) {
+                r = EMPTY_TRANSLATION;
+            }
+            return r;
         }
 
         @Override
@@ -202,19 +281,35 @@ public class FindMatchesTest {
 
         @Override
         public Map<String, ExternalTMX> getTransMemories() {
+            if (externalTmx == null) {
+                return Collections.emptyMap();
+            }
+
             Map<String, ExternalTMX> transMemories = new TreeMap<>();
             try {
-                ExternalTMX newTMX = ExternalTMFactory.load(testTmx);
-                transMemories.put(testTmx.getPath(), newTMX);
+                ExternalTMX newTMX = ExternalTMFactory.load(externalTmx);
+                transMemories.put(externalTmx.getPath(), newTMX);
             } catch (Exception ignored) {
             }
             return Collections.unmodifiableMap(transMemories);
         }
     }
 
-    @AfterClass
-    public static void tearDown() throws IOException {
-        FileUtils.deleteDirectory(tmpDir.toFile());
-        assertFalse(tmpDir.toFile().exists());
+    public static class ProjectTMXMock extends ProjectTMX {
+
+        public ProjectTMXMock(Language sourceLanguage, Language targetLanguage,
+                           boolean isSentenceSegmentingEnabled,
+                          File file, CheckOrphanedCallback callback) throws Exception {
+            super(sourceLanguage, targetLanguage, isSentenceSegmentingEnabled, file, callback);
+        }
+
+        public Map<String, TMXEntry> getDefaultsMap() {
+            return defaults;
+        };
+
+        public Map<EntryKey, TMXEntry> getAlternativesMap() {
+            return alternatives;
+        }
     }
+
 }


### PR DESCRIPTION
`FindMatches` class ctor has a argument of boolean `allowSeparateSegmentMatch`.
This PR add a test case with the option and test the chunk of the feature. 

## Pull request type

- Other (describe below)
Improve test coverage, Quality Assurance 

## What does this PR change?

- ProjectTMX: change a scope of `defaults` and `alternatives` fields as `protected` for mocking
- ProjectTMXTest: update `TestProject` internal class
- ProjectTMXTest: add the case `testSegmented`
- `calcMatchStatisticsTest` to handle `Segmenter` and `TestProject`
- update `SegmenterTest` 
- refactor `FindMatches`, `CalcMatchStatistics`, `ExternalTMFactory`, and `ProjectTMX`.

## Other information

- #963 
- #1174