### PR TITLE
chore: use custom launch4j binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ tasks.named('updateDaemonJvm') {
 def os = osdetector.os
 def osArch = osdetector.classifier
 
-// Define target Java version to compatible.
-def javaVersion = 11;
 
 // OmegaT distribution package meta data.
 def shortDescription = 'The free translation memory tool'

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     alias(libs.plugins.versions)
     alias(libs.plugins.launch4j)
     alias(libs.plugins.ssh)
+    id("com.google.osdetector") version "1.7.3"
 }
 
 apply from: 'gradle/utils.gradle'
@@ -33,6 +34,11 @@ def gradleOnJava17OrLater = JavaVersion.current().isCompatibleWith(JavaVersion.V
 tasks.named('updateDaemonJvm') {
     jvmVersion = JavaVersion.VERSION_17
 }
+def os = osdetector.os
+def osArch = osdetector.classifier
+
+// Define target Java version to compatible.
+def javaVersion = 11;
 
 // OmegaT distribution package meta data.
 def shortDescription = 'The free translation memory tool'
@@ -391,6 +397,16 @@ dependencies {
     testIntegrationImplementation sourceSets.main.output, sourceSets.test.output
     testIntegrationImplementation(testFixtures(project.rootProject))
     testIntegrationRuntimeOnly(libs.slf4j.jdk14)
+
+    if ("linux-aarch_64".equals(osArch)) {
+        launch4jBin 'org.omegat:launch4j:3.52:workdir-linux'
+    } else if ("linux-x86_64".equals(osArch)) {
+        launch4jBin 'org.omegat:launch4j:3.52:workdir-linux64'
+    } else if ("windows".equals(os)) {
+        launch4jBin 'org.omegat:launch4j:3.52:workdir-win32'
+    } else if ("osx".equals(os)) {
+        launch4jBin 'org.omegat:launch4j:3.52:workdir-macosx-x86'
+    }
 
     jacocoAggregation project(':aligner')
     jacocoAggregation project(":machinetranslators:apertium")

--- a/build.gradle
+++ b/build.gradle
@@ -398,14 +398,17 @@ dependencies {
     testIntegrationImplementation(testFixtures(project.rootProject))
     testIntegrationRuntimeOnly(libs.slf4j.jdk14)
 
-    if ("linux-aarch_64".equals(osArch)) {
-        launch4jBin 'org.omegat:launch4j:3.52:workdir-linux'
-    } else if ("linux-x86_64".equals(osArch)) {
-        launch4jBin 'org.omegat:launch4j:3.52:workdir-linux64'
-    } else if ("windows".equals(os)) {
-        launch4jBin 'org.omegat:launch4j:3.52:workdir-win32'
+    // workdir classifiers are hard-coded in gralde-launch4j plugin
+    if ("windows".equals(os)) {
+        launch4jBin 'org.omegat:launch4j:3.55:workdir-win32'
     } else if ("osx".equals(os)) {
-        launch4jBin 'org.omegat:launch4j:3.52:workdir-macosx-x86'
+        launch4jBin 'org.omegat:launch4j:3.55:workdir-mac'
+    } else if ("linux-x86_64".equals(osArch)) {
+        launch4jBin 'org.omegat:launch4j:3.55:workdir-linux64'
+    } else if ("linux-aarch_64".equals(osArch)) {
+        // gradle-launch4j plugin use the classifier
+        // for architectures other than x86_64 on linux
+        launch4jBin 'org.omegat:launch4j:3.55:workdir-linux'
     }
 
     jacocoAggregation project(':aligner')


### PR DESCRIPTION
When building OmegaT from source on Linux ARM64 platform, it failed to run `launch4j`.
The `launch4j` somehow dead project, so I maintain the forked version of the `launch4j` and the topic branch here use the forked version of it. Because `gradle-launch4j` has a bug which configuration syntax `launch4jBin` does not support multi-platform project, I detect os and arch then conditional configuration is used.

## Pull request type
- Build and release changes 

## Which ticket is resolved?


-    Support Windows 11 and Linux on ARM64 for development environment
-    https://sourceforge.net/p/omegat/feature-requests/1773/


## What does this PR change?

- detect os and architecture
- use forked version of launch4j

## Other information
