### PR TITLE
fix: respect foreign match penalty in segmented matches

### DIFF
--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -204,11 +204,18 @@ public class NearString {
         public final int scoreNoStem;
         /** adjusted similarity score for match including all tokens */
         public final int adjustedScore;
+        /** penalty of the match */
+        public final int penalty;
 
         public Scores(int score, int scoreNoStem, int adjustedScore) {
+            this(score, scoreNoStem, adjustedScore, 0);
+        }
+
+        public Scores(int score, int scoreNoStem, int adjustedScore, int penalty) {
             this.score = score;
             this.scoreNoStem = scoreNoStem;
             this.adjustedScore = adjustedScore;
+            this.penalty = penalty;
         }
 
         public String toString() {

--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -333,13 +333,7 @@ public class FindMatches {
                                 maxPenalty = PENALTY_FOR_FUZZY;
                             }
                         }
-                        Matcher matcher = SEARCH_FOR_PENALTY.matcher(segmentMatch.get(0).projs[0]);
-                        if (matcher.find()) {
-                            int penalty = Integer.parseInt(matcher.group(1));
-                            if (penalty > maxPenalty) {
-                                maxPenalty = penalty;
-                            }
-                        }
+                        maxPenalty = Math.max(maxPenalty, segmentMatch.get(0).scores[0].penalty);
                     } else {
                         fsrc.add("");
                         ftrans.add("");
@@ -451,7 +445,7 @@ public class FindMatches {
         }
 
         addNearString(key, entry, comesFrom, fuzzy, new NearString.Scores(similarityStem, similarityNoStem,
-                simAdjusted), tmxName);
+                simAdjusted, penalty), tmxName);
     }
 
     /**

--- a/test/data/tmx/segment_2.tmx
+++ b/test/data/tmx/segment_2.tmx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx PUBLIC "-//LISA OSCAR:1998//DTD for Translation Memory eXchange//EN" "tmx14.dtd">
+
+<tmx version="1.4">
+    <header creationtoolversion="0.1" adminlang="en" segtype="paragraph" creationdate="20230930T155211Z"
+    datatype="unknown" srclang="ja" creationtool="txt2tmx" o-tmf="TextEdit"></header>
+    <body>
+        <tu>
+            <tuv xml:lang="en">
+                <seg>weird behavior</seg>
+            </tuv>
+            <tuv xml:lang="ja">
+                <seg>地力の搾取と浪費が現われる。(1)</seg>
+            </tuv>
+        </tu>
+    </body>
+</tmx>

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -42,7 +42,6 @@ import java.util.TreeMap;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.omegat.core.Core;
@@ -220,7 +219,6 @@ public class FindMatchesTest {
         assertEquals("ZZZ", result.get(2).translation); // sr
     }
 
-    @Ignore("Should be enalbed when the bug fix proposed.")
     @Test
     public void testSearchBUGS1251() throws Exception {
         ProjectProperties prop = new ProjectProperties(tmpDir.toFile());
@@ -243,10 +241,17 @@ public class FindMatchesTest {
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
         List<NearString> result = finder.search(srcText, false, iStopped);
         assertEquals(srcText, result.get(0).source);
-        assertEquals(1, result.size());
+        assertEquals(2, result.size());
+        // match normal
         assertEquals("TM", result.get(0).comesFrom.name());
         assertEquals(90, result.get(0).scores[0].score);
         assertEquals("weird behavior", result.get(0).translation);
+        assertTrue(result.get(0).projs[0].contains("penalty-010"));
+        // match segmented, with penalty
+        assertEquals("TM_SUBSEG", result.get(1).comesFrom.name());
+        assertEquals(90, result.get(1).scores[0].score);
+        // FIXME
+        //assertTrue(result.get(1).projs[0].contains("penalty-010"));
     }
 
     @Test

--- a/test/src/org/omegat/gui/matches/FindMatchesThreadTest.java
+++ b/test/src/org/omegat/gui/matches/FindMatchesThreadTest.java
@@ -43,7 +43,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.omegat.core.Core;
@@ -89,7 +88,6 @@ public class FindMatchesThreadTest {
         Core.registerTokenizerClass(LuceneEnglishTokenizer.class);
     }
 
-    @Ignore("Should be enalbed when the bug fix proposed.")
     @Test
     public void testSearchBUGS1248() throws Exception {
         ProjectProperties prop = new ProjectProperties(tmpDir.toFile());


### PR DESCRIPTION
PR #1223 respect a penalty value of an external TM, but ignore a penalty of foreign language match


## Which ticket is resolved?
- BUGS#1251

## What does this PR change?

- Extent Scores class to hold penalty
- Calculate `maxPenalty` with `Scores.penalty`
- Enable Unit tests 

## Other information

- [x] Unit test of the case of foreign language match
