### PR TITLE
refactor: reduce Core dependency for aligner

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -51,6 +51,8 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.text.JTextComponent;
 
 import org.omegat.core.Core;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -50,13 +50,11 @@ import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.text.JTextComponent;
 
-import tokyo.northside.logging.ILogger;
-import tokyo.northside.logging.LoggerFactory;
-
 import org.omegat.core.Core;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;
+import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.LanguageComboBoxRenderer;
@@ -80,7 +78,6 @@ public class AlignFilePickerController {
     Language targetLanguage = allLangs.get(allLangs.size() - 1);
 
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
-    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignFilePickerController.class, BUNDLE);
 
     /**
      * Set the source file for alignment.
@@ -320,7 +317,7 @@ public class AlignFilePickerController {
                     field.setText(files.get(0).getAbsolutePath());
                     return true;
                 } catch (Exception e) {
-                    LOGGER.atInfo().setCause(e).log();
+                    Log.log(e);
                     return false;
                 }
             }
@@ -358,7 +355,7 @@ public class AlignFilePickerController {
                     }
                     return true;
                 } catch (Exception e) {
-                    LOGGER.atInfo().setCause(e).log();
+                    Log.log(e);
                     return false;
                 }
             }
@@ -384,7 +381,7 @@ public class AlignFilePickerController {
                     } catch (CancellationException e) {
                         // Ignore
                     } catch (Exception e) {
-                        LOGGER.atInfo().setCause(e).log();
+                        Log.log(e);
                         JOptionPane.showMessageDialog(frame, BUNDLE.getString("ALIGNER_ERROR_LOADING"),
                                 BUNDLE.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                     }
@@ -446,7 +443,7 @@ public class AlignFilePickerController {
                 } catch (CancellationException e) {
                     // Ignore
                 } catch (Exception e) {
-                    LOGGER.atInfo().setCause(e).log();
+                    Log.log(e);
                     message = e.getLocalizedMessage();
                 }
                 picker.okButton.setEnabled(enabled);

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -495,13 +495,15 @@ public class AlignFilePickerController {
      * </ol>
      *
      * @param args command arguments.
+     * @throws Exception when failed to ininitalize OmegaT core. 
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
         Preferences.init();
         PluginUtils.loadPlugins(Collections.emptyMap());
-
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
         AlignFilePickerController picker = new AlignFilePickerController();
         if (args.length == 4) {
             picker.sourceLanguage = new Language(args[0]);

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -29,7 +29,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -172,31 +171,28 @@ public class AlignFilePickerController {
         picker.sourceLanguagePicker.setRenderer(new LanguageComboBoxRenderer());
         picker.sourceLanguagePicker.setSelectedItem(sourceLanguage);
         picker.sourceLanguagePicker.setName("sourceLanguagePicker");
-        picker.sourceLanguagePicker.addItemListener(new ItemListener() {
-            @Override
-            public void itemStateChanged(ItemEvent e) {
-                if (e.getStateChange() != ItemEvent.SELECTED) {
-                    return;
-                }
-                if (e.getItem() instanceof String) {
-                    String newVal = (String) e.getItem();
-                    if (Language.verifySingleLangCode(newVal)) {
-                        sourceLanguage = new Language(newVal);
-                    } else {
-                        sourceLanguage = null;
-                        JOptionPane.showMessageDialog(frame,
-                                BUNDLE.getString("NP_INVALID_SOURCE_LOCALE")
-                                        + BUNDLE.getString("NP_LOCALE_SUGGESTION"),
-                                BUNDLE.getString("TF_ERROR"), JOptionPane.ERROR_MESSAGE);
-                        picker.sourceLanguagePicker.requestFocusInWindow();
-                    }
-                } else if (e.getItem() instanceof Language) {
-                    sourceLanguage = (Language) e.getItem();
-                } else {
-                    throw new IllegalArgumentException();
-                }
-                updatePicker(picker);
+        picker.sourceLanguagePicker.addItemListener(e -> {
+            if (e.getStateChange() != ItemEvent.SELECTED) {
+                return;
             }
+            if (e.getItem() instanceof String) {
+                String newVal = (String) e.getItem();
+                if (Language.verifySingleLangCode(newVal)) {
+                    sourceLanguage = new Language(newVal);
+                } else {
+                    sourceLanguage = null;
+                    JOptionPane.showMessageDialog(frame,
+                            BUNDLE.getString("NP_INVALID_SOURCE_LOCALE")
+                                    + BUNDLE.getString("NP_LOCALE_SUGGESTION"),
+                            BUNDLE.getString("TF_ERROR"), JOptionPane.ERROR_MESSAGE);
+                    picker.sourceLanguagePicker.requestFocusInWindow();
+                }
+            } else if (e.getItem() instanceof Language) {
+                sourceLanguage = (Language) e.getItem();
+            } else {
+                throw new IllegalArgumentException();
+            }
+            updatePicker(picker);
         });
         picker.targetLanguagePicker
                 .setModel(new DefaultComboBoxModel<>(new Vector<>(Language.getLanguages())));
@@ -228,7 +224,7 @@ public class AlignFilePickerController {
         });
         picker.sourceChooseFileButton.addActionListener(e -> {
             File file = chooseFile(frame, BUNDLE.getString("ALIGNER_FILEPICKER_CHOOSE_SOURCE"),
-                    StringUtil.isEmpty(sourceFile) ? sourceDefaultDir : sourceFile);
+                    StringUtil.isEmpty(sourceFile) ? sourceDefaultDir : sourceFile, "aligner_choose_source");
             if (file != null) {
                 sourceDefaultDir = file.getParent();
                 targetDefaultDir = targetDefaultDir == null ? sourceDefaultDir : targetDefaultDir;
@@ -239,7 +235,7 @@ public class AlignFilePickerController {
         });
         picker.targetChooseFileButton.addActionListener(e -> {
             File file = chooseFile(frame, BUNDLE.getString("ALIGNER_FILEPICKER_CHOOSE_TARGET"),
-                    StringUtil.isEmpty(targetFile) ? targetDefaultDir : targetFile);
+                    StringUtil.isEmpty(targetFile) ? targetDefaultDir : targetFile, "aligner_choose_target");
             if (file != null) {
                 targetDefaultDir = file.getParent();
                 sourceDefaultDir = sourceDefaultDir == null ? targetDefaultDir : sourceDefaultDir;
@@ -466,8 +462,9 @@ public class AlignFilePickerController {
         return result;
     }
 
-    static File chooseFile(Component parent, String title, String dir) {
+    static File chooseFile(Component parent, String title, String dir, String name) {
         JFileChooser chooser = new JFileChooser(dir);
+        chooser.setName(name);
         chooser.setDialogTitle(title);
         chooser.setFileFilter(new FileFilter() {
             @Override

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -54,8 +54,6 @@ import tokyo.northside.logging.ILogger;
 import tokyo.northside.logging.LoggerFactory;
 
 import org.omegat.core.Core;
-import org.omegat.core.segmentation.SRX;
-import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;
@@ -81,8 +79,8 @@ public class AlignFilePickerController {
     Language sourceLanguage = allLangs.get(0);
     Language targetLanguage = allLangs.get(allLangs.size() - 1);
 
-    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignFilePickerController.class);
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
+    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignFilePickerController.class, BUNDLE);
 
     /**
      * Set the source file for alignment.
@@ -499,16 +497,13 @@ public class AlignFilePickerController {
      * <li>Target file path
      * </ol>
      *
-     * @param args
-     * @throws Exception
+     * @param args command arguments.
      */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
         Preferences.init();
         PluginUtils.loadPlugins(Collections.emptyMap());
