### PR TITLE
fix: passing filter context

### DIFF
--- a/src/org/omegat/filters2/hhc/HHCFilter2.java
+++ b/src/org/omegat/filters2/hhc/HHCFilter2.java
@@ -85,7 +85,7 @@ public class HHCFilter2 extends HTMLFilter2 {
         Parser parser = new Parser();
         try {
             parser.setInputHTML(all.toString());
-            parser.visitAllNodesWith(new HHCFilterVisitor(this, outfile));
+            parser.visitAllNodesWith(new HHCFilterVisitor(this, outfile, fc));
         } catch (ParserException pe) {
             System.out.println(pe);
         }

--- a/src/org/omegat/filters2/hhc/HHCFilterVisitor.java
+++ b/src/org/omegat/filters2/hhc/HHCFilterVisitor.java
@@ -29,6 +29,8 @@ package org.omegat.filters2.hhc;
 import java.io.BufferedWriter;
 
 import org.htmlparser.Tag;
+
+import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.html2.FilterVisitor;
 import org.omegat.util.HTMLUtils;
 
@@ -40,8 +42,8 @@ import org.omegat.util.HTMLUtils;
  * @author Didier Briel
  */
 class HHCFilterVisitor extends FilterVisitor {
-    HHCFilterVisitor(HHCFilter2 hhcfilter, BufferedWriter bufwriter) {
-        super(hhcfilter, bufwriter, null);
+    HHCFilterVisitor(HHCFilter2 hhcfilter, BufferedWriter bufwriter, FilterContext fc) {
+        super(hhcfilter, bufwriter, null, fc);
     }
 
     // ///////////////////////////////////////////////////////////////////////

--- a/src/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/org/omegat/filters2/html2/FilterVisitor.java
@@ -48,6 +48,7 @@ import org.htmlparser.Text;
 import org.htmlparser.nodes.TextNode;
 import org.htmlparser.visitors.NodeVisitor;
 import org.omegat.core.Core;
+import org.omegat.filters2.FilterContext;
 import org.omegat.util.HTMLUtils;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
@@ -67,8 +68,10 @@ public class FilterVisitor extends NodeVisitor {
     protected HTMLFilter2 filter;
     private BufferedWriter writer;
     private HTMLOptions options;
+    private FilterContext filterContext;
 
-    public FilterVisitor(HTMLFilter2 htmlfilter, BufferedWriter bufwriter, HTMLOptions opts) {
+    public FilterVisitor(HTMLFilter2 htmlfilter, BufferedWriter bufwriter, HTMLOptions opts,
+                         FilterContext fc) {
         this.filter = htmlfilter;
         // HHC filter has no options
         if (opts != null) {
@@ -79,6 +82,7 @@ public class FilterVisitor extends NodeVisitor {
             this.options = new HTMLOptions(new TreeMap<>());
         }
         this.writer = bufwriter;
+        filterContext = fc;
     }
 
     // ///////////////////////////////////////////////////////////////////////
@@ -540,8 +544,7 @@ public class FilterVisitor extends NodeVisitor {
         boolean changed = true;
         while (changed) {
             changed = false;
-            boolean removeTags = Core.getFilterMaster().getConfig().isRemoveTags();
-            if (!removeTags) {
+            if (!filterContext.isRemoveAllTags()) {
                 for (int i = 0; i < firstTagToIncludeFromPreceding; i++) {
                     Node node = allNodesInParagraph.get(i);
                     if (node instanceof Tag) {

--- a/src/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/org/omegat/filters2/html2/FilterVisitor.java
@@ -544,7 +544,8 @@ public class FilterVisitor extends NodeVisitor {
         boolean changed = true;
         while (changed) {
             changed = false;
-            if (!filterContext.isRemoveAllTags()) {
+            boolean removeTags = Core.getFilterMaster().getConfig().isRemoveTags();
+            if (!removeTags) {
                 for (int i = 0; i < firstTagToIncludeFromPreceding; i++) {
                     Node node = allNodesInParagraph.get(i);
                     if (node instanceof Tag) {

--- a/src/org/omegat/filters2/html2/HTMLFilter2.java
+++ b/src/org/omegat/filters2/html2/HTMLFilter2.java
@@ -200,7 +200,7 @@ public class HTMLFilter2 extends AbstractFilter {
         Parser parser = new Parser();
         try {
             parser.setInputHTML(all.toString());
-            parser.visitAllNodesWith(new FilterVisitor(this, outfile, options));
+            parser.visitAllNodesWith(new FilterVisitor(this, outfile, options, fc));
         } catch (ParserException pe) {
             Log.logErrorRB(pe, "HTML_EXCEPTION_PARSER");
         } catch (StringIndexOutOfBoundsException se) {


### PR DESCRIPTION
## Pull request type
- Other (describe below)
refactoring

## Which ticket is resolved?


## What does this PR change?

- Filters components must respect filter context but FilterVisitor class does not.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
