### PR TITLE
Have command line aligner correctly load plugins

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -523,7 +523,9 @@ public class AlignFilePickerController {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
         Preferences.init();
+        Core.initializeGUI(Collections.emptyMap());
         PluginUtils.loadPlugins(Collections.emptyMap());
+        FilterMaster.setFilterClasses(PluginUtils.getFilterClasses());
         Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
         Core.setSegmenter(new Segmenter(SRX.getDefault()));
         AlignFilePickerController picker = new AlignFilePickerController();

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -60,6 +60,7 @@ import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.LanguageComboBoxRenderer;
 import org.omegat.util.gui.StaticUIUtils;
+import org.omegat.util.gui.UIDesignManager;
 
 /**
  * Controller for align file picker UI
@@ -523,7 +524,7 @@ public class AlignFilePickerController {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
 
         Preferences.init();
-        Core.initializeGUI(Collections.emptyMap());
+        UIDesignManager.initialize();
         PluginUtils.loadPlugins(Collections.emptyMap());
         FilterMaster.setFilterClasses(PluginUtils.getFilterClasses());
         Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -108,6 +108,7 @@ import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.DelegatingComboBoxRenderer;
+import org.omegat.util.gui.FontUtil;
 import org.omegat.util.gui.RoundedCornerBorder;
 import org.omegat.util.gui.Styles;
 
@@ -542,7 +543,7 @@ public class AlignPanelController {
 
         alignPanel.table.setTransferHandler(new AlignTransferHandler());
         alignPanel.table.addPropertyChangeListener("dropLocation", new DropLocationListener());
-        alignPanel.table.setFont(Core.getMainWindow().getApplicationFont());
+        alignPanel.table.setFont(FontUtil.getScaledFont());
         CoreEvents.registerFontChangedEventListener(alignPanel.table::setFont);
 
         // Set initial state


### PR DESCRIPTION
Command line aligner did not properly load filter plugins: you could open the UI but any file would be unsupported

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

Bug

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