-        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
-        Core.setSegmenter(new Segmenter(SRX.getDefault()));
 
         AlignFilePickerController picker = new AlignFilePickerController();
         if (args.length == 4) {

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -29,10 +29,10 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -79,7 +79,6 @@ import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
-import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
@@ -122,8 +121,8 @@ import gen.core.filters.Filters;
  * @author Aaron Madlon-Kay
  */
 public class AlignPanelController {
-    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignPanelController.class);
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
+    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignPanelController.class, BUNDLE);
     private final Aligner aligner;
     private final String defaultSaveDir;
     private boolean modified = false;
@@ -161,10 +160,16 @@ public class AlignPanelController {
     }
 
     private Phase phase = Phase.ALIGN;
+    private final Segmenter segmenter;
 
     public AlignPanelController(Aligner aligner, String defaultSaveDir) {
+        this(aligner, defaultSaveDir, Core.getSegmenter());
+    }
+
+    public AlignPanelController(Aligner aligner, String defaultSaveDir, Segmenter segmenter) {
         this.aligner = aligner;
         this.defaultSaveDir = defaultSaveDir;
+        this.segmenter = segmenter;
     }
 
     /**
@@ -222,8 +227,7 @@ public class AlignPanelController {
             }
         };
         alignPanel.comparisonComboBox.addActionListener(comparisonListener);
-        alignPanel.comparisonComboBox
-                .setRenderer(new EnumRenderer<ComparisonMode>("ALIGNER_ENUM_COMPARISON_MODE_"));
+        alignPanel.comparisonComboBox.setRenderer(new EnumRenderer<>("ALIGNER_ENUM_COMPARISON_MODE_"));
 
         ActionListener algorithmListener = e -> {
             AlgorithmClass newValue = (AlgorithmClass) ((JComboBox<?>) e.getSource()).getSelectedItem();
@@ -235,8 +239,7 @@ public class AlignPanelController {
             }
         };
         alignPanel.algorithmComboBox.addActionListener(algorithmListener);
-        alignPanel.algorithmComboBox
-                .setRenderer(new EnumRenderer<AlgorithmClass>("ALIGNER_ENUM_ALGORITHM_CLASS_"));
+        alignPanel.algorithmComboBox.setRenderer(new EnumRenderer<>("ALIGNER_ENUM_ALGORITHM_CLASS_"));
 
         ActionListener calculatorListener = e -> {
             CalculatorType newValue = (CalculatorType) ((JComboBox<?>) e.getSource()).getSelectedItem();
@@ -248,8 +251,7 @@ public class AlignPanelController {
             }
         };
         alignPanel.calculatorComboBox.addActionListener(calculatorListener);
-        alignPanel.calculatorComboBox
-                .setRenderer(new EnumRenderer<CalculatorType>("ALIGNER_ENUM_CALCULATOR_TYPE_"));
+        alignPanel.calculatorComboBox.setRenderer(new EnumRenderer<>("ALIGNER_ENUM_CALCULATOR_TYPE_"));
 
         ActionListener counterListener = e -> {
             CounterType newValue = (CounterType) ((JComboBox<?>) e.getSource()).getSelectedItem();
@@ -279,10 +281,9 @@ public class AlignPanelController {
         ActionListener segmentingRulesListener = e -> {
             if (confirmReset(alignMenuFrame)) {
                 SegmentationCustomizer customizer = new SegmentationCustomizer(false, SRX.getDefault(),
-                        Core.getSegmenter().getSRX(), null);
+                        segmenter.getSRX(), null);
                 if (customizer.show(alignMenuFrame)) {
                     customizedSRX = customizer.getResult();
-                    Core.setSegmenter(new Segmenter(customizedSRX));
                     reloadBeads();
                 }
             }
@@ -290,19 +291,15 @@ public class AlignPanelController {
         alignPanel.segmentingRulesButton.addActionListener(segmentingRulesListener);
         alignMenuFrame.segmentingRulesItem.addActionListener(segmentingRulesListener);
 
-        ActionListener filterSettingsListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (confirmReset(alignMenuFrame)) {
-                    FiltersCustomizer customizer = new FiltersCustomizer(false,
-                            FilterMaster.createDefaultFiltersConfig(), Core.getFilterMaster().getConfig(),
-                            null);
-                    if (customizer.show(alignMenuFrame)) {
-                        customizedFilters = customizer.getResult();
-                        Core.setFilterMaster(new FilterMaster(customizedFilters));
-                        aligner.clearLoaded();
-                        reloadBeads();
-                    }
+        ActionListener filterSettingsListener = e -> {
+            if (confirmReset(alignMenuFrame)) {
+                FiltersCustomizer customizer = new FiltersCustomizer(false,
+                        FilterMaster.createDefaultFiltersConfig(), Core.getFilterMaster().getConfig(), null);
+                if (customizer.show(alignMenuFrame)) {
+                    customizedFilters = customizer.getResult();
+                    Core.setFilterMaster(new FilterMaster(customizedFilters));
+                    aligner.clearLoaded();
+                    reloadBeads();
                 }
             }
         };
@@ -319,22 +316,19 @@ public class AlignPanelController {
             }
         });
 
-        ActionListener oneAdjustListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                int[] rows = alignPanel.table.getSelectedRows();
-                int col = alignPanel.table.getSelectedColumn();
-                boolean up = e.getSource().equals(alignPanel.moveUpButton)
-                        || e.getSource().equals(alignMenuFrame.moveUpItem);
-                BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
-                if ((e.getModifiers() & Java8Compat.getMenuShortcutKeyMaskEx()) != 0) {
-                    int trgRow = up ? model.prevBeadFromRow(rows[0])
-                            : model.nextBeadFromRow(rows[rows.length - 1]);
-                    moveRows(rows, col, trgRow);
-                } else {
-                    int offset = up ? -1 : 1;
-                    slideRows(rows, col, offset);
-                }
+        ActionListener oneAdjustListener = e -> {
+            int[] rows = alignPanel.table.getSelectedRows();
+            int col = alignPanel.table.getSelectedColumn();
+            boolean up = e.getSource().equals(alignPanel.moveUpButton)
+                    || e.getSource().equals(alignMenuFrame.moveUpItem);
+            BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
+            if ((e.getModifiers() & Java8Compat.getMenuShortcutKeyMaskEx()) != 0) {
+                int trgRow = up ? model.prevBeadFromRow(rows[0])
+                        : model.nextBeadFromRow(rows[rows.length - 1]);
+                moveRows(rows, col, trgRow);
+            } else {
+                int offset = up ? -1 : 1;
+                slideRows(rows, col, offset);
             }
         };
         alignPanel.moveUpButton.addActionListener(oneAdjustListener);
@@ -342,115 +336,96 @@ public class AlignPanelController {
         alignPanel.moveDownButton.addActionListener(oneAdjustListener);
         alignMenuFrame.moveDownItem.addActionListener(oneAdjustListener);
 
-        ActionListener mergeListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                int[] rows = alignPanel.table.getSelectedRows();
-                int col = alignPanel.table.getSelectedColumn();
-                BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
-                if (rows.length == 1) {
-                    rows = new int[] { rows[0], model.nextNonEmptyCell(rows[0], col) };
-                }
-                int beads = model.beadsInRowSpan(rows);
-                if (beads >= 1) {
-                    if (beads == 1) {
-                        mergeRows(rows, col);
-                    } else {
-                        moveRows(rows, col, rows[0]);
-                    }
+        ActionListener mergeListener = e -> {
+            int[] rows = alignPanel.table.getSelectedRows();
+            int col = alignPanel.table.getSelectedColumn();
+            BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
+            if (rows.length == 1) {
+                rows = new int[] { rows[0], model.nextNonEmptyCell(rows[0], col) };
+            }
+            int beads = model.beadsInRowSpan(rows);
+            if (beads >= 1) {
+                if (beads == 1) {
+                    mergeRows(rows, col);
+                } else {
+                    moveRows(rows, col, rows[0]);
                 }
             }
         };
         alignPanel.mergeButton.addActionListener(mergeListener);
         alignMenuFrame.mergeItem.addActionListener(mergeListener);
 
-        ActionListener splitListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                int[] rows = alignPanel.table.getSelectedRows();
-                int col = alignPanel.table.getSelectedColumn();
-                BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
-                int beads = model.beadsInRowSpan(rows);
-                if (beads == 1) {
-                    if (rows.length == 1) {
-                        splitRow(rows[0], col);
-                    } else {
-                        splitBead(rows, col);
-                    }
+        ActionListener splitListener = e -> {
+            int[] rows = alignPanel.table.getSelectedRows();
+            int col = alignPanel.table.getSelectedColumn();
+            BeadTableModel model = (BeadTableModel) alignPanel.table.getModel();
+            int beads = model.beadsInRowSpan(rows);
+            if (beads == 1) {
+                if (rows.length == 1) {
+                    splitRow(rows[0], col);
+                } else {
+                    splitBead(rows, col);
                 }
             }
         };
         alignPanel.splitButton.addActionListener(splitListener);
         alignMenuFrame.splitItem.addActionListener(splitListener);
 
-        ActionListener editListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent arg0) {
-                int row = alignPanel.table.getSelectedRow();
-                int col = alignPanel.table.getSelectedColumn();
-                editRow(row, col);
-            }
+        ActionListener editListener = arg0 -> {
+            int row = alignPanel.table.getSelectedRow();
+            int col = alignPanel.table.getSelectedColumn();
+            editRow(row, col);
         };
         alignPanel.editButton.addActionListener(editListener);
         alignMenuFrame.editItem.addActionListener(editListener);
 
-        ListSelectionListener selectionListener = new ListSelectionListener() {
-            @Override
-            public void valueChanged(ListSelectionEvent e) {
-                updateCommandAvailability(alignPanel, alignMenuFrame);
-            }
-        };
+        ListSelectionListener selectionListener = e -> updateCommandAvailability(alignPanel, alignMenuFrame);
         alignPanel.table.getColumnModel().getSelectionModel().addListSelectionListener(selectionListener);
         alignPanel.table.getSelectionModel().addListSelectionListener(selectionListener);
 
-        ActionListener saveListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (!confirmSaveTMX(alignPanel)) {
-                    return;
-                }
-                while (true) {
-                    JFileChooser chooser = new JFileChooser();
-                    chooser.setSelectedFile(new File(defaultSaveDir, getOutFileName()));
-                    chooser.setDialogTitle(BUNDLE.getString("ALIGNER_PANEL_DIALOG_SAVE"));
-                    if (JFileChooser.APPROVE_OPTION == chooser.showSaveDialog(alignMenuFrame)) {
-                        File file = chooser.getSelectedFile();
-                        if (file.isFile()) {
-                            if (JOptionPane.OK_OPTION != JOptionPane.showConfirmDialog(alignMenuFrame,
-                                    StringUtil.format(BUNDLE.getString("ALIGNER_PANEL_DIALOG_OVERWRITE"),
-                                            file.getName()),
-                                    BUNDLE.getString("ALIGNER_DIALOG_WARNING_TITLE"),
-                                    JOptionPane.WARNING_MESSAGE)) {
-                                continue;
-                            }
-                        }
-                        List<MutableBead> beads = ((BeadTableModel) alignPanel.table.getModel()).getData();
-                        try {
-                            aligner.writePairsToTMX(file,
-                                    MutableBead.beadsToEntries(aligner.srcLang, aligner.trgLang, beads));
-                            modified = false;
-                        } catch (Exception ex) {
-                            LOGGER.atInfo().setCause(ex).log();
-                            JOptionPane.showMessageDialog(alignMenuFrame, BUNDLE.getString("ALIGNER_PANEL_SAVE_ERROR"),
-                                    BUNDLE.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
+        ActionListener saveListener = e -> {
+            if (!confirmSaveTMX(alignPanel)) {
+                return;
+            }
+            while (true) {
+                JFileChooser chooser = new JFileChooser();
+                chooser.setSelectedFile(new File(defaultSaveDir, getOutFileName()));
+                chooser.setDialogTitle(BUNDLE.getString("ALIGNER_PANEL_DIALOG_SAVE"));
+                if (JFileChooser.APPROVE_OPTION == chooser.showSaveDialog(alignMenuFrame)) {
+                    File file = chooser.getSelectedFile();
+                    if (file.isFile()) {
+                        if (JOptionPane.OK_OPTION != JOptionPane.showConfirmDialog(alignMenuFrame,
+                                StringUtil.format(BUNDLE.getString("ALIGNER_PANEL_DIALOG_OVERWRITE"),
+                                        file.getName()),
+                                BUNDLE.getString("ALIGNER_DIALOG_WARNING_TITLE"),
+                                JOptionPane.WARNING_MESSAGE)) {
+                            continue;
                         }
                     }
-                    break;
+                    List<MutableBead> beads = ((BeadTableModel) alignPanel.table.getModel()).getData();
+                    try {
+                        aligner.writePairsToTMX(file,
+                                MutableBead.beadsToEntries(aligner.srcLang, aligner.trgLang, beads));
+                        modified = false;
+                    } catch (Exception ex) {
+                        LOGGER.atInfo().setCause(ex).log();
+                        JOptionPane.showMessageDialog(alignMenuFrame,
+                                BUNDLE.getString("ALIGNER_PANEL_SAVE_ERROR"), BUNDLE.getString("ERROR_TITLE"),
+                                JOptionPane.ERROR_MESSAGE);
+                    }
                 }
+                break;
             }
         };
         alignPanel.saveButton.addActionListener(saveListener);
         alignMenuFrame.saveItem.addActionListener(saveListener);
 
-        ActionListener resetListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (confirmReset(alignMenuFrame)) {
-                    if (phase == Phase.ALIGN) {
-                        aligner.restoreDefaults();
-                    }
-                    reloadBeads();
+        ActionListener resetListener = e -> {
+            if (confirmReset(alignMenuFrame)) {
+                if (phase == Phase.ALIGN) {
+                    aligner.restoreDefaults();
                 }
+                reloadBeads();
             }
         };
         alignPanel.resetButton.addActionListener(resetListener);
@@ -464,101 +439,58 @@ public class AlignPanelController {
         };
         alignMenuFrame.reloadItem.addActionListener(reloadListener);
 
-        ActionListener removeTagsListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                boolean newValue = ((AbstractButton) e.getSource()).isSelected();
-                if (newValue != aligner.removeTags && confirmReset(alignMenuFrame)) {
-                    aligner.removeTags = newValue;
-                    aligner.clearLoaded();
-                    reloadBeads();
-                } else {
-                    alignPanel.removeTagsCheckBox.setSelected(aligner.removeTags);
-                    alignMenuFrame.removeTagsItem.setSelected(aligner.removeTags);
-                }
+        ActionListener removeTagsListener = e -> {
+            boolean newValue = ((AbstractButton) e.getSource()).isSelected();
+            if (newValue != aligner.removeTags && confirmReset(alignMenuFrame)) {
+                aligner.removeTags = newValue;
+                aligner.clearLoaded();
+                reloadBeads();
+            } else {
+                alignPanel.removeTagsCheckBox.setSelected(aligner.removeTags);
+                alignMenuFrame.removeTagsItem.setSelected(aligner.removeTags);
             }
         };
         alignPanel.removeTagsCheckBox.addActionListener(removeTagsListener);
         alignMenuFrame.removeTagsItem.addActionListener(removeTagsListener);
 
-        alignPanel.continueButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                phase = Phase.EDIT;
-                updatePanel();
-            }
+        alignPanel.continueButton.addActionListener(e -> {
+            phase = Phase.EDIT;
+            updatePanel();
         });
 
-        ActionListener highlightListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                doHighlight = ((AbstractButton) e.getSource()).isSelected();
-                updateHighlight();
-            }
+        ActionListener highlightListener = e -> {
+            doHighlight = ((AbstractButton) e.getSource()).isSelected();
+            updateHighlight();
         };
         alignPanel.highlightCheckBox.addActionListener(highlightListener);
         alignMenuFrame.highlightItem.addActionListener(highlightListener);
 
-        ActionListener highlightPatternListener = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                PatternPanelController patternEditor = new PatternPanelController(highlightPattern);
-                highlightPattern = patternEditor.show(alignMenuFrame);
-                Preferences.setPreference(Preferences.ALIGNER_HIGHLIGHT_PATTERN, highlightPattern.pattern());
-                updateHighlight();
-            }
+        ActionListener highlightPatternListener = e -> {
+            PatternPanelController patternEditor = new PatternPanelController(highlightPattern);
+            highlightPattern = patternEditor.show(alignMenuFrame);
+            Preferences.setPreference(Preferences.ALIGNER_HIGHLIGHT_PATTERN, highlightPattern.pattern());
+            updateHighlight();
         };
         alignPanel.highlightPatternButton.addActionListener(highlightPatternListener);
         alignMenuFrame.highlightPatternItem.addActionListener(highlightPatternListener);
 
-        alignMenuFrame.markAcceptedItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                setStatus(MutableBead.Status.ACCEPTED, alignPanel.table.getSelectedRows());
-            }
-        });
+        alignMenuFrame.markAcceptedItem
+                .addActionListener(e -> setStatus(Status.ACCEPTED, alignPanel.table.getSelectedRows()));
 
-        alignMenuFrame.markNeedsReviewItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                setStatus(MutableBead.Status.NEEDS_REVIEW, alignPanel.table.getSelectedRows());
-            }
-        });
+        alignMenuFrame.markNeedsReviewItem
+                .addActionListener(e -> setStatus(Status.NEEDS_REVIEW, alignPanel.table.getSelectedRows()));
 
-        alignMenuFrame.clearMarkItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                setStatus(MutableBead.Status.DEFAULT, alignPanel.table.getSelectedRows());
-            }
-        });
+        alignMenuFrame.clearMarkItem
+                .addActionListener(e -> setStatus(Status.DEFAULT, alignPanel.table.getSelectedRows()));
 
-        alignMenuFrame.toggleSelectedItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                toggleEnabled(alignPanel.table.getSelectedRows());
-            }
-        });
+        alignMenuFrame.toggleSelectedItem
+                .addActionListener(e -> toggleEnabled(alignPanel.table.getSelectedRows()));
 
-        alignMenuFrame.closeItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                closeFrame(alignMenuFrame);
-            }
-        });
+        alignMenuFrame.closeItem.addActionListener(e -> closeFrame(alignMenuFrame));
 
-        alignMenuFrame.keepAllItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                toggleAllEnabled(true);
-            }
-        });
+        alignMenuFrame.keepAllItem.addActionListener(e -> toggleAllEnabled(true));
 
-        alignMenuFrame.keepNoneItem.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                toggleAllEnabled(false);
-            }
-        });
+        alignMenuFrame.keepNoneItem.addActionListener(e -> toggleAllEnabled(false));
 
         alignMenuFrame.realignPendingItem.addActionListener(e -> {
             realignPending();
@@ -597,13 +529,13 @@ public class AlignPanelController {
         });
 
         alignMenuFrame.resetItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R,
-                Java8Compat.getMenuShortcutKeyMaskEx() | KeyEvent.SHIFT_DOWN_MASK));
-        alignMenuFrame.realignPendingItem.setAccelerator(
-                KeyStroke.getKeyStroke(KeyEvent.VK_R, Java8Compat.getMenuShortcutKeyMaskEx()));
-        alignMenuFrame.saveItem.setAccelerator(
-                KeyStroke.getKeyStroke(KeyEvent.VK_S, Java8Compat.getMenuShortcutKeyMaskEx()));
-        alignMenuFrame.closeItem.setAccelerator(
-                KeyStroke.getKeyStroke(KeyEvent.VK_W, Java8Compat.getMenuShortcutKeyMaskEx()));
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx() | KeyEvent.SHIFT_DOWN_MASK));
+        alignMenuFrame.realignPendingItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R,
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+        alignMenuFrame.saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+        alignMenuFrame.closeItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
 
         // emacs-like keys for table navigation
         // See javax.swing.plaf.BasicTableUI.Actions for supported action names.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -89,8 +89,6 @@ import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
 import org.apache.commons.io.FilenameUtils;
-import tokyo.northside.logging.ILogger;
-import tokyo.northside.logging.LoggerFactory;
 
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
@@ -106,6 +104,7 @@ import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.segmentation.SegmentationCustomizer;
 import org.omegat.util.Java8Compat;
 import org.omegat.util.Language;
+import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.DelegatingComboBoxRenderer;
@@ -121,7 +120,6 @@ import gen.core.filters.Filters;
  */
 public class AlignPanelController {
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
-    private static final ILogger LOGGER = LoggerFactory.getLogger(AlignPanelController.class, BUNDLE);
     private final Aligner aligner;
     private final String defaultSaveDir;
     private boolean modified = false;
@@ -402,7 +400,7 @@ public class AlignPanelController {
                                 MutableBead.beadsToEntries(aligner.srcLang, aligner.trgLang, beads));
                         modified = false;
                     } catch (Exception ex) {
-                        LOGGER.atInfo().setCause(ex).log();
+                        Log.log(ex);
                         JOptionPane.showMessageDialog(alignMenuFrame,
                                 BUNDLE.getString("ALIGNER_PANEL_SAVE_ERROR"), BUNDLE.getString("ERROR_TITLE"),
                                 JOptionPane.ERROR_MESSAGE);
@@ -813,7 +811,7 @@ public class AlignPanelController {
                 } catch (CancellationException ex) {
                     // Ignore
                 } catch (Exception e) {
-                    LOGGER.atInfo().setCause(e).log();
+                    Log.log(e);
                     JOptionPane.showMessageDialog(alignPanel, BUNDLE.getString("ALIGNER_ERROR_LOADING"),
                             BUNDLE.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                 }
@@ -985,7 +983,7 @@ public class AlignPanelController {
                 try {
                     Core.getProject().saveProjectProperties();
                 } catch (Exception ex) {
-                    LOGGER.atInfo().setCause(ex).log();
+                    Log.log(ex);
                     JOptionPane.showMessageDialog(comp, BUNDLE.getString("CT_ERROR_SAVING_PROJ"),
                             BUNDLE.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                 }
@@ -1018,7 +1016,7 @@ public class AlignPanelController {
                 try {
                     Core.getProject().saveProjectProperties();
                 } catch (Exception ex) {
-                    LOGGER.atInfo().setCause(ex).log();
+                    Log.log(ex);
                     JOptionPane.showMessageDialog(comp, BUNDLE.getString("CT_ERROR_SAVING_PROJ"),
                             BUNDLE.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                 }
@@ -1949,7 +1947,7 @@ public class AlignPanelController {
                     return model.canMoveTo(trgRow, realRows.get(realRows.size() - 1), col, false);
                 }
             } catch (Exception e) {
-                LOGGER.atInfo().setCause(e).log();
+                Log.log(e);
             }
             return false;
         }
@@ -1975,7 +1973,7 @@ public class AlignPanelController {
                 moveRows(rows, col, trgRow);
                 return true;
             } catch (Exception e) {
-                LOGGER.atInfo().setCause(e).log();
+                Log.log(e);
             }
             return false;
         }

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -95,7 +95,6 @@ import tokyo.northside.logging.LoggerFactory;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.segmentation.SRX;
-import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.gui.align.Aligner.AlgorithmClass;
 import org.omegat.gui.align.Aligner.CalculatorType;
@@ -160,16 +159,10 @@ public class AlignPanelController {
     }
 
     private Phase phase = Phase.ALIGN;
-    private final Segmenter segmenter;
 
     public AlignPanelController(Aligner aligner, String defaultSaveDir) {
-        this(aligner, defaultSaveDir, Core.getSegmenter());
-    }
-
-    public AlignPanelController(Aligner aligner, String defaultSaveDir, Segmenter segmenter) {
         this.aligner = aligner;
         this.defaultSaveDir = defaultSaveDir;
-        this.segmenter = segmenter;
     }
 
     /**
@@ -281,9 +274,10 @@ public class AlignPanelController {
         ActionListener segmentingRulesListener = e -> {
             if (confirmReset(alignMenuFrame)) {
                 SegmentationCustomizer customizer = new SegmentationCustomizer(false, SRX.getDefault(),
-                        segmenter.getSRX(), null);
+                        aligner.getSegmenter().getSRX(), null);
                 if (customizer.show(alignMenuFrame)) {
                     customizedSRX = customizer.getResult();
+                    aligner.updateSegmenter(customizedSRX);
                     reloadBeads();
                 }
             }

--- a/aligner/src/main/java/org/omegat/gui/align/Aligner.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Aligner.java
@@ -164,7 +164,7 @@ public class Aligner {
     private List<String> trgRaw;
     private List<Entry<String, String>> idPairs;
     List<ComparisonMode> allowedModes;
-    private final Segmenter segmenter;
+    private Segmenter segmenter;
     private final FilterMaster fm;
 
     public Aligner(String srcFile, Language srcLang, String trgFile, Language trgLang) {
@@ -174,10 +174,18 @@ public class Aligner {
         this.trgLang = trgLang;
         restoreDefaults();
         SRX srx = Preferences.getSRX();
-        segmenter = srx != null ? new Segmenter(srx) : new Segmenter(SRX.getDefault());
+        updateSegmenter(srx != null ? srx : SRX.getDefault());
         Filters filters = Preferences.getFilters() != null ? Preferences.getFilters()
                 : FilterMaster.createDefaultFiltersConfig();
         fm = new FilterMaster(filters);
+    }
+
+    void updateSegmenter(SRX srx) {
+        segmenter = new Segmenter(srx);
+    }
+
+    Segmenter getSegmenter() {
+        return segmenter;
     }
 
     /**
@@ -330,7 +338,8 @@ public class Aligner {
             throw new UnsupportedOperationException();
         }
         return IntStream.range(0, srcRaw.size())
-                .mapToObj(i -> new Alignment(Arrays.asList(srcRaw.get(i)), Arrays.asList(trgRaw.get(i))));
+                .mapToObj(i -> new Alignment(Collections.singletonList(srcRaw.get(i)),
+                        Collections.singletonList(trgRaw.get(i))));
     }
 
     /**
@@ -364,7 +373,8 @@ public class Aligner {
             throw new UnsupportedOperationException();
         }
         return idPairs.stream()
-                .map(e -> new Alignment(Arrays.asList(e.getKey()), Arrays.asList(e.getValue())));
+                .map(e -> new Alignment(Collections.singletonList(e.getKey()),
+                        Collections.singletonList(e.getValue())));
     }
 
     /**

--- a/aligner/src/main/java/org/omegat/gui/align/Aligner.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Aligner.java
@@ -57,21 +57,26 @@ import net.loomchild.maligna.matrix.MatrixFactory;
 import tokyo.northside.logging.ILogger;
 import tokyo.northside.logging.LoggerFactory;
 
-import org.omegat.core.Core;
 import org.omegat.core.data.ParseEntry;
 import org.omegat.core.data.ParseEntry.ParseEntryResult;
 import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.IFilter;
 import org.omegat.filters2.IParseCallback;
+import org.omegat.filters2.master.FilterMaster;
 import org.omegat.util.Language;
 import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TMXWriter2;
 
+import gen.core.filters.Filters;
+
 /**
- * Class to drive alignment of input files. Responsible for filtering and performing automatic alignment with
- * mALIGNa.
+ * Class to drive alignment of input files. Responsible for filtering and
+ * performing automatic alignment with mALIGNa.
  *
  * @author Aaron Madlon-Kay
  *
@@ -89,24 +94,27 @@ public class Aligner {
     boolean removeTags = false;
 
     /**
-     * Modes indicating the ways in which the source text can be sent to the alignment algorithm.
+     * Modes indicating the ways in which the source text can be sent to the
+     * alignment algorithm.
      */
     enum ComparisonMode {
         /**
-         * Take all source lines and align against all target lines. This is the default as it makes no
-         * demands of the input files.
+         * Take all source lines and align against all target lines. This is the
+         * default as it makes no demands of the input files.
          */
         HEAPWISE,
 
         /**
-         * This mode is only available when the source and target files extract to the same number of text
-         * units. Source and target strings with the same index are aligned separately.
+         * This mode is only available when the source and target files extract
+         * to the same number of text units. Source and target strings with the
+         * same index are aligned separately.
          */
         PARSEWISE,
 
         /**
-         * This mode is only available when the source and target files provide IDs for all their text units.
-         * Each unit with matching ID is aligned separately.
+         * This mode is only available when the source and target files provide
+         * IDs for all their text units. Each unit with matching ID is aligned
+         * separately.
          */
         ID
     }
@@ -144,8 +152,7 @@ public class Aligner {
     }
 
     enum CounterType {
-        CHAR,
-        WORD
+        CHAR, WORD
     }
 
     ComparisonMode comparisonMode;
@@ -157,6 +164,8 @@ public class Aligner {
     private List<String> trgRaw;
     private List<Entry<String, String>> idPairs;
     List<ComparisonMode> allowedModes;
+    private final Segmenter segmenter;
+    private final FilterMaster fm;
 
     public Aligner(String srcFile, Language srcLang, String trgFile, Language trgLang) {
         this.srcFile = srcFile;
@@ -164,11 +173,17 @@ public class Aligner {
         this.trgFile = trgFile;
         this.trgLang = trgLang;
         restoreDefaults();
+        SRX srx = Preferences.getSRX();
+        segmenter = srx != null ? new Segmenter(srx) : new Segmenter(SRX.getDefault());
+        Filters filters = Preferences.getFilters() != null ? Preferences.getFilters()
+                : FilterMaster.createDefaultFiltersConfig();
+        fm = new FilterMaster(filters);
     }
 
     /**
-     * Parse the input files and extract the alignable text, which is retained in memory so that different
-     * alignment settings can be tried without re-parsing the files. This determines the available
+     * Parse the input files and extract the alignable text, which is retained
+     * in memory so that different alignment settings can be tried without
+     * re-parsing the files. This determines the available
      * {@link ComparisonMode}s, available in {@link #allowedModes}.
      *
      * @throws Exception
@@ -247,21 +262,21 @@ public class Aligner {
     private Entry<List<String>, List<String>> parseFile(String file) throws Exception {
         final List<String> ids = new ArrayList<>();
         final List<String> rawSegs = new ArrayList<>();
-        Core.getFilterMaster().loadFile(file, new FilterContext(srcLang, trgLang, true).setRemoveAllTags(removeTags),
+        fm.loadFile(file, new FilterContext(srcLang, trgLang, true).setRemoveAllTags(removeTags),
                 new IParseCallback() {
                     @Override
                     public void linkPrevNextSegments() {
                     }
 
                     @Override
-                    public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                            IFilter filter) {
+                    public void addEntry(String id, String source, String translation, boolean isFuzzy,
+                            String comment, IFilter filter) {
                         process(source, id);
                     }
 
                     @Override
-                    public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
-                            String path, IFilter filter, List<ProtectedPart> protectedParts) {
+                    public void addEntry(String id, String source, String translation, boolean isFuzzy,
+                            String comment, String path, IFilter filter, List<ProtectedPart> protectedParts) {
                         process(source, id != null ? id : path);
                     }
 
@@ -274,7 +289,7 @@ public class Aligner {
                     }
 
                     private void process(String text, String id) {
-                        boolean removeSpaces = Core.getFilterMaster().getConfig().isRemoveSpacesNonseg();
+                        boolean removeSpaces = fm.getConfig().isRemoveSpacesNonseg();
                         text = StringUtil.normalizeUnicode(ParseEntry.stripSomeChars(text,
                                 new ParseEntryResult(), removeTags, removeSpaces));
                         if (!text.trim().isEmpty()) {
@@ -289,8 +304,8 @@ public class Aligner {
     }
 
     /**
-     * Segment the specified list of strings into a flat list of strings. The resulting list will be free of
-     * empty strings.
+     * Segment the specified list of strings into a flat list of strings. The
+     * resulting list will be free of empty strings.
      *
      * @param language
      *            The language of the texts to be segmented
@@ -299,16 +314,16 @@ public class Aligner {
      * @return Flattened list of segments
      */
     private List<String> segmentAll(Language language, List<String> rawTexts) {
-        return rawTexts.stream().flatMap(text -> Core.getSegmenter().segment(language, text, null, null).stream())
+        return rawTexts.stream().flatMap(text -> segmenter.segment(language, text, null, null).stream())
                 .filter(s -> !s.isEmpty()).collect(Collectors.toList());
     }
 
     /**
-     * Align {@link ComparisonMode#PARSEWISE} without first segmenting the source and target strings. No
-     * alignment algorithm is applied.
+     * Align {@link ComparisonMode#PARSEWISE} without first segmenting the
+     * source and target strings. No alignment algorithm is applied.
      *
-     * @return List of beads where each entry of {@link #srcRaw} is aligned by index with each entry of
-     *         {@link #trgRaw}
+     * @return List of beads where each entry of {@link #srcRaw} is aligned by
+     *         index with each entry of {@link #trgRaw}
      */
     private Stream<Alignment> alignParsewiseNotSegmented() {
         if (!allowedModes.contains(ComparisonMode.PARSEWISE)) {
@@ -319,28 +334,28 @@ public class Aligner {
     }
 
     /**
-     * Align {@link ComparisonMode#PARSEWISE} the source and target strings. Each pair is segmented and
-     * aligned separately by algorithm.
+     * Align {@link ComparisonMode#PARSEWISE} the source and target strings.
+     * Each pair is segmented and aligned separately by algorithm.
      *
-     * @return List of beads where each entry of {@link #srcRaw} is aligned by index with each entry of
-     *         {@link #trgRaw}
+     * @return List of beads where each entry of {@link #srcRaw} is aligned by
+     *         index with each entry of {@link #trgRaw}
      */
     private Stream<Alignment> alignParsewiseSegmented() {
         if (!allowedModes.contains(ComparisonMode.PARSEWISE)) {
             throw new UnsupportedOperationException();
         }
         return IntStream.range(0, srcRaw.size()).mapToObj(i -> {
-            List<String> source = Core.getSegmenter().segment(srcLang, srcRaw.get(i), null, null).stream()
+            List<String> source = segmenter.segment(srcLang, srcRaw.get(i), null, null).stream()
                     .filter(s -> !s.isEmpty()).collect(Collectors.toList());
-            List<String> target = Core.getSegmenter().segment(trgLang, trgRaw.get(i), null, null).stream()
+            List<String> target = segmenter.segment(trgLang, trgRaw.get(i), null, null).stream()
                     .filter(s -> !s.isEmpty()).collect(Collectors.toList());
             return doAlign(algorithmClass, calculatorType, counterType, source, target);
         }).flatMap(List::stream);
     }
 
     /**
-     * Align by {@link ComparisonMode#ID} without first segmenting the source and target strings. No alignment
-     * algorithm is applied.
+     * Align by {@link ComparisonMode#ID} without first segmenting the source
+     * and target strings. No alignment algorithm is applied.
      *
      * @return List of beads aligned by ID
      */
@@ -353,8 +368,8 @@ public class Aligner {
     }
 
     /**
-     * Align source and target strings by {@link ComparisonMode#ID}. Each pair is segmented and aligned
-     * separately by algorithm.
+     * Align source and target strings by {@link ComparisonMode#ID}. Each pair
+     * is segmented and aligned separately by algorithm.
      *
      * @return List of beads aligned by ID
      */
@@ -363,16 +378,17 @@ public class Aligner {
             throw new UnsupportedOperationException();
         }
         return idPairs.stream().map(e -> {
-            List<String> source = Core.getSegmenter().segment(srcLang, e.getKey(), null, null).stream()
+            List<String> source = segmenter.segment(srcLang, e.getKey(), null, null).stream()
                     .filter(s -> !s.isEmpty()).collect(Collectors.toList());
-            List<String> target = Core.getSegmenter().segment(trgLang, e.getValue(), null, null).stream()
+            List<String> target = segmenter.segment(trgLang, e.getValue(), null, null).stream()
                     .filter(s -> !s.isEmpty()).collect(Collectors.toList());
             return doAlign(algorithmClass, calculatorType, counterType, source, target);
         }).flatMap(List::stream);
     }
 
     /**
-     * Align {@link ComparisonMode#HEAPWISE}. Input text is optionally segmented, then aligned by algorithm.
+     * Align {@link ComparisonMode#HEAPWISE}. Input text is optionally
+     * segmented, then aligned by algorithm.
      *
      * @param doSegmenting
      *            Whether to segment the text
@@ -386,9 +402,13 @@ public class Aligner {
 
     /**
      * Write string pair entries as TMX file.
-     * @param outFile target output.
-     * @param pairs List of map.entry with String.
-     * @throws Exception when got I/O error.
+     * 
+     * @param outFile
+     *            target output.
+     * @param pairs
+     *            List of map.entry with String.
+     * @throws Exception
+     *             when got I/O error.
      */
     public void writePairsToTMX(File outFile, List<Entry<String, String>> pairs) throws Exception {
         TMXWriter2 writer = null;
@@ -411,8 +431,9 @@ public class Aligner {
     }
 
     /**
-     * Perform alignment according to the current settings and return the resulting list of beads. Will call
-     * {@link #loadFiles()} if it has not yet been called.
+     * Perform alignment according to the current settings and return the
+     * resulting list of beads. Will call {@link #loadFiles()} if it has not yet
+     * been called.
      *
      * @return List of beads
      * @throws Exception
@@ -435,8 +456,8 @@ public class Aligner {
     }
 
     /**
-     * Align the input files according to the current settings to a list
-     * of pairs where
+     * Align the input files according to the current settings to a list of
+     * pairs where
      * <ol>
      * <li>key = source text
      * <li>value = target text
@@ -456,7 +477,8 @@ public class Aligner {
     }
 
     /**
-     * Obtain appropriate calculator according to the specified {@link CalculatorType}.
+     * Obtain appropriate calculator according to the specified
+     * {@link CalculatorType}.
      *
      * @param calculatorType
      * @param counterType
@@ -480,7 +502,8 @@ public class Aligner {
      * Obtain appropriate counter according to the specified
      * {@link CounterType}.
      *
-     * @param counterType counter type.
+     * @param counterType
+     *            counter type.
      * @return counter object.
      */
     private static Counter getCounter(CounterType counterType) {
@@ -495,11 +518,13 @@ public class Aligner {
     }
 
     /**
-     * Obtain an appropriate aligned algorithm object according
-     * to the specified {@link AlgorithmClass}.
+     * Obtain an appropriate aligned algorithm object according to the specified
+     * {@link AlgorithmClass}.
      *
-     * @param algorithmClass algorithm requested.
-     * @param calculator calculator object.
+     * @param algorithmClass
+     *            algorithm requested.
+     * @param calculator
+     *            calculator object.
      * @return algorithm object.
      */
     private static AlignAlgorithm getAlgorithm(AlgorithmClass algorithmClass, Calculator calculator) {
@@ -516,7 +541,8 @@ public class Aligner {
     }
 
     /**
-     * Use mALIGNa to align the specified source and target texts, according to the specified parameters.
+     * Use mALIGNa to align the specified source and target texts, according to
+     * the specified parameters.
      *
      * @param algorithmClass
      * @param calculatorType

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
@@ -33,6 +33,7 @@ import java.util.ResourceBundle;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
 
+import org.omegat.core.data.ProjectProperties;
 import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
@@ -69,7 +70,8 @@ public final class AlignerModule {
             }
 
             private void unregisterMenu() {
-                MenuExtender.removeMenuItems(MenuExtender.MenuKey.TOOLS, Collections.singletonList(alignerMenu));
+                MenuExtender.removeMenuItems(MenuExtender.MenuKey.TOOLS,
+                        Collections.singletonList(alignerMenu));
             }
 
             private void registerMenu() {
@@ -84,15 +86,16 @@ public final class AlignerModule {
                 Component mainWindow = Core.getMainWindow().getApplicationFrame();
                 AlignFilePickerController picker = new AlignFilePickerController();
                 if (Core.getProject().isProjectLoaded()) {
-                    String srcRoot = Core.getProject().getProjectProperties().getSourceRoot();
+                    ProjectProperties props = Core.getProject().getProjectProperties();
+                    String srcRoot = props.getSourceRoot();
                     String curFile = Core.getEditor().getCurrentFile();
                     if (curFile != null) {
                         picker.setSourceFile(srcRoot + curFile);
                     }
                     picker.setSourceDefaultDir(srcRoot);
-                    picker.setDefaultSaveDir(Core.getProject().getProjectProperties().getTMRoot());
-                    picker.setSourceLanguage(Core.getProject().getProjectProperties().getSourceLanguage());
-                    picker.setTargetLanguage(Core.getProject().getProjectProperties().getTargetLanguage());
+                    picker.setDefaultSaveDir(props.getTMRoot());
+                    picker.setSourceLanguage(props.getSourceLanguage());
+                    picker.setTargetLanguage(props.getTargetLanguage());
                 } else {
                     String srcLang = Preferences.getPreference(Preferences.SOURCE_LOCALE);
                     if (!StringUtil.isEmpty(srcLang)) {

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
@@ -33,11 +33,11 @@ import java.util.ResourceBundle;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
 
-import org.omegat.core.data.ProjectProperties;
 import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;

--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -79,11 +79,17 @@ public class AlignerWindowTest extends TestCoreGUI {
         picker.comboBox("targetLanguagePicker").requireSelection("fr - French");
         //
         picker.button("sourceChooseFileButton").click();
-        picker.fileChooser().selectFile(new File(tmpDir, SOURCE_PATH));
-        picker.fileChooser().approve();
+        picker.fileChooser("aligner_choose_source").requireVisible();
+        picker.fileChooser("aligner_choose_source").selectFile(new File(tmpDir, SOURCE_PATH));
+        picker.fileChooser("aligner_choose_source").approve();
+        robot().waitForIdle();
+        //
         picker.button("targetChooseFileButton").click();
-        picker.fileChooser().selectFile(new File(tmpDir, TARGET_PATH));
-        picker.fileChooser().approve();
+        picker.fileChooser("aligner_choose_target").requireVisible();
+        picker.fileChooser("aligner_choose_target").selectFile(new File(tmpDir, TARGET_PATH));
+        picker.fileChooser("aligner_choose_target").approve();
+        robot().waitForIdle();
+        //
         String srcFile = picker.textBox("sourceLanguageFileField").text();
         assertNotNull(srcFile);
         assertTrue(srcFile.endsWith(SOURCE_PATH.substring(SOURCE_PATH.indexOf('/') + 1)));

--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -99,6 +99,7 @@ public class AlignerWindowTest extends TestCoreGUI {
         //
         picker.button("OK").requireEnabled(Timeout.timeout(100));
         picker.button("OK").click();
+        robot().waitForIdle();
         //
         FrameFixture aligner = WindowFinder.findFrame("ALIGN_MENU_FRAME").withTimeout(5000).using(robot());
         aligner.requireTitle("Align");
@@ -137,7 +138,7 @@ public class AlignerWindowTest extends TestCoreGUI {
                 .requireText(Pattern.compile("Average Score:\\s(-|\\d\\.\\d{3})"));
         //
         aligner.button("align_panel_continue_button").click();
-        aligner.button("align_panel_save_button").requireEnabled();
+        aligner.button("align_panel_save_button").requireEnabled(Timeout.timeout(100));
         aligner.panel("align_panel").label("align_panel_instructions_label")
                 .requireText("Step 2: Make manual corrections");
         aligner.panel("align_controls_panel").requireVisible();


### PR DESCRIPTION
The Aligner depends on the Core configuration of segmentation and the filters.
It is not good to access Core API throughout the code, but it can be taken in ctor once.

## Pull request type

- Other (describe below)
refactor

## What does this PR change?

- Add a constructor to take the segmenter as an argument for testing.
- Logger is instantiated with Bundle.
- Rewrite action listeners with lambdas.
- Aligner class holds its own the segmenter and the filter master objects.

## Other information
- [x] Acceptance test
