### PR TITLE
fix: aligner: fix initialize average distance label

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanel.form
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanel.form
@@ -342,8 +342,8 @@
                 </Component>
                 <Component class="javax.swing.JLabel" name="averageDistanceLabel">
                   <Properties>
-                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-                      <ResourceString bundle="org/omegat/gui/align/Bundle.properties" key="ALIGNER_PANEL_LABEL_AVGSCORE" replaceFormat="BUNDLE.getString(&quot;{key}&quot;)"/>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="StringUtil.format(BUNDLE.getString(&quot;ALIGNER_PANEL_LABEL_AVGSCORE&quot;), &quot;-&quot;)" type="code"/>
                     </Property>
                   </Properties>
                   <AuxValues>

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanel.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanel.java
@@ -34,6 +34,7 @@ import org.omegat.gui.align.Aligner.AlgorithmClass;
 import org.omegat.gui.align.Aligner.CalculatorType;
 import org.omegat.gui.align.Aligner.ComparisonMode;
 import org.omegat.gui.align.Aligner.CounterType;
+import org.omegat.util.StringUtil;
 
 /**
  * UI component for displaying and editing the results of algorithmic alignment.
@@ -204,7 +205,7 @@ public class AlignPanel extends javax.swing.JPanel {
         jPanel7.add(comparisonComboBox);
         jPanel7.add(filler5);
 
-        averageDistanceLabel.setText(BUNDLE.getString("ALIGNER_PANEL_LABEL_AVGSCORE")); // NOI18N
+        averageDistanceLabel.setText(StringUtil.format(BUNDLE.getString("ALIGNER_PANEL_LABEL_AVGSCORE"), "-"));
         jPanel7.add(averageDistanceLabel);
         jPanel7.add(filler6);
 

--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import org.assertj.swing.data.TableCell;
 import org.assertj.swing.finder.WindowFinder;
@@ -81,12 +82,12 @@ public class AlignerWindowTest extends TestCoreGUI {
         //
         aligner.panel("align_panel").label("align_panel_instructions_label")
                 .requireText("Step 1: Adjust alignment parameters");
-        aligner.panel("align_panel").label("align_panel_average_distance_label")
-                .requireText("Average Score: 1.011");
+        aligner.panel("align_panel").comboBox("align_panel_comparison_cb").requireSelection("Heapwise");
+        aligner.panel("align_panel").comboBox("align_panel_algorithm_cb").requireSelection("Viterbi");
+        aligner.panel("align_panel").comboBox("align_panel_calculator_cb").requireSelection("Normal");
         //
         aligner.panel("align_panel").table("align_panel_table").requireRowCount(5);
         aligner.panel("align_panel").table("align_panel_table").requireColumnCount(3);
-        //
         aligner.panel("align_panel").table("align_panel_table").requireCellValue(TableCell.row(0).column(0),
                 "true");
         aligner.panel("align_panel").table("align_panel_table").requireCellValue(TableCell.row(0).column(1),
@@ -101,10 +102,8 @@ public class AlignerWindowTest extends TestCoreGUI {
                 "And then this is a very, very, very long sentence.");
         aligner.panel("align_panel").table("align_panel_table").requireCellValue(TableCell.row(2).column(2),
                 "Et puis c'est une phrase très, très, très longue.");
-        //
-        aligner.panel("align_panel").comboBox("align_panel_comparison_cb").requireSelection("Heapwise");
-        aligner.panel("align_panel").comboBox("align_panel_algorithm_cb").requireSelection("Viterbi");
-        aligner.panel("align_panel").comboBox("align_panel_calculator_cb").requireSelection("Normal");
+        aligner.panel("align_panel").label("align_panel_average_distance_label")
+                .requireText(Pattern.compile("Average Score:\\s(-|\\d\\.\\d{3})"));
         //
         aligner.button("align_panel_continue_button").click();
         aligner.button("align_panel_save_button").requireEnabled();


### PR DESCRIPTION
## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

-  aligner average distance can be {0} which expected a numeric value
- https://sourceforge.net/p/omegat/bugs/1275/

## What does this PR change?

- Fix the label initializer
- update expectation of acceptance test

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
