### PR TITLE
HunspellSpellcheckerTest: multiple initializations

### DIFF
--- a/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
+++ b/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
@@ -41,8 +41,10 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
 import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.spellchecker.ISpellChecker;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;
@@ -124,6 +126,23 @@ public class HunspellSpellcheckerTest {
         assertThat(checker.suggest("Erruer")).as("Get suggestion").contains("Erreur", "Errer");
     }
 
+    @Test
+    public void testReinitializeWhenProjectChanged() throws Exception {
+        ProjectProperties props = new ProjectProperties(tmpDir.toFile());
+        props.setTargetLanguage(new Language("fr_FR"));
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return props;
+            }
+        });
+        HunSpellCheckerMock checker = new HunSpellCheckerMock();
+        assertThat(checker.initialize()).as("Success initialize").isTrue();
+        CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        assertThat(checker.getCounter()).as("Hunspell Checker initialized once").isEqualTo(3);
+    }
+
     private static void copyFile(String target) throws IOException {
         try (InputStream is = HunspellSpellcheckerTest.class.getResourceAsStream(DICTIONARY_PATH + target)) {
             if (is == null) {
@@ -132,5 +151,22 @@ public class HunspellSpellcheckerTest {
             Files.copy(is, configDir.resolve("spelling/" + target));
         }
 
+    }
+
+    static class HunSpellCheckerMock extends HunSpellChecker {
+        private int counter = 0;
+        public HunSpellCheckerMock() {
+            super();
+        }
+
+        @Override
+        public boolean initialize() {
+            counter++;
+            return super.initialize();
+        }
+
+        public int getCounter() {
+            return counter;
+        }
     }
 }


### PR DESCRIPTION
User observed multiple HUNSPELL_CHECKER_INITIALIZED logs when user reloading project. The report is posted in RFE#1769 Spell checker dictionary as a language module. 

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->


## What does this PR change?

- Add a regression test
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
