### PR TITLE
chore: hunspell dependency for test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -376,6 +376,7 @@ dependencies {
 
     testImplementation(libs.languagetool.server) {
         exclude module: "logback-classic"
+        exclude module: "hunspell"
     }
     testRuntimeOnly(libs.slf4j.jdk14)
 


### PR DESCRIPTION
- languagetool-server depends on lt-core that has a dependency for the hunspell.
- OmegaT explicitly depends on dumont hunspell 2.1.2 but LT 6.1 depends on 2.1.1

## Pull request type
- Other (describe below)

