### PR TITLE
chore: fix error on Integration Test

### DIFF
--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
@@ -49,7 +50,6 @@ import org.omegat.core.KnownException;
 import org.omegat.core.team2.gui.PassphraseDialog;
 import org.omegat.core.team2.gui.UserPassDialog;
 import org.omegat.core.team2.impl.TeamUtils.Credentials;
-import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.StaticUIUtils;
@@ -281,8 +281,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
     }
 
     private void askYesNoGUI(CredentialItem item, String promptText, URIish uri, String promptedFingerprint) {
-        IMainWindow mw = Core.getMainWindow();
-        int choice = mw.showConfirmDialog(promptText, null, JOptionPane.YES_NO_OPTION,
+        int choice = Core.getMainWindow().showConfirmDialog(promptText, null, JOptionPane.YES_NO_OPTION,
                 JOptionPane.WARNING_MESSAGE);
         if (choice == JOptionPane.YES_OPTION) {
             ((CredentialItem.YesNoType) item).setValue(true);
@@ -325,10 +324,10 @@ public class GITCredentialsProvider extends CredentialsProvider {
      */
     private Credentials askCredentialsGUI(URIish uri, Credentials credentials, boolean passwordOnly,
             String msg) {
-        IMainWindow mw = Core.getMainWindow();
+        JFrame parent = Core.getMainWindow().getApplicationFrame();
         if (passwordOnly) {
-            PassphraseDialog passphraseDialog = new PassphraseDialog(mw.getApplicationFrame());
-            passphraseDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
+            PassphraseDialog passphraseDialog = new PassphraseDialog(parent);
+            passphraseDialog.setLocationRelativeTo(parent);
             if (uri.getScheme() == null) {
                 // asked passphrase
                 passphraseDialog.setTitleDesc(OStrings.getString(
@@ -347,8 +346,8 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 return credentials;
             }
         } else {
-            UserPassDialog userPassDialog = new UserPassDialog(mw.getApplicationFrame());
-            userPassDialog.setLocationRelativeTo(Core.getMainWindow().getApplicationFrame());
+            UserPassDialog userPassDialog = new UserPassDialog(parent);
+            userPassDialog.setLocationRelativeTo(parent);
             userPassDialog.setDescription(OStrings.getString(
                     credentials.username == null ? "TEAM_USERPASS_FIRST" : "TEAM_USERPASS_WRONG",
                     uri.getHumanishName()));

--- a/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -49,9 +49,9 @@ import org.omegat.core.KnownException;
 import org.omegat.core.team2.ProjectTeamSettings;
 import org.omegat.core.team2.gui.UserPassDialog;
 import org.omegat.core.team2.impl.TeamUtils.Credentials;
-import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
+import org.omegat.util.gui.StaticUIUtils;
 
 import gen.core.project.RepositoryDefinition;
 
@@ -194,11 +194,11 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
             return getAuthenticatorInstance(kind, url, credentials);
         }
 
-        if (Core.getMainWindow() == null || Core.getMainWindow() instanceof ConsoleWindow) {
+        if (StaticUIUtils.isGUI()) {
+            return ask(kind, url, OStrings.getString("TEAM_USERPASS_FIRST", url.getPath()));
+        } else {
             // run on headless.
             return askCUI(kind, url, OStrings.getString("TEAM_USERPASS_FIRST", url.getPath()));
-        } else {
-            return ask(kind, url, OStrings.getString("TEAM_USERPASS_FIRST", url.getPath()));
         }
     }
 
@@ -207,11 +207,11 @@ public class SVNAuthenticationManager implements ISVNAuthenticationManager {
         if (predefinedUser != null && predefinedPass != null) {
             throw new KnownException("TEAM_PREDEFINED_CREDENTIALS_ERROR");
         }
-        if (Core.getMainWindow() == null) {
+        if (StaticUIUtils.isGUI()) {
+            return ask(kind, url, OStrings.getString("TEAM_USERPASS_WRONG", url.getPath()));
+        } else {
             // run on headless.
             return askCUI(kind, url, OStrings.getString("TEAM_USERPASS_WRONG", url.getPath()));
-        } else {
-            return ask(kind, url, OStrings.getString("TEAM_USERPASS_WRONG", url.getPath()));
         }
     }
 

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -26,11 +26,11 @@
 
 FROM debian:bookworm-slim
 ARG CAVER=1.0.3-1
-ARG JAVA=11
-ARG JDKVER=jdk_11.0.23.0.0+9
+ARG JAVA=17
+ARG JDKVER=jdk_17.0.9.0.0+9
 ARG GRADLE=8.8
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git inotify-tools curl subversion unzip rsync  \
- java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit openjdk-17-jdk
+ java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit
 RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh
 RUN chown -R omegat.omegat /home/omegat
 COPY --chown=omegat ssh_config /home/omegat/.ssh/config

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -432,6 +432,7 @@ public final class TestTeamIntegration {
                     + dir.getAbsolutePath() + " " + repo + " " + delay + " " + SEG_COUNT);
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.inheritIO();
+            pb.redirectErrorStream(true);
             p = pb.start();
         }
 

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -29,7 +29,6 @@ package org.omegat.core.data;
 import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.Frame;
-import java.awt.HeadlessException;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -44,7 +43,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-import javax.swing.JFrame;
 import javax.swing.JMenu;
 
 import org.madlonkay.supertmxmerge.StmProperties;
@@ -70,6 +68,7 @@ import org.omegat.gui.glossary.GlossaryEntry;
 import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.gui.glossary.GlossaryReaderTSV;
 import org.omegat.gui.glossary.IGlossaries;
+import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.gui.main.IMainMenu;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Log;
@@ -81,7 +80,6 @@ import org.omegat.util.TestPreferencesInitializer;
 import org.omegat.util.gui.MenuExtender.MenuKey;
 
 import com.vlsolutions.swing.docking.Dockable;
-import com.vlsolutions.swing.docking.DockingDesktop;
 import gen.core.project.RepositoryDefinition;
 
 /**
@@ -595,37 +593,20 @@ public final class TestTeamIntegrationChild {
         }
     };
 
-    static IMainWindow mainWindow = new IMainWindow() {
+    static IMainWindow mainWindow = new ConsoleWindow() {
+        @Override
         public void unlockUI() {
         }
 
-        public void showStatusMessageRB(String messageKey, Object... params) {
-        }
-
-        public void showTimedStatusMessageRB(String messageKey, Object... params) {
-        }
-
+        @Override
         public void showProgressMessage(String messageText) {
         }
 
-        public void showMessageDialog(String message) {
-        }
-
+        @Override
         public void showLengthMessage(String messageText) {
         }
 
-        public void showErrorDialogRB(String title, String message, Object... args) {
-            System.err.println(message);
-        }
-
-        public int showConfirmDialog(Object message, String title, int optionType, int messageType)
-                throws HeadlessException {
-            return 0;
-        }
-
-        public void setCursor(Cursor cursor) {
-        }
-
+        @Override
         public void lockUI() {
         }
 
@@ -673,20 +654,7 @@ public final class TestTeamIntegrationChild {
             return menu;
         }
 
-        @Override
-        public DockingDesktop getDesktop() {
-            return null;
-        }
-
-        @Override
-        public void resetDesktopLayout() {
-        }
-
         public Cursor getCursor() {
-            return null;
-        }
-
-        public JFrame getApplicationFrame() {
             return null;
         }
 
@@ -708,9 +676,6 @@ public final class TestTeamIntegrationChild {
         }
 
         public void addDockable(Dockable pane) {
-        }
-
-        public void showLockInsertMessage(String messageText, String toolTip) {
         }
     };
 

--- a/test/fixtures/org/omegat/core/TestCoreInitializer.java
+++ b/test/fixtures/org/omegat/core/TestCoreInitializer.java
@@ -28,8 +28,8 @@ package org.omegat.core;
 import org.omegat.core.threads.IAutoSave;
 import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.glossary.IGlossaries;
-import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.gui.main.IMainWindow;
+import org.omegat.util.gui.StaticUIUtils;
 
 /**
  * Core initializer for unit tests.
@@ -52,10 +52,9 @@ public final class TestCoreInitializer {
     public static void initMainWindow(IMainWindow mainWindow) throws Exception {
         Core.setMainWindow(mainWindow);
 
-        if (mainWindow instanceof ConsoleWindow) {
-            return;
+        if (StaticUIUtils.isGUI()) {
+            Core.initializeGUIimpl(mainWindow);
         }
-        Core.initializeGUIimpl(mainWindow);
     }
 
     public static void initGlossary(IGlossaries glossaries) {


### PR DESCRIPTION
When changing a way to detect gui environment, the integration test failed to launch.
This PR is to fix the issue.

## Pull request type

- Build and release changes -> [build/release]
    - Fix the weekly release
    - Improve integration test code to debug child process error

## What does this PR change?

- inherit ConsoleWindow to implement TestIntegrationChild.mainWindow 
- TestIntegration: set `ProcessBuilder.redirectErrorStream(true)`
- Bump target JDK to 17

## Other information

related #1133