### PR TITLE
fix: OmegaT failed to start when malformed jar in plugin folder

### DIFF
--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -328,6 +328,10 @@ public final class PluginUtils {
         for (URL url : urlList) {
             try (JarInputStream jarStream = new JarInputStream(url.openStream())) {
                 Manifest mf = jarStream.getManifest();
+                if (mf == null) {
+                    // mf can be null when a jar file does not have a manifest.
+                    continue;
+                }
                 String pluginClass = mf.getMainAttributes().getValue(OMEGAT_PLUGINS);
                 String oldPluginClass = mf.getMainAttributes().getValue(OMEGAT_PLUGIN);
 


### PR DESCRIPTION
- Fix BUGS#1276 OmegaT failed to start if there are 'jar' file w/o manifest in plugin folder

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- OmegaT failed to start if there are 'jar' file w/o manifest in plugin folder
- https://sourceforge.net/p/omegat/bugs/1276/

## What does this PR change?

- add null check

## Other information

Users ML

https://sourceforge.net/p/omegat/mailman/omegat-users/thread/a4fb41d0-4643-437c-9dea-97d5a3248d3b%40uibk.ac.at/#msg58844040