### PR TITLE
chore: bump spotless gradle plugin@7.0.0.BETA4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -187,7 +187,7 @@ xmlunit = ["xmlunit-core", "xmlunit-assertj", "assertj"]
 
 [plugins]
 spotbugs = {id = "com.github.spotbugs", version = "6.0.26"}
-spotless = {id = "com.diffplug.spotless", version = "6.25.0"}
+spotless = {id = "com.diffplug.spotless", version = "7.0.0.BETA4"}
 launch4j = {id = "edu.sc.seis.launch4j", version = "3.0.6"}
 versions = {id = "com.github.ben-manes.versions", version = "0.51.0"}
 ssh = {id = "org.hidetake.ssh", version = "2.11.2"}


### PR DESCRIPTION
- Support for p2 cache directory in an Eclipse step



## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?
- Bump Gradle plugin spotless@7.0.0.BETA4 from 6.25.0
- It supports Eclipse p2 cache in maven local folder
- Reduce network connectivity error in CI check


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
