### PR TITLE
move junixsocket to 2.10.1 for macOS notarization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ dependencies {
         // For ed25519 and ecdsa support of jsch, java16+ or BC
         implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
         // For ssh agent support of jsch, Java16+ or junixsocket
-        implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.4.0'
+        implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.10.1'
         // For gpg signing
         implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:5.11.1.202105131744-r'
         // For subversion

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -2,7 +2,7 @@
  OmegaT 6.0.2
 ----------------------------------------------------------------------
   0 Enhancement
-  4 Bug fixes
+  5 Bug fixes
   0 Localisation updates
 ----------------------------------------------------------------------
 
@@ -19,6 +19,9 @@
 
   - Translation memories are not correctly reloaded after team synchronization
   https://sourceforge.net/p/omegat/bugs/1164/
+
+  - macOS notarization fails with junixsocket libraries
+  https://sourceforge.net/p/omegat/bugs/1283/
 
 ----------------------------------------------------------------------
  OmegaT 6.0.1 (2024-08-17)

--- a/test/data/plugin/bundled/MANIFEST.MF
+++ b/test/data/plugin/bundled/MANIFEST.MF
@@ -59,8 +59,8 @@ Class-Path: lib/vldocking-3.0.5.jar lib/slf4j-jdk14-1.7.32.jar lib/org.e
  ib/morfologik-polish-2.0.0.jar lib/morfologik-stemming-2.1.0.jar lib/mo
  rfologik-fsa-2.1.0.jar lib/hppc-0.7.1.jar lib/annotations-12.0.jar lib/
  lucene-backward-codecs-5.2.1.jar lib/berkeleylm-1.1.2.jar lib/JavaEWAH-
- 1.1.13.jar lib/jzlib-1.1.1.jar lib/junixsocket-native-common-2.4.0.jar 
- lib/junixsocket-common-2.4.0.jar lib/eddsa-0.3.0.jar lib/sequence-libra
+ 1.1.13.jar lib/jzlib-1.1.1.jar lib/junixsocket-native-common-2.10.1.jar 
+ lib/junixsocket-common-2.10.1.jar lib/eddsa-0.3.0.jar lib/sequence-libra
  ry-1.0.4.jar lib/sqljet-1.1.15.jar lib/jsch.agentproxy.svnkit-trilead-s
  sh2-0.0.7.jar lib/trilead-ssh2-1.0.0-build222.jar lib/lz4-java-1.4.1.ja
  r lib/beansbinding-1.2.1.jar lib/diffutils-1.2.1.jar lib/groovy-ant-3.0


### PR DESCRIPTION
Current junixsocket is too old and block OmegaT 6.0 macOS notarization.

https://sourceforge.net/p/omegat/bugs/1283/

This fix upgrades the library to its latest version and allows 6.0 macOS notarization.