### PR TITLE
[BUGS#1251][6.0][backport] fix: FindMatches#search ignore penalty when segmented matches

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,7 +2,7 @@
  OmegaT 6.0.2
 ----------------------------------------------------------------------
   0 Enhancement
-  4 Bug fixes
+  5 Bug fixes
   0 Localisation updates
 ----------------------------------------------------------------------
 
@@ -10,6 +10,11 @@
 
   - Preferences/CutomColorSelector don't show notification immediately when modifying color
   https://sourceforge.net/p/omegat/bugs/1273/
+
+  - tm/penalty-nnn value is not respected
+  - FindMatcher always search separate segment match without penalty
+  https://sourceforge.net/p/omegat/bugs/1248/
+  https://sourceforge.net/p/omegat/bugs/1251/
 
   - [Revert regression] List of issues stays hidden in the background
   https://sourceforge.net/p/omegat/bugs/1225/

--- a/src/org/omegat/core/data/ProjectTMX.java
+++ b/src/org/omegat/core/data/ProjectTMX.java
@@ -74,14 +74,14 @@ public class ProjectTMX {
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<String, TMXEntry> defaults;
+    protected Map<String, TMXEntry> defaults;
 
     /**
      * Storage for alternative translations for current project.
      *
      * It must be used with synchronization around ProjectTMX.
      */
-    Map<EntryKey, TMXEntry> alternatives;
+    protected Map<EntryKey, TMXEntry> alternatives;
 
     final CheckOrphanedCallback checkOrphanedCallback;
 

--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -47,7 +47,7 @@ import org.omegat.util.TMXProp;
  */
 public class NearString {
     public enum MATCH_SOURCE {
-        MEMORY, TM, FILES
+        MEMORY, TM, FILES, TM_SUBSEG
     };
 
     public enum SORT_KEY {
@@ -55,15 +55,23 @@ public class NearString {
     }
 
     public NearString(final EntryKey key, final String source, final String translation, MATCH_SOURCE comesFrom,
-            final boolean fuzzyMark, final int nearScore, final int nearScoreNoStem, final int adjustedScore,
-            final byte[] nearData, final String projName, final String creator, final long creationDate,
+                      final boolean fuzzyMark, final int nearScore, final int nearScoreNoStem, final int adjustedScore,
+                      final byte[] nearData, final String projName, final String creator, final long creationDate,
+                      final String changer, final long changedDate, final List<TMXProp> props) {
+        this(key, source, translation, comesFrom, fuzzyMark, new Scores(nearScore, nearScoreNoStem,
+                adjustedScore, 0), nearData, projName, creator, creationDate, changer, changedDate, props);
+    }
+
+    public NearString(final EntryKey key, final String source, final String translation, MATCH_SOURCE comesFrom,
+            final boolean fuzzyMark, final Scores scores, final byte[] nearData, final String projName,
+                      final String creator, final long creationDate,
             final String changer, final long changedDate, final List<TMXProp> props) {
         this.key = key;
         this.source = source;
         this.translation = translation;
         this.comesFrom = comesFrom;
         this.fuzzyMark = fuzzyMark;
-        this.scores = new Scores[] { new Scores(nearScore, nearScoreNoStem, adjustedScore) };
+        this.scores = new Scores[] { scores };
         this.attr = nearData;
         this.projs = new String[] { projName == null ? "" : projName };
         this.props = props;
@@ -77,27 +85,35 @@ public class NearString {
             MATCH_SOURCE comesFrom, final boolean fuzzyMark, final int nearScore, final int nearScoreNoStem,
             final int adjustedScore, final byte[] nearData, final String projName, final String creator,
             final long creationDate, final String changer, final long changedDate, final List<TMXProp> props) {
+        return merge(ns, key, source, translation, comesFrom, fuzzyMark, new Scores(nearScore,
+                nearScoreNoStem, adjustedScore, 0), nearData, projName, creator, creationDate, changer,
+                changedDate, props);
+    }
+
+    public static NearString merge(NearString ns, final EntryKey key, final String source, final String translation,
+                                   MATCH_SOURCE comesFrom, final boolean fuzzyMark, final Scores scores,
+                                   final byte[] nearData, final String projName, final String creator,
+                                   final long creationDate, final String changer, final long changedDate, final List<TMXProp> props) {
 
         List<String> projs = new ArrayList<>();
-        List<Scores> scores = new ArrayList<>();
+        List<Scores> mergedScores = new ArrayList<>();
         projs.addAll(Arrays.asList(ns.projs));
-        scores.addAll(Arrays.asList(ns.scores));
+        mergedScores.addAll(Arrays.asList(ns.scores));
 
         NearString merged;
-        if (nearScore > ns.scores[0].score) {
-            merged = new NearString(key, source, translation, comesFrom, fuzzyMark, nearScore,
-                    nearScoreNoStem, adjustedScore, nearData, null, creator, creationDate, changer, changedDate, props);
+        if (scores.score > ns.scores[0].score) {
+            merged = new NearString(key, source, translation, comesFrom, fuzzyMark, scores,
+                    nearData, null, creator, creationDate, changer, changedDate, props);
             projs.add(0, projName);
-            scores.add(0, merged.scores[0]);
+            mergedScores.add(0, merged.scores[0]);
         } else {
-            merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark, nearScore,
-                    nearScoreNoStem, adjustedScore, ns.attr, null, ns.creator, ns.creationDate, ns.changer,
-                    ns.changedDate, ns.props);
+            merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark, scores,
+                    ns.attr, null, ns.creator, ns.creationDate, ns.changer, ns.changedDate, ns.props);
             projs.add(projName);
-            scores.add(merged.scores[0]);
+            mergedScores.add(merged.scores[0]);
         }
         merged.projs = projs.toArray(new String[projs.size()]);
-        merged.scores = scores.toArray(new Scores[scores.size()]);
+        merged.scores = mergedScores.toArray(new Scores[mergedScores.size()]);
         return merged;
     }
 
@@ -130,11 +146,13 @@ public class NearString {
         public final int scoreNoStem;
         /** adjusted similarity score for match including all tokens */
         public final int adjustedScore;
+        public final int penalty;
 
-        public Scores(int score, int scoreNoStem, int adjustedScore) {
+        public Scores(int score, int scoreNoStem, int adjustedScore, int penalty) {
             this.score = score;
             this.scoreNoStem = scoreNoStem;
             this.adjustedScore = adjustedScore;
+            this.penalty = penalty;
         }
 
         public String toString() {

--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -47,7 +47,7 @@ import org.omegat.util.TMXProp;
  */
 public class NearString {
     public enum MATCH_SOURCE {
-        MEMORY, TM, FILES, TM_SUBSEG
+        MEMORY, TM, FILES, SUBSEGMENTS
     };
 
     public enum SORT_KEY {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -313,7 +313,7 @@ public class FindMatches {
                 String foundSrc = Core.getSegmenter().glue(sourceLang, sourceLang, fsrc, spaces, brules);
                 // glue found translations
                 String foundTrans = Core.getSegmenter().glue(sourceLang, targetLang, ftrans, spaces, brules);
-                processEntry(null, foundSrc, foundTrans, NearString.MATCH_SOURCE.TM_SUBSEG, false, maxPenalty,
+                processEntry(null, foundSrc, foundTrans, NearString.MATCH_SOURCE.SUBSEGMENTS, false, maxPenalty,
                         String.join(",", tmxNames), "", 0, "", 0, null);
             }
         }

--- a/test/data/tmx/penalty-010/segment_1.tmx
+++ b/test/data/tmx/penalty-010/segment_1.tmx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx PUBLIC "-//LISA OSCAR:1998//DTD for Translation Memory eXchange//EN" "tmx14.dtd">
+
+<tmx version="1.4">
+    <header creationtoolversion="0.1" adminlang="en" segtype="paragraph" creationdate="20230930T155211Z" datatype="unknown" srclang="ja" creationtool="txt2tmx" o-tmf="TextEdit"></header>
+    <body>
+        <tu>
+            <tuv xml:lang="fr">
+                <seg>weird behavior</seg>
+            </tuv>
+            <tuv xml:lang="ja">
+                <seg>地力の搾取と浪費が現われる。(1)</seg>
+            </tuv>
+        </tu>
+    </body>
+</tmx>

--- a/test/data/tmx/test-multiple-entries.tmx
+++ b/test/data/tmx/test-multiple-entries.tmx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+<header  datatype="plaintext" srclang="en-US" adminlang="EN-US" o-tmf="OmegaT TMX" segtype="sentence"
+creationtoolversion="test" creationtool="test"/>
+  <body>
+<!-- Default translations -->
+    <tu>
+      <tuv lang="en-US">
+        <seg>Other</seg>
+      </tuv>
+      <tuv lang="co" changeid="id" changedate="20200523T143256Z">
+        <seg>Altre</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="en-US">
+        <seg>For installation on Linux.</seg>
+      </tuv>
+      <tuv lang="co" changeid="id" changedate="20200526T131725Z" creationid="id" creationdate="20200526T131725Z">
+        <seg>Per l’installazioni nant’à i sistemi Linux.</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="en-US">
+        <seg>For installation on other operating systems (such as FreeBSD and Solaris).</seg>
+      </tuv>
+      <tuv lang="co" changeid="id" changedate="20200526T131840Z" creationid="id"
+      creationdate="20200526T131840Z">
+        <seg>Per l’installazioni nant’à d’altri sistemi (cum’è FreeBSD è Solaris).</seg>
+      </tuv>
+    </tu>
+<!-- Alternative translations -->
+    <tu>
+      <prop type="file">website/download.html</prop>
+      <prop type="prev">For installation on Linux.</prop>
+      <prop type="next">For installation on other operating systems (such as FreeBSD and Solaris).&lt;br0/></prop>
+      <tuv lang="en-US">
+        <seg>Other</seg>
+      </tuv>
+      <tuv lang="co" changeid="id" changedate="20200526T131742Z" creationid="id" creationdate="20200526T131742Z">
+        <seg>Altri</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -186,7 +186,7 @@ public class FindMatchesTest {
         assertEquals("weird behavior", result.get(0).translation);
         assertTrue(result.get(0).projs[0].contains("penalty-010"));
         // match segmented, with penalty
-        assertEquals("TM_SUBSEG", result.get(1).comesFrom.name());
+        assertEquals("SUBSEGMENTS", result.get(1).comesFrom.name());
         assertEquals(90, result.get(1).scores[0].score);
         assertTrue(result.get(1).projs[0].contains("penalty-010"));
     }

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -309,7 +309,9 @@ public class FindMatchesTest {
             List<SourceTextEntry> ste = new ArrayList<>();
             ste.add(new SourceTextEntry(new EntryKey("source.txt", "XXX", null, "", "", null),
                     1, null, null, new ArrayList<>()));
-            ste.add(new SourceTextEntry(new EntryKey("source.txt", "地力の搾取と浪費が現われる。(1)", null, "", "", null),
+            ste.add(new SourceTextEntry(new EntryKey("source.txt",
+                    "\u5730\u529B\u306E\u643E\u53D6\u3068\u6D6A\u8CBB\u304C\u73FE\u308F\u308C\u308B\u3002(1)",
+                    null, "", "", null),
                     1, null, null, Collections.emptyList()));
             ste.add(new SourceTextEntry(new EntryKey("website/download.html", "Other", "id",
                     "For installation on Linux.",


### PR DESCRIPTION
Backport PR #963

## Pull request type

- Bug fix -> [bug]


## Which ticket is resolved?

- https://sourceforge.net/p/omegat/bugs/1251/

## What does this PR change?

- Backport test case from PR #963
- Backport core fix from PR #963
- Extend NearString.Scores to hold penalty
- Update FindMatches.search to handle segmented search with penalty 

## Other information
