### PR TITLE
fix: testAcceptance: aligner test expectation unstable

### DIFF
--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -79,13 +79,13 @@ public class AlignerWindowTest extends TestCoreGUI {
         picker.comboBox("targetLanguagePicker").requireSelection("fr - French");
         //
         picker.button("sourceChooseFileButton").click();
-        picker.fileChooser("aligner_choose_source").requireVisible();
+        picker.fileChooser("aligner_choose_source").requireEnabled(Timeout.timeout(1000));
         picker.fileChooser("aligner_choose_source").selectFile(new File(tmpDir, SOURCE_PATH));
         picker.fileChooser("aligner_choose_source").approve();
         robot().waitForIdle();
         //
         picker.button("targetChooseFileButton").click();
-        picker.fileChooser("aligner_choose_target").requireVisible();
+        picker.fileChooser("aligner_choose_target").requireEnabled(Timeout.timeout(1000));
         picker.fileChooser("aligner_choose_target").selectFile(new File(tmpDir, TARGET_PATH));
         picker.fileChooser("aligner_choose_target").approve();
         robot().waitForIdle();


### PR DESCRIPTION
A test case for aligner GUI test is flows.

## Pull request type

- Other (describe below)
Fix unstable test expectation

## What does this PR change?

- put timeout for waiting file chooser

## Other information