### PR TITLE
Add direct links to items in the HTML manual

### DIFF
--- a/doc_src/en/App_ApplicationFolder.xml
+++ b/doc_src/en/App_ApplicationFolder.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="application.folder">
-  <title id="application.folder.title">Application Folder</title>
+  <title id="application.folder.title">
+  Application Folder</title>
 
   <para>The application folder contains the <filename>OmegaT.jar</filename>
   application and a number of other important files.</para>
@@ -44,14 +45,16 @@
   
   <variablelist>
 	<varlistentry id="application.folder.omegat.license">
-	  <term id="application.folder.omegat.license.title">OmegaT-license.txt</term>
+      <term id="application.folder.omegat.license.title">
+      OmegaT-license.txt</term>
 	  <listitem>
 		<para>OmegaT's distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.omegat.jar">
-	  <term id="application.folder.omegat.jar.title">OmegaT.jar</term>
+      <term id="application.folder.omegat.jar.title">
+      OmegaT.jar</term>
 	  <listitem>
 		<para>OmegaT's executable. Used when launching OmegaT from the command
 		line. See the <link linkend="launch.with.command.line"
@@ -60,7 +63,8 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.changes">
-	  <term id="application.folder.changes.title">changes.txt</term>
+      <term id="application.folder.changes.title">
+      changes.txt</term>
 	  <listitem>
 		<para>The list of improvements and bug fixes. Check it if you need
 		information on OmegaT's evolution.</para>
@@ -68,28 +72,32 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.doc.license">
-	  <term id="application.folder.doc.license.title">doc-license.txt</term>
+      <term id="application.folder.doc.license.title">
+      doc-license.txt</term>
 	  <listitem>
 		<para>The documentation distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.index.html">
-	  <term id="application.folder.index.html.title">index.html</term>
+      <term id="application.folder.index.html.title">
+      index.html</term>
 	  <listitem>
 		<para>The index to the multilingual user manual.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.join.html">
-	  <term id="application.folder.join.html.title">join.html</term>
+      <term id="application.folder.join.html.title">
+      join.html</term>
 	  <listitem>
 		<para>A link to the support page.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.readme.txt">
-	  <term id="application.folder.readme.txt.title">readme.txt</term>
+      <term id="application.folder.readme.txt.title">
+      readme.txt</term>
 	  <listitem>
 		<para>Simple installation and running instructions.</para>
 	  </listitem>
@@ -97,20 +105,23 @@
 
 
 	<varlistentry id="application.folder.docs">
-	  <term id="application.folder.docs.title">docs/</term>
+      <term id="application.folder.docs.title">
+      docs/</term>
 	  <listitem>
 		<para>The documentation folder.
 
 		<variablelist>
 		  <varlistentry id="application.folder.docs.contributors">
-			<term id="application.folder.docs.contributors.title">contributors.txt</term>
+            <term id="application.folder.docs.contributors.title">
+            contributors.txt</term>
 			<listitem>
 			  <para>The list of individual contributors.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.en">
-			<term id="application.folder.docs.en.title">en/</term>
+            <term id="application.folder.docs.en.title">
+            en/</term>
 			<listitem>
 			  <para>Each translated user manual comes in a different language
 			  folder.</para>
@@ -118,14 +129,16 @@
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.index.html">
-			<term id="application.folder.docs.index.html.title">index.html</term>
+            <term id="application.folder.docs.index.html.title">
+            index.html</term>
 			<listitem>
 			  <para>The index to the multilingual user manual.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.librairies.txt">
-			<term id="application.folder.docs.librairies.txt.title">libraries.txt</term>
+            <term id="application.folder.docs.librairies.txt.title">
+            libraries.txt</term>
 			<listitem>
 			  <para>The list of libraries used by OmegaT.</para>
 			</listitem>
@@ -136,21 +149,24 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.images">
-	  <term id="application.folder.images.title">images/</term>
+      <term id="application.folder.images.title">
+      images/</term>
 	  <listitem>
 		<para>The folder where images used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.lib">
-	  <term id="application.folder.lib.title">lib/</term>
+      <term id="application.folder.lib.title">
+      lib/</term>
 	  <listitem>
 		<para>The folder where the libraries used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.plugins">
-	  <term id="application.folder.plugins.title">plugins/</term>
+      <term id="application.folder.plugins.title">
+      plugins/</term>
 	  <listitem>
 		<para>The folder where you can install external plugins. The prefered
 		location for plugin manual installs is the <link
@@ -164,7 +180,8 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.scripts">
-	  <term id="application.folder.scripts.title">scripts/</term>
+      <term id="application.folder.scripts.title">
+      scripts/</term>
 	  <listitem>
 		<para>The folder where distributed scripts are located. See the <link
 		linkend="windows.scripts" endterm="windows.scripts.title"/> window for

--- a/doc_src/en/App_ApplicationFolder.xml
+++ b/doc_src/en/App_ApplicationFolder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="application.folder">
-  <title id="application.folder.title">Application Folder</title>
+  <title id="application.folder.title"><link linkend="application.folder"> </link>Application Folder</title>
 
   <para>The application folder contains the <filename>OmegaT.jar</filename>
   application and a number of other important files.</para>
@@ -44,14 +44,14 @@
   
   <variablelist>
 	<varlistentry id="application.folder.omegat.license">
-      <term id="application.folder.omegat.license.title">OmegaT-license.txt</term>
+      <term id="application.folder.omegat.license.title"><link linkend="application.folder.omegat.license"> </link>OmegaT-license.txt</term>
 	  <listitem>
 		<para>OmegaT's distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.omegat.jar">
-      <term id="application.folder.omegat.jar.title">OmegaT.jar</term>
+      <term id="application.folder.omegat.jar.title"><link linkend="application.folder.omegat.jar"> </link>OmegaT.jar</term>
 	  <listitem>
 		<para>OmegaT's executable. Used when launching OmegaT from the command
 		line. See the <link linkend="launch.with.command.line"
@@ -60,7 +60,7 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.changes">
-      <term id="application.folder.changes.title">changes.txt</term>
+      <term id="application.folder.changes.title"><link linkend="application.folder.changes"> </link>changes.txt</term>
 	  <listitem>
 		<para>The list of improvements and bug fixes. Check it if you need
 		information on OmegaT's evolution.</para>
@@ -68,28 +68,28 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.doc.license">
-      <term id="application.folder.doc.license.title">doc-license.txt</term>
+      <term id="application.folder.doc.license.title"><link linkend="application.folder.doc.license"> </link>doc-license.txt</term>
 	  <listitem>
 		<para>The documentation distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.index.html">
-      <term id="application.folder.index.html.title">index.html</term>
+      <term id="application.folder.index.html.title"><link linkend="application.folder.index.html"> </link>index.html</term>
 	  <listitem>
 		<para>The index to the multilingual user manual.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.join.html">
-      <term id="application.folder.join.html.title">join.html</term>
+      <term id="application.folder.join.html.title"><link linkend="application.folder.join.html"> </link>join.html</term>
 	  <listitem>
 		<para>A link to the support page.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.readme.txt">
-      <term id="application.folder.readme.txt.title">readme.txt</term>
+      <term id="application.folder.readme.txt.title"><link linkend="application.folder.readme.txt"> </link>readme.txt</term>
 	  <listitem>
 		<para>Simple installation and running instructions.</para>
 	  </listitem>
@@ -97,20 +97,20 @@
 
 
 	<varlistentry id="application.folder.docs">
-      <term id="application.folder.docs.title">docs/</term>
+      <term id="application.folder.docs.title"><link linkend="application.folder.docs"> </link>docs/</term>
 	  <listitem>
 		<para>The documentation folder.
 
 		<variablelist>
 		  <varlistentry id="application.folder.docs.contributors">
-            <term id="application.folder.docs.contributors.title">contributors.txt</term>
+            <term id="application.folder.docs.contributors.title"><link linkend="application.folder.docs.contributors"> </link>contributors.txt</term>
 			<listitem>
 			  <para>The list of individual contributors.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.en">
-            <term id="application.folder.docs.en.title">en/</term>
+            <term id="application.folder.docs.en.title"><link linkend="application.folder.docs.en"> </link>en/</term>
 			<listitem>
 			  <para>Each translated user manual comes in a different language
 			  folder.</para>
@@ -118,14 +118,14 @@
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.index.html">
-            <term id="application.folder.docs.index.html.title">index.html</term>
+            <term id="application.folder.docs.index.html.title"><link linkend="application.folder.docs.index.html"> </link>index.html</term>
 			<listitem>
 			  <para>The index to the multilingual user manual.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.librairies.txt">
-            <term id="application.folder.docs.librairies.txt.title">libraries.txt</term>
+            <term id="application.folder.docs.librairies.txt.title"><link linkend="application.folder.docs.librairies.txt"> </link>libraries.txt</term>
 			<listitem>
 			  <para>The list of libraries used by OmegaT.</para>
 			</listitem>
@@ -136,21 +136,21 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.images">
-      <term id="application.folder.images.title">images/</term>
+      <term id="application.folder.images.title"><link linkend="application.folder.images"> </link>images/</term>
 	  <listitem>
 		<para>The folder where images used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.lib">
-      <term id="application.folder.lib.title">lib/</term>
+      <term id="application.folder.lib.title"><link linkend="application.folder.lib"> </link>lib/</term>
 	  <listitem>
 		<para>The folder where the libraries used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.plugins">
-      <term id="application.folder.plugins.title">plugins/</term>
+      <term id="application.folder.plugins.title"><link linkend="application.folder.plugins"> </link>plugins/</term>
 	  <listitem>
 		<para>The folder where you can install external plugins. The prefered
 		location for plugin manual installs is the <link
@@ -164,7 +164,7 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.scripts">
-      <term id="application.folder.scripts.title">scripts/</term>
+      <term id="application.folder.scripts.title"><link linkend="application.folder.scripts"> </link>scripts/</term>
 	  <listitem>
 		<para>The folder where distributed scripts are located. See the <link
 		linkend="windows.scripts" endterm="windows.scripts.title"/> window for

--- a/doc_src/en/App_ApplicationFolder.xml
+++ b/doc_src/en/App_ApplicationFolder.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="application.folder">
-  <title id="application.folder.title">
-  Application Folder</title>
+  <title id="application.folder.title">Application Folder</title>
 
   <para>The application folder contains the <filename>OmegaT.jar</filename>
   application and a number of other important files.</para>
@@ -45,16 +44,14 @@
   
   <variablelist>
 	<varlistentry id="application.folder.omegat.license">
-      <term id="application.folder.omegat.license.title">
-      OmegaT-license.txt</term>
+      <term id="application.folder.omegat.license.title">OmegaT-license.txt</term>
 	  <listitem>
 		<para>OmegaT's distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.omegat.jar">
-      <term id="application.folder.omegat.jar.title">
-      OmegaT.jar</term>
+      <term id="application.folder.omegat.jar.title">OmegaT.jar</term>
 	  <listitem>
 		<para>OmegaT's executable. Used when launching OmegaT from the command
 		line. See the <link linkend="launch.with.command.line"
@@ -63,8 +60,7 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.changes">
-      <term id="application.folder.changes.title">
-      changes.txt</term>
+      <term id="application.folder.changes.title">changes.txt</term>
 	  <listitem>
 		<para>The list of improvements and bug fixes. Check it if you need
 		information on OmegaT's evolution.</para>
@@ -72,32 +68,28 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.doc.license">
-      <term id="application.folder.doc.license.title">
-      doc-license.txt</term>
+      <term id="application.folder.doc.license.title">doc-license.txt</term>
 	  <listitem>
 		<para>The documentation distribution license. The GPL version 3.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.index.html">
-      <term id="application.folder.index.html.title">
-      index.html</term>
+      <term id="application.folder.index.html.title">index.html</term>
 	  <listitem>
 		<para>The index to the multilingual user manual.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.join.html">
-      <term id="application.folder.join.html.title">
-      join.html</term>
+      <term id="application.folder.join.html.title">join.html</term>
 	  <listitem>
 		<para>A link to the support page.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.readme.txt">
-      <term id="application.folder.readme.txt.title">
-      readme.txt</term>
+      <term id="application.folder.readme.txt.title">readme.txt</term>
 	  <listitem>
 		<para>Simple installation and running instructions.</para>
 	  </listitem>
@@ -105,23 +97,20 @@
 
 
 	<varlistentry id="application.folder.docs">
-      <term id="application.folder.docs.title">
-      docs/</term>
+      <term id="application.folder.docs.title">docs/</term>
 	  <listitem>
 		<para>The documentation folder.
 
 		<variablelist>
 		  <varlistentry id="application.folder.docs.contributors">
-            <term id="application.folder.docs.contributors.title">
-            contributors.txt</term>
+            <term id="application.folder.docs.contributors.title">contributors.txt</term>
 			<listitem>
 			  <para>The list of individual contributors.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.en">
-            <term id="application.folder.docs.en.title">
-            en/</term>
+            <term id="application.folder.docs.en.title">en/</term>
 			<listitem>
 			  <para>Each translated user manual comes in a different language
 			  folder.</para>
@@ -129,16 +118,14 @@
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.index.html">
-            <term id="application.folder.docs.index.html.title">
-            index.html</term>
+            <term id="application.folder.docs.index.html.title">index.html</term>
 			<listitem>
 			  <para>The index to the multilingual user manual.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="application.folder.docs.librairies.txt">
-            <term id="application.folder.docs.librairies.txt.title">
-            libraries.txt</term>
+            <term id="application.folder.docs.librairies.txt.title">libraries.txt</term>
 			<listitem>
 			  <para>The list of libraries used by OmegaT.</para>
 			</listitem>
@@ -149,24 +136,21 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.images">
-      <term id="application.folder.images.title">
-      images/</term>
+      <term id="application.folder.images.title">images/</term>
 	  <listitem>
 		<para>The folder where images used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.lib">
-      <term id="application.folder.lib.title">
-      lib/</term>
+      <term id="application.folder.lib.title">lib/</term>
 	  <listitem>
 		<para>The folder where the libraries used by OmegaT are stored.</para>
 	  </listitem>
 	</varlistentry>
 
 	<varlistentry id="application.folder.plugins">
-      <term id="application.folder.plugins.title">
-      plugins/</term>
+      <term id="application.folder.plugins.title">plugins/</term>
 	  <listitem>
 		<para>The folder where you can install external plugins. The prefered
 		location for plugin manual installs is the <link
@@ -180,8 +164,7 @@
 	</varlistentry>
 
 	<varlistentry id="application.folder.scripts">
-      <term id="application.folder.scripts.title">
-      scripts/</term>
+      <term id="application.folder.scripts.title">scripts/</term>
 	  <listitem>
 		<para>The folder where distributed scripts are located. See the <link
 		linkend="windows.scripts" endterm="windows.scripts.title"/> window for

--- a/doc_src/en/App_Bidi.xml
+++ b/doc_src/en/App_Bidi.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.bidi">
-  <title id="app.bidi.title">Directional Formatting Characters</title>
+  <title id="app.bidi.title">
+  Directional Formatting Characters</title>
 
   <para>Bidi control characters are available from <link
   linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -29,7 +30,8 @@
   show a visual indication of their position.</para>
 
   <section id="app.bidi.marks">
-	<title id="app.bidi.marks.title">Marks</title>
+	<title id="app.bidi.marks.title">
+    Marks</title>
 
 	<para>To change the position of a character with weak or neutral
 	directionality (like punctuation symbols), insert an LRM or RLM character
@@ -50,7 +52,8 @@
   </section>
 
   <section id="app.bidi.embeddings">
-	<title id="app.bidi.embeddings.title">Embeddings</title>
+	<title id="app.bidi.embeddings.title">
+    Embeddings</title>
 
 	<para>Embeddings can be used to create a longer section of text (containing
 	several words and spaces) that must flow in the direction opposite that of
@@ -66,8 +69,8 @@
 	  </listitem>
 	  <listitem>
 		<para>To create a
-  right-to-left embedding in a left-to-right segment, insert a
-  right-to-left embedding (RLE) character, type or insert the right-to-left
+		right-to-left embedding in a left-to-right segment, insert a
+		right-to-left embedding (RLE) character, type or insert the right-to-left
 		text, and then insert the PDF character.</para>
 	  </listitem>
 	</itemizedlist>

--- a/doc_src/en/App_Bidi.xml
+++ b/doc_src/en/App_Bidi.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.bidi">
-  <title id="app.bidi.title">Directional Formatting Characters</title>
+  <title id="app.bidi.title"><link linkend="app.bidi"> </link>Directional Formatting Characters</title>
 
   <para>Bidi control characters are available from <link
   linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -29,7 +29,7 @@
   show a visual indication of their position.</para>
 
   <section id="app.bidi.marks">
-	<title id="app.bidi.marks.title">Marks</title>
+	<title id="app.bidi.marks.title"><link linkend="app.bidi.marks"> </link>Marks</title>
 
 	<para>To change the position of a character with weak or neutral
 	directionality (like punctuation symbols), insert an LRM or RLM character
@@ -50,7 +50,7 @@
   </section>
 
   <section id="app.bidi.embeddings">
-	<title id="app.bidi.embeddings.title">Embeddings</title>
+	<title id="app.bidi.embeddings.title"><link linkend="app.bidi.embeddings"> </link>Embeddings</title>
 
 	<para>Embeddings can be used to create a longer section of text (containing
 	several words and spaces) that must flow in the direction opposite that of

--- a/doc_src/en/App_Bidi.xml
+++ b/doc_src/en/App_Bidi.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.bidi">
-  <title id="app.bidi.title">
-  Directional Formatting Characters</title>
+  <title id="app.bidi.title">Directional Formatting Characters</title>
 
   <para>Bidi control characters are available from <link
   linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -30,8 +29,7 @@
   show a visual indication of their position.</para>
 
   <section id="app.bidi.marks">
-	<title id="app.bidi.marks.title">
-    Marks</title>
+	<title id="app.bidi.marks.title">Marks</title>
 
 	<para>To change the position of a character with weak or neutral
 	directionality (like punctuation symbols), insert an LRM or RLM character
@@ -52,8 +50,7 @@
   </section>
 
   <section id="app.bidi.embeddings">
-	<title id="app.bidi.embeddings.title">
-    Embeddings</title>
+	<title id="app.bidi.embeddings.title">Embeddings</title>
 
 	<para>Embeddings can be used to create a longer section of text (containing
 	several words and spaces) that must flow in the direction opposite that of

--- a/doc_src/en/App_ConfigurationFolder.xml
+++ b/doc_src/en/App_ConfigurationFolder.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="configuration.folder">
-  <title id="configuration.folder.title">Configuration Folder</title>
+  <title id="configuration.folder.title">
+  Configuration Folder</title>
   <para>The configuration folder stores the majority of the OmegaT options and
   preferences for the user.</para>
   
@@ -12,11 +13,12 @@
   directly.</para>
 
   <section id="configuration.folder.location">
-    <title id="configuration.folder.location.title">Location</title>	
+	<title id="configuration.folder.location.title">
+    Location</title>	
 	<para>The location of the default configuration folder varies by system (the <emphasis>~</emphasis> character represents your home folder):<variablelist>
-	  <varlistentry><term>Linux</term><listitem><para><filename>~/.omegat</filename></para></listitem></varlistentry>
-	  <varlistentry><term>macOS</term><listitem><para><filename>~/Library/Preferences/OmegaT</filename></para></listitem></varlistentry>
-	  <varlistentry><term>Windows</term><listitem><para><filename>~\AppData\Roaming\OmegaT</filename></para></listitem></varlistentry>
+	<varlistentry><term>Linux</term><listitem><para><filename>~/.omegat</filename></para></listitem></varlistentry>
+	<varlistentry><term>macOS</term><listitem><para><filename>~/Library/Preferences/OmegaT</filename></para></listitem></varlistentry>
+	<varlistentry><term>Windows</term><listitem><para><filename>~\AppData\Roaming\OmegaT</filename></para></listitem></varlistentry>
 	</variablelist></para>
 
 	<note>
@@ -35,10 +37,12 @@
   </section>
   
   <section id="configuration.folder.default.contents">
-    <title id="configuration.folder.default.contents.title">Default  contents</title>
+	<title id="configuration.folder.default.contents.title">
+    Default  contents</title>
 	<variablelist>
 	  <varlistentry id="configuration.folder.default.contents.omegat.prefs">
-		<term id="configuration.folder.default.contents.omegat.prefs.title">omegat.prefs</term>
+		<term id="configuration.folder.default.contents.omegat.prefs.title">
+		omegat.prefs</term>
 		<listitem>
 		  <para>This file includes a number of important user
 		  preferences.</para>
@@ -47,7 +51,8 @@
 		  interface. They must be modified manually.</para>
 		  
 		  <example id="no.source.file.display">
-			<title id="no.source.file.display.title">Do not automatically
+			<title id="no.source.file.display.title">
+			  Do not automatically
 			display the Source Files list</title>
 			<para>To prevent the Source Files list window from automatically
 			opening when a project is loaded, find
@@ -65,14 +70,16 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.uilayout">
-		<term id="configuration.folder.default.contents.uilayout.title">uiLayout.xml</term>
+		<term id="configuration.folder.default.contents.uilayout.title">
+		uiLayout.xml</term>
 		<listitem>
 		  <para>This file describes the overall OmegaT layout.</para>
 		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.logs">
-		<term id="configuration.folder.default.contents.logs.title">logs/</term>
+		<term id="configuration.folder.default.contents.logs.title">
+		logs/</term>
 		<listitem>
 		  <para>This folder contains a number of log files. The file name format is
 		  <filename>OmegaT_99999_yyyyMMdd-hhmmss.log</filename>.</para>
@@ -93,14 +100,16 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.default.contents.script">
-		<term id="configuration.folder.default.contents.script.title">script/</term>
+		<term id="configuration.folder.default.contents.script.title">
+		script/</term>
 		<listitem>
 		  <para>If the applicable functions are used, this folder can contain up
 		  to three text files:</para>
 
 		  <variablelist>
 			<varlistentry id="configuration.folder.default.contents.script.selection">
-			  <term id="configuration.folder.default.contents.script.selection.title">selection.txt</term>
+			  <term id="configuration.folder.default.contents.script.selection.title">
+			  selection.txt</term>
 			  <listitem>
 				<para>This file stores the currently selected text when <link
 				linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -110,9 +119,10 @@
 				called.</para>
 			  </listitem>
 			</varlistentry>
-		  
+			
 			<varlistentry id="configuration.folder.default.contents.script.source">
-			  <term id="configuration.folder.default.contents.script.source.title">source.txt</term>
+			  <term id="configuration.folder.default.contents.script.source.title">
+			  source.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>original text</emphasis>
 				from of the current segment when the <link
@@ -124,7 +134,8 @@
 			</varlistentry>
 
 			<varlistentry id="configuration.folder.default.contents.script.target">
-			  <term id="configuration.folder.default.contents.script.target.title">target.txt</term>
+			  <term id="configuration.folder.default.contents.script.target.title">
+			  target.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>translated
 				text</emphasis> from the current segment when the <link
@@ -145,11 +156,13 @@
   </section>
   
   <section id="configuration.folder.extra.contents">
-    <title id="configuration.folder.extra.contents.title">Additional contents</title>
+	<title id="configuration.folder.extra.contents.title">
+    Additional contents</title>
 
 	<variablelist>
 	  <varlistentry id="configuration.folder.extra.contents.editorshortcuts">
-		<term id="configuration.folder.extra.contents.editorshortcuts.title">EditorShortcuts.properties</term>
+		<term id="configuration.folder.extra.contents.editorshortcuts.title">
+		EditorShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized editor shortcuts. See
 		  the <link linkend="app.shortcuts.customization"
@@ -157,9 +170,10 @@
 		  details.</para>
 		</listitem>
 	  </varlistentry>
-	
-	  <varlistentry id="configuration.folder.extra.contents.maninmenushortcut">
-		<term id="configuration.folder.extra.contents.maninmenushortcut.title">MainMenuShortcuts.properties</term>
+	  
+	  <varlistentry id="configuration.folder.extra.contents.mainmenushortcut">
+		<term id="configuration.folder.extra.contents.mainmenushortcut.title">
+		MainMenuShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized user interface
 		  shortcuts. See the <link linkend="app.shortcuts.customization"
@@ -167,19 +181,21 @@
 		  details.</para>
 		</listitem>
 	  </varlistentry>
-	
+	  
 	  <varlistentry id="configuration.folder.extra.contents.filters">
-		<term id="configuration.folder.extra.contents.filters.title">filters.xml</term>
+		<term id="configuration.folder.extra.contents.filters.title">
+		filters.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized file filters. See the
 		  <link linkend="dialogs.preferences.file.filters"
-		  endterm="dialogs.preferences.file.filters.title"/> preferences for
+				endterm="dialogs.preferences.file.filters.title"/> preferences for
 		  details.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.finder">
-		<term id="configuration.folder.extra.contents.finder.title">finder.xml</term>
+		<term id="configuration.folder.extra.contents.finder.title">
+		finder.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized external search
 		  parameters. See the <link
@@ -187,63 +203,68 @@
 		  endterm="dialogs.preferences.external.searches.title"/> preferences
 		  for details.</para>
 		</listitem>
-	</varlistentry>
-	
-	<varlistentry id="configuration.folder.extra.contents.omegat.autotext">
-	  <term id="configuration.folder.extra.contents.omegat.autotext.title">omegat.autotext</term>
-	  <listitem>
-		<para>This parameter file contains customized autotext parameters. See
-		the <link linkend="dialog.preferences.auto.completion"
-		endterm="dialog.preferences.auto.completion.title"/> preferences for
-		details.</para>
-	  </listitem>
-	</varlistentry>
+	  </varlistentry>
+	  
+	  <varlistentry id="configuration.folder.extra.contents.omegat.autotext">
+		<term id="configuration.folder.extra.contents.omegat.autotext.title">
+		omegat.autotext</term>
+		<listitem>
+		  <para>This parameter file contains customized autotext parameters. See
+		  the <link linkend="dialog.preferences.auto.completion"
+		  endterm="dialog.preferences.auto.completion.title"/> preferences for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="configuration.folder.extra.contents.repositories">
-	  <term id="configuration.folder.extra.contents.repositories.title">repositories.properties</term>
-	  <listitem>
-		<para>This file contains the login information for your team project
-		repositories.<warning><para>The file contents are not
-		encrypted.</para></warning>See the <link
-		linkend="how.to.setup.team.project"
-		endterm="how.to.setup.team.project.title"/> how-to for details.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.repositories">
+		<term id="configuration.folder.extra.contents.repositories.title">
+		repositories.properties</term>
+		<listitem>
+		  <para>This file contains the login information for your team project
+		  repositories.<warning><para>The file contents are not
+		  encrypted.</para></warning>See the <link
+		  linkend="how.to.setup.team.project"
+		  endterm="how.to.setup.team.project.title"/> how-to for details.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="configuration.folder.extra.contents.segmentation">
-	  <term id="configuration.folder.extra.contents.segmentation.title">segmentation.conf</term>
-	  <listitem>
-		<para>This parameter file contains customized segmentation
-		parameters. See the <link
-		linkend="dialogs.preferences.segmentation.setup"
-		endterm="dialogs.preferences.segmentation.setup.title"/> preferences for
-		details.</para>
-	  </listitem>
-	</varlistentry>
-	
-	<varlistentry id="configuration.folder.extra.contents.plugin">
-	  <term id="configuration.folder.extra.contents.plugin.title">plugins/</term>
-	  <listitem>
-		<para>This folder provides the standard location for manually
-		installed OmegaT extension plugins. See the <link
-		linkend="dialogs.preferences.plugins"
-		endterm="dialogs.preferences.plugins.title"/> preference for
-		details.</para>
-		<para>It is also possible to install plugins in the application <link
-		linkend="application.folder.plugins"
-		endterm="application.folder.plugins.title"/> folder.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.segmentation">
+		<term id="configuration.folder.extra.contents.segmentation.title">
+		segmentation.conf</term>
+		<listitem>
+		  <para>This parameter file contains customized segmentation
+		  parameters. See the <link
+		  linkend="dialogs.preferences.segmentation.setup"
+		  endterm="dialogs.preferences.segmentation.setup.title"/> preferences for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="configuration.folder.extra.contents.plugin">
+		<term id="configuration.folder.extra.contents.plugin.title">
+		plugins/</term>
+		<listitem>
+		  <para>This folder provides the standard location for manually
+		  installed OmegaT extension plugins. See the <link
+		  linkend="dialogs.preferences.plugins"
+		  endterm="dialogs.preferences.plugins.title"/> preference for
+		  details.</para>
+		  <para>It is also possible to install plugins in the application <link
+		  linkend="application.folder.plugins"
+		  endterm="application.folder.plugins.title"/> folder.</para>
+		</listitem>
+	  </varlistentry>
 
-	<varlistentry id="configuration.folder.extra.contents.spelling">
-	  <term id="configuration.folder.extra.contents.spelling.title">spelling/</term>
-	  <listitem>
-		<para>This folder contains your custom spelling dictionaries. See the <link
-		linkend="dialog.preferences.spellchecker"
-		endterm="dialog.preferences.spellchecker.title"/> preferences for
-		details.</para>
-	  </listitem>
-	</varlistentry>
+	  <varlistentry id="configuration.folder.extra.contents.spelling">
+		<term id="configuration.folder.extra.contents.spelling.title">
+		spelling/</term>
+		<listitem>
+		  <para>This folder contains your custom spelling dictionaries. See the <link
+		  linkend="dialog.preferences.spellchecker"
+		  endterm="dialog.preferences.spellchecker.title"/> preferences for
+		  details.</para>
+		</listitem>
+	  </varlistentry>
 	</variablelist>
   </section>
 </section>

--- a/doc_src/en/App_ConfigurationFolder.xml
+++ b/doc_src/en/App_ConfigurationFolder.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="configuration.folder">
-  <title id="configuration.folder.title">Configuration Folder</title>
+  <title id="configuration.folder.title"><link linkend="configuration.folder"> </link>Configuration Folder</title>
   <para>The configuration folder stores the majority of the OmegaT options and
   preferences for the user.</para>
   
@@ -12,7 +12,7 @@
   directly.</para>
 
   <section id="configuration.folder.location">
-	<title id="configuration.folder.location.title">Location</title>	
+	<title id="configuration.folder.location.title"><link linkend="configuration.folder.location"> </link>Location</title>	
 	<para>The location of the default configuration folder varies by system (the <emphasis>~</emphasis> character represents your home folder):<variablelist>
 	<varlistentry><term>Linux</term><listitem><para><filename>~/.omegat</filename></para></listitem></varlistentry>
 	<varlistentry><term>macOS</term><listitem><para><filename>~/Library/Preferences/OmegaT</filename></para></listitem></varlistentry>
@@ -35,10 +35,10 @@
   </section>
   
   <section id="configuration.folder.default.contents">
-	<title id="configuration.folder.default.contents.title">Default  contents</title>
+	<title id="configuration.folder.default.contents.title"><link linkend="configuration.folder.default.contents"> </link>Default  contents</title>
 	<variablelist>
 	  <varlistentry id="configuration.folder.default.contents.omegat.prefs">
-		<term id="configuration.folder.default.contents.omegat.prefs.title">omegat.prefs</term>
+		<term id="configuration.folder.default.contents.omegat.prefs.title"><link linkend="configuration.folder.default.contents.omegat.prefs"> </link>omegat.prefs</term>
 		<listitem>
 		  <para>This file includes a number of important user
 		  preferences.</para>
@@ -47,9 +47,7 @@
 		  interface. They must be modified manually.</para>
 		  
 		  <example id="no.source.file.display">
-			<title id="no.source.file.display.title">
-			  Do not automatically
-			display the Source Files list</title>
+			<title id="no.source.file.display.title"><link linkend="no.source.file.display"> </link>Do not automatically display the Source Files list</title>
 			<para>To prevent the Source Files list window from automatically
 			opening when a project is loaded, find
 			<token>&lt;project_files_show_on_load></token> and replace
@@ -66,14 +64,14 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.uilayout">
-		<term id="configuration.folder.default.contents.uilayout.title">uiLayout.xml</term>
+		<term id="configuration.folder.default.contents.uilayout.title"><link linkend="configuration.folder.default.contents.uilayout"> </link>uiLayout.xml</term>
 		<listitem>
 		  <para>This file describes the overall OmegaT layout.</para>
 		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.logs">
-		<term id="configuration.folder.default.contents.logs.title">logs/</term>
+		<term id="configuration.folder.default.contents.logs.title"><link linkend="configuration.folder.default.contents.logs"> </link>logs/</term>
 		<listitem>
 		  <para>This folder contains a number of log files. The file name format is
 		  <filename>OmegaT_99999_yyyyMMdd-hhmmss.log</filename>.</para>
@@ -94,14 +92,14 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.default.contents.script">
-		<term id="configuration.folder.default.contents.script.title">script/</term>
+		<term id="configuration.folder.default.contents.script.title"><link linkend="configuration.folder.default.contents.script"> </link>script/</term>
 		<listitem>
 		  <para>If the applicable functions are used, this folder can contain up
 		  to three text files:</para>
 
 		  <variablelist>
 			<varlistentry id="configuration.folder.default.contents.script.selection">
-			  <term id="configuration.folder.default.contents.script.selection.title">selection.txt</term>
+			  <term id="configuration.folder.default.contents.script.selection.title"><link linkend="configuration.folder.default.contents.script.selection"> </link>selection.txt</term>
 			  <listitem>
 				<para>This file stores the currently selected text when <link
 				linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -113,7 +111,7 @@
 			</varlistentry>
 			
 			<varlistentry id="configuration.folder.default.contents.script.source">
-			  <term id="configuration.folder.default.contents.script.source.title">source.txt</term>
+			  <term id="configuration.folder.default.contents.script.source.title"><link linkend="configuration.folder.default.contents.script.source"> </link>source.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>original text</emphasis>
 				from of the current segment when the <link
@@ -125,7 +123,7 @@
 			</varlistentry>
 
 			<varlistentry id="configuration.folder.default.contents.script.target">
-			  <term id="configuration.folder.default.contents.script.target.title">target.txt</term>
+			  <term id="configuration.folder.default.contents.script.target.title"><link linkend="configuration.folder.default.contents.script.target"> </link>target.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>translated
 				text</emphasis> from the current segment when the <link
@@ -146,11 +144,11 @@
   </section>
   
   <section id="configuration.folder.extra.contents">
-	<title id="configuration.folder.extra.contents.title">Additional contents</title>
+	<title id="configuration.folder.extra.contents.title"><link linkend="configuration.folder.extra.contents"> </link>Additional contents</title>
 
 	<variablelist>
 	  <varlistentry id="configuration.folder.extra.contents.editorshortcuts">
-		<term id="configuration.folder.extra.contents.editorshortcuts.title">EditorShortcuts.properties</term>
+		<term id="configuration.folder.extra.contents.editorshortcuts.title"><link linkend="configuration.folder.extra.contents.editorshortcuts"> </link>EditorShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized editor shortcuts. See
 		  the <link linkend="app.shortcuts.customization"
@@ -160,7 +158,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.mainmenushortcut">
-		<term id="configuration.folder.extra.contents.mainmenushortcut.title">MainMenuShortcuts.properties</term>
+		<term id="configuration.folder.extra.contents.mainmenushortcut.title"><link linkend="configuration.folder.extra.contents.mainmenushortcut"> </link>MainMenuShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized user interface
 		  shortcuts. See the <link linkend="app.shortcuts.customization"
@@ -170,7 +168,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.filters">
-		<term id="configuration.folder.extra.contents.filters.title">filters.xml</term>
+		<term id="configuration.folder.extra.contents.filters.title"><link linkend="configuration.folder.extra.contents.filters"> </link>filters.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized file filters. See the
 		  <link linkend="dialogs.preferences.file.filters"
@@ -180,7 +178,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.finder">
-		<term id="configuration.folder.extra.contents.finder.title">finder.xml</term>
+		<term id="configuration.folder.extra.contents.finder.title"><link linkend="configuration.folder.extra.contents.finder"> </link>finder.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized external search
 		  parameters. See the <link
@@ -191,7 +189,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.omegat.autotext">
-		<term id="configuration.folder.extra.contents.omegat.autotext.title">omegat.autotext</term>
+		<term id="configuration.folder.extra.contents.omegat.autotext.title"><link linkend="configuration.folder.extra.contents.omegat.autotext"> </link>omegat.autotext</term>
 		<listitem>
 		  <para>This parameter file contains customized autotext parameters. See
 		  the <link linkend="dialog.preferences.auto.completion"
@@ -201,7 +199,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.repositories">
-		<term id="configuration.folder.extra.contents.repositories.title">repositories.properties</term>
+		<term id="configuration.folder.extra.contents.repositories.title"><link linkend="configuration.folder.extra.contents.repositories"> </link>repositories.properties</term>
 		<listitem>
 		  <para>This file contains the login information for your team project
 		  repositories.<warning><para>The file contents are not
@@ -212,7 +210,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.segmentation">
-		<term id="configuration.folder.extra.contents.segmentation.title">segmentation.conf</term>
+		<term id="configuration.folder.extra.contents.segmentation.title"><link linkend="configuration.folder.extra.contents.segmentation"> </link>segmentation.conf</term>
 		<listitem>
 		  <para>This parameter file contains customized segmentation
 		  parameters. See the <link
@@ -223,7 +221,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.plugin">
-		<term id="configuration.folder.extra.contents.plugin.title">plugins/</term>
+		<term id="configuration.folder.extra.contents.plugin.title"><link linkend="configuration.folder.extra.contents.plugin"> </link>plugins/</term>
 		<listitem>
 		  <para>This folder provides the standard location for manually
 		  installed OmegaT extension plugins. See the <link
@@ -237,7 +235,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.spelling">
-		<term id="configuration.folder.extra.contents.spelling.title">spelling/</term>
+		<term id="configuration.folder.extra.contents.spelling.title"><link linkend="configuration.folder.extra.contents.spelling"> </link>spelling/</term>
 		<listitem>
 		  <para>This folder contains your custom spelling dictionaries. See the <link
 		  linkend="dialog.preferences.spellchecker"

--- a/doc_src/en/App_ConfigurationFolder.xml
+++ b/doc_src/en/App_ConfigurationFolder.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="configuration.folder">
-  <title id="configuration.folder.title">
-  Configuration Folder</title>
+  <title id="configuration.folder.title">Configuration Folder</title>
   <para>The configuration folder stores the majority of the OmegaT options and
   preferences for the user.</para>
   
@@ -13,8 +12,7 @@
   directly.</para>
 
   <section id="configuration.folder.location">
-	<title id="configuration.folder.location.title">
-    Location</title>	
+	<title id="configuration.folder.location.title">Location</title>	
 	<para>The location of the default configuration folder varies by system (the <emphasis>~</emphasis> character represents your home folder):<variablelist>
 	<varlistentry><term>Linux</term><listitem><para><filename>~/.omegat</filename></para></listitem></varlistentry>
 	<varlistentry><term>macOS</term><listitem><para><filename>~/Library/Preferences/OmegaT</filename></para></listitem></varlistentry>
@@ -37,12 +35,10 @@
   </section>
   
   <section id="configuration.folder.default.contents">
-	<title id="configuration.folder.default.contents.title">
-    Default  contents</title>
+	<title id="configuration.folder.default.contents.title">Default  contents</title>
 	<variablelist>
 	  <varlistentry id="configuration.folder.default.contents.omegat.prefs">
-		<term id="configuration.folder.default.contents.omegat.prefs.title">
-		omegat.prefs</term>
+		<term id="configuration.folder.default.contents.omegat.prefs.title">omegat.prefs</term>
 		<listitem>
 		  <para>This file includes a number of important user
 		  preferences.</para>
@@ -70,16 +66,14 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.uilayout">
-		<term id="configuration.folder.default.contents.uilayout.title">
-		uiLayout.xml</term>
+		<term id="configuration.folder.default.contents.uilayout.title">uiLayout.xml</term>
 		<listitem>
 		  <para>This file describes the overall OmegaT layout.</para>
 		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.default.contents.logs">
-		<term id="configuration.folder.default.contents.logs.title">
-		logs/</term>
+		<term id="configuration.folder.default.contents.logs.title">logs/</term>
 		<listitem>
 		  <para>This folder contains a number of log files. The file name format is
 		  <filename>OmegaT_99999_yyyyMMdd-hhmmss.log</filename>.</para>
@@ -100,16 +94,14 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.default.contents.script">
-		<term id="configuration.folder.default.contents.script.title">
-		script/</term>
+		<term id="configuration.folder.default.contents.script.title">script/</term>
 		<listitem>
 		  <para>If the applicable functions are used, this folder can contain up
 		  to three text files:</para>
 
 		  <variablelist>
 			<varlistentry id="configuration.folder.default.contents.script.selection">
-			  <term id="configuration.folder.default.contents.script.selection.title">
-			  selection.txt</term>
+			  <term id="configuration.folder.default.contents.script.selection.title">selection.txt</term>
 			  <listitem>
 				<para>This file stores the currently selected text when <link
 				linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -121,8 +113,7 @@
 			</varlistentry>
 			
 			<varlistentry id="configuration.folder.default.contents.script.source">
-			  <term id="configuration.folder.default.contents.script.source.title">
-			  source.txt</term>
+			  <term id="configuration.folder.default.contents.script.source.title">source.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>original text</emphasis>
 				from of the current segment when the <link
@@ -134,8 +125,7 @@
 			</varlistentry>
 
 			<varlistentry id="configuration.folder.default.contents.script.target">
-			  <term id="configuration.folder.default.contents.script.target.title">
-			  target.txt</term>
+			  <term id="configuration.folder.default.contents.script.target.title">target.txt</term>
 			  <listitem>
 				<para>This file contains the <emphasis>translated
 				text</emphasis> from the current segment when the <link
@@ -156,13 +146,11 @@
   </section>
   
   <section id="configuration.folder.extra.contents">
-	<title id="configuration.folder.extra.contents.title">
-    Additional contents</title>
+	<title id="configuration.folder.extra.contents.title">Additional contents</title>
 
 	<variablelist>
 	  <varlistentry id="configuration.folder.extra.contents.editorshortcuts">
-		<term id="configuration.folder.extra.contents.editorshortcuts.title">
-		EditorShortcuts.properties</term>
+		<term id="configuration.folder.extra.contents.editorshortcuts.title">EditorShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized editor shortcuts. See
 		  the <link linkend="app.shortcuts.customization"
@@ -172,8 +160,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.mainmenushortcut">
-		<term id="configuration.folder.extra.contents.mainmenushortcut.title">
-		MainMenuShortcuts.properties</term>
+		<term id="configuration.folder.extra.contents.mainmenushortcut.title">MainMenuShortcuts.properties</term>
 		<listitem>
 		  <para>This parameter file contains customized user interface
 		  shortcuts. See the <link linkend="app.shortcuts.customization"
@@ -183,8 +170,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.filters">
-		<term id="configuration.folder.extra.contents.filters.title">
-		filters.xml</term>
+		<term id="configuration.folder.extra.contents.filters.title">filters.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized file filters. See the
 		  <link linkend="dialogs.preferences.file.filters"
@@ -194,8 +180,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.finder">
-		<term id="configuration.folder.extra.contents.finder.title">
-		finder.xml</term>
+		<term id="configuration.folder.extra.contents.finder.title">finder.xml</term>
 		<listitem>
 		  <para>This parameter file contains customized external search
 		  parameters. See the <link
@@ -206,8 +191,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.omegat.autotext">
-		<term id="configuration.folder.extra.contents.omegat.autotext.title">
-		omegat.autotext</term>
+		<term id="configuration.folder.extra.contents.omegat.autotext.title">omegat.autotext</term>
 		<listitem>
 		  <para>This parameter file contains customized autotext parameters. See
 		  the <link linkend="dialog.preferences.auto.completion"
@@ -217,8 +201,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.repositories">
-		<term id="configuration.folder.extra.contents.repositories.title">
-		repositories.properties</term>
+		<term id="configuration.folder.extra.contents.repositories.title">repositories.properties</term>
 		<listitem>
 		  <para>This file contains the login information for your team project
 		  repositories.<warning><para>The file contents are not
@@ -229,8 +212,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.segmentation">
-		<term id="configuration.folder.extra.contents.segmentation.title">
-		segmentation.conf</term>
+		<term id="configuration.folder.extra.contents.segmentation.title">segmentation.conf</term>
 		<listitem>
 		  <para>This parameter file contains customized segmentation
 		  parameters. See the <link
@@ -241,8 +223,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="configuration.folder.extra.contents.plugin">
-		<term id="configuration.folder.extra.contents.plugin.title">
-		plugins/</term>
+		<term id="configuration.folder.extra.contents.plugin.title">plugins/</term>
 		<listitem>
 		  <para>This folder provides the standard location for manually
 		  installed OmegaT extension plugins. See the <link
@@ -256,8 +237,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="configuration.folder.extra.contents.spelling">
-		<term id="configuration.folder.extra.contents.spelling.title">
-		spelling/</term>
+		<term id="configuration.folder.extra.contents.spelling.title">spelling/</term>
 		<listitem>
 		  <para>This folder contains your custom spelling dictionaries. See the <link
 		  linkend="dialog.preferences.spellchecker"

--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -3,8 +3,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="file.filters">
-  <title id="file.filters.title">
-  File Filters</title>
+  <title id="file.filters.title">File Filters</title>
 
   <warning>
 	<para>File filters are either local and specific to a given project, or
@@ -62,13 +61,11 @@
   filters.</para>
 
   <section id="file.filters.general">
-	<title id="file.filters.general.title">
-    Common preferences</title>
+	<title id="file.filters.general.title">Common preferences</title>
 	
 	<variablelist>
 	  <varlistentry id="file.filters.general.hide">
-		<term id="file.filters.general.hide.title">
-		Hide leading and trailing tags</term>
+		<term id="file.filters.general.hide.title">Hide leading and trailing tags</term>
 		<listitem>
 		  <para>Leading and trailing tags are generally required by OmegaT to
 		  properly recreate the translated segment. Hiding them from the
@@ -93,8 +90,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.general.preserve">
-		<term id="file.filters.general.preserve.title">
-		Preserve spaces for all tags</term>
+		<term id="file.filters.general.preserve.title">Preserve spaces for all tags</term>
 		<listitem>
 		  <para>If the source documents contain whitespace used to control the
 		  layout, the whitespace that must be will retained in the translated
@@ -103,8 +99,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="file.filters.general.do.not.use.name">
-		<term id="file.filters.general.do.not.use.name.title">
-		Do not use the file name to identify alternate translations</term>
+		<term id="file.filters.general.do.not.use.name.title">Do not use the file name to identify alternate translations</term>
 		<listitem>
 		  <para>The source file name is one of the elements that characterize an
 		  alternative translation. If this option is checked, only the
@@ -119,8 +114,7 @@
   </section>
   
   <section id="edit.filter.dialog">
-	<title id="edit.filter.dialog.title">
-    Edit</title>
+	<title id="edit.filter.dialog.title">Edit</title>
 	
     <para>Double-click the editable fields to make simple modifications or click
     on the <guibutton>Edit...</guibutton> button to access the modification
@@ -209,8 +203,7 @@
     </section>
 
     <section id="target.name">
-	  <title id="target.name.title">
-      Translated filename</title>
+	  <title id="target.name.title">Translated filename</title>
 	  
 	  <para>Files in the <link linkend="project.folder.target"
 	  endterm="project.folder.target.title"/> folder are overwritten every time
@@ -225,8 +218,7 @@
 
 	  <variablelist>
         <varlistentry id="target.name.filename">
-		  <term id="target.name.filename.title">
-		  ${filename}</term>
+		  <term id="target.name.filename.title">${filename}</term>
           <listitem>
 			<para>The default pattern. It represents the complete filename of
 			the source file, including the extension. Using this pattern assigns
@@ -235,56 +227,49 @@
 		</varlistentry>
 
         <varlistentry id="target.name.nameonly">
-		  <term id="target.name.nameonly.title">
-		  ${nameOnly}</term>
+		  <term id="target.name.nameonly.title">${nameOnly}</term>
           <listitem>
 			<para>name of the source file, without the extension</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.extension">
-		  <term id="target.name.extension.title">
-		  ${extension} </term>
+		  <term id="target.name.extension.title">${extension} </term>
           <listitem>
 			<para>original file extension</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.targetlocale">
-		  <term id="target.name.targetlocale.title">
-		  ${targetLocale}</term>
+		  <term id="target.name.targetlocale.title">${targetLocale}</term>
           <listitem>
 			<para>target language+region code (xx_YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.language">
-		  <term id="target.name.target.language.title">
-		  ${targetLanguage}</term>
+		  <term id="target.name.target.language.title">${targetLanguage}</term>
           <listitem>
 			<para>target language+region (xx-YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.language.code">
-		  <term id="target.name.target.language.code.title">
-		  ${targetLanguageCode}</term>
+		  <term id="target.name.target.language.code.title">${targetLanguageCode}</term>
           <listitem>
 			<para>target language code (xx)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.country.code">
-		  <term id="target.name.target.country.code.title">
-		  ${targetCountryCode}</term>
+		  <term id="target.name.target.country.code.title">${targetCountryCode}</term>
           <listitem>
 			<para>target region code (YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.timestamp">
-		  <term id="target.name.timestamp.title">
-		  ${timestamp-????}</term>
+		  <term id="target.name.timestamp.title">${timestamp-????}</term>
           <listitem>
 			<para>system time when the file was created</para>
 
@@ -294,48 +279,42 @@
 		</varlistentry>
 
         <varlistentry id="target.name.os.name">
-		  <term id="target.name.os.name.title">
-		  ${system-os-name}</term>
+		  <term id="target.name.os.name.title">${system-os-name}</term>
           <listitem>
 			<para>name of the operating system</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.user.name">
-		  <term id="target.name.user.name.title">
-		  ${system-user-name}</term>
+		  <term id="target.name.user.name.title">${system-user-name}</term>
           <listitem>
 			<para>user’s login name</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.host.name">
-		  <term id="target.name.host.name.title">
-		  ${system-host-name}</term>
+		  <term id="target.name.host.name.title">${system-host-name}</term>
           <listitem>
 			<para>host name on the system</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.source.encoding">
-		  <term id="target.name.source.encoding.title">
-		  ${file-source-encoding}</term>
+		  <term id="target.name.source.encoding.title">${file-source-encoding}</term>
           <listitem>
 			<para>encoding of the source file</para>
 		  </listitem>
 		</varlistentry>
 		
         <varlistentry id="target.name.target.encoding">
-		  <term id="target.name.target.encoding.title">
-		  ${file-target-encoding}</term>
+		  <term id="target.name.target.encoding.title">${file-target-encoding}</term>
           <listitem>
 			<para>encoding of the target file</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.locale">
-		  <term id="target.name.target.locale.title">
-		  ${targetLocaleLCID}</term>
+		  <term id="target.name.target.locale.title">${targetLocaleLCID}</term>
           <listitem>
 			<para>Microsoft target locale</para>
           </listitem>
@@ -353,8 +332,7 @@
 	  example below.</para>
 
 	  <example id="target.name.example">
-		<title id="target.name.example.title">
-		Target file names</title>
+		<title id="target.name.example.title">Target file names</title>
 		<para>For a source file named Document.xx.docx, using the variable
 		variants below will produce the following results:</para>
 
@@ -388,8 +366,7 @@
   </section>
   
   <section id="filters.options">
-	<title id="filters.options.title">
-    Options</title>
+	<title id="filters.options.title">Options</title>
 
     <para>Several filters offer options. Select the filter in the list and click
     <guibutton>Options...</guibutton> to modify them. </para>
@@ -398,8 +375,7 @@
 
 	<variablelist>
 	  <varlistentry id="file.filters.text">
-		<term id="file.filters.text.title">
-		Text files</term>
+		<term id="file.filters.text.title">Text files</term>
 		<listitem>
 		  <para>
 			<variablelist>
@@ -444,8 +420,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="file.filter.microsoft">
-		<term id="file.filter.microsoft.title">
-		Microsoft Office Open XML files</term>
+		<term id="file.filter.microsoft.title">Microsoft Office Open XML files</term>
 		<listitem>
 		  <warning>
 			<para>The <code>Microsoft Office Open XML (legacy filter)</code> is
@@ -524,8 +499,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.xhtml">
-		<term id="file.filters.xhtml.title">
-		XHTML Files</term>
+		<term id="file.filters.xhtml.title">XHTML Files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -610,8 +584,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.html.xhtml">
-		<term id="file.filters.html.xhtml.title">
-		HTML and XHTML files</term>
+		<term id="file.filters.html.xhtml.title">HTML and XHTML files</term>
 		<listitem>
 		  <para>Only the options not available under the XHTML files filter (see
 		  above) are described here.</para>
@@ -678,8 +651,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.ftl">
-		<term id="file.filters.mozilla.ftl.title">
-		Mozilla FTL</term>
+		<term id="file.filters.mozilla.ftl.title">Mozilla FTL</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -694,8 +666,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.dtd">
-		<term id="file.filters.mozilla.dtd.title">
-		Mozilla DTD</term>
+		<term id="file.filters.mozilla.dtd.title">Mozilla DTD</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -710,8 +681,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.po">
-		<term id="file.filters.po.title">
-		PO files</term>
+		<term id="file.filters.po.title">PO files</term>
 		<listitem>
 		  <para>The filter checks printf variables ('%s', etc.) by
 		  default. See the <link
@@ -784,8 +754,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.moodle.php">
-		<term id="file.filters.moodle.php.title">
-		Moodle PHP</term>
+		<term id="file.filters.moodle.php.title">Moodle PHP</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -801,8 +770,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filter.java.bundle">
-		<term id="file.filter.java.bundle.title">
-		Java Resource bundle</term>
+		<term id="file.filter.java.bundle.title">Java Resource bundle</term>
 		<listitem>
 		  <para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by
 		  default. See the <link
@@ -841,8 +809,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.odf">
-		<term id="file.filters.odf.title">
-		Open Document Format (ODF) files</term>
+		<term id="file.filters.odf.title">Open Document Format (ODF) files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -858,8 +825,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.xliff">
-		<term id="file.filters.xliff.title">
-		XLIFF (legacy filter)</term>
+		<term id="file.filters.xliff.title">XLIFF (legacy filter)</term>
 		<listitem>
 		  <warning>
 			<para>This filter is the original OmegaT XLIFF filter. You should

--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -3,7 +3,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="file.filters">
-  <title id="file.filters.title">File Filters</title>
+  <title id="file.filters.title"><link linkend="file.filters"> </link>File Filters</title>
 
   <warning>
 	<para>File filters are either local and specific to a given project, or
@@ -61,11 +61,11 @@
   filters.</para>
 
   <section id="file.filters.general">
-	<title id="file.filters.general.title">Common preferences</title>
+	<title id="file.filters.general.title"><link linkend="file.filters.general"> </link>Common preferences</title>
 	
 	<variablelist>
 	  <varlistentry id="file.filters.general.hide">
-		<term id="file.filters.general.hide.title">Hide leading and trailing tags</term>
+		<term id="file.filters.general.hide.title"><link linkend="file.filters.general.hide"> </link>Hide leading and trailing tags</term>
 		<listitem>
 		  <para>Leading and trailing tags are generally required by OmegaT to
 		  properly recreate the translated segment. Hiding them from the
@@ -78,9 +78,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.general.remove">
-		<term id="file.filters.general.remove.title">
-		  Remove leading and trailing whitespace in non-segmented
-		projects</term>
+		<term id="file.filters.general.remove.title"><link linkend="file.filters.general.remove"> </link>Remove leading and trailing whitespace in non-segmented projects</term>
 		<listitem>
 		  <para> By default, OmegaT removes any leading and trailing whitespace
 		  from the translatable contents. In non-segmented projects, disable
@@ -90,7 +88,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.general.preserve">
-		<term id="file.filters.general.preserve.title">Preserve spaces for all tags</term>
+		<term id="file.filters.general.preserve.title"><link linkend="file.filters.general.preserve"> </link>Preserve spaces for all tags</term>
 		<listitem>
 		  <para>If the source documents contain whitespace used to control the
 		  layout, the whitespace that must be will retained in the translated
@@ -99,7 +97,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="file.filters.general.do.not.use.name">
-		<term id="file.filters.general.do.not.use.name.title">Do not use the file name to identify alternate translations</term>
+		<term id="file.filters.general.do.not.use.name.title"><link linkend="file.filters.general.do.not.use.name"> </link>Do not use the file name to identify alternate translations</term>
 		<listitem>
 		  <para>The source file name is one of the elements that characterize an
 		  alternative translation. If this option is checked, only the
@@ -114,7 +112,7 @@
   </section>
   
   <section id="edit.filter.dialog">
-	<title id="edit.filter.dialog.title">Edit</title>
+	<title id="edit.filter.dialog.title"><link linkend="edit.filter.dialog"> </link>Edit</title>
 	
     <para>Double-click the editable fields to make simple modifications or click
     on the <guibutton>Edit...</guibutton> button to access the modification
@@ -131,9 +129,7 @@
 	customize the target file name.</para>
 
     <section id="source.filetype.and.filename.pattern">
-	  <title id="source.filetype.and.filename.pattern.title">
-		Source filename
-	  pattern</title>
+	  <title id="source.filetype.and.filename.pattern.title"><link linkend="source.filetype.and.filename.pattern"> </link>Source filename pattern</title>
 
 	  <para> To associate a filter to a file, OmegaT checks its file extension
 	  and attempts to match it to a source filename patterns in a filter.</para>
@@ -167,9 +163,7 @@
     </section>
 
     <section id="source.and.target.files.encoding">
-	  <title id="source.and.target.files.encoding.title">
-		Source and translated
-	  file encoding</title>
+	  <title id="source.and.target.files.encoding.title"><link linkend="source.and.target.files.encoding"> </link>Source and translated file encoding</title>
 
 	  <para>Most file formats allow various possible encodings. By default, the
 	  encoding of the translated file is the same as that of the source
@@ -203,7 +197,7 @@
     </section>
 
     <section id="target.name">
-	  <title id="target.name.title">Translated filename</title>
+	  <title id="target.name.title"><link linkend="target.name"> </link>Translated filename</title>
 	  
 	  <para>Files in the <link linkend="project.folder.target"
 	  endterm="project.folder.target.title"/> folder are overwritten every time
@@ -218,7 +212,7 @@
 
 	  <variablelist>
         <varlistentry id="target.name.filename">
-		  <term id="target.name.filename.title">${filename}</term>
+		  <term id="target.name.filename.title"><link linkend="target.name.filename"> </link>${filename}</term>
           <listitem>
 			<para>The default pattern. It represents the complete filename of
 			the source file, including the extension. Using this pattern assigns
@@ -227,49 +221,49 @@
 		</varlistentry>
 
         <varlistentry id="target.name.nameonly">
-		  <term id="target.name.nameonly.title">${nameOnly}</term>
+		  <term id="target.name.nameonly.title"><link linkend="target.name.nameonly"> </link>${nameOnly}</term>
           <listitem>
 			<para>name of the source file, without the extension</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.extension">
-		  <term id="target.name.extension.title">${extension} </term>
+		  <term id="target.name.extension.title"><link linkend="target.name.extension"> </link>${extension} </term>
           <listitem>
 			<para>original file extension</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.targetlocale">
-		  <term id="target.name.targetlocale.title">${targetLocale}</term>
+		  <term id="target.name.targetlocale.title"><link linkend="target.name.targetlocale"> </link>${targetLocale}</term>
           <listitem>
 			<para>target language+region code (xx_YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.language">
-		  <term id="target.name.target.language.title">${targetLanguage}</term>
+		  <term id="target.name.target.language.title"><link linkend="target.name.target.language"> </link>${targetLanguage}</term>
           <listitem>
 			<para>target language+region (xx-YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.language.code">
-		  <term id="target.name.target.language.code.title">${targetLanguageCode}</term>
+		  <term id="target.name.target.language.code.title"><link linkend="target.name.target.language.code"> </link>${targetLanguageCode}</term>
           <listitem>
 			<para>target language code (xx)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.country.code">
-		  <term id="target.name.target.country.code.title">${targetCountryCode}</term>
+		  <term id="target.name.target.country.code.title"><link linkend="target.name.target.country.code"> </link>${targetCountryCode}</term>
           <listitem>
 			<para>target region code (YY)</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.timestamp">
-		  <term id="target.name.timestamp.title">${timestamp-????}</term>
+		  <term id="target.name.timestamp.title"><link linkend="target.name.timestamp"> </link>${timestamp-????}</term>
           <listitem>
 			<para>system time when the file was created</para>
 
@@ -279,42 +273,42 @@
 		</varlistentry>
 
         <varlistentry id="target.name.os.name">
-		  <term id="target.name.os.name.title">${system-os-name}</term>
+		  <term id="target.name.os.name.title"><link linkend="target.name.os.name"> </link>${system-os-name}</term>
           <listitem>
 			<para>name of the operating system</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.user.name">
-		  <term id="target.name.user.name.title">${system-user-name}</term>
+		  <term id="target.name.user.name.title"><link linkend="target.name.user.name"> </link>${system-user-name}</term>
           <listitem>
 			<para>user’s login name</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.host.name">
-		  <term id="target.name.host.name.title">${system-host-name}</term>
+		  <term id="target.name.host.name.title"><link linkend="target.name.host.name"> </link>${system-host-name}</term>
           <listitem>
 			<para>host name on the system</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.source.encoding">
-		  <term id="target.name.source.encoding.title">${file-source-encoding}</term>
+		  <term id="target.name.source.encoding.title"><link linkend="target.name.source.encoding"> </link>${file-source-encoding}</term>
           <listitem>
 			<para>encoding of the source file</para>
 		  </listitem>
 		</varlistentry>
 		
         <varlistentry id="target.name.target.encoding">
-		  <term id="target.name.target.encoding.title">${file-target-encoding}</term>
+		  <term id="target.name.target.encoding.title"><link linkend="target.name.target.encoding"> </link>${file-target-encoding}</term>
           <listitem>
 			<para>encoding of the target file</para>
           </listitem>
 		</varlistentry>
 
         <varlistentry id="target.name.target.locale">
-		  <term id="target.name.target.locale.title">${targetLocaleLCID}</term>
+		  <term id="target.name.target.locale.title"><link linkend="target.name.target.locale"> </link>${targetLocaleLCID}</term>
           <listitem>
 			<para>Microsoft target locale</para>
           </listitem>
@@ -332,7 +326,7 @@
 	  example below.</para>
 
 	  <example id="target.name.example">
-		<title id="target.name.example.title">Target file names</title>
+		<title id="target.name.example.title"><link linkend="target.name.example"> </link>Target file names</title>
 		<para>For a source file named Document.xx.docx, using the variable
 		variants below will produce the following results:</para>
 
@@ -366,7 +360,7 @@
   </section>
   
   <section id="filters.options">
-	<title id="filters.options.title">Options</title>
+	<title id="filters.options.title"><link linkend="filters.options"> </link>Options</title>
 
     <para>Several filters offer options. Select the filter in the list and click
     <guibutton>Options...</guibutton> to modify them. </para>
@@ -375,7 +369,7 @@
 
 	<variablelist>
 	  <varlistentry id="file.filters.text">
-		<term id="file.filters.text.title">Text files</term>
+		<term id="file.filters.text.title"><link linkend="file.filters.text"> </link>Text files</term>
 		<listitem>
 		  <para>
 			<variablelist>
@@ -420,7 +414,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="file.filter.microsoft">
-		<term id="file.filter.microsoft.title">Microsoft Office Open XML files</term>
+		<term id="file.filter.microsoft.title"><link linkend="file.filter.microsoft"> </link>Microsoft Office Open XML files</term>
 		<listitem>
 		  <warning>
 			<para>The <code>Microsoft Office Open XML (legacy filter)</code> is
@@ -499,7 +493,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.xhtml">
-		<term id="file.filters.xhtml.title">XHTML Files</term>
+		<term id="file.filters.xhtml.title"><link linkend="file.filters.xhtml"> </link>XHTML Files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -537,10 +531,7 @@
 				comma.</para>
 				
 				<example id="file.filters.xhtml.example">
-				  <title id="file.filters.xhtml.example.title">
-					Ignore the
-					content part of &lt;meta name="robots" content="index,
-				  follow"&gt;</title>
+				  <title id="file.filters.xhtml.example.title"><link linkend="file.filters.xhtml.example"> </link>Ignore the content part of &lt;meta name="robots" content="index, follow"&gt;</title>
 				  <para>To ignore this content:</para>
 
 				  <para><code>&lt;meta name="robots" content="index,
@@ -584,7 +575,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.html.xhtml">
-		<term id="file.filters.html.xhtml.title">HTML and XHTML files</term>
+		<term id="file.filters.html.xhtml.title"><link linkend="file.filters.html.xhtml"> </link>HTML and XHTML files</term>
 		<listitem>
 		  <para>Only the options not available under the XHTML files filter (see
 		  above) are described here.</para>
@@ -651,7 +642,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.ftl">
-		<term id="file.filters.mozilla.ftl.title">Mozilla FTL</term>
+		<term id="file.filters.mozilla.ftl.title"><link linkend="file.filters.mozilla.ftl"> </link>Mozilla FTL</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -666,7 +657,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.dtd">
-		<term id="file.filters.mozilla.dtd.title">Mozilla DTD</term>
+		<term id="file.filters.mozilla.dtd.title"><link linkend="file.filters.mozilla.dtd"> </link>Mozilla DTD</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -681,7 +672,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.po">
-		<term id="file.filters.po.title">PO files</term>
+		<term id="file.filters.po.title"><link linkend="file.filters.po"> </link>PO files</term>
 		<listitem>
 		  <para>The filter checks printf variables ('%s', etc.) by
 		  default. See the <link
@@ -754,7 +745,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.moodle.php">
-		<term id="file.filters.moodle.php.title">Moodle PHP</term>
+		<term id="file.filters.moodle.php.title"><link linkend="file.filters.moodle.php"> </link>Moodle PHP</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -770,7 +761,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filter.java.bundle">
-		<term id="file.filter.java.bundle.title">Java Resource bundle</term>
+		<term id="file.filter.java.bundle.title"><link linkend="file.filter.java.bundle"> </link>Java Resource bundle</term>
 		<listitem>
 		  <para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by
 		  default. See the <link
@@ -809,7 +800,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.odf">
-		<term id="file.filters.odf.title">Open Document Format (ODF) files</term>
+		<term id="file.filters.odf.title"><link linkend="file.filters.odf"> </link>Open Document Format (ODF) files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -825,7 +816,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.xliff">
-		<term id="file.filters.xliff.title">XLIFF (legacy filter)</term>
+		<term id="file.filters.xliff.title"><link linkend="file.filters.xliff"> </link>XLIFF (legacy filter)</term>
 		<listitem>
 		  <warning>
 			<para>This filter is the original OmegaT XLIFF filter. You should

--- a/doc_src/en/App_FileFilters.xml
+++ b/doc_src/en/App_FileFilters.xml
@@ -3,7 +3,8 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="file.filters">
-  <title id="file.filters.title">File Filters</title>
+  <title id="file.filters.title">
+  File Filters</title>
 
   <warning>
 	<para>File filters are either local and specific to a given project, or
@@ -41,7 +42,7 @@
 
   <para>Some filters provide a <guibutton>Options...</guibutton> button to
   further customize their settings.</para>
-	
+  
   <para>Click the <guibutton>Restore Defaults</guibutton> button to reset the
   file filters to their default settings.</para>
 
@@ -61,11 +62,13 @@
   filters.</para>
 
   <section id="file.filters.general">
-	<title id="file.filters.general.title">Common preferences</title>
-	  
+	<title id="file.filters.general.title">
+    Common preferences</title>
+	
 	<variablelist>
-	  <varlistentry>
-		<term>Hide leading and trailing tags</term>
+	  <varlistentry id="file.filters.general.hide">
+		<term id="file.filters.general.hide.title">
+		Hide leading and trailing tags</term>
 		<listitem>
 		  <para>Leading and trailing tags are generally required by OmegaT to
 		  properly recreate the translated segment. Hiding them from the
@@ -77,8 +80,9 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Remove leading and trailing whitespace in non-segmented
+	  <varlistentry id="file.filters.general.remove">
+		<term id="file.filters.general.remove.title">
+		  Remove leading and trailing whitespace in non-segmented
 		projects</term>
 		<listitem>
 		  <para> By default, OmegaT removes any leading and trailing whitespace
@@ -88,16 +92,19 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Preserve spaces for all tags</term>
+	  <varlistentry id="file.filters.general.preserve">
+		<term id="file.filters.general.preserve.title">
+		Preserve spaces for all tags</term>
 		<listitem>
 		  <para>If the source documents contain whitespace used to control the
 		  layout, the whitespace that must be will retained in the translated
 		  document.</para>
 		</listitem>
 	  </varlistentry>
-	  <varlistentry>
-		<term>Do not use the file name to identify alternate translations</term>
+	  
+	  <varlistentry id="file.filters.general.do.not.use.name">
+		<term id="file.filters.general.do.not.use.name.title">
+		Do not use the file name to identify alternate translations</term>
 		<listitem>
 		  <para>The source file name is one of the elements that characterize an
 		  alternative translation. If this option is checked, only the
@@ -110,9 +117,10 @@
 	  </varlistentry>
 	</variablelist>
   </section>
-	
+  
   <section id="edit.filter.dialog">
-    <title id="edit.filter.dialog.title">Edit</title>
+	<title id="edit.filter.dialog.title">
+    Edit</title>
 	
     <para>Double-click the editable fields to make simple modifications or click
     on the <guibutton>Edit...</guibutton> button to access the modification
@@ -129,7 +137,8 @@
 	customize the target file name.</para>
 
     <section id="source.filetype.and.filename.pattern">
-	  <title id="source.filetype.and.filename.pattern.title">Source filename
+	  <title id="source.filetype.and.filename.pattern.title">
+		Source filename
 	  pattern</title>
 
 	  <para> To associate a filter to a file, OmegaT checks its file extension
@@ -143,7 +152,7 @@
 
 	  <para>You can change or add filename patterns to associate different files
 	  to a filter.</para>
-		
+	  
 	  <warning>
 		<para>Associating a file extension to a filter is not sufficient to have
 		the filter properly handle the file. The file structure must also be
@@ -152,8 +161,8 @@
 		to understand the contents of a LibreOffice Writer
 		file.</para>
 	  </warning>
-		
-		
+	  
+	  
 	  <para>Source filename patterns use wild card characters : The
 	  <literal>*</literal> character matches zero or more characters, while the
 	  <literal>?</literal> character matches exactly one character.</para>
@@ -164,7 +173,8 @@
     </section>
 
     <section id="source.and.target.files.encoding">
-	  <title id="source.and.target.files.encoding.title">Source and translated
+	  <title id="source.and.target.files.encoding.title">
+		Source and translated
 	  file encoding</title>
 
 	  <para>Most file formats allow various possible encodings. By default, the
@@ -199,7 +209,8 @@
     </section>
 
     <section id="target.name">
-	  <title id="target.name.title">Translated filename</title>
+	  <title id="target.name.title">
+      Translated filename</title>
 	  
 	  <para>Files in the <link linkend="project.folder.target"
 	  endterm="project.folder.target.title"/> folder are overwritten every time
@@ -213,8 +224,9 @@
 	  dialog offers various options:</para>
 
 	  <variablelist>
-        <varlistentry>
-          <term>${filename}</term>
+        <varlistentry id="target.name.filename">
+		  <term id="target.name.filename.title">
+		  ${filename}</term>
           <listitem>
 			<para>The default pattern. It represents the complete filename of
 			the source file, including the extension. Using this pattern assigns
@@ -222,50 +234,57 @@
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${nameOnly}</term>
+        <varlistentry id="target.name.nameonly">
+		  <term id="target.name.nameonly.title">
+		  ${nameOnly}</term>
           <listitem>
 			<para>name of the source file, without the extension</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${extension} </term>
+        <varlistentry id="target.name.extension">
+		  <term id="target.name.extension.title">
+		  ${extension} </term>
           <listitem>
 			<para>original file extension</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${targetLocale}</term>
+        <varlistentry id="target.name.targetlocale">
+		  <term id="target.name.targetlocale.title">
+		  ${targetLocale}</term>
           <listitem>
 			<para>target language+region code (xx_YY)</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${targetLanguage}</term>
+        <varlistentry id="target.name.target.language">
+		  <term id="target.name.target.language.title">
+		  ${targetLanguage}</term>
           <listitem>
 			<para>target language+region (xx-YY)</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${targetLanguageCode}</term>
+        <varlistentry id="target.name.target.language.code">
+		  <term id="target.name.target.language.code.title">
+		  ${targetLanguageCode}</term>
           <listitem>
 			<para>target language code (xx)</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${targetCountryCode}</term>
+        <varlistentry id="target.name.target.country.code">
+		  <term id="target.name.target.country.code.title">
+		  ${targetCountryCode}</term>
           <listitem>
 			<para>target region code (YY)</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${timestamp-????}</term>
+        <varlistentry id="target.name.timestamp">
+		  <term id="target.name.timestamp.title">
+		  ${timestamp-????}</term>
           <listitem>
 			<para>system time when the file was created</para>
 
@@ -274,52 +293,58 @@
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${system-os-name}</term>
+        <varlistentry id="target.name.os.name">
+		  <term id="target.name.os.name.title">
+		  ${system-os-name}</term>
           <listitem>
 			<para>name of the operating system</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${system-user-name}</term>
+        <varlistentry id="target.name.user.name">
+		  <term id="target.name.user.name.title">
+		  ${system-user-name}</term>
           <listitem>
 			<para>user’s login name</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${system-host-name}</term>
+        <varlistentry id="target.name.host.name">
+		  <term id="target.name.host.name.title">
+		  ${system-host-name}</term>
           <listitem>
 			<para>host name on the system</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${file-source-encoding}</term>
+        <varlistentry id="target.name.source.encoding">
+		  <term id="target.name.source.encoding.title">
+		  ${file-source-encoding}</term>
           <listitem>
 			<para>encoding of the source file</para>
 		  </listitem>
 		</varlistentry>
-		  
-        <varlistentry>
-          <term>${file-target-encoding}</term>
+		
+        <varlistentry id="target.name.target.encoding">
+		  <term id="target.name.target.encoding.title">
+		  ${file-target-encoding}</term>
           <listitem>
 			<para>encoding of the target file</para>
           </listitem>
 		</varlistentry>
 
-        <varlistentry>
-          <term>${targetLocaleLCID}</term>
+        <varlistentry id="target.name.target.locale">
+		  <term id="target.name.target.locale.title">
+		  ${targetLocaleLCID}</term>
           <listitem>
 			<para>Microsoft target locale</para>
           </listitem>
 		</varlistentry>
 	  </variablelist>
-		
+	  
 	  <para>Additional variants are available for <literal>${nameOnly}</literal>
 	  and <literal>${extension}</literal>.</para>
-		
+	  
 	  <para>If the use of multiple periods makes identifying the file name and
 	  extension ambiguous, you can use variables of the form
 	  <literal>${nameOnly-</literal><emphasis>number</emphasis>} or
@@ -328,7 +353,8 @@
 	  example below.</para>
 
 	  <example id="target.name.example">
-		<title id="target.name.example.title">Target file names</title>
+		<title id="target.name.example.title">
+		Target file names</title>
 		<para>For a source file named Document.xx.docx, using the variable
 		variants below will produce the following results:</para>
 
@@ -360,9 +386,10 @@
 	  </example>
     </section>
   </section>
-	
+  
   <section id="filters.options">
-    <title id="filters.options.title">Options</title>
+	<title id="filters.options.title">
+    Options</title>
 
     <para>Several filters offer options. Select the filter in the list and click
     <guibutton>Options...</guibutton> to modify them. </para>
@@ -371,7 +398,8 @@
 
 	<variablelist>
 	  <varlistentry id="file.filters.text">
-		<term id="file.filters.text.title">Text files</term>
+		<term id="file.filters.text.title">
+		Text files</term>
 		<listitem>
 		  <para>
 			<variablelist>
@@ -414,9 +442,10 @@
 		  </para>
 		</listitem>
 	  </varlistentry>
-		
+	  
 	  <varlistentry id="file.filter.microsoft">
-		<term id="file.filter.microsoft.title">Microsoft Office Open XML files</term>
+		<term id="file.filter.microsoft.title">
+		Microsoft Office Open XML files</term>
 		<listitem>
 		  <warning>
 			<para>The <code>Microsoft Office Open XML (legacy filter)</code> is
@@ -442,60 +471,61 @@
 			  <listitem>
 				<para>Comments and sheet names.</para>
 			  </listitem>
-			  </varlistentry>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Power Point</term>
-				<listitem>
-				  <para>Slide comments, slide masters, and slide layouts.</para>
-				</listitem>
-			  </varlistentry>
+			<varlistentry>
+			  <term>Power Point</term>
+			  <listitem>
+				<para>Slide comments, slide masters, and slide layouts.</para>
+			  </listitem>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Global</term>
-				<listitem>
-				  <para>External links, charts, diagrams, drawings, and
-				  WordArt.</para>
-				</listitem>
-			  </varlistentry>
-			  
-			  <varlistentry>
-				<term>Other Options:</term>
-				<listitem>
-				  <variablelist>
-					<varlistentry>
-					  <term>Aggregate tags</term>
-					  <listitem>
-						<para>Tags that do not enclose translatable text will be
-						aggregated into a single tag.</para>
-					  </listitem>
-					</varlistentry>
+			<varlistentry>
+			  <term>Global</term>
+			  <listitem>
+				<para>External links, charts, diagrams, drawings, and
+				WordArt.</para>
+			  </listitem>
+			</varlistentry>
+			
+			<varlistentry>
+			  <term>Other Options:</term>
+			  <listitem>
+				<variablelist>
+				  <varlistentry>
+					<term>Aggregate tags</term>
+					<listitem>
+					  <para>Tags that do not enclose translatable text will be
+					  aggregated into a single tag.</para>
+					</listitem>
+				  </varlistentry>
 
-					<varlistentry>
-					  <term>Preserve spaces for all tags</term>
-					  <listitem>
-						<para>Whitespace (i.e., spaces and newlines) will be
-						preserved, even if this option is not defined in the
-						document.</para>
-					  </listitem>
-					</varlistentry>
+				  <varlistentry>
+					<term>Preserve spaces for all tags</term>
+					<listitem>
+					  <para>Whitespace (i.e., spaces and newlines) will be
+					  preserved, even if this option is not defined in the
+					  document.</para>
+					</listitem>
+				  </varlistentry>
 
-					<varlistentry>
-					  <term>Start a new paragraph on Word soft-returns</term>
-					  <listitem>
-						<para>Enable this option if soft-returns are intended to
-						be paragraph starters.</para>
-					  </listitem>
-					</varlistentry>
-				  </variablelist>
-				</listitem>
-			  </varlistentry>
+				  <varlistentry>
+					<term>Start a new paragraph on Word soft-returns</term>
+					<listitem>
+					  <para>Enable this option if soft-returns are intended to
+					  be paragraph starters.</para>
+					</listitem>
+				  </varlistentry>
+				</variablelist>
+			  </listitem>
+			</varlistentry>
 		  </variablelist>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.xhtml">
-		<term id="file.filters.xhtml.title">XHTML Files</term>
+		<term id="file.filters.xhtml.title">
+		XHTML Files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -515,12 +545,12 @@
 			<varlistentry>
 			  <term>Ignored paragraphs (regular expression)</term>
 			  <listitem>
-				  <para>Any paragraph matching the regular expression
-				  is ignored while loading and is not displayed for
-				  translation.</para>
+				<para>Any paragraph matching the regular expression
+				is ignored while loading and is not displayed for
+				translation.</para>
 
-				  <para>This option is convenient when dealing with HTML parts
-				  that only contain non translatable text.</para>
+				<para>This option is convenient when dealing with HTML parts
+				that only contain non translatable text.</para>
 			  </listitem>
 			</varlistentry>
 			<varlistentry>
@@ -533,8 +563,9 @@
 				comma.</para>
 				
 				<example id="file.filters.xhtml.example">
-				  <title id="file.filters.xhtml.example.title">Ignore the
-				  content part of &lt;meta name="robots" content="index,
+				  <title id="file.filters.xhtml.example.title">
+					Ignore the
+					content part of &lt;meta name="robots" content="index,
 				  follow"&gt;</title>
 				  <para>To ignore this content:</para>
 
@@ -559,7 +590,8 @@
 
 				<example id="file.filters.xhtml.ignore.translate.no">
 				  <title
-				  id="file.filters.xhtml.ignore.translate.no.title">Ignore tags
+					  id="file.filters.xhtml.ignore.translate.no.title">
+					Ignore tags
 				  that contain translate=&quot;no&quot;</title>
 				  <para>To ignore this content:</para>
 
@@ -577,8 +609,9 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>HTML and XHTML files</term>
+	  <varlistentry id="file.filters.html.xhtml">
+		<term id="file.filters.html.xhtml.title">
+		HTML and XHTML files</term>
 		<listitem>
 		  <para>Only the options not available under the XHTML files filter (see
 		  above) are described here.</para>
@@ -645,7 +678,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.ftl">
-		<term id="file.filters.mozilla.ftl.title">Mozilla FTL</term>
+		<term id="file.filters.mozilla.ftl.title">
+		Mozilla FTL</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -660,14 +694,15 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.mozilla.dtd">
-		<term id="file.filters.mozilla.dtd.title">Mozilla DTD</term>
+		<term id="file.filters.mozilla.dtd.title">
+		Mozilla DTD</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
 			  <term>Remove untranslated strings in the target files</term>
 			  <listitem>
-				  <para>Having untranslated contents in the translated files
-				  sometimes creates compatibility issues.</para>
+				<para>Having untranslated contents in the translated files
+				sometimes creates compatibility issues.</para>
 			  </listitem>
 			</varlistentry>
 		  </variablelist>
@@ -675,80 +710,82 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.po">
-		<term id="file.filters.po.title">PO files</term>
+		<term id="file.filters.po.title">
+		PO files</term>
 		<listitem>
-			<para>The filter checks printf variables ('%s', etc.) by
-			default. See the <link
-			linkend="dialogs.preferences.tag.processing.programming.variables"
-			endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
-			preference for details.</para>
+		  <para>The filter checks printf variables ('%s', etc.) by
+		  default. See the <link
+		  linkend="dialogs.preferences.tag.processing.programming.variables"
+		  endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
+		  preference for details.</para>
 
-			<variablelist>
-			  <varlistentry>
-				<term>Allow blank target segments</term>
-				<listitem>
-				  <para>OmegaT always reproduces the source contents when a
-				  segment is not provided. Use this option to leave a non
-				  translated segment blank.</para>
-				</listitem>
-			  </varlistentry>
-			  
-			  <varlistentry>
-				<term>Translate blank source segments</term>
-				<listitem>
-				  <para>Blank source segments sometimes act as placeholders for
-				  parts that do not exist in the source language but are
-				  necessary in the target language. Use this option to provide a
-				  translation based on the associated comments.</para>
-				</listitem>
-			  </varlistentry>
-			  
-			  <varlistentry>
-				<term>Ignore PO header</term>
-				<listitem>
-				  <para>The PO header will not be displayed for translation.</para>
-				</listitem>
-			  </varlistentry>
+		  <variablelist>
+			<varlistentry>
+			  <term>Allow blank target segments</term>
+			  <listitem>
+				<para>OmegaT always reproduces the source contents when a
+				segment is not provided. Use this option to leave a non
+				translated segment blank.</para>
+			  </listitem>
+			</varlistentry>
+			
+			<varlistentry>
+			  <term>Translate blank source segments</term>
+			  <listitem>
+				<para>Blank source segments sometimes act as placeholders for
+				parts that do not exist in the source language but are
+				necessary in the target language. Use this option to provide a
+				translation based on the associated comments.</para>
+			  </listitem>
+			</varlistentry>
+			
+			<varlistentry>
+			  <term>Ignore PO header</term>
+			  <listitem>
+				<para>The PO header will not be displayed for translation.</para>
+			  </listitem>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Auto replace plural specification</term>
-				<listitem>
-				  <para>Override the plural specification in the header and use
-				  the target language default.</para>
-				</listitem>
-			  </varlistentry>
+			<varlistentry>
+			  <term>Auto replace plural specification</term>
+			  <listitem>
+				<para>Override the plural specification in the header and use
+				the target language default.</para>
+			  </listitem>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Format:</term>
-				<listitem>
-				  <variablelist>
-					<varlistentry>
-					  <term>Standard</term>
-					  <listitem>
-						<para>PO files that use <literal>msgid</literal> as the
-						source container and expect the translation to be put in
-						<literal>msgstr</literal></para>
-					  </listitem>
-					</varlistentry>
-					
-					<varlistentry>
-					  <term>Monolingual</term>
-					  <listitem>
-						<para>PO files that use <literal>msgid</literal> as an
-						ID code, use <literal>msgstr</literal> as the source
-						container and expect the translation to overwrite
-						<literal>msgstr</literal></para>
-					  </listitem>
-					</varlistentry>
-				  </variablelist>
-				</listitem>
-			  </varlistentry>
-			</variablelist>
-		  </listitem>
+			<varlistentry>
+			  <term>Format:</term>
+			  <listitem>
+				<variablelist>
+				  <varlistentry>
+					<term>Standard</term>
+					<listitem>
+					  <para>PO files that use <literal>msgid</literal> as the
+					  source container and expect the translation to be put in
+					  <literal>msgstr</literal></para>
+					</listitem>
+				  </varlistentry>
+				  
+				  <varlistentry>
+					<term>Monolingual</term>
+					<listitem>
+					  <para>PO files that use <literal>msgid</literal> as an
+					  ID code, use <literal>msgstr</literal> as the source
+					  container and expect the translation to overwrite
+					  <literal>msgstr</literal></para>
+					</listitem>
+				  </varlistentry>
+				</variablelist>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
+		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.moodle.php">
-		<term id="file.filters.moodle.php.title">Moodle PHP</term>
+		<term id="file.filters.moodle.php.title">
+		Moodle PHP</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -764,46 +801,48 @@
 	  </varlistentry>
 
 	  <varlistentry id="file.filter.java.bundle">
-		<term id="file.filter.java.bundle.title">Java Resource bundle</term>
+		<term id="file.filter.java.bundle.title">
+		Java Resource bundle</term>
 		<listitem>
-			<para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by
-			default. See the <link
-			linkend="dialogs.preferences.tag.processing.programming.variables"
-			endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
-			preference for details.</para>
+		  <para>The filter checks Java MessageFormat patterns (e.g. \{0\}) by
+		  default. See the <link
+		  linkend="dialogs.preferences.tag.processing.programming.variables"
+		  endterm="dialogs.preferences.tag.processing.programming.variables.title"/>
+		  preference for details.</para>
 
-			<variablelist>
-			  <varlistentry>
-				<term>Force Unicode literals compatibility with Java 8</term>
-				<listitem>
-				  <para>Java 8 requires ISO-8859-1 encoding and uses Unicode
-				  literals for characters outside that character set. Java 9 and
-				  above requires UTF-8 encoding. This option forces Java 8
-				  compatibility.</para>
-				</listitem>
-			  </varlistentry>
+		  <variablelist>
+			<varlistentry>
+			  <term>Force Unicode literals compatibility with Java 8</term>
+			  <listitem>
+				<para>Java 8 requires ISO-8859-1 encoding and uses Unicode
+				literals for characters outside that character set. Java 9 and
+				above requires UTF-8 encoding. This option forces Java 8
+				compatibility.</para>
+			  </listitem>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Remove untranslated strings in the target files</term>
-				<listitem>
-				  <para>Having untranslated contents in the translated files
-				  sometimes create compatibility issues.</para>
-				</listitem>
-			  </varlistentry>
+			<varlistentry>
+			  <term>Remove untranslated strings in the target files</term>
+			  <listitem>
+				<para>Having untranslated contents in the translated files
+				sometimes create compatibility issues.</para>
+			  </listitem>
+			</varlistentry>
 
-			  <varlistentry>
-				<term>Keep Unicode literals (\\uXXXX)</term>
-				<listitem>
-				  <para>Some applications require some Unicode literals to be
-				  kept. This option allows for that.</para>
-				</listitem>
-			  </varlistentry>
-			</variablelist>
+			<varlistentry>
+			  <term>Keep Unicode literals (\\uXXXX)</term>
+			  <listitem>
+				<para>Some applications require some Unicode literals to be
+				kept. This option allows for that.</para>
+			  </listitem>
+			</varlistentry>
+		  </variablelist>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="file.filters.odf">
-		<term id="file.filters.odf.title">Open Document Format (ODF) files</term>
+		<term id="file.filters.odf.title">
+		Open Document Format (ODF) files</term>
 		<listitem>
 		  <variablelist>
 			<varlistentry>
@@ -818,8 +857,9 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry  id="file.filters.xliff">
-		<term id="file.filters.xliff.title">XLIFF (legacy filter)</term>
+	  <varlistentry id="file.filters.xliff">
+		<term id="file.filters.xliff.title">
+		XLIFF (legacy filter)</term>
 		<listitem>
 		  <warning>
 			<para>This filter is the original OmegaT XLIFF filter. You should

--- a/doc_src/en/App_Glossaries.xml
+++ b/doc_src/en/App_Glossaries.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.glossaries">
-  <title id="app.glossaries.title">Glossaries</title>
+  <title id="app.glossaries.title">
+  Glossaries</title>
 
   <para>Glossaries are terminology files stored in the <link
   linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -17,8 +18,9 @@
   <para>There are 2 kinds of glossary files:</para>
 
   <variablelist>
-	<varlistentry>
-	  <term>The project glossary</term>
+	<varlistentry id="app.glossaries.project.glossary">
+	  <term id="app.glossaries.project.glossary.title">
+      The project glossary</term>
 	  <listitem>
 		<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
 		linkend="menus.edit.create.glossary.entry"
@@ -59,8 +61,9 @@
 	  </listitem>
 	</varlistentry>
 	
-	<varlistentry>
-	  <term>Reference glossaries</term>
+	<varlistentry id="app.glossaries.reference.glossaries">
+	  <term id="app.glossaries.reference.glossaries.title">
+      Reference glossaries</term>
 	  <listitem>
 		<para>They are terminology files in a format recognized by OmegaT. You
 		cannot modify them from the OmegaT interface like the project glossary,
@@ -76,7 +79,8 @@
   </note>
 
   <section id="glossaries.glossary.folder">
-    <title id="glossaries.glossary.folder.title">The glossaries folder</title>
+	<title id="glossaries.glossary.folder.title">
+    The glossaries folder</title>
 
     <para>By default, each project contains a <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -102,7 +106,8 @@
   </section>
 
   <section id="glossaries.default.glossary">
-    <title id="glossaries.default.glossary.title">Project glossary</title>
+	<title id="glossaries.default.glossary.title">
+    Project glossary</title>
 
     <para>The writable project glossary is located in the <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -119,7 +124,8 @@
   </section>
 
   <section id="glossaries.fileformat">
-    <title id="glossaries.fileformat.title">File format</title>
+	<title id="glossaries.fileformat.title">
+    File format</title>
 
     <para>OmegaT glossary files are simple plain text files containing
     three-column lists, with the source term in the first column, an optional
@@ -138,80 +144,81 @@
     <para>The encoding used to read reference glossaries depends on
     their file extension:</para>
 
-    <table id="glossary.extensions">
-      <title>Format, extensions and expected encoding</title>
+    <table id="glossaries.fileformat.extensions">
+	  <title id="glossaries.fileformat.extensions.title">
+      Format, extensions and expected encoding</title>
 	  <tgroup cols="3">
-      <thead>
-        <row>
-          <entry>Format</entry>
+		<thead>
+          <row>
+			<entry>Format</entry>
 
-          <entry>Extension</entry>
+			<entry>Extension</entry>
 
-          <entry>Encoding</entry>
-        </row>
-      </thead>
+			<entry>Encoding</entry>
+          </row>
+		</thead>
 
-      <tbody>
-        <row>
-          <entry>TSV</entry>
+		<tbody>
+          <row>
+			<entry>TSV</entry>
 
-          <entry>
-            <filename>.txt</filename>
-          </entry>
+			<entry>
+              <filename>.txt</filename>
+			</entry>
 
-          <entry>UTF-8</entry>
-        </row>
+			<entry>UTF-8</entry>
+          </row>
 
-        <row>
-          <entry>TSV</entry>
+          <row>
+			<entry>TSV</entry>
 
-          <entry>
-            <filename>.utf8</filename>
-          </entry>
+			<entry>
+              <filename>.utf8</filename>
+			</entry>
 
-          <entry>UTF-8</entry>
-        </row>
+			<entry>UTF-8</entry>
+          </row>
 
-        <row>
-          <entry>TSV</entry>
+          <row>
+			<entry>TSV</entry>
 
-          <entry>
-            <filename>.tab</filename>
-          </entry>
+			<entry>
+              <filename>.tab</filename>
+			</entry>
 
-          <entry>OS default encoding</entry>
-        </row>
+			<entry>OS default encoding</entry>
+          </row>
 
-        <row>
-          <entry>TSV</entry>
+          <row>
+			<entry>TSV</entry>
 
-          <entry>
-            <filename>.tsv</filename>
-          </entry>
+			<entry>
+              <filename>.tsv</filename>
+			</entry>
 
-          <entry>OS default encoding</entry>
-        </row>
+			<entry>OS default encoding</entry>
+          </row>
 
-        <row>
-          <entry>CSV</entry>
+          <row>
+			<entry>CSV</entry>
 
-          <entry>
-            <filename>.csv</filename>
-          </entry>
+			<entry>
+              <filename>.csv</filename>
+			</entry>
 
-          <entry>UTF-8</entry>
-        </row>
+			<entry>UTF-8</entry>
+          </row>
 
-        <row>
-          <entry>TBX</entry>
+          <row>
+			<entry>TBX</entry>
 
-          <entry>
-            <filename>.tbx</filename>
-          </entry>
+			<entry>
+              <filename>.tbx</filename>
+			</entry>
 
-          <entry>UTF-8</entry>
-        </row>
-      </tbody>
+			<entry>UTF-8</entry>
+          </row>
+		</tbody>
       </tgroup>
     </table>
   </section>

--- a/doc_src/en/App_Glossaries.xml
+++ b/doc_src/en/App_Glossaries.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.glossaries">
-  <title id="app.glossaries.title">
-  Glossaries</title>
+  <title id="app.glossaries.title">Glossaries</title>
 
   <para>Glossaries are terminology files stored in the <link
   linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -19,8 +18,7 @@
 
   <variablelist>
 	<varlistentry id="app.glossaries.project.glossary">
-	  <term id="app.glossaries.project.glossary.title">
-      The project glossary</term>
+	  <term id="app.glossaries.project.glossary.title">The project glossary</term>
 	  <listitem>
 		<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
 		linkend="menus.edit.create.glossary.entry"
@@ -62,8 +60,7 @@
 	</varlistentry>
 	
 	<varlistentry id="app.glossaries.reference.glossaries">
-	  <term id="app.glossaries.reference.glossaries.title">
-      Reference glossaries</term>
+	  <term id="app.glossaries.reference.glossaries.title">Reference glossaries</term>
 	  <listitem>
 		<para>They are terminology files in a format recognized by OmegaT. You
 		cannot modify them from the OmegaT interface like the project glossary,
@@ -79,8 +76,7 @@
   </note>
 
   <section id="glossaries.glossary.folder">
-	<title id="glossaries.glossary.folder.title">
-    The glossaries folder</title>
+	<title id="glossaries.glossary.folder.title">The glossaries folder</title>
 
     <para>By default, each project contains a <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -106,8 +102,7 @@
   </section>
 
   <section id="glossaries.default.glossary">
-	<title id="glossaries.default.glossary.title">
-    Project glossary</title>
+	<title id="glossaries.default.glossary.title">Project glossary</title>
 
     <para>The writable project glossary is located in the <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -124,8 +119,7 @@
   </section>
 
   <section id="glossaries.fileformat">
-	<title id="glossaries.fileformat.title">
-    File format</title>
+	<title id="glossaries.fileformat.title">File format</title>
 
     <para>OmegaT glossary files are simple plain text files containing
     three-column lists, with the source term in the first column, an optional
@@ -145,8 +139,7 @@
     their file extension:</para>
 
     <table id="glossaries.fileformat.extensions">
-	  <title id="glossaries.fileformat.extensions.title">
-      Format, extensions and expected encoding</title>
+	  <title id="glossaries.fileformat.extensions.title">Format, extensions and expected encoding</title>
 	  <tgroup cols="3">
 		<thead>
           <row>

--- a/doc_src/en/App_Glossaries.xml
+++ b/doc_src/en/App_Glossaries.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.glossaries">
-  <title id="app.glossaries.title">Glossaries</title>
+  <title id="app.glossaries.title"><link linkend="app.glossaries"> </link>Glossaries</title>
 
   <para>Glossaries are terminology files stored in the <link
   linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -18,7 +18,7 @@
 
   <variablelist>
 	<varlistentry id="app.glossaries.project.glossary">
-	  <term id="app.glossaries.project.glossary.title">The project glossary</term>
+	  <term id="app.glossaries.project.glossary.title"><link linkend="app.glossaries.project.glossary"> </link>The project glossary</term>
 	  <listitem>
 		<para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
 		linkend="menus.edit.create.glossary.entry"
@@ -60,7 +60,7 @@
 	</varlistentry>
 	
 	<varlistentry id="app.glossaries.reference.glossaries">
-	  <term id="app.glossaries.reference.glossaries.title">Reference glossaries</term>
+	  <term id="app.glossaries.reference.glossaries.title"><link linkend="app.glossaries.reference.glossaries"> </link>Reference glossaries</term>
 	  <listitem>
 		<para>They are terminology files in a format recognized by OmegaT. You
 		cannot modify them from the OmegaT interface like the project glossary,
@@ -76,7 +76,7 @@
   </note>
 
   <section id="glossaries.glossary.folder">
-	<title id="glossaries.glossary.folder.title">The glossaries folder</title>
+	<title id="glossaries.glossary.folder.title"><link linkend="glossaries.glossary.folder"> </link>The glossaries folder</title>
 
     <para>By default, each project contains a <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -102,7 +102,7 @@
   </section>
 
   <section id="glossaries.default.glossary">
-	<title id="glossaries.default.glossary.title">Project glossary</title>
+	<title id="glossaries.default.glossary.title"><link linkend="glossaries.default.glossary"> </link>Project glossary</title>
 
     <para>The writable project glossary is located in the <link
     linkend="project.folder.glossary" endterm="project.folder.glossary.title"/>
@@ -119,7 +119,7 @@
   </section>
 
   <section id="glossaries.fileformat">
-	<title id="glossaries.fileformat.title">File format</title>
+	<title id="glossaries.fileformat.title"><link linkend="glossaries.fileformat"> </link>File format</title>
 
     <para>OmegaT glossary files are simple plain text files containing
     three-column lists, with the source term in the first column, an optional
@@ -139,7 +139,7 @@
     their file extension:</para>
 
     <table id="glossaries.fileformat.extensions">
-	  <title id="glossaries.fileformat.extensions.title">Format, extensions and expected encoding</title>
+	  <title id="glossaries.fileformat.extensions.title"><link linkend="glossaries.fileformat.extensions"> </link>Format, extensions and expected encoding</title>
 	  <tgroup cols="3">
 		<thead>
           <row>

--- a/doc_src/en/App_PostProcessingCommands.xml
+++ b/doc_src/en/App_PostProcessingCommands.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="post.processing.commands">
-  <title id="post.processing.commands.title">
-  Post-Processing Commands</title>
+  <title id="post.processing.commands.title">Post-Processing Commands</title>
 
   <para>See the <link
   linkend="dialogs.project.properties.external.processing.command"
@@ -16,8 +15,7 @@
   
 
   <section id="post.processing.commands.template.variables">
-	<title id="post.processing.commands.template.variables.title">
-    Template Variables</title>
+	<title id="post.processing.commands.template.variables.title">Template Variables</title>
     <para>The command is passed to Java runtime exec as a string with the
     template values expanded. All the arguments should be quoted,
     e.g. <literal>&quot;${fileName}&quot;</literal>.</para>

--- a/doc_src/en/App_PostProcessingCommands.xml
+++ b/doc_src/en/App_PostProcessingCommands.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="post.processing.commands">
-  <title id="post.processing.commands.title">Post-Processing Commands</title>
+  <title id="post.processing.commands.title">
+  Post-Processing Commands</title>
 
   <para>See the <link
   linkend="dialogs.project.properties.external.processing.command"
@@ -12,10 +13,11 @@
   linkend="dialogs.preferences.saving.and.output.external.post-processing.command"
   endterm="dialogs.preferences.saving.and.output.external.post-processing.command.title"/>
   preference for global commands.</para>
-	
+  
 
   <section id="post.processing.commands.template.variables">
-    <title id="post.processing.commands.template.variables.title">Template Variables</title>
+	<title id="post.processing.commands.template.variables.title">
+    Template Variables</title>
     <para>The command is passed to Java runtime exec as a string with the
     template values expanded. All the arguments should be quoted,
     e.g. <literal>&quot;${fileName}&quot;</literal>.</para>
@@ -24,8 +26,9 @@
     on the template list are environment variables for your system.</para>
 	
     <table id="post.processing.commands.template.variables.table">
-      <title
-      id="post.processing.commands.template.variables.table.title">Template
+	  <title
+		  id="post.processing.commands.template.variables.table.title">
+		Template
       Variables</title>
       <tgroup cols="2" colsep="1">
         <colspec align="left" colname="1" colnum="1"/>
@@ -111,7 +114,8 @@
   </section>
   
   <section id="post.processing.commands.user.defined.scripts">
-    <title id="post.processing.commands.user.defined.scripts.title">Local
+	<title id="post.processing.commands.user.defined.scripts.title">
+      Local
     Scripts</title>
     <para>
       In addition to a regular command, you can call a script. Never run
@@ -119,20 +123,21 @@
       local post-processing commands are disabled by default.
     </para>
     <para>
-        Template variables can be used with both regular commands and custom
-        scripts. You may need to use an absolute path for your script. The PATH
-        OmegaT uses may not be the same as the current user’s PATH.
+      Template variables can be used with both regular commands and custom
+      scripts. You may need to use an absolute path for your script. The PATH
+      OmegaT uses may not be the same as the current user’s PATH.
     </para>
     <para>
-        STDOUT and STDERR are written to the <link
-        linkend="configuration.folder.default.contents.logs.title">omegat.log</link>
-        file. The exit code and STDERR or the last STDOUT will appear on the
-        status bar.
+      STDOUT and STDERR are written to the <link
+      linkend="configuration.folder.default.contents.logs.title">omegat.log</link>
+      file. The exit code and STDERR or the last STDOUT will appear on the
+      status bar.
     </para>
   </section>
 
   <section id="post.processing.commands.linux.and.macos">
-    <title id="post.processing.commands.linux.and.macos.title">Linux and
+	<title id="post.processing.commands.linux.and.macos.title">
+      Linux and
     macOS</title>
     <para>
       You should use a shebang, e.g. <literal>#! /bin/bash</literal> or
@@ -143,29 +148,30 @@
   </section>
   
   <example id="post.processing.commands.example">
-	  <title id="post.processing.commands.example.title">Simple example of a
-	  post-processing commands:</title>
-	  <variablelist>
-		<varlistentry>
-		  <term>Open the target folder in Linux</term>
-		  <listitem>
-			<programlisting>xdg-open ${targetRoot}</programlisting>
-		  </listitem>
-		</varlistentry
-		>
-		<varlistentry>
-		  <term>Open the target folder in macOS</term>
-		  <listitem>
-			<programlisting>open ${targetRoot}</programlisting>
-		  </listitem>
-		</varlistentry>
+	<title id="post.processing.commands.example.title">
+      Simple example of a
+	post-processing commands:</title>
+	<variablelist>
+	  <varlistentry>
+		<term>Open the target folder in Linux</term>
+		<listitem>
+		  <programlisting>xdg-open ${targetRoot}</programlisting>
+		</listitem>
+	  </varlistentry
+	  >
+	  <varlistentry>
+		<term>Open the target folder in macOS</term>
+		<listitem>
+		  <programlisting>open ${targetRoot}</programlisting>
+		</listitem>
+	  </varlistentry>
 
-		<varlistentry>
-		  <term>Open the target folder in Windows Powershell</term>
-		  <listitem>
-			<programlisting>Invoke-Item ${targetRoot}</programlisting>
-		  </listitem>
-		</varlistentry>
-	  </variablelist>
-	</example>
-  </section>
+	  <varlistentry>
+		<term>Open the target folder in Windows Powershell</term>
+		<listitem>
+		  <programlisting>Invoke-Item ${targetRoot}</programlisting>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+  </example>
+</section>

--- a/doc_src/en/App_PostProcessingCommands.xml
+++ b/doc_src/en/App_PostProcessingCommands.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="post.processing.commands">
-  <title id="post.processing.commands.title">Post-Processing Commands</title>
+  <title id="post.processing.commands.title"><link linkend="post.processing.commands"> </link>Post-Processing Commands</title>
 
   <para>See the <link
   linkend="dialogs.project.properties.external.processing.command"
@@ -15,7 +15,7 @@
   
 
   <section id="post.processing.commands.template.variables">
-	<title id="post.processing.commands.template.variables.title">Template Variables</title>
+	<title id="post.processing.commands.template.variables.title"><link linkend="post.processing.commands.template.variables"> </link>Template Variables</title>
     <para>The command is passed to Java runtime exec as a string with the
     template values expanded. All the arguments should be quoted,
     e.g. <literal>&quot;${fileName}&quot;</literal>.</para>
@@ -112,9 +112,7 @@
   </section>
   
   <section id="post.processing.commands.user.defined.scripts">
-	<title id="post.processing.commands.user.defined.scripts.title">
-      Local
-    Scripts</title>
+	<title id="post.processing.commands.user.defined.scripts.title"><link linkend="post.processing.commands.user.defined.scripts"> </link>Local Scripts</title>
     <para>
       In addition to a regular command, you can call a script. Never run
       post-processing scripts from untrusted sources. For security reasons,
@@ -134,9 +132,7 @@
   </section>
 
   <section id="post.processing.commands.linux.and.macos">
-	<title id="post.processing.commands.linux.and.macos.title">
-      Linux and
-    macOS</title>
+	<title id="post.processing.commands.linux.and.macos.title"><link linkend="post.processing.commands.linux.and.macos"> </link>Linux and macOS</title>
     <para>
       You should use a shebang, e.g. <literal>#! /bin/bash</literal> or
       <literal>#! /usr/bin/env python3</literal>. And the script must be
@@ -146,9 +142,7 @@
   </section>
   
   <example id="post.processing.commands.example">
-	<title id="post.processing.commands.example.title">
-      Simple example of a
-	post-processing commands:</title>
+	<title id="post.processing.commands.example.title"><link linkend="post.processing.commands.example"> </link>Simple example of a post-processing commands:</title>
 	<variablelist>
 	  <varlistentry>
 		<term>Open the target folder in Linux</term>

--- a/doc_src/en/App_Regex.xml
+++ b/doc_src/en/App_Regex.xml
@@ -4,7 +4,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="app.regex">
-  <title id="app.regex.title">Regular expressions</title>
+  <title id="app.regex.title"><link linkend="app.regex"> </link>Regular expressions</title>
 
   <para>This appendix is intended for users interested in exploring a powerful
   way to boost their productivity. Although seen as daunting and complex, even
@@ -29,13 +29,13 @@
   
   <variablelist>
     <varlistentry id="app.regex.digit">
-	  <term id="app.regex.digit.title">[0-9]</term>
+	  <term id="app.regex.digit.title"><link linkend="app.regex.digit"> </link>[0-9]</term>
       <listitem><para>Any single digit from 0 to 9.</para>
       </listitem>
     </varlistentry>
 
 	<varlistentry id="app.regex.word">
-	  <term id="app.regex.word.title">\w+</term>
+	  <term id="app.regex.word.title"><link linkend="app.regex.word"> </link>\w+</term>
       <listitem><para>Represents one or more “word characters”, namely
       the letters of the alphabet, digits, and
       underscore symbols.</para>
@@ -43,7 +43,7 @@
     </varlistentry>
 
 	<varlistentry id="app.regex.horizontal.space">
-	  <term id="app.regex.horizontal.space.title">\h?</term>
+	  <term id="app.regex.horizontal.space.title"><link linkend="app.regex.horizontal.space"> </link>\h?</term>
       <listitem><para>Represents zero or one horizontal whitespace
       character (this includes regular and non-breaking spaces as well as
       tabs, but not line break characters, which belong to the “vertical
@@ -57,7 +57,7 @@
 
   <variablelist>
     <varlistentry id="app.regex.searches">
-	  <term id="app.regex.searches.title">Searches</term>
+	  <term id="app.regex.searches.title"><link linkend="app.regex.searches"> </link>Searches</term>
       <listitem>
         <para>Searches include a <link
         linkend="windows.text.search.methods.regex"
@@ -72,7 +72,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.custom.tags">
-	  <term id="app.regex.custom.tags.title">Custom tags</term>
+	  <term id="app.regex.custom.tags.title"><link linkend="app.regex.custom.tags"> </link>Custom tags</term>
       <listitem>
         <para>Custom tags are tags defined with regular expressions that are
         handled exactly like native OmegaT tags. See the <link
@@ -86,7 +86,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.flagged.text">
-	  <term id="app.regex.flagged.text.title">Flagged text</term>
+	  <term id="app.regex.flagged.text.title"><link linkend="app.regex.flagged.text"> </link>Flagged text</term>
       <listitem>
         <para>The <link
         linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
@@ -100,7 +100,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.alignment">
-	  <term id="app.regex.alignment.title">Text highlighting in alignments</term>
+	  <term id="app.regex.alignment.title"><link linkend="app.regex.alignment"> </link>Text highlighting in alignments</term>
       <listitem>
         <para>Visual cues can help verifying that your alignment is correct. The
         <link linkend="windows.aligner.adjust.highlight"
@@ -114,7 +114,7 @@
     </varlistentry>	
 
     <varlistentry id="app.regex.segmentation">
-	  <term id="app.regex.segmentation.title">Segmentation</term>
+	  <term id="app.regex.segmentation.title"><link linkend="app.regex.segmentation"> </link>Segmentation</term>
       <listitem>
         <para>Segmentation rules and language patterns are defined with regular
         expressions. You can modify them freely to improve the segmentation of a
@@ -136,7 +136,7 @@
   </variablelist>
 
   <section id="app.regex.four.rules">
-	<title id="app.regex.four.rules.title">The 4 rules</title>
+	<title id="app.regex.four.rules.title"><link linkend="app.regex.four.rules"> </link>The 4 rules</title>
 
     <para>Regular expressions are used to find text, including characters that
     are not visible on the screen or when printed out, such as spaces, tabs, or
@@ -159,7 +159,7 @@
 
     <variablelist>
       <varlistentry id="app.regex.four.rules.match.self">
-		<term id="app.regex.four.rules.match.self.title">Most characters simply match themselves</term>
+		<term id="app.regex.four.rules.match.self.title"><link linkend="app.regex.four.rules.match.self"> </link>Most characters simply match themselves</term>
         <listitem>
           <para>The majority of characters in a regular expression simply
           <emphasis>look for themselves</emphasis> in the text
@@ -173,9 +173,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.four.rules.backslash.special.meaning">
-		<term id="app.regex.four.rules.backslash.special.meaning.title">
-		  Digits and letters of the alphabet preceded by a backslash
-        (<literal>\</literal>) take on a special meaning</term>
+		<term id="app.regex.four.rules.backslash.special.meaning.title"><link linkend="app.regex.four.rules.backslash.special.meaning"> </link>Digits and letters of the alphabet preceded by a backslash (<literal>\</literal>) take on a special meaning</term>
         <listitem>
           <para>Unlike a letter on its own, which simply represents itself as
           noted above, a letter preceded by a <literal>\</literal> has a special
@@ -203,7 +201,7 @@
       </varlistentry>
       
       <varlistentry id="app.regex.four.rules.twelve.characters">
-		<term id="app.regex.four.rules.twelve.characters.title">Twelve characters have a special meaning by default</term>
+		<term id="app.regex.four.rules.twelve.characters.title"><link linkend="app.regex.four.rules.twelve.characters"> </link>Twelve characters have a special meaning by default</term>
         <listitem>
           <para>That special meaning has to be cancelled by another character to
           match the character itself.</para>
@@ -220,9 +218,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.four.rules.backslash">
-		<term id="app.regex.four.rules.backslash.title">
-		  The <literal>\</literal> character is a very special
-        character</term>
+		<term id="app.regex.four.rules.backslash.title"><link linkend="app.regex.four.rules.backslash"> </link>The <literal>\</literal> character is a very special character</term>
         <listitem>
           <para>As stated above, the <literal>\</literal> character has the
           default special meaning of either cancelling or activating the special
@@ -239,7 +235,7 @@
   </section>
 
   <section id="app.regex.twelve.characters">
-	<title id="app.regex.twelve.characters.title">The 12 characters</title>
+	<title id="app.regex.twelve.characters.title"><link linkend="app.regex.twelve.characters"> </link>The 12 characters</title>
 	
     <para>The twelve special characters are the <emphasis>backslash</emphasis>
     <literal>\</literal>, the <emphasis>caret</emphasis> <literal>^</literal>,
@@ -262,7 +258,7 @@
     
     <variablelist>
       <varlistentry id="app.regex.twelve.characters.backslash">
-		<term id="app.regex.twelve.characters.backslash.title">The BACKSLASH: <literal>\</literal></term>
+		<term id="app.regex.twelve.characters.backslash.title"><link linkend="app.regex.twelve.characters.backslash"> </link>The BACKSLASH: <literal>\</literal></term>
         <listitem>
           <para>This character either cancels or activates the special meaning of the following character.</para>
           
@@ -309,7 +305,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.caret">
-		<term id="app.regex.twelve.characters.caret.title">The CARET: <literal>^</literal></term>
+		<term id="app.regex.twelve.characters.caret.title"><link linkend="app.regex.twelve.characters.caret"> </link>The CARET: <literal>^</literal></term>
         <listitem>
           <para>When it is the first character in the expression, the
           <emphasis>caret</emphasis> character matches the beginning of a
@@ -383,7 +379,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.dollar">
-		<term id="app.regex.twelve.characters.dollar.title">The DOLLAR sign: <literal>$</literal></term>
+		<term id="app.regex.twelve.characters.dollar.title"><link linkend="app.regex.twelve.characters.dollar"> </link>The DOLLAR sign: <literal>$</literal></term>
         <listitem>
           <para>When it is the last character in an expression, the
           <emphasis>dollar</emphasis> sign matches the end of a line.</para>
@@ -422,7 +418,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.period">
-		<term id="app.regex.twelve.characters.period.title">The PERIOD: <literal>.</literal></term>
+		<term id="app.regex.twelve.characters.period.title"><link linkend="app.regex.twelve.characters.period"> </link>The PERIOD: <literal>.</literal></term>
         <listitem>
           <para>Matches any single character.</para>
 
@@ -472,7 +468,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.vertical.bar">
-		<term id="app.regex.twelve.characters.vertical.bar.title">The VERTICAL BAR: <literal>|</literal></term>
+		<term id="app.regex.twelve.characters.vertical.bar.title"><link linkend="app.regex.twelve.characters.vertical.bar"> </link>The VERTICAL BAR: <literal>|</literal></term>
         <listitem>
           <para>This character functions as an “OR” and matches either
           of the expressions that precede or follow it.</para>
@@ -520,7 +516,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.question.mark">
-		<term id="app.regex.twelve.characters.question.mark.title">The QUESTION MARK: <literal>?</literal></term>
+		<term id="app.regex.twelve.characters.question.mark.title"><link linkend="app.regex.twelve.characters.question.mark"> </link>The QUESTION MARK: <literal>?</literal></term>
         <listitem>
           <para>This character specifies that either zero or one
           instance of the preceding character or expression should be
@@ -575,7 +571,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.asterisk">
-		<term id="app.regex.twelve.characters.asterisk.title">The ASTERISK: <literal>*</literal></term>
+		<term id="app.regex.twelve.characters.asterisk.title"><link linkend="app.regex.twelve.characters.asterisk"> </link>The ASTERISK: <literal>*</literal></term>
         <listitem>
           <para>This character specifies that zero or more instances of the
           preceding character or expression should be matched.</para>
@@ -620,7 +616,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.plus">
-		<term id="app.regex.twelve.characters.plus.title">The PLUS sign: <literal>+</literal></term>
+		<term id="app.regex.twelve.characters.plus.title"><link linkend="app.regex.twelve.characters.plus"> </link>The PLUS sign: <literal>+</literal></term>
         <listitem>
           <para>This character specifies that one or more instances of
           the preceding character or expression should be matched.</para>
@@ -660,7 +656,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.parens">
-		<term id="app.regex.twelve.characters.open.parens.title">The OPENING PARENTHESIS: <literal>(</literal></term>
+		<term id="app.regex.twelve.characters.open.parens.title"><link linkend="app.regex.twelve.characters.open.parens"> </link>The OPENING PARENTHESIS: <literal>(</literal></term>
 
         <listitem>
           <para>This character starts a <emphasis>group</emphasis>, which is a
@@ -719,7 +715,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.close.parens">
-		<term id="app.regex.twelve.characters.close.parens.title">The CLOSING PARENTHESIS: <literal>)</literal></term>
+		<term id="app.regex.twelve.characters.close.parens.title"><link linkend="app.regex.twelve.characters.close.parens"> </link>The CLOSING PARENTHESIS: <literal>)</literal></term>
 
         <listitem>
           <para>This character closes a group. It is special because it can
@@ -772,7 +768,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.bracket">
-		<term id="app.regex.twelve.characters.open.bracket.title">The OPENING SQUARE BRACKET: <literal>[</literal></term>
+		<term id="app.regex.twelve.characters.open.bracket.title"><link linkend="app.regex.twelve.characters.open.bracket"> </link>The OPENING SQUARE BRACKET: <literal>[</literal></term>
 
         <listitem>
           <para>This character must be paired with the closing square bracket
@@ -819,7 +815,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.brace">
-		<term id="app.regex.twelve.characters.open.brace.title">The OPENING CURLY BRACE: <literal>{</literal></term>
+		<term id="app.regex.twelve.characters.open.brace.title"><link linkend="app.regex.twelve.characters.open.brace"> </link>The OPENING CURLY BRACE: <literal>{</literal></term>
 
         <listitem>
           <para>This character must be paired with the closing curly
@@ -877,9 +873,7 @@
   </section>
 
   <section id="app.regex.types.of.expressions">
-	<title id="app.regex.types.of.expressions.title">
-      Lots of
-    expressions</title>
+	<title id="app.regex.types.of.expressions.title"><link linkend="app.regex.types.of.expressions"> </link>Lots of expressions</title>
 
     <para>This section presents various types of regular expression, ranging
     from the simple to the complex.</para>
@@ -892,16 +886,13 @@
     </note>
 
     <section id="app.regex.types.of.expressions.simple.expressions">
-	  <title id="app.regex.types.of.expressions.simple.expressions.title">
-		
-        Simple expressions
-      </title>
+	  <title id="app.regex.types.of.expressions.simple.expressions.title"><link linkend="app.regex.types.of.expressions.simple.expressions"> </link>Simple expressions </title>
       <para>The simplest regular expression consist of a single character,
       or combination of a <literal>\</literal> and a character constituting a
       unit with a single meaning.</para>
       
       <table id="app.regex.characters">
-		<title id="app.regex.characters.title">Characters</title>
+		<title id="app.regex.characters.title"><link linkend="app.regex.characters"> </link>Characters</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -948,7 +939,7 @@
     </section>
 
     <section id="app.regex.types.of.expressions.case">
-	  <title id="app.regex.types.of.expressions.case.title">Case</title>
+	  <title id="app.regex.types.of.expressions.case.title"><link linkend="app.regex.types.of.expressions.case"> </link>Case</title>
 
       
       <para>Ordinary OmegaT searches are case insensitive by default: they match
@@ -964,14 +955,14 @@
 
       <variablelist>
         <varlistentry id="app.regex.twelve.characters.case.insensitive">
-		  <term id="app.regex.twelve.characters.case.insensitive.title"><literal>(?i)</literal></term>
+		  <term id="app.regex.twelve.characters.case.insensitive.title"><link linkend="app.regex.twelve.characters.case.insensitive"> </link><literal>(?i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case insensitive.</para>
           </listitem>
         </varlistentry>
         <varlistentry id="app.regex.twelve.characters.case.sensitive">
-		  <term id="app.regex.twelve.characters.case.sensitive.title"><literal>(?-i)</literal></term>
+		  <term id="app.regex.twelve.characters.case.sensitive.title"><link linkend="app.regex.twelve.characters.case.sensitive"> </link><literal>(?-i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case sensitive.</para>
@@ -989,7 +980,7 @@
     </section>
 
     <section id="app.regex.types.of.expressions.classes">
-	  <title id="app.regex.types.of.expressions.classes.title">Classes</title>
+	  <title id="app.regex.types.of.expressions.classes.title"><link linkend="app.regex.types.of.expressions.classes"> </link>Classes</title>
 
       <para>Regular expressions allow you to create sets of characters—known as
       <emphasis>classes</emphasis>. Searches will match any of the characters in
@@ -1029,7 +1020,7 @@
       shorthand.</para>
       
       <table id="app.regex.classes">
-		<title id="app.regex.classes.title">Examples of classes</title>
+		<title id="app.regex.classes.title"><link linkend="app.regex.classes"> </link>Examples of classes</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1137,9 +1128,7 @@
       expressions.</para>
 
       <table id="app.regex.unicode.blocks">
-		<title id="app.regex.unicode.blocks.title">
-		  Unicode blocks, scripts and
-        categories</title>
+		<title id="app.regex.unicode.blocks.title"><link linkend="app.regex.unicode.blocks"> </link>Unicode blocks, scripts and categories</title>
         
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1197,9 +1186,7 @@
     </section>
 
     <section id="app.regex.more.advanced.expressions">
-	  <title id="app.regex.more.advanced.expressions.title">
-		More advanced
-      expressions</title>
+	  <title id="app.regex.more.advanced.expressions.title"><link linkend="app.regex.more.advanced.expressions"> </link>More advanced expressions</title>
       
       <para>Some expressions specify a position rather than a character. They
       indicate where in the text to look for the match, but do not include any
@@ -1208,7 +1195,7 @@
       endterm="app.regex.tools.title" /> section for more information.</para>
 
       <table id="app.regex.boundary.matchers">
-		<title id="app.regex.boundary.matchers.title">Expressions that mark a position</title>
+		<title id="app.regex.boundary.matchers.title"><link linkend="app.regex.boundary.matchers"> </link>Expressions that mark a position</title>
 		
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1304,16 +1291,14 @@
   </section>
 
   <section id="app.regex.more.examples">
-	<title id="app.regex.more.examples.title">More examples</title>
+	<title id="app.regex.more.examples.title"><link linkend="app.regex.more.examples"> </link>More examples</title>
 
     <para>This section presents a few examples demonstrating how the various
     expressions described above can be combined to perform powerful searches in
     OmegaT.</para>
     
     <table id="regex.examples">
-	  <title id="regex.examples.title">
-		Examples of regular expressions that use
-      the above expressions</title>
+	  <title id="regex.examples.title"><link linkend="regex.examples"> </link>Examples of regular expressions that use the above expressions</title>
 
       <tgroup align="left" cols="2" rowsep="1">
         <colspec align="left" colnum="1"/>
@@ -1426,7 +1411,7 @@
   </section>
 
   <section id="app.regex.tools">
-	<title id="app.regex.tools.title">References</title>
+	<title id="app.regex.tools.title"><link linkend="app.regex.tools"> </link>References</title>
 
     <para>Although OmegaT does not offer fancy colouring for your regular
     expressions, you can get a lot of practice by using the <link
@@ -1439,9 +1424,7 @@
 
     <variablelist>
       <varlistentry id="app.regex.java">
-		<term id="app.regex.java.title">
-		  <ulink url="&javaregex;">Java Regex
-        documentation</ulink></term>
+		<term id="app.regex.java.title"><ulink url="&javaregex;">Java Regex documentation</ulink></term>
         <listitem>
           <para>The official reference for regular expressions used in
           Java.</para>
@@ -1454,9 +1437,7 @@
 
     <variablelist>
       <varlistentry id="app.regex.tools.regex101">
-		<term id="app.regex.tools.regex101.title">
-		  <ulink
-			  url="https://regex101.com">https://regex101.com</ulink></term>
+		<term id="app.regex.tools.regex101.title"><ulink url="https://regex101.com">https://regex101.com</ulink></term>
           <listitem>
             <para>An online regular expression matcher that lets you enter the
             text you want to search and the regular expressions you want to
@@ -1465,9 +1446,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.tools.regular.expression.info">
-		<term id="app.regex.tools.regular.expression.info.title">
-		  <ulink
-			  url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
+		<term id="app.regex.tools.regular.expression.info.title"><ulink url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
           <listitem>
             <para>One of the most thorough regular expression tutorial and
             reference on the web.</para>

--- a/doc_src/en/App_Regex.xml
+++ b/doc_src/en/App_Regex.xml
@@ -4,7 +4,8 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="app.regex">
-  <title id="app.regex.title">Regular expressions</title>
+  <title id="app.regex.title">
+  Regular expressions</title>
 
   <para>This appendix is intended for users interested in exploring a powerful
   way to boost their productivity. Although seen as daunting and complex, even
@@ -28,22 +29,25 @@
   <para>Here are a few examples.</para>
   
   <variablelist>
-    <varlistentry>
-      <term>[0-9]</term>
+    <varlistentry id="app.regex.digit">
+	  <term id="app.regex.digit.title">
+      [0-9]</term>
       <listitem><para>Any single digit from 0 to 9.</para>
       </listitem>
     </varlistentry>
 
-	<varlistentry>
-      <term>\w+</term>
+	<varlistentry id="app.regex.word">
+	  <term id="app.regex.word.title">
+      \w+</term>
       <listitem><para>Represents one or more “word characters”, namely
       the letters of the alphabet, digits, and
       underscore symbols.</para>
       </listitem>
     </varlistentry>
 
-	<varlistentry>
-      <term>\h?</term>
+	<varlistentry id="app.regex.horizontal.space">
+	  <term id="app.regex.horizontal.space.title">
+      \h?</term>
       <listitem><para>Represents zero or one horizontal whitespace
       character (this includes regular and non-breaking spaces as well as
       tabs, but not line break characters, which belong to the “vertical
@@ -56,8 +60,9 @@
   as an option:</para>
 
   <variablelist>
-    <varlistentry>
-      <term>Searches</term>
+    <varlistentry id="app.regex.searches">
+	  <term id="app.regex.searches.title">
+      Searches</term>
       <listitem>
         <para>Searches include a <link
         linkend="windows.text.search.methods.regex"
@@ -71,8 +76,9 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Custom tags</term>
+    <varlistentry id="app.regex.custom.tags">
+	  <term id="app.regex.custom.tags.title">
+      Custom tags</term>
       <listitem>
         <para>Custom tags are tags defined with regular expressions that are
         handled exactly like native OmegaT tags. See the <link
@@ -85,8 +91,9 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Flagged text</term>
+    <varlistentry id="app.regex.flagged.text">
+	  <term id="app.regex.flagged.text.title">
+      Flagged text</term>
       <listitem>
         <para>The <link
         linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
@@ -99,12 +106,13 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Text highlighting in alignments</term>
+    <varlistentry id="app.regex.alignment">
+	  <term id="app.regex.alignment.title">
+      Text highlighting in alignments</term>
       <listitem>
         <para>Visual cues can help verifying that your alignment is correct. The
         <link linkend="windows.aligner.adjust.highlight"
-        endterm="windows.aligner.adjust.highlight.title"/> setting allows you to
+			  endterm="windows.aligner.adjust.highlight.title"/> setting allows you to
         define strings that OmegaT will highlight in the aligned
         documents.</para>
 
@@ -113,8 +121,9 @@
       </listitem>
     </varlistentry>	
 
-    <varlistentry>
-      <term>Segmentation</term>
+    <varlistentry id="app.regex.segmentation">
+	  <term id="app.regex.segmentation.title">
+      Segmentation</term>
       <listitem>
         <para>Segmentation rules and language patterns are defined with regular
         expressions. You can modify them freely to improve the segmentation of a
@@ -136,7 +145,8 @@
   </variablelist>
 
   <section id="app.regex.four.rules">
-    <title id="app.regex.four.rules.title">The 4 rules</title>
+	<title id="app.regex.four.rules.title">
+    The 4 rules</title>
 
     <para>Regular expressions are used to find text, including characters that
     are not visible on the screen or when printed out, such as spaces, tabs, or
@@ -158,8 +168,9 @@
     <para>There are four rules to keep in mind.</para>
 
     <variablelist>
-      <varlistentry>
-        <term>Most characters simply match themselves</term>
+      <varlistentry id="app.regex.four.rules.match.self">
+		<term id="app.regex.four.rules.match.self.title">
+		Most characters simply match themselves</term>
         <listitem>
           <para>The majority of characters in a regular expression simply
           <emphasis>look for themselves</emphasis> in the text
@@ -172,8 +183,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Digits and letters of the alphabet preceded by a backslash
+      <varlistentry id="app.regex.four.rules.backslash.special.meaning">
+		<term id="app.regex.four.rules.backslash.special.meaning.title">
+		  Digits and letters of the alphabet preceded by a backslash
         (<literal>\</literal>) take on a special meaning</term>
         <listitem>
           <para>Unlike a letter on its own, which simply represents itself as
@@ -200,9 +212,10 @@
           </note>
         </listitem>
       </varlistentry>
-        
-      <varlistentry>
-      <term>Twelve characters have a special meaning by default</term>
+      
+      <varlistentry id="app.regex.four.rules.twelve.characters">
+		<term id="app.regex.four.rules.twelve.characters.title">
+		Twelve characters have a special meaning by default</term>
         <listitem>
           <para>That special meaning has to be cancelled by another character to
           match the character itself.</para>
@@ -218,8 +231,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>The <literal>\</literal> character is a very special
+      <varlistentry id="app.regex.four.rules.backslash">
+		<term id="app.regex.four.rules.backslash.title">
+		  The <literal>\</literal> character is a very special
         character</term>
         <listitem>
           <para>As stated above, the <literal>\</literal> character has the
@@ -237,8 +251,9 @@
   </section>
 
   <section id="app.regex.twelve.characters">
-    <title id="app.regex.twelve.characters.title">The 12 characters</title>
-  
+	<title id="app.regex.twelve.characters.title">
+    The 12 characters</title>
+	
     <para>The twelve special characters are the <emphasis>backslash</emphasis>
     <literal>\</literal>, the <emphasis>caret</emphasis> <literal>^</literal>,
     the <emphasis>dollar sign</emphasis> <literal>$</literal>, the
@@ -258,629 +273,642 @@
     expressions that rely on the character as well as of text that they do, or
     do not, match.</para>
     
-      <variablelist>
-        <varlistentry>
-          <term>The BACKSLASH: <literal>\</literal></term>
-          <listitem>
-            <para>This character either cancels or activates the special meaning of the following character.</para>
-            
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+    <variablelist>
+      <varlistentry id="app.regex.twelve.characters.backslash">
+		<term id="app.regex.twelve.characters.backslash.title">
+		The BACKSLASH: <literal>\</literal></term>
+        <listitem>
+          <para>This character either cancels or activates the special meaning of the following character.</para>
+          
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>0\.[0-9]</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>0\.[0-9]</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>A number between <emphasis>0.0</emphasis> and
-                      <emphasis>0.9</emphasis>, or just the final
-                      <emphasis>0.5</emphasis> in numbers such as 10.5 or
-                      560.5.</para>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>A number between <emphasis>0.0</emphasis> and
+                    <emphasis>0.9</emphasis>, or just the final
+                    <emphasis>0.5</emphasis> in numbers such as 10.5 or
+                    560.5.</para>
 
-                      <para>The <literal>\.</literal> cancels the “any
-                      character” meaning of the period to match the decimal
-                      point, while the <literal>\d</literal> turns the
-                      ordinarily lowercase “d” letter into an expression that
-                      matches any digit between 0 and 9.</para>
-                    </entry>
-                  </row>
+                    <para>The <literal>\.</literal> cancels the “any
+                    character” meaning of the period to match the decimal
+                    point, while the <literal>\d</literal> turns the
+                    ordinarily lowercase “d” letter into an expression that
+                    matches any digit between 0 and 9.</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>Sequences such as 0,1, 0-3, or the first three
-                      characters of 0x002E, which would be matched if the
-                      expression was just <literal>0.[0-9]</literal>, with no
-                      backslash before the period</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>Sequences such as 0,1, 0-3, or the first three
+                    characters of 0x002E, which would be matched if the
+                    expression was just <literal>0.[0-9]</literal>, with no
+                    backslash before the period</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The CARET: <literal>^</literal></term>
-          <listitem>
-            <para>When it is the first character in the expression, the
-            <emphasis>caret</emphasis> character matches the beginning of a
-            line.</para>
+      <varlistentry id="app.regex.twelve.characters.caret">
+		<term id="app.regex.twelve.characters.caret.title">
+		The CARET: <literal>^</literal></term>
+        <listitem>
+          <para>When it is the first character in the expression, the
+          <emphasis>caret</emphasis> character matches the beginning of a
+          line.</para>
 
-            <para>When it is the first character in <link
-            linkend="app.regex.types.of.expressions.classes">a character class
-            enclosed in brackets</link>, it matches all the characters that are
-            not part of that class.</para>
+          <para>When it is the first character in <link
+          linkend="app.regex.types.of.expressions.classes">a character class
+          enclosed in brackets</link>, it matches all the characters that are
+          not part of that class.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry>
-                      <orderedlist>
-                        <listitem>
-                          <para><literal>^A</literal></para>
-                        </listitem>
-        
-                        <listitem>
-                          <para>[^abc]</para>
-                        </listitem>
-                      </orderedlist>
-                    </entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry>
+                    <orderedlist>
+                      <listitem>
+                        <para><literal>^A</literal></para>
+                      </listitem>
+					  
+                      <listitem>
+                        <para>[^abc]</para>
+                      </listitem>
+                    </orderedlist>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <orderedlist>
-                        <listitem>
-                          <para>The uppercase “A” in the following sentence: “A
-                          long, but exciting journey was about to begin”.</para>
-                        </listitem>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <orderedlist>
+                      <listitem>
+                        <para>The uppercase “A” in the following sentence: “A
+                        long, but exciting journey was about to begin”.</para>
+                      </listitem>
 
-                        <listitem>
-                          <para>Any character that is <emphasis>not</emphasis>
-                          “a”, “b”, or “c”. In the word “back”, for instance,
-                          only the “k” is matched.</para>
-                        </listitem>
-                      </orderedlist>
-                    </entry>
-                  </row>
+                      <listitem>
+                        <para>Any character that is <emphasis>not</emphasis>
+                        “a”, “b”, or “c”. In the word “back”, for instance,
+                        only the “k” is matched.</para>
+                      </listitem>
+                    </orderedlist>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <orderedlist>
-                        <listitem>
-                          <para>The uppercase “A” in the following sentence: “My
-                          friend is writing a book called <emphasis>A Long
-                          Journey</emphasis>”.</para>
-                        </listitem>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <orderedlist>
+                      <listitem>
+                        <para>The uppercase “A” in the following sentence: “My
+                        friend is writing a book called <emphasis>A Long
+                        Journey</emphasis>”.</para>
+                      </listitem>
                       
-                        <listitem>
-                          <para>The lowercase “a”, “b”, or “c” in the word
-                          “back”.</para>
-                        </listitem>
-                      </orderedlist>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                      <listitem>
+                        <para>The lowercase “a”, “b”, or “c” in the word
+                        “back”.</para>
+                      </listitem>
+                    </orderedlist>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The DOLLAR sign: <literal>$</literal></term>
-          <listitem>
-            <para>When it is the last character in an expression, the
-            <emphasis>dollar</emphasis> sign matches the end of a line.</para>
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+      <varlistentry id="app.regex.twelve.characters.dollar">
+		<term id="app.regex.twelve.characters.dollar.title">
+		The DOLLAR sign: <literal>$</literal></term>
+        <listitem>
+          <para>When it is the last character in an expression, the
+          <emphasis>dollar</emphasis> sign matches the end of a line.</para>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>^\w+:$</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>^\w+:$</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>A line that consists of a single word and ends with
-                      a colon:</para>
-                      <para><emphasis>Questions:</emphasis></para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>A line that consists of a single word and ends with
+                    a colon:</para>
+                    <para><emphasis>Questions:</emphasis></para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>A line that consists of a single word, but does not
-                      end in a colon:</para>
-                      <para><emphasis>Questions?</emphasis></para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>A line that consists of a single word, but does not
+                    end in a colon:</para>
+                    <para><emphasis>Questions?</emphasis></para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The PERIOD: <literal>.</literal></term>
-          <listitem>
-            <para>Matches any single character.</para>
+      <varlistentry id="app.regex.twelve.characters.period">
+		<term id="app.regex.twelve.characters.period.title">
+		The PERIOD: <literal>.</literal></term>
+        <listitem>
+          <para>Matches any single character.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>c.t</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>c.t</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>Any combinations of three letters
-                        starting with “c” and ending with “t”:
-                        “<emphasis>cat</emphasis>”,
-                        “<emphasis>cut</emphasis>”,
-                        “<emphasis>cot</emphasis>”, or even nonsensical
-                        combinations such as “<emphasis>czt</emphasis>”
-                        or “<emphasis>cqt</emphasis>”.
-                      </para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>Any combinations of three letters
+                    starting with “c” and ending with “t”:
+                    “<emphasis>cat</emphasis>”,
+                    “<emphasis>cut</emphasis>”,
+                    “<emphasis>cot</emphasis>”, or even nonsensical
+                    combinations such as “<emphasis>czt</emphasis>”
+                    or “<emphasis>cqt</emphasis>”.
+                    </para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>Combinations containing three letters that
-                      start with “c” and ending with “t”, but are
-                      split across more than one line.</para>
-                      <para>What is the missing letter?</para>
-                        <simplelist>
-                          <member><literal>c</literal></member>
-                          <member><literal></literal></member>
-                          <member><literal>t</literal></member>
-                        </simplelist>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>Combinations containing three letters that
+                    start with “c” and ending with “t”, but are
+                    split across more than one line.</para>
+                    <para>What is the missing letter?</para>
+                    <simplelist>
+                      <member><literal>c</literal></member>
+                      <member><literal></literal></member>
+                      <member><literal>t</literal></member>
+                    </simplelist>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The VERTICAL BAR: <literal>|</literal></term>
-          <listitem>
-            <para>This character functions as an “OR” and matches either
-            of the expressions that precede or follow it.</para>
+      <varlistentry id="app.regex.twelve.characters.vertical.bar">
+		<term id="app.regex.twelve.characters.vertical.bar.title">
+		The VERTICAL BAR: <literal>|</literal></term>
+        <listitem>
+          <para>This character functions as an “OR” and matches either
+          of the expressions that precede or follow it.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>^An|^The</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>^An|^The</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>The initial “An” or “The” in phrases such as:
-                        <simplelist>
-                          <member>“An apple a day…”</member>
-                          <member>“The apple of my eye…”</member>
-                        </simplelist>
-                      </para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>The initial “An” or “The” in phrases such as:
+                    <simplelist>
+                      <member>“An apple a day…”</member>
+                      <member>“The apple of my eye…”</member>
+                    </simplelist>
+                    </para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>The initial “An” or “The” in phrases such as:
-                        <simplelist>
-                          <member>“A story called <emphasis>An Unsung
-                          Hero</emphasis>.”</member>
-                          <member>“They work for <emphasis>The Daily
-                            Post</emphasis>.”</member>
-                        </simplelist>
-                      </para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>The initial “An” or “The” in phrases such as:
+                    <simplelist>
+                      <member>“A story called <emphasis>An Unsung
+                      Hero</emphasis>.”</member>
+                      <member>“They work for <emphasis>The Daily
+                      Post</emphasis>.”</member>
+                    </simplelist>
+                    </para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The QUESTION MARK: <literal>?</literal></term>
-          <listitem>
-            <para>This character specifies that either zero or one
-            instance of the preceding character or expression should be
-            matched.</para>
+      <varlistentry id="app.regex.twelve.characters.question.mark">
+		<term id="app.regex.twelve.characters.question.mark.title">
+		The QUESTION MARK: <literal>?</literal></term>
+        <listitem>
+          <para>This character specifies that either zero or one
+          instance of the preceding character or expression should be
+          matched.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry>
-                      <literal>an?␣</literal> (where “␣” represents a
-                      single space).
-                    </entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry>
+                    <literal>an?␣</literal> (where “␣” represents a
+                    single space).
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>Either the “a ” or the “an ” in:
-                        <simplelist>
-                          <member>“I have a question.”</member>
-                          <member>“I know an excellent doctor.”</member>
-                        </simplelist>
-                      </para>
-                      
-                      <para>It will also find the final “an ” of “Can ” in a
-                      sentence such as “Can I help you?”, or the final “a ” of
-                      “pasta ” in “We had pasta for lunch.”</para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>Either the “a ” or the “an ” in:
+                    <simplelist>
+                      <member>“I have a question.”</member>
+                      <member>“I know an excellent doctor.”</member>
+                    </simplelist>
+                    </para>
+                    
+                    <para>It will also find the final “an ” of “Can ” in a
+                    sentence such as “Can I help you?”, or the final “a ” of
+                    “pasta ” in “We had pasta for lunch.”</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>Neither the “a” nor the “an” in:
-                        <simplelist>
-                          <member>The indefinite article: “a” (or
-                          “an”).</member>
-                        </simplelist>
-                      </para>
-                      <para>They are not followed by a space.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>Neither the “a” nor the “an” in:
+                    <simplelist>
+                      <member>The indefinite article: “a” (or
+                      “an”).</member>
+                    </simplelist>
+                    </para>
+                    <para>They are not followed by a space.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The ASTERISK: <literal>*</literal></term>
-          <listitem>
-            <para>This character specifies that zero or more instances of the
-            preceding character or expression should be matched.</para>
+      <varlistentry id="app.regex.twelve.characters.asterisk">
+		<term id="app.regex.twelve.characters.asterisk.title">
+		The ASTERISK: <literal>*</literal></term>
+        <listitem>
+          <para>This character specifies that zero or more instances of the
+          preceding character or expression should be matched.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>run\w*</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>run\w*</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>The word “run”, as well as “runs”, “runner”,
-                      “runway”, “runt” in “grunt” or “brunt”, and any other word
-                      or sequence of characters containing “run” followed by
-                      zero or more “<emphasis>word characters</emphasis>” (which
-                      include digits and the underscore, so the part before the
-                      “@” in an email address such as run_123@example.email.org
-                      is also a match).</para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>The word “run”, as well as “runs”, “runner”,
+                    “runway”, “runt” in “grunt” or “brunt”, and any other word
+                    or sequence of characters containing “run” followed by
+                    zero or more “<emphasis>word characters</emphasis>” (which
+                    include digits and the underscore, so the part before the
+                    “@” in an email address such as run_123@example.email.org
+                    is also a match).</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>The complete phrase in “run-on” or
-                      “run'n'gun”, because the hyphen and apostrophe are not
-                      included in <literal>\w</literal>. Only the initial “run”
-                      in those phrases is matched.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>The complete phrase in “run-on” or
+                    “run'n'gun”, because the hyphen and apostrophe are not
+                    included in <literal>\w</literal>. Only the initial “run”
+                    in those phrases is matched.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The PLUS sign: <literal>+</literal></term>
-          <listitem>
-            <para>This character specifies that one or more instances of
-            the preceding character or expression should be matched.</para>
+      <varlistentry id="app.regex.twelve.characters.plus">
+		<term id="app.regex.twelve.characters.plus.title">
+		The PLUS sign: <literal>+</literal></term>
+        <listitem>
+          <para>This character specifies that one or more instances of
+          the preceding character or expression should be matched.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>\d+.d</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>\d+.d</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>Numbers such as “1.5”, “23.2” or “5235.8” with a
-                      single decimal place and any number of digits before the
-                      decimal point.</para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>Numbers such as “1.5”, “23.2” or “5235.8” with a
+                    single decimal place and any number of digits before the
+                    decimal point.</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>The entire value of numbers such as “5,235.8” or
-                      “21,571.9”. Only the portion of the after the thousands
-                      separator will be matched.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>The entire value of numbers such as “5,235.8” or
+                    “21,571.9”. Only the portion of the after the thousands
+                    separator will be matched.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The OPENING PARENTHESIS: <literal>(</literal></term>
+      <varlistentry id="app.regex.twelve.characters.open.parens">
+		<term id="app.regex.twelve.characters.open.parens.title">
+		The OPENING PARENTHESIS: <literal>(</literal></term>
 
-          <listitem>
-            <para>This character starts a <emphasis>group</emphasis>, which is a
-            set of characters treated as a single unit. Groups are numbered, and
-            their contents group are stored in memory. They can be reused later
-            in the search expression using
-            <literal>\<option>n</option></literal>, where <option>n</option> is
-            the number of the group.</para>
+        <listitem>
+          <para>This character starts a <emphasis>group</emphasis>, which is a
+          set of characters treated as a single unit. Groups are numbered, and
+          their contents group are stored in memory. They can be reused later
+          in the search expression using
+          <literal>\<option>n</option></literal>, where <option>n</option> is
+          the number of the group.</para>
 
-            <note>
-              <para>The content of the group can also be used in the <link
-              linkend="windows.text.replace">replacement text</link>. Use
-              <literal>$<option>n</option></literal>, where <option>n</option>
-              is the number of the group defined in the search.</para>
-            </note>
+          <note>
+            <para>The content of the group can also be used in the <link
+            linkend="windows.text.replace">replacement text</link>. Use
+            <literal>$<option>n</option></literal>, where <option>n</option>
+            is the number of the group defined in the search.</para>
+          </note>
 
-            <para>Parentheses are always used in opening and closing pairs.
-            Trying to use only the opening or closing parenthesis on its own
-            will cause an error.</para>
+          <para>Parentheses are always used in opening and closing pairs.
+          Trying to use only the opening or closing parenthesis on its own
+          will cause an error.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>(\b\w+\b)\h\1\b</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>(\b\w+\b)\h\1\b</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>Doubled up words separated by a space, such as the
-                      consecutive “an” in the following sentence:</para>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>Doubled up words separated by a space, such as the
+                    consecutive “an” in the following sentence:</para>
 
-					  <para>“I bought an an apple.”</para>
-                    </entry>
-                  </row>
+					<para>“I bought an an apple.”</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>The “that, that” in the following sentence:</para>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>The “that, that” in the following sentence:</para>
 
-					  <para>“But that, that is just unbelievable”, because the
-                      first “that” is followed by both a comma and a space
-                      rather than only a space.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+					<para>“But that, that is just unbelievable”, because the
+                    first “that” is followed by both a comma and a space
+                    rather than only a space.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The CLOSING PARENTHESIS: <literal>)</literal></term>
+      <varlistentry id="app.regex.twelve.characters.close.parens">
+		<term id="app.regex.twelve.characters.close.parens.title">
+		The CLOSING PARENTHESIS: <literal>)</literal></term>
 
-          <listitem>
-            <para>This character closes a group. It is special because it can
-            never be used on its own. It must be preceded by the
-            <literal>\</literal> if you need to match the closing parenthesis
-            character itself.</para>
+        <listitem>
+          <para>This character closes a group. It is special because it can
+          never be used on its own. It must be preceded by the
+          <literal>\</literal> if you need to match the closing parenthesis
+          character itself.</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>^\d+\)</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>^\d+\)</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>The sequence number (including the parenthesis) at
-                      the beginning of each line in a list such as:</para>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>The sequence number (including the parenthesis) at
+                    the beginning of each line in a list such as:</para>
 
-                      <simplelist>
-                        <member>1) Apples</member>
-                        <member>2) Oranges</member>
-                        <member>3) Pears</member>
-                      </simplelist>
-                    </entry>
-                  </row>
+                    <simplelist>
+                      <member>1) Apples</member>
+                      <member>2) Oranges</member>
+                      <member>3) Pears</member>
+                    </simplelist>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>Sequence numbers that are not at the beginning of a
-                      line.</para>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>Sequence numbers that are not at the beginning of a
+                    line.</para>
 
-                      <para>Follow these steps:</para>
-                      <simplelist>
-                        <member>Step 1) Preparation</member>
-                        <member>Step 2) …</member>
-                      </simplelist>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                    <para>Follow these steps:</para>
+                    <simplelist>
+                      <member>Step 1) Preparation</member>
+                      <member>Step 2) …</member>
+                    </simplelist>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The OPENING SQUARE BRACKET: <literal>[</literal></term>
+      <varlistentry id="app.regex.twelve.characters.open.bracket">
+		<term id="app.regex.twelve.characters.open.bracket.title">
+		The OPENING SQUARE BRACKET: <literal>[</literal></term>
 
-          <listitem>
-            <para>This character must be paired with the closing square bracket
-            to enclose a set of individual characters that each represent a
-            valid potential match.</para>
+        <listitem>
+          <para>This character must be paired with the closing square bracket
+          to enclose a set of individual characters that each represent a
+          valid potential match.</para>
 
-            <para>Only the opening bracket is special and needs to be preceded
-            by a backslash to search for the bracket character itself. If you
-            only want to match the closing bracket as itself, you do not need to
-            precede it with a backslash. (You can still add it, but it will have
-            no effect on the expression or the result.)</para>
+          <para>Only the opening bracket is special and needs to be preceded
+          by a backslash to search for the bracket character itself. If you
+          only want to match the closing bracket as itself, you do not need to
+          precede it with a backslash. (You can still add it, but it will have
+          no effect on the expression or the result.)</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>li[cs]en[cs]e</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>li[cs]en[cs]e</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>The correct “licence” and “license” spellings, as
-                      well as the potential “lisence” and “lisense”
-                      misspellings</para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>The correct “licence” and “license” spellings, as
+                    well as the potential “lisence” and “lisense”
+                    misspellings</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>More egregious misspellings such as “licensse” or
-                      “lissense”.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>More egregious misspellings such as “licensse” or
+                    “lissense”.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
 
-        <varlistentry>
-          <term>The OPENING CURLY BRACE: <literal>{</literal></term>
+      <varlistentry id="app.regex.twelve.characters.open.brace">
+		<term id="app.regex.twelve.characters.open.brace.title">
+		The OPENING CURLY BRACE: <literal>{</literal></term>
 
-          <listitem>
-            <para>This character must be paired with the closing curly
-            brace to encloses an <emphasis>exact number</emphasis>,
-            <emphasis>minimum</emphasis>, <emphasis>maximum</emphasis>,
-            or <emphasis>range</emphasis> specifying how many instances of
-            the preceding character or group should be matched.</para>
+        <listitem>
+          <para>This character must be paired with the closing curly
+          brace to encloses an <emphasis>exact number</emphasis>,
+          <emphasis>minimum</emphasis>, <emphasis>maximum</emphasis>,
+          or <emphasis>range</emphasis> specifying how many instances of
+          the preceding character or group should be matched.</para>
 
-            <para>Only the opening brace is special and needs to be
-            preceded by a backslash to search for the brace character
-            itself. If you only want to match the closing brace as
-            itself, you do not need to precede it with a backslash. (You
-            can still add it, but it will have no effect on the
-            expression or the result.)</para>
+          <para>Only the opening brace is special and needs to be
+          preceded by a backslash to search for the brace character
+          itself. If you only want to match the closing brace as
+          itself, you do not need to precede it with a backslash. (You
+          can still add it, but it will have no effect on the
+          expression or the result.)</para>
 
-            <informaltable>
-              <tgroup cols="2">
-                <colspec colwidth="300*"/>
-                <colspec colwidth="700*"/>
+          <informaltable>
+            <tgroup cols="2">
+              <colspec colwidth="300*"/>
+              <colspec colwidth="700*"/>
 
-                <tbody>
-                  <row>
-                    <entry></entry>
-                    <entry><literal>\d{4}/\d{1,3}</literal></entry>
-                  </row>
+              <tbody>
+                <row>
+                  <entry></entry>
+                  <entry><literal>\d{4}/\d{1,3}</literal></entry>
+                </row>
 
-                  <row>
-                    <entry>Matches</entry>
-                    <entry>
-                      <para>Codes such as “1234/5”, “1472/69”, or “9513/842”
-                      consisting of four digits, a forward slash, and one to
-                      three more digits.</para>
-                    </entry>
-                  </row>
+                <row>
+                  <entry>Matches</entry>
+                  <entry>
+                    <para>Codes such as “1234/5”, “1472/69”, or “9513/842”
+                    consisting of four digits, a forward slash, and one to
+                    three more digits.</para>
+                  </entry>
+                </row>
 
-                  <row>
-                    <entry>Does not match</entry>
-                    <entry>
-                      <para>Codes such as “123/45”, “1472/6985”, or
-                      “95133/15746”.</para>
-                      <para><emphasis role="bold">Caution:</emphasis>
-                      Although the last two codes above are not matched
-                      completely, the expression will return the
-                      “<emphasis>1472/698</emphasis>” portion of “1472/6985”,
-                      as well as the “<emphasis>5133/157</emphasis>” of
-                      “95133/15746”.</para>
-                    </entry>
-                  </row>
-                </tbody>
-              </tgroup>
-            </informaltable>
-          </listitem>
-        </varlistentry>
-      </variablelist>
+                <row>
+                  <entry>Does not match</entry>
+                  <entry>
+                    <para>Codes such as “123/45”, “1472/6985”, or
+                    “95133/15746”.</para>
+                    <para><emphasis role="bold">Caution:</emphasis>
+                    Although the last two codes above are not matched
+                    completely, the expression will return the
+                    “<emphasis>1472/698</emphasis>” portion of “1472/6985”,
+                    as well as the “<emphasis>5133/157</emphasis>” of
+                    “95133/15746”.</para>
+                  </entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
+        </listitem>
+      </varlistentry>
+    </variablelist>
   </section>
 
   <section id="app.regex.types.of.expressions">
-    <title id="app.regex.types.of.expressions.title">Lots of
+	<title id="app.regex.types.of.expressions.title">
+      Lots of
     expressions</title>
 
     <para>This section presents various types of regular expression, ranging
     from the simple to the complex.</para>
-      
+    
     <note>
       <para>Remember that most <emphasis>alphabetic</emphasis> characters
       preceded by a <literal>\</literal> turn into an expression that represents
@@ -889,7 +917,8 @@
     </note>
 
     <section id="app.regex.types.of.expressions.simple.expressions">
-      <title id="app.regex.types.of.expressions.simple.expressions.title">
+	  <title id="app.regex.types.of.expressions.simple.expressions.title">
+		
         Simple expressions
       </title>
       <para>The simplest regular expression consist of a single character,
@@ -897,7 +926,8 @@
       unit with a single meaning.</para>
       
       <table id="app.regex.characters">
-        <title id="app.regex.characters.title">Characters</title>
+		<title id="app.regex.characters.title">
+		Characters</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -944,13 +974,14 @@
     </section>
 
     <section id="app.regex.types.of.expressions.case">
-      <title id="app.regex.types.of.expressions.case.title">Case</title>
+	  <title id="app.regex.types.of.expressions.case.title">
+      Case</title>
 
       
       <para>Ordinary OmegaT searches are case insensitive by default: they match
       both uppercase and lowercase characters, unless you choose to enable the
       <link linkend="windows.text.search.options"
-      endterm="windows.text.search.options.title"/> option. Doing so makes the
+			endterm="windows.text.search.options.title"/> option. Doing so makes the
       entire search expression case sensitive.</para>
 
       <para>In contrast, Regular expressions are case sensitive by default. This
@@ -959,15 +990,17 @@
       to specify case sensitivity within the expression:</para>
 
       <variablelist>
-        <varlistentry>
-          <term><literal>(?i)</literal></term>
+        <varlistentry id="app.regex.twelve.characters.case.insensitive">
+		  <term id="app.regex.twelve.characters.case.insensitive.title">
+		  <literal>(?i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case insensitive.</para>
           </listitem>
         </varlistentry>
-        <varlistentry>
-          <term><literal>(?-i)</literal></term>
+        <varlistentry id="app.regex.twelve.characters.case.sensitive">
+		  <term id="app.regex.twelve.characters.case.sensitive.title">
+		  <literal>(?-i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case sensitive.</para>
@@ -985,7 +1018,8 @@
     </section>
 
     <section id="app.regex.types.of.expressions.classes">
-      <title id="app.regex.types.of.expressions.classes.title">Classes</title>
+	  <title id="app.regex.types.of.expressions.classes.title">
+      Classes</title>
 
       <para>Regular expressions allow you to create sets of characters—known as
       <emphasis>classes</emphasis>. Searches will match any of the characters in
@@ -1025,7 +1059,8 @@
       shorthand.</para>
       
       <table id="app.regex.classes">
-        <title id="app.regex.classes.title">Examples of classes</title>
+		<title id="app.regex.classes.title">
+		Examples of classes</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1133,7 +1168,8 @@
       expressions.</para>
 
       <table id="app.regex.unicode.blocks">
-        <title id="app.regex.unicode.blocks.title">Unicode blocks, scripts and
+		<title id="app.regex.unicode.blocks.title">
+		  Unicode blocks, scripts and
         categories</title>
         
         <tgroup align="left" cols="2" rowsep="1">
@@ -1157,7 +1193,7 @@
                 <emphasis role="bold">not</emphasis> in the Greek block.</para>
               </entry>
             </row>
-          
+			
             <row>
               <entry><literal>\p{IsHan}</literal></entry>
               <entry>
@@ -1168,7 +1204,7 @@
                 script</ulink>)</para>
               </entry>
             </row>
-          
+			
             <row>
               <entry><literal>\p{Lu}</literal></entry>
               <entry>
@@ -1177,7 +1213,7 @@
                 category</ulink>)</para>
               </entry>
             </row>
-          
+			
             <row>
               <entry><literal>\p{Sc}</literal></entry>
               <entry>
@@ -1192,7 +1228,8 @@
     </section>
 
     <section id="app.regex.more.advanced.expressions">
-      <title id="app.regex.more.advanced.expressions.title">More advanced
+	  <title id="app.regex.more.advanced.expressions.title">
+		More advanced
       expressions</title>
       
       <para>Some expressions specify a position rather than a character. They
@@ -1202,8 +1239,9 @@
       endterm="app.regex.tools.title" /> section for more information.</para>
 
       <table id="app.regex.boundary.matchers">
-        <title id="app.regex.boundary.matchers.title">Expressions that mark a position</title>
-      
+		<title id="app.regex.boundary.matchers.title">
+		Expressions that mark a position</title>
+		
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
 
@@ -1221,28 +1259,28 @@
                 <para>The beginning of a line</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>$</literal></entry>
               <entry>
                 <para>The end of a line</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>\b</literal></entry>
               <entry>
                 <para>A word boundary</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>\B</literal></entry>
               <entry>
                 <para><emphasis>Not</emphasis> a word boundary</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>(?=u)</literal></entry>
               <entry>
@@ -1254,7 +1292,7 @@
                 in “qigong” or “Iraq”.</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>(?!u)</literal></entry>
               <entry>
@@ -1278,7 +1316,7 @@
                 in “quick”, but not the one in “run”.</para>
               </entry>
             </row>
-        
+			
             <row>
               <entry><literal>(?&lt;!q)</literal></entry>
               <entry>
@@ -1298,14 +1336,16 @@
   </section>
 
   <section id="app.regex.more.examples">
-    <title id="app.regex.more.examples.title">More examples</title>
+	<title id="app.regex.more.examples.title">
+    More examples</title>
 
     <para>This section presents a few examples demonstrating how the various
     expressions described above can be combined to perform powerful searches in
     OmegaT.</para>
     
     <table id="regex.examples">
-      <title id="regex.examples.title">Examples of regular expressions that use
+	  <title id="regex.examples.title">
+		Examples of regular expressions that use
       the above expressions</title>
 
       <tgroup align="left" cols="2" rowsep="1">
@@ -1367,23 +1407,23 @@
               month and day separated by a slash, period, or hyphen, such
               as:</para>
 			  
-                <itemizedlist>
-                  <listitem>
-                    <para>2002/11/8</para>
-                  </listitem>
-                  <listitem>
-                    <para>1969.7.20</para>
-                  </listitem>
-                  <listitem>
-                    <para>2022-10-31</para>
-                  </listitem>
-                </itemizedlist>
+              <itemizedlist>
+                <listitem>
+                  <para>2002/11/8</para>
+                </listitem>
+                <listitem>
+                  <para>1969.7.20</para>
+                </listitem>
+                <listitem>
+                  <para>2022-10-31</para>
+                </listitem>
+              </itemizedlist>
 
-				<note>
-                  <para>This expression finds number and separator patterns
-                  matching possible dates, but does not validate them. It will
-                  also find patterns such as “5136/36/71”.</para>
-				</note>
+			  <note>
+                <para>This expression finds number and separator patterns
+                matching possible dates, but does not validate them. It will
+                also find patterns such as “5136/36/71”.</para>
+			  </note>
             </entry>
           </row>
 
@@ -1419,7 +1459,8 @@
   </section>
 
   <section id="app.regex.tools">
-    <title id="app.regex.tools.title">References</title>
+	<title id="app.regex.tools.title">
+    References</title>
 
     <para>Although OmegaT does not offer fancy colouring for your regular
     expressions, you can get a lot of practice by using the <link
@@ -1430,46 +1471,49 @@
 
     <para>The Java technical reference is useful as a canonical reference.
 
-      <variablelist>
-        <varlistentry id="app.regex.java">
-          <term id="app.regex.java.title"><ulink url="&javaregex;">Java Regex
-          documentation</ulink></term>
-          <listitem>
-            <para>The official reference for regular expressions used in
-            Java.</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-      
-      If you want to learn more about using regular expressions, the two
-      following sites have proven very useful.
+    <variablelist>
+      <varlistentry id="app.regex.java">
+		<term id="app.regex.java.title">
+		  <ulink url="&javaregex;">Java Regex
+        documentation</ulink></term>
+        <listitem>
+          <para>The official reference for regular expressions used in
+          Java.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    
+    If you want to learn more about using regular expressions, the two
+    following sites have proven very useful.
 
-      <variablelist>
-        <varlistentry id="app.regex.tools.regex101">
-          <term id="app.regex.tools.regex101.title"><ulink
-          url="https://regex101.com">https://regex101.com</ulink></term>
+    <variablelist>
+      <varlistentry id="app.regex.tools.regex101">
+		<term id="app.regex.tools.regex101.title">
+		  <ulink
+			  url="https://regex101.com">https://regex101.com</ulink></term>
           <listitem>
             <para>An online regular expression matcher that lets you enter the
             text you want to search and the regular expressions you want to
             test.</para>
           </listitem>
-        </varlistentry>
+      </varlistentry>
 
-        <varlistentry id="app.regex.tools.regular.expression.info">
-          <term id="app.regex.tools.regular.expression.info.title"><ulink
-          url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
+      <varlistentry id="app.regex.tools.regular.expression.info">
+		<term id="app.regex.tools.regular.expression.info.title">
+		  <ulink
+			  url="https://www.regular-expressions.info">https://www.regular-expressions.info</ulink></term>
           <listitem>
             <para>One of the most thorough regular expression tutorial and
             reference on the web.</para>
           </listitem>
-        </varlistentry>
-      </variablelist>
+      </varlistentry>
+    </variablelist>
 
-      <note>
-        <para>OmegaT does not support either site in any way. If you find other
-        interesting references—in any language—the OmegaT team would love to
-        hear about them.</para>
-      </note>
+    <note>
+      <para>OmegaT does not support either site in any way. If you find other
+      interesting references—in any language—the OmegaT team would love to
+      hear about them.</para>
+    </note>
     </para>
   </section>
 </section>

--- a/doc_src/en/App_Regex.xml
+++ b/doc_src/en/App_Regex.xml
@@ -4,8 +4,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <section id="app.regex">
-  <title id="app.regex.title">
-  Regular expressions</title>
+  <title id="app.regex.title">Regular expressions</title>
 
   <para>This appendix is intended for users interested in exploring a powerful
   way to boost their productivity. Although seen as daunting and complex, even
@@ -30,15 +29,13 @@
   
   <variablelist>
     <varlistentry id="app.regex.digit">
-	  <term id="app.regex.digit.title">
-      [0-9]</term>
+	  <term id="app.regex.digit.title">[0-9]</term>
       <listitem><para>Any single digit from 0 to 9.</para>
       </listitem>
     </varlistentry>
 
 	<varlistentry id="app.regex.word">
-	  <term id="app.regex.word.title">
-      \w+</term>
+	  <term id="app.regex.word.title">\w+</term>
       <listitem><para>Represents one or more “word characters”, namely
       the letters of the alphabet, digits, and
       underscore symbols.</para>
@@ -46,8 +43,7 @@
     </varlistentry>
 
 	<varlistentry id="app.regex.horizontal.space">
-	  <term id="app.regex.horizontal.space.title">
-      \h?</term>
+	  <term id="app.regex.horizontal.space.title">\h?</term>
       <listitem><para>Represents zero or one horizontal whitespace
       character (this includes regular and non-breaking spaces as well as
       tabs, but not line break characters, which belong to the “vertical
@@ -61,8 +57,7 @@
 
   <variablelist>
     <varlistentry id="app.regex.searches">
-	  <term id="app.regex.searches.title">
-      Searches</term>
+	  <term id="app.regex.searches.title">Searches</term>
       <listitem>
         <para>Searches include a <link
         linkend="windows.text.search.methods.regex"
@@ -77,8 +72,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.custom.tags">
-	  <term id="app.regex.custom.tags.title">
-      Custom tags</term>
+	  <term id="app.regex.custom.tags.title">Custom tags</term>
       <listitem>
         <para>Custom tags are tags defined with regular expressions that are
         handled exactly like native OmegaT tags. See the <link
@@ -92,8 +86,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.flagged.text">
-	  <term id="app.regex.flagged.text.title">
-      Flagged text</term>
+	  <term id="app.regex.flagged.text.title">Flagged text</term>
       <listitem>
         <para>The <link
         linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"
@@ -107,8 +100,7 @@
     </varlistentry>
 
     <varlistentry id="app.regex.alignment">
-	  <term id="app.regex.alignment.title">
-      Text highlighting in alignments</term>
+	  <term id="app.regex.alignment.title">Text highlighting in alignments</term>
       <listitem>
         <para>Visual cues can help verifying that your alignment is correct. The
         <link linkend="windows.aligner.adjust.highlight"
@@ -122,8 +114,7 @@
     </varlistentry>	
 
     <varlistentry id="app.regex.segmentation">
-	  <term id="app.regex.segmentation.title">
-      Segmentation</term>
+	  <term id="app.regex.segmentation.title">Segmentation</term>
       <listitem>
         <para>Segmentation rules and language patterns are defined with regular
         expressions. You can modify them freely to improve the segmentation of a
@@ -145,8 +136,7 @@
   </variablelist>
 
   <section id="app.regex.four.rules">
-	<title id="app.regex.four.rules.title">
-    The 4 rules</title>
+	<title id="app.regex.four.rules.title">The 4 rules</title>
 
     <para>Regular expressions are used to find text, including characters that
     are not visible on the screen or when printed out, such as spaces, tabs, or
@@ -169,8 +159,7 @@
 
     <variablelist>
       <varlistentry id="app.regex.four.rules.match.self">
-		<term id="app.regex.four.rules.match.self.title">
-		Most characters simply match themselves</term>
+		<term id="app.regex.four.rules.match.self.title">Most characters simply match themselves</term>
         <listitem>
           <para>The majority of characters in a regular expression simply
           <emphasis>look for themselves</emphasis> in the text
@@ -214,8 +203,7 @@
       </varlistentry>
       
       <varlistentry id="app.regex.four.rules.twelve.characters">
-		<term id="app.regex.four.rules.twelve.characters.title">
-		Twelve characters have a special meaning by default</term>
+		<term id="app.regex.four.rules.twelve.characters.title">Twelve characters have a special meaning by default</term>
         <listitem>
           <para>That special meaning has to be cancelled by another character to
           match the character itself.</para>
@@ -251,8 +239,7 @@
   </section>
 
   <section id="app.regex.twelve.characters">
-	<title id="app.regex.twelve.characters.title">
-    The 12 characters</title>
+	<title id="app.regex.twelve.characters.title">The 12 characters</title>
 	
     <para>The twelve special characters are the <emphasis>backslash</emphasis>
     <literal>\</literal>, the <emphasis>caret</emphasis> <literal>^</literal>,
@@ -275,8 +262,7 @@
     
     <variablelist>
       <varlistentry id="app.regex.twelve.characters.backslash">
-		<term id="app.regex.twelve.characters.backslash.title">
-		The BACKSLASH: <literal>\</literal></term>
+		<term id="app.regex.twelve.characters.backslash.title">The BACKSLASH: <literal>\</literal></term>
         <listitem>
           <para>This character either cancels or activates the special meaning of the following character.</para>
           
@@ -323,8 +309,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.caret">
-		<term id="app.regex.twelve.characters.caret.title">
-		The CARET: <literal>^</literal></term>
+		<term id="app.regex.twelve.characters.caret.title">The CARET: <literal>^</literal></term>
         <listitem>
           <para>When it is the first character in the expression, the
           <emphasis>caret</emphasis> character matches the beginning of a
@@ -398,8 +383,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.dollar">
-		<term id="app.regex.twelve.characters.dollar.title">
-		The DOLLAR sign: <literal>$</literal></term>
+		<term id="app.regex.twelve.characters.dollar.title">The DOLLAR sign: <literal>$</literal></term>
         <listitem>
           <para>When it is the last character in an expression, the
           <emphasis>dollar</emphasis> sign matches the end of a line.</para>
@@ -438,8 +422,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.period">
-		<term id="app.regex.twelve.characters.period.title">
-		The PERIOD: <literal>.</literal></term>
+		<term id="app.regex.twelve.characters.period.title">The PERIOD: <literal>.</literal></term>
         <listitem>
           <para>Matches any single character.</para>
 
@@ -489,8 +472,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.vertical.bar">
-		<term id="app.regex.twelve.characters.vertical.bar.title">
-		The VERTICAL BAR: <literal>|</literal></term>
+		<term id="app.regex.twelve.characters.vertical.bar.title">The VERTICAL BAR: <literal>|</literal></term>
         <listitem>
           <para>This character functions as an “OR” and matches either
           of the expressions that precede or follow it.</para>
@@ -538,8 +520,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.question.mark">
-		<term id="app.regex.twelve.characters.question.mark.title">
-		The QUESTION MARK: <literal>?</literal></term>
+		<term id="app.regex.twelve.characters.question.mark.title">The QUESTION MARK: <literal>?</literal></term>
         <listitem>
           <para>This character specifies that either zero or one
           instance of the preceding character or expression should be
@@ -594,8 +575,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.asterisk">
-		<term id="app.regex.twelve.characters.asterisk.title">
-		The ASTERISK: <literal>*</literal></term>
+		<term id="app.regex.twelve.characters.asterisk.title">The ASTERISK: <literal>*</literal></term>
         <listitem>
           <para>This character specifies that zero or more instances of the
           preceding character or expression should be matched.</para>
@@ -640,8 +620,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.plus">
-		<term id="app.regex.twelve.characters.plus.title">
-		The PLUS sign: <literal>+</literal></term>
+		<term id="app.regex.twelve.characters.plus.title">The PLUS sign: <literal>+</literal></term>
         <listitem>
           <para>This character specifies that one or more instances of
           the preceding character or expression should be matched.</para>
@@ -681,8 +660,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.parens">
-		<term id="app.regex.twelve.characters.open.parens.title">
-		The OPENING PARENTHESIS: <literal>(</literal></term>
+		<term id="app.regex.twelve.characters.open.parens.title">The OPENING PARENTHESIS: <literal>(</literal></term>
 
         <listitem>
           <para>This character starts a <emphasis>group</emphasis>, which is a
@@ -741,8 +719,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.close.parens">
-		<term id="app.regex.twelve.characters.close.parens.title">
-		The CLOSING PARENTHESIS: <literal>)</literal></term>
+		<term id="app.regex.twelve.characters.close.parens.title">The CLOSING PARENTHESIS: <literal>)</literal></term>
 
         <listitem>
           <para>This character closes a group. It is special because it can
@@ -795,8 +772,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.bracket">
-		<term id="app.regex.twelve.characters.open.bracket.title">
-		The OPENING SQUARE BRACKET: <literal>[</literal></term>
+		<term id="app.regex.twelve.characters.open.bracket.title">The OPENING SQUARE BRACKET: <literal>[</literal></term>
 
         <listitem>
           <para>This character must be paired with the closing square bracket
@@ -843,8 +819,7 @@
       </varlistentry>
 
       <varlistentry id="app.regex.twelve.characters.open.brace">
-		<term id="app.regex.twelve.characters.open.brace.title">
-		The OPENING CURLY BRACE: <literal>{</literal></term>
+		<term id="app.regex.twelve.characters.open.brace.title">The OPENING CURLY BRACE: <literal>{</literal></term>
 
         <listitem>
           <para>This character must be paired with the closing curly
@@ -926,8 +901,7 @@
       unit with a single meaning.</para>
       
       <table id="app.regex.characters">
-		<title id="app.regex.characters.title">
-		Characters</title>
+		<title id="app.regex.characters.title">Characters</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -974,8 +948,7 @@
     </section>
 
     <section id="app.regex.types.of.expressions.case">
-	  <title id="app.regex.types.of.expressions.case.title">
-      Case</title>
+	  <title id="app.regex.types.of.expressions.case.title">Case</title>
 
       
       <para>Ordinary OmegaT searches are case insensitive by default: they match
@@ -991,16 +964,14 @@
 
       <variablelist>
         <varlistentry id="app.regex.twelve.characters.case.insensitive">
-		  <term id="app.regex.twelve.characters.case.insensitive.title">
-		  <literal>(?i)</literal></term>
+		  <term id="app.regex.twelve.characters.case.insensitive.title"><literal>(?i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case insensitive.</para>
           </listitem>
         </varlistentry>
         <varlistentry id="app.regex.twelve.characters.case.sensitive">
-		  <term id="app.regex.twelve.characters.case.sensitive.title">
-		  <literal>(?-i)</literal></term>
+		  <term id="app.regex.twelve.characters.case.sensitive.title"><literal>(?-i)</literal></term>
           <listitem>
             <para>Makes the part of the expression to the right of the modifier
             case sensitive.</para>
@@ -1018,8 +989,7 @@
     </section>
 
     <section id="app.regex.types.of.expressions.classes">
-	  <title id="app.regex.types.of.expressions.classes.title">
-      Classes</title>
+	  <title id="app.regex.types.of.expressions.classes.title">Classes</title>
 
       <para>Regular expressions allow you to create sets of characters—known as
       <emphasis>classes</emphasis>. Searches will match any of the characters in
@@ -1059,8 +1029,7 @@
       shorthand.</para>
       
       <table id="app.regex.classes">
-		<title id="app.regex.classes.title">
-		Examples of classes</title>
+		<title id="app.regex.classes.title">Examples of classes</title>
 
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1239,8 +1208,7 @@
       endterm="app.regex.tools.title" /> section for more information.</para>
 
       <table id="app.regex.boundary.matchers">
-		<title id="app.regex.boundary.matchers.title">
-		Expressions that mark a position</title>
+		<title id="app.regex.boundary.matchers.title">Expressions that mark a position</title>
 		
         <tgroup align="left" cols="2" rowsep="1">
           <colspec align="left" colnum="1"/>
@@ -1336,8 +1304,7 @@
   </section>
 
   <section id="app.regex.more.examples">
-	<title id="app.regex.more.examples.title">
-    More examples</title>
+	<title id="app.regex.more.examples.title">More examples</title>
 
     <para>This section presents a few examples demonstrating how the various
     expressions described above can be combined to perform powerful searches in
@@ -1459,8 +1426,7 @@
   </section>
 
   <section id="app.regex.tools">
-	<title id="app.regex.tools.title">
-    References</title>
+	<title id="app.regex.tools.title">References</title>
 
     <para>Although OmegaT does not offer fancy colouring for your regular
     expressions, you can get a lot of practice by using the <link

--- a/doc_src/en/App_Segmentation.xml
+++ b/doc_src/en/App_Segmentation.xml
@@ -2,12 +2,10 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.segmentation">
-  <title id="app.segmentation.title">Segmentation</title>
+  <title id="app.segmentation.title"><link linkend="app.segmentation"> </link>Segmentation</title>
 
   <section id="dialog.preferences.segmentation.setup.type">
-	<title id="dialog.preferences.segmentation.setup.type.title">
-      Paragraph or
-	sentence?</title>
+	<title id="dialog.preferences.segmentation.setup.type.title"><link linkend="dialog.preferences.segmentation.setup.type"> </link>Paragraph or sentence?</title>
 	
 	<para>Translation memory tools work with textual units called segments. When
 	a translation is entered, the segment containing the source text is stored
@@ -41,10 +39,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.segmentation.setup.structure.level.segmentation">
-		<term
-			id="dialogs.preferences.segmentation.setup.structure.level.segmentation.title">
-		  Paragraph-Level
-		segmentation</term>
+		<term id="dialogs.preferences.segmentation.setup.structure.level.segmentation.title"><link linkend="dialogs.preferences.segmentation.setup.structure.level.segmentation"> </link>Paragraph-Level segmentation</term>
 
 		<listitem>
 		  <para>OmegaT first parses the text for paragraph-level
@@ -60,10 +55,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.segmentation.rules.sentence.level.segmentation">
-		<term
-			id="dialogs.preferences.segmentation.rules.sentence.level.segmentation.title">
-		  Sentence-level
-        segmentation</term>
+		<term id="dialogs.preferences.segmentation.rules.sentence.level.segmentation.title"><link linkend="dialogs.preferences.segmentation.rules.sentence.level.segmentation"> </link>Sentence-level segmentation</term>
 
         <listitem>
 		  <para>After dividing the source file into structural units, OmegaT
@@ -97,9 +89,7 @@
   </section>
   
   <section id="dialog.preferences.segmentation.setup.scope">
-	<title id="dialog.preferences.segmentation.setup.scope.title">
-      Global or
-	local?</title>
+	<title id="dialog.preferences.segmentation.setup.scope.title"><link linkend="dialog.preferences.segmentation.setup.scope"> </link>Global or local?</title>
 
 	<note>
 	  <para>The same mechanisms and dialogs are used to define global and local
@@ -124,7 +114,7 @@
 
 
   <section id="dialog.preferences.segmentation.setup.rules.based.segmentation">
-	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">Rules</title>
+	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title"><link linkend="dialog.preferences.segmentation.setup.rules.based.segmentation"> </link>Rules</title>
 	<para>OmegaT provides predefined segmentation rules, and the translator can
 	use regular expressions to modify them. See the <link linkend="app.regex"
 	endterm="app.regex.title"/> appendix for details.</para>
@@ -143,7 +133,7 @@
 	</warning>
 
 	<table id="segmentation.simple.examples">
-	  <title id="segmentation.simple.examples.title">A few simple examples</title>
+	  <title id="segmentation.simple.examples.title"><link linkend="segmentation.simple.examples"> </link>A few simple examples</title>
       <tgroup cols="5">
 		<colspec align="left" colnum="1"/>
 		<colspec align="left" colnum="2"/>

--- a/doc_src/en/App_Segmentation.xml
+++ b/doc_src/en/App_Segmentation.xml
@@ -2,10 +2,12 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.segmentation">
-  <title id="app.segmentation.title">Segmentation</title>
+  <title id="app.segmentation.title">
+  Segmentation</title>
 
   <section id="dialog.preferences.segmentation.setup.type">
-	<title id="dialog.preferences.segmentation.setup.type.title">Paragraph or
+	<title id="dialog.preferences.segmentation.setup.type.title">
+      Paragraph or
 	sentence?</title>
 	
 	<para>Translation memory tools work with textual units called segments. When
@@ -41,7 +43,8 @@
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.segmentation.setup.structure.level.segmentation">
 		<term
-			id="dialogs.preferences.segmentation.setup.structure.level.segmentation.title">Paragraph-Level
+			id="dialogs.preferences.segmentation.setup.structure.level.segmentation.title">
+		  Paragraph-Level
 		segmentation</term>
 
 		<listitem>
@@ -58,8 +61,9 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.segmentation.rules.sentence.level.segmentation">
-        <term
-			id="dialogs.preferences.segmentation.rules.sentence.level.segmentation.title">Sentence-level
+		<term
+			id="dialogs.preferences.segmentation.rules.sentence.level.segmentation.title">
+		  Sentence-level
         segmentation</term>
 
         <listitem>
@@ -94,7 +98,8 @@
   </section>
   
   <section id="dialog.preferences.segmentation.setup.scope">
-	<title id="dialog.preferences.segmentation.setup.scope.title">Global or
+	<title id="dialog.preferences.segmentation.setup.scope.title">
+      Global or
 	local?</title>
 
 	<note>
@@ -120,7 +125,8 @@
 
 
   <section id="dialog.preferences.segmentation.setup.rules.based.segmentation">
-	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">Rules</title>
+	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">
+    Rules</title>
 	<para>OmegaT provides predefined segmentation rules, and the translator can
 	use regular expressions to modify them. See the <link linkend="app.regex"
 	endterm="app.regex.title"/> appendix for details.</para>
@@ -139,7 +145,8 @@
 	</warning>
 
 	<table id="segmentation.simple.examples">
-	  <title id="segmentation.simple.examples.title">A few simple examples</title>
+	  <title id="segmentation.simple.examples.title">
+      A few simple examples</title>
       <tgroup cols="5">
 		<colspec align="left" colnum="1"/>
 		<colspec align="left" colnum="2"/>

--- a/doc_src/en/App_Segmentation.xml
+++ b/doc_src/en/App_Segmentation.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.segmentation">
-  <title id="app.segmentation.title">
-  Segmentation</title>
+  <title id="app.segmentation.title">Segmentation</title>
 
   <section id="dialog.preferences.segmentation.setup.type">
 	<title id="dialog.preferences.segmentation.setup.type.title">
@@ -125,8 +124,7 @@
 
 
   <section id="dialog.preferences.segmentation.setup.rules.based.segmentation">
-	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">
-    Rules</title>
+	<title id="dialog.preferences.segmentation.setup.rules.based.segmentation.title">Rules</title>
 	<para>OmegaT provides predefined segmentation rules, and the translator can
 	use regular expressions to modify them. See the <link linkend="app.regex"
 	endterm="app.regex.title"/> appendix for details.</para>
@@ -145,8 +143,7 @@
 	</warning>
 
 	<table id="segmentation.simple.examples">
-	  <title id="segmentation.simple.examples.title">
-      A few simple examples</title>
+	  <title id="segmentation.simple.examples.title">A few simple examples</title>
       <tgroup cols="5">
 		<colspec align="left" colnum="1"/>
 		<colspec align="left" colnum="2"/>

--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -2,12 +2,10 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.shortcuts">
-  <title id="app.shortcuts.title">
-  OmegaT Shortcuts</title>
+  <title id="app.shortcuts.title">OmegaT Shortcuts</title>
 
   <section id="app.shortcuts.description">
-	<title id="app.shortcuts.description.title">
-    Description</title>
+	<title id="app.shortcuts.description.title">Description</title>
 
     <para>The OmegaT interface generally does not rely on buttons to give access
     to its functions. Instead, they are called from the menus or, for the
@@ -29,8 +27,7 @@
     keys:</para>
 	
     <table id="app.shortcut.description">
-	  <title id="app.shortcut.description.title">
-      Modifier key identifiers</title>
+	  <title id="app.shortcut.description.title">Modifier key identifiers</title>
 
       <tgroup cols="3">
         <thead>
@@ -89,8 +86,7 @@
   </section>
   
   <section id="app.shortcuts.customization">
-	<title id="app.shortcuts.customization.title">
-    Customization</title>
+	<title id="app.shortcuts.customization.title">Customization</title>
 
     <para>OmegaT assigns shortcuts to most of the functions available in the
     <link linkend="menus.project" endterm="menus.project.title"/>, <link
@@ -109,8 +105,7 @@
 
 	<variablelist>
       <varlistentry id="app.shortcuts.customization.MainMenuShortcuts.properties">
-		<term id="app.shortcuts.customization.MainMenuShortcuts.properties.title">
-		MainMenuShortcuts.properties</term>
+		<term id="app.shortcuts.customization.MainMenuShortcuts.properties.title">MainMenuShortcuts.properties</term>
         <listitem>
           <para>The shortcut definition file for the menus and a few other
           items.</para>
@@ -118,8 +113,7 @@
       </varlistentry>
 
 	  <varlistentry id="app.shortcuts.customization.EditorShortcuts.properties">
-		<term id="app.shortcuts.customization.EditorShortcuts.properties.title">
-		EditorShortcuts.properties</term>
+		<term id="app.shortcuts.customization.EditorShortcuts.properties.title">EditorShortcuts.properties</term>
         <listitem><para>The shortcut definition file for the editor.</para>
         </listitem>
       </varlistentry>
@@ -182,8 +176,7 @@
   </section>
 
   <section id="app.shortcuts.syntax">
-	<title id="app.shortcuts.syntax.title">
-    Syntax</title>
+	<title id="app.shortcuts.syntax.title">Syntax</title>
 
     <para>The basic syntax of the shortcut definitions files is simply:</para>
 
@@ -282,8 +275,7 @@
     </example>
 
     <example id="example.shortcut.addition">
-	  <title id="example.shortcut.addition.title">
-      Adding a shortcut</title>
+	  <title id="example.shortcut.addition.title">Adding a shortcut</title>
 
       <para>If your language pair calls for the frequent use of <link
       linkend="menus.edit.create.alternative.translation">alternative
@@ -348,8 +340,7 @@
   
 
   <section id="app.shortcuts.lists">
-	<title id="app.shortcuts.lists.title">
-    Lists of functions and codes</title>
+	<title id="app.shortcuts.lists.title">Lists of functions and codes</title>
     <section id="app.shortcuts.lists.function.codes.menus">
 	  <title id="app.shortcuts.lists.function.codes.menus.title">
 		Menu
@@ -1143,8 +1134,7 @@
       </note>
 
       <table id="app.shortcuts.lists.function.codes.options.menu.table">
-		<title id="app.shortcuts.lists.function.codes.options.menu.table.title">
-		Options Menu</title>
+		<title id="app.shortcuts.lists.function.codes.options.menu.table.title">Options Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1315,8 +1305,7 @@
       default values, are presented in the table below</para>
 
       <table id="app.shortcuts.lists.function.codes.editor.table">
-		<title id="app.shortcuts.lists.function.codes.editor.table.title">
-		Editor</title>
+		<title id="app.shortcuts.lists.function.codes.editor.table.title">Editor</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>

--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.shortcuts">
-  <title id="app.shortcuts.title">OmegaT Shortcuts</title>
+  <title id="app.shortcuts.title"><link linkend="app.shortcuts"> </link>OmegaT Shortcuts</title>
 
   <section id="app.shortcuts.description">
-	<title id="app.shortcuts.description.title">Description</title>
+	<title id="app.shortcuts.description.title"><link linkend="app.shortcuts.description"> </link>Description</title>
 
     <para>The OmegaT interface generally does not rely on buttons to give access
     to its functions. Instead, they are called from the menus or, for the
@@ -27,7 +27,7 @@
     keys:</para>
 	
     <table id="app.shortcut.description">
-	  <title id="app.shortcut.description.title">Modifier key identifiers</title>
+	  <title id="app.shortcut.description.title"><link linkend="app.shortcut.description"> </link>Modifier key identifiers</title>
 
       <tgroup cols="3">
         <thead>
@@ -71,9 +71,7 @@
     to avoid listing multiple notations for every shortcut.</para>
 
     <example id="example.avoid.listing.multiple.notations">
-	  <title id="example.avoid.listing.multiple.notations.title">
-		How we avoid
-	  listing multiple notations:</title>
+	  <title id="example.avoid.listing.multiple.notations.title"><link linkend="example.avoid.listing.multiple.notations"> </link>How we avoid listing multiple notations:</title>
 	  <para>On Windows and Linux:
 	  <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo></para>
 
@@ -86,7 +84,7 @@
   </section>
   
   <section id="app.shortcuts.customization">
-	<title id="app.shortcuts.customization.title">Customization</title>
+	<title id="app.shortcuts.customization.title"><link linkend="app.shortcuts.customization"> </link>Customization</title>
 
     <para>OmegaT assigns shortcuts to most of the functions available in the
     <link linkend="menus.project" endterm="menus.project.title"/>, <link
@@ -105,7 +103,7 @@
 
 	<variablelist>
       <varlistentry id="app.shortcuts.customization.MainMenuShortcuts.properties">
-		<term id="app.shortcuts.customization.MainMenuShortcuts.properties.title">MainMenuShortcuts.properties</term>
+		<term id="app.shortcuts.customization.MainMenuShortcuts.properties.title"><link linkend="app.shortcuts.customization.MainMenuShortcuts.properties"> </link>MainMenuShortcuts.properties</term>
         <listitem>
           <para>The shortcut definition file for the menus and a few other
           items.</para>
@@ -113,7 +111,7 @@
       </varlistentry>
 
 	  <varlistentry id="app.shortcuts.customization.EditorShortcuts.properties">
-		<term id="app.shortcuts.customization.EditorShortcuts.properties.title">EditorShortcuts.properties</term>
+		<term id="app.shortcuts.customization.EditorShortcuts.properties.title"><link linkend="app.shortcuts.customization.EditorShortcuts.properties"> </link>EditorShortcuts.properties</term>
         <listitem><para>The shortcut definition file for the editor.</para>
         </listitem>
       </varlistentry>
@@ -176,7 +174,7 @@
   </section>
 
   <section id="app.shortcuts.syntax">
-	<title id="app.shortcuts.syntax.title">Syntax</title>
+	<title id="app.shortcuts.syntax.title"><link linkend="app.shortcuts.syntax"> </link>Syntax</title>
 
     <para>The basic syntax of the shortcut definitions files is simply:</para>
 
@@ -244,9 +242,7 @@
     folder</link>, as noted above, and make the changes you want there.</para>
     
     <example id="example.shortcut.modification">
-	  <title id="example.shortcut.modification.title">
-		Modifying a
-      shortcut</title>
+	  <title id="example.shortcut.modification.title"><link linkend="example.shortcut.modification"> </link>Modifying a shortcut</title>
 
       <para>The default shortcut for <link linkend="menus.project.close">closing
       a project</link> is defined on Windows and Linux as:</para>
@@ -275,7 +271,7 @@
     </example>
 
     <example id="example.shortcut.addition">
-	  <title id="example.shortcut.addition.title">Adding a shortcut</title>
+	  <title id="example.shortcut.addition.title"><link linkend="example.shortcut.addition"> </link>Adding a shortcut</title>
 
       <para>If your language pair calls for the frequent use of <link
       linkend="menus.edit.create.alternative.translation">alternative
@@ -340,11 +336,9 @@
   
 
   <section id="app.shortcuts.lists">
-	<title id="app.shortcuts.lists.title">Lists of functions and codes</title>
+	<title id="app.shortcuts.lists.title"><link linkend="app.shortcuts.lists"> </link>Lists of functions and codes</title>
     <section id="app.shortcuts.lists.function.codes.menus">
-	  <title id="app.shortcuts.lists.function.codes.menus.title">
-		Menu
-      functions</title>
+	  <title id="app.shortcuts.lists.function.codes.menus.title"><link linkend="app.shortcuts.lists.function.codes.menus"> </link>Menu functions</title>
 
       <para>The functions that can be modified in the
       <filename>MainMenuShortcuts.properties</filename> file, along with their
@@ -1134,7 +1128,7 @@
       </note>
 
       <table id="app.shortcuts.lists.function.codes.options.menu.table">
-		<title id="app.shortcuts.lists.function.codes.options.menu.table.title">Options Menu</title>
+		<title id="app.shortcuts.lists.function.codes.options.menu.table.title"><link linkend="app.shortcuts.lists.function.codes.options.menu.table"> </link>Options Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1296,16 +1290,14 @@
     </section>
 	
     <section id="app.shortcuts.lists.function.codes.windows">
-	  <title id="app.shortcuts.lists.function.codes.windows.title">
-		Editor
-      functions</title>
+	  <title id="app.shortcuts.lists.function.codes.windows.title"><link linkend="app.shortcuts.lists.function.codes.windows"> </link>Editor functions</title>
 
       <para>The shortcuts that can be modified in the
       <filename>EditorShortcuts.properties</filename> file, along with their
       default values, are presented in the table below</para>
 
       <table id="app.shortcuts.lists.function.codes.editor.table">
-		<title id="app.shortcuts.lists.function.codes.editor.table.title">Editor</title>
+		<title id="app.shortcuts.lists.function.codes.editor.table.title"><link linkend="app.shortcuts.lists.function.codes.editor.table"> </link>Editor</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>

--- a/doc_src/en/App_ShortCuts.xml
+++ b/doc_src/en/App_ShortCuts.xml
@@ -2,15 +2,17 @@
 <!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="app.shortcuts">
-  <title id="app.shortcuts.title">OmegaT Shortcuts</title>
+  <title id="app.shortcuts.title">
+  OmegaT Shortcuts</title>
 
   <section id="app.shortcuts.description">
-    <title id="app.shortcuts.description.title">Description</title>
+	<title id="app.shortcuts.description.title">
+    Description</title>
 
     <para>The OmegaT interface generally does not rely on buttons to give access
     to its functions. Instead, they are called from the menus or, for the
     majority of functions, from their assigned default shortcut.</para>
-  
+	
     <para>Learning the most frequent shortcuts will not take long once you start
     working with OmegaT. The shortcuts are indicated next to each menu item,
     allowing them to learn new shortcuts gradually as you use the
@@ -18,7 +20,7 @@
 
     <para>You can customize the majority of the shortcuts in OmegaT. See the
     <link endterm="app.shortcuts.customization.title"
-    linkend="app.shortcuts.customization"/> section for details.</para>
+		  linkend="app.shortcuts.customization"/> section for details.</para>
 
     <para>OmegaT runs on any platform that runs a Java Runtime Environment
     (Windows, macOS, and Linux being the most mainstream). The modifier keys
@@ -27,7 +29,8 @@
     keys:</para>
 	
     <table id="app.shortcut.description">
-      <title id="app.shortcut.description.title">Modifier key identifiers</title>
+	  <title id="app.shortcut.description.title">
+      Modifier key identifiers</title>
 
       <tgroup cols="3">
         <thead>
@@ -66,12 +69,13 @@
         </tbody>
       </tgroup>
     </table>
-        
+    
     <para>The <emphasis role="bold">Key identifiers</emphasis> above enable us
     to avoid listing multiple notations for every shortcut.</para>
 
     <example id="example.avoid.listing.multiple.notations">
-	  <title id="example.avoid.listing.multiple.notations.title">How we avoid
+	  <title id="example.avoid.listing.multiple.notations.title">
+		How we avoid
 	  listing multiple notations:</title>
 	  <para>On Windows and Linux:
 	  <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo></para>
@@ -85,7 +89,8 @@
   </section>
   
   <section id="app.shortcuts.customization">
-    <title id="app.shortcuts.customization.title">Customization</title>
+	<title id="app.shortcuts.customization.title">
+    Customization</title>
 
     <para>OmegaT assigns shortcuts to most of the functions available in the
     <link linkend="menus.project" endterm="menus.project.title"/>, <link
@@ -103,16 +108,18 @@
     <para>There are two shortcut definition files.</para>
 
 	<variablelist>
-      <varlistentry>
-        <term id="MainMenuShortcuts.properties">MainMenuShortcuts.properties</term>
+      <varlistentry id="app.shortcuts.customization.MainMenuShortcuts.properties">
+		<term id="app.shortcuts.customization.MainMenuShortcuts.properties.title">
+		MainMenuShortcuts.properties</term>
         <listitem>
           <para>The shortcut definition file for the menus and a few other
           items.</para>
         </listitem>
       </varlistentry>
 
-	  <varlistentry>
-        <term id="EditorShortcuts.properties">EditorShortcuts.properties</term>
+	  <varlistentry id="app.shortcuts.customization.EditorShortcuts.properties">
+		<term id="app.shortcuts.customization.EditorShortcuts.properties.title">
+		EditorShortcuts.properties</term>
         <listitem><para>The shortcut definition file for the editor.</para>
         </listitem>
       </varlistentry>
@@ -134,39 +141,39 @@
             <itemizedlist>
               <listitem>
                 <para><ulink
-                url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.properties">MainMenuShortcuts.properties</ulink></para>
+						  url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.properties">MainMenuShortcuts.properties</ulink></para>
               </listitem>
 
               <listitem>
                 <para><ulink
-                url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.properties">EditorShortcuts.properties</ulink></para>
+						  url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.properties">EditorShortcuts.properties</ulink></para>
               </listitem>
             </itemizedlist>
           </listitem>
         </varlistentry>
 		
         <varlistentry><term>macOS default shortcuts</term>
-          <listitem>
-            <itemizedlist>
-              <listitem>
-                <para><ulink
-                url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties">MainMenuShortcuts.mac.properties</ulink></para>
-              </listitem>
+        <listitem>
+          <itemizedlist>
+            <listitem>
+              <para><ulink
+						url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/MainMenuShortcuts.mac.properties">MainMenuShortcuts.mac.properties</ulink></para>
+            </listitem>
 
-              <listitem>
-                <para><ulink
-                url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.mac.properties">EditorShortcuts.mac.properties</ulink></para>
-              </listitem>
-            </itemizedlist>
-          </listitem>
+            <listitem>
+              <para><ulink
+						url="https://github.com/omegat-org/omegat/tree/master/src/org/omegat/gui/main/EditorShortcuts.mac.properties">EditorShortcuts.mac.properties</ulink></para>
+            </listitem>
+          </itemizedlist>
+        </listitem>
         </varlistentry>
       </variablelist>
 
       <para>The macOS files must be renamed <link
-      linkend="MainMenuShortcuts.properties"
-      endterm="MainMenuShortcuts.properties"/> and <link
-      linkend="EditorShortcuts.properties"
-      endterm="EditorShortcuts.properties"/> for OmegaT to recognize
+      linkend="configuration.folder.extra.contents.mainmenushortcut"
+      endterm="configuration.folder.extra.contents.mainmenushortcut.title"/> and <link
+      linkend="configuration.folder.extra.contents.editorshortcuts"
+      endterm="configuration.folder.extra.contents.editorshortcuts.title"/> for OmegaT to recognize
       them.</para>
     </note>
 
@@ -175,7 +182,8 @@
   </section>
 
   <section id="app.shortcuts.syntax">
-    <title id="app.shortcuts.syntax.title">Syntax</title>
+	<title id="app.shortcuts.syntax.title">
+    Syntax</title>
 
     <para>The basic syntax of the shortcut definitions files is simply:</para>
 
@@ -192,11 +200,11 @@
       <listitem>
         <para>0 or more <code>modifier</code></para>
       </listitem>
-    
+      
       <listitem>
         <para>followed by 0 or 1 <code>event</code></para>
       </listitem>
-    
+      
       <listitem>
         <para>followed by 1 <code>key</code></para>
       </listitem>
@@ -243,7 +251,8 @@
     folder</link>, as noted above, and make the changes you want there.</para>
     
     <example id="example.shortcut.modification">
-      <title id="example.shortcut.modification.title">Modifying a
+	  <title id="example.shortcut.modification.title">
+		Modifying a
       shortcut</title>
 
       <para>The default shortcut for <link linkend="menus.project.close">closing
@@ -273,7 +282,8 @@
     </example>
 
     <example id="example.shortcut.addition">
-      <title id="example.shortcut.addition.title">Adding a shortcut</title>
+	  <title id="example.shortcut.addition.title">
+      Adding a shortcut</title>
 
       <para>If your language pair calls for the frequent use of <link
       linkend="menus.edit.create.alternative.translation">alternative
@@ -307,20 +317,20 @@
         </listitem>
 
 		<listitem>
-            <para>The line is currently a comment. Delete the <code>#</code> at
-            the beginning of the line so OmegaT will recognize the shortcut, and
-            add <option>alt X</option> after the <code>=</code> sign at the end
-            of the line:</para>
-			
-            <para><code>editMultipleAlternate=alt X</code></para>
+          <para>The line is currently a comment. Delete the <code>#</code> at
+          the beginning of the line so OmegaT will recognize the shortcut, and
+          add <option>alt X</option> after the <code>=</code> sign at the end
+          of the line:</para>
+		  
+          <para><code>editMultipleAlternate=alt X</code></para>
         </listitem>
 
 		<listitem>
-            <para>Save and close the file. The next time you start OmegaT, your
-            new shortcut should be active and displayed next to the name of the
-            function in the menu.</para>
-          </listitem>
-        </orderedlist>
+          <para>Save and close the file. The next time you start OmegaT, your
+          new shortcut should be active and displayed next to the name of the
+          function in the menu.</para>
+        </listitem>
+      </orderedlist>
     </example>
 
     <para>Save the file after you have finished making your changes. If OmegaT
@@ -338,9 +348,11 @@
   
 
   <section id="app.shortcuts.lists">
-    <title id="app.shortcuts.lists.title">Lists of functions and codes</title>
+	<title id="app.shortcuts.lists.title">
+    Lists of functions and codes</title>
     <section id="app.shortcuts.lists.function.codes.menus">
-      <title id="app.shortcuts.lists.function.codes.menus.title">Menu
+	  <title id="app.shortcuts.lists.function.codes.menus.title">
+		Menu
       functions</title>
 
       <para>The functions that can be modified in the
@@ -350,8 +362,9 @@
       <filename>EditorShortcuts.properties</filename>.</para>
 
       <table id="app.shortcuts.lists.function.codes.project.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.project.menu.table.title">Project
+		<title
+			id="app.shortcuts.lists.function.codes.project.menu.table.title">
+		  Project
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -538,8 +551,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.edit.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.edit.menu.table.title">Edit
+		<title
+			id="app.shortcuts.lists.function.codes.edit.menu.table.title">
+		  Edit
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -762,7 +776,7 @@
               <entry>insertCharsLRE</entry>
             </row>
 
-             <row>
+            <row>
               <entry>Insert Bidi Control Character/Right-to-Left Embedding
               (RLE U+202B)</entry>
               <entry>insertCharsRLE</entry>
@@ -807,8 +821,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.goto.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.goto.menu.table.title">Go To
+		<title
+			id="app.shortcuts.lists.function.codes.goto.menu.table.title">
+		  Go To
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -951,8 +966,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.view.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.view.menu.table.title">View
+		<title
+			id="app.shortcuts.lists.function.codes.view.menu.table.title">
+		  View
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -1060,8 +1076,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.tools.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.tools.menu.table.title">Tools
+		<title
+			id="app.shortcuts.lists.function.codes.tools.menu.table.title">
+		  Tools
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -1126,7 +1143,8 @@
       </note>
 
       <table id="app.shortcuts.lists.function.codes.options.menu.table">
-        <title id="app.shortcuts.lists.function.codes.options.menu.table.title">Options Menu</title>
+		<title id="app.shortcuts.lists.function.codes.options.menu.table.title">
+		Options Menu</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1204,8 +1222,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.help.menu.table">
-        <title
-        id="app.shortcuts.lists.function.codes.help.menu.table.title">Help
+		<title
+			id="app.shortcuts.lists.function.codes.help.menu.table.title">
+		  Help
         Menu</title>
 
         <tgroup cols="4" colsep="1">
@@ -1254,8 +1273,9 @@
       </table>
       
       <table id="app.shortcuts.lists.function.codes.search.window.table">
-        <title
-        id="app.shortcuts.lists.function.codes.search.window.table.title">Search
+		<title
+			id="app.shortcuts.lists.function.codes.search.window.table.title">
+		  Search
         Window</title>
 
         <tgroup cols="4" colsep="1">
@@ -1284,9 +1304,10 @@
         </tgroup>
       </table>
     </section>
-  
+	
     <section id="app.shortcuts.lists.function.codes.windows">
-      <title id="app.shortcuts.lists.function.codes.windows.title">Editor
+	  <title id="app.shortcuts.lists.function.codes.windows.title">
+		Editor
       functions</title>
 
       <para>The shortcuts that can be modified in the
@@ -1294,7 +1315,8 @@
       default values, are presented in the table below</para>
 
       <table id="app.shortcuts.lists.function.codes.editor.table">
-        <title id="app.shortcuts.lists.function.codes.editor.table.title">Editor</title>
+		<title id="app.shortcuts.lists.function.codes.editor.table.title">
+		Editor</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>
@@ -1430,8 +1452,9 @@
       </table>
 
       <table id="app.shortcuts.lists.function.codes.autocompleter.table">
-        <title
-        id="app.shortcuts.lists.function.codes.autocompleter.table.title">Autocompleter</title>
+		<title
+			id="app.shortcuts.lists.function.codes.autocompleter.table.title">
+		Autocompleter</title>
 
         <tgroup cols="4" colsep="1">
           <colspec align="left" colname="1" colnum="1"/>

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="dialogs.project.properties">
-  <title id="dialogs.project.properties.title"><guilabel>Project
+  <title id="dialogs.project.properties.title">
+    <guilabel>Project
   Properties</guilabel></title>
 
   <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
@@ -19,8 +20,9 @@
   
 
   <section id="dialogs.project.properties.languages">
-    <title
-    id="dialogs.project.properties.languages.title"><guilabel>Languages</guilabel></title>
+	<title
+		id="dialogs.project.properties.languages.title">
+    <guilabel>Languages</guilabel></title>
 
     <para>Select the source and target languages from the drop-down list,
     or enter them manually.</para>
@@ -49,7 +51,7 @@
 	  <listitem>
 		<para>find spelling mistakes from the dictionaries installed in the
 		<link linkend="dialog.preferences.spellchecker"
-		endterm="dialog.preferences.spellchecker.title"/> preferences,</para>
+			  endterm="dialog.preferences.spellchecker.title"/> preferences,</para>
 	  </listitem>
 
 	  <listitem>
@@ -60,7 +62,7 @@
 	  </listitem>
 	</itemizedlist>
 
-	  <para>and so on.</para>
+	<para>and so on.</para>
 
 	<warning>
 	  <para>Make sure you enter the correct language codes and that
@@ -70,26 +72,28 @@
 	  the language codes.</para>
 	</warning>
 
-	  
-      <para>OmegaT automatically selects the tokenizers that correspond to the
+	
+    <para>OmegaT automatically selects the tokenizers that correspond to the
     source and target languages but you can manually modify those
     settings. Tokenizers allow OmegaT to provide better matches.</para>
   </section>
 
   <section id="dialogs.project.properties.options">
-    <title
-    id="dialogs.project.properties.options.title"><guilabel>Options</guilabel></title>
+	<title
+		id="dialogs.project.properties.options.title">
+    <guilabel>Options</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.project.properties.options.segmentation">
-        <term
-        id="dialogs.project.properties.options.segmentation.title"><option>Sentence-level
+		<term
+			id="dialogs.project.properties.options.segmentation.title">
+		  <option>Sentence-level
         segmenting</option></term>
 
 		<listitem>		  
           <para>Sentence-level segmentation splits paragraphs or other text
           blocks in the source file into segments based on segmentation
-					rules.</para>
+		  rules.</para>
 
 		  <para>Disable this option if you prefer not to further segment the
 		  paragraphs.</para>
@@ -143,22 +147,23 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.local.segmentation">
-        <term
-        id="dialogs.project.properties.local.segmentation.title"><guibutton>Local
+		<term
+			id="dialogs.project.properties.local.segmentation.title">
+		  <guibutton>Local
         Segmentation Rules...</guibutton></term>
 
 		<listitem>
 		  <para>By default, segmentation rules are global and apply to all
 		  projects.</para>
 		  
-			<para>The segmentation rules presented when you open the <link
-			linkend="dialogs.preferences.segmentation.setup"
-			endterm="dialogs.preferences.segmentation.setup.title"/> preferences
-			(using <link linkend="menus.options"
-			endterm="menus.options.title"/><link
-			linkend="menus.options.segmentation"
-			endterm="menus.options.segmentation.title"/>) are the global
-			rules.</para>
+		  <para>The segmentation rules presented when you open the <link
+		  linkend="dialogs.preferences.segmentation.setup"
+		  endterm="dialogs.preferences.segmentation.setup.title"/> preferences
+		  (using <link linkend="menus.options"
+		  endterm="menus.options.title"/><link
+		  linkend="menus.options.segmentation"
+		  endterm="menus.options.segmentation.title"/>) are the global
+		  rules.</para>
 
 		  <para>Use this button to create local rules specific to your
 		  project. Check the <option>Use local segmentation rules</option>
@@ -188,8 +193,9 @@
 	  
 	  
       <varlistentry id="dialogs.project.properties.auto.propagation">
-        <term
-        id="dialogs.project.properties.auto.propagation.title"><option>Auto-propagation
+		<term
+			id="dialogs.project.properties.auto.propagation.title">
+		  <option>Auto-propagation
         of translations</option></term>
 
 		<listitem>
@@ -211,7 +217,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.hide.tags">
-        <term id="dialogs.project.properties.hide.tags.title"><option>Hide
+		<term id="dialogs.project.properties.hide.tags.title">
+		  <option>Hide
         tags</option></term>
 
 		<listitem>
@@ -230,27 +237,28 @@
 			this does not normally prevent the translated file from opening, keep the
 			following points in mind when using this function:</para>
 			<itemizedlist>
-				<listitem>
-					<para>You will have to manually apply bold, italics, or other text
-					decorations in the translated file.</para>
-				</listitem>
-				<listitem>
-					<para>If you simply want to reduce the number of tags in a
-					<application>Microsoft Word</application> (2007 and later) document,
-					you can use the <link
-					linkend="windows.scripts.distribution.tagwipe"
-					endterm="windows.scripts.distribution.tagwipe.title"/> script.</para>
-					<para>See the <link linkend="windows.scripts"
-						endterm="windows.scripts.title"/> section for details.</para>
-				</listitem>
+			  <listitem>
+				<para>You will have to manually apply bold, italics, or other text
+				decorations in the translated file.</para>
+			  </listitem>
+			  <listitem>
+				<para>If you simply want to reduce the number of tags in a
+				<application>Microsoft Word</application> (2007 and later) document,
+				you can use the <link
+				linkend="windows.scripts.distribution.tagwipe"
+				endterm="windows.scripts.distribution.tagwipe.title"/> script.</para>
+				<para>See the <link linkend="windows.scripts"
+				endterm="windows.scripts.title"/> section for details.</para>
+			  </listitem>
 			</itemizedlist>
-			</note>
-      </listitem>
+		  </note>
+		</listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.processing.command">
-        <term
-        id="dialogs.project.properties.external.processing.command.title"><option>Local
+		<term
+			id="dialogs.project.properties.external.processing.command.title">
+		  <option>Local
         post-processing commands</option></term>
 
 		<listitem>
@@ -283,7 +291,7 @@
 		  endterm="project.folder.omegat.project.file.title"/> file. Only enable
 		  local post-processing commands if you trust the source of that
 		  file.</para>
-		
+		  
 		  <para>The template variables list gives you access to various project
 		  data and system variables.</para>
 
@@ -305,7 +313,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.filters">
-        <term id="dialogs.project.properties.filters.title"><guibutton>Local
+		<term id="dialogs.project.properties.filters.title">
+		  <guibutton>Local
         File Filters...</guibutton></term>
 
         <listitem>
@@ -322,7 +331,7 @@
 		  linkend="project.folder.omegat.filters"
 		  endterm="project.folder.omegat.filters.title"/> file located in its
 		  <link linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder. These settings will supersede the global file filter
+				endterm="project.folder.omegat.folder.title"/> folder. These settings will supersede the global file filter
 		  settings.</para>
 
 		  <note>
@@ -336,8 +345,9 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.repository.mapping">
-        <term
-        id="dialogs.project.properties.repository.mapping.title"><guibutton>Repository
+		<term
+			id="dialogs.project.properties.repository.mapping.title">
+		  <guibutton>Repository
         Mapping...</guibutton></term>
 
         <listitem>
@@ -353,8 +363,9 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.searches">
-        <term
-        id="dialogs.project.properties.external.searches.title"><guibutton>Local
+		<term
+			id="dialogs.project.properties.external.searches.title">
+		  <guibutton>Local
         External Searches</guibutton></term>
 
         <listitem>
@@ -369,9 +380,9 @@
 
 		  <para>The project will store the new set of external searches in the
 		  <link linkend="project.folder.omegat.finder"
-		  endterm="project.folder.omegat.finder.title"/> file located in its
+				endterm="project.folder.omegat.finder.title"/> file located in its
 		  <link linkend="project.folder.omegat.folder"
-		  endterm="project.folder.omegat.folder.title"/> folder. These
+				endterm="project.folder.omegat.folder.title"/> folder. These
 		  settings will supersede the global external searches settings.</para>
 
 		  <para>To delete project specific external searches, click on the
@@ -396,7 +407,8 @@
   </section>
 
   <section id="dialogs.project.properties.file.locations">
-    <title id="dialogs.project.properties.file.locations.title"><guilabel>File
+	<title id="dialogs.project.properties.file.locations.title">
+      <guilabel>File
     locations</guilabel></title>
 
 	<para>An OmegaT translation project consists of a number of resources in
@@ -424,7 +436,8 @@
 	<variablelist>
 	  <varlistentry id="dialogs.project.properties.file.locations.browse">
 		<term
-		id="dialogs.project.properties.file.locations.browse.title"><guibutton>Browse</guibutton></term>
+			id="dialogs.project.properties.file.locations.browse.title">
+		<guibutton>Browse</guibutton></term>
 
 		<listitem>
 		  <para>The <guibutton>Browse</guibutton> button is available for all
@@ -443,7 +456,8 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.source.files">
 		<term
-		id="dialogs.project.properties.file.locations.source.files.title"><option>Source
+			id="dialogs.project.properties.file.locations.source.files.title">
+		  <option>Source
 		files folder</option></term>
 
 		<listitem>
@@ -461,13 +475,14 @@
 		  <variablelist>
 			<varlistentry id="dialogs.project.properties.file.locations.exclusions">
 			  <term
-			  id="dialogs.project.properties.file.locations.exclusions.title"><guibutton>Exclusions...</guibutton></term>
+				  id="dialogs.project.properties.file.locations.exclusions.title">
+			  <guibutton>Exclusions...</guibutton></term>
 
 			  <listitem>
 				<para>Click the <guibutton>Exclusions...</guibutton> button to specify 
 				files or folders that should be ignored by OmegaT. An ignored file
 				or folder is:</para>
-		  
+				
 				<itemizedlist>
 				  <listitem>
 					<para>not displayed in the <link linkend="panes.editor"
@@ -494,7 +509,7 @@
 				a pattern, or edit one either by double-clicking it or selecting it
 				and pressing <keycap>F2</keycap>. Use the
 				<ulink
-				url="https://ant.apache.org/manual/dirtasks.html#patterns">Apache
+					url="https://ant.apache.org/manual/dirtasks.html#patterns">Apache
 				ant syntax</ulink> to define exclusions.</para>
 			  </listitem>
 			</varlistentry>
@@ -504,7 +519,8 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translation.memories">
 		<term
-		id="dialogs.project.properties.file.locations.translation.memories.title"><option>Translation
+			id="dialogs.project.properties.file.locations.translation.memories.title">
+		  <option>Translation
 		memories folder</option></term>
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
@@ -522,13 +538,14 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.glossaries">
 		<term
-		id="dialogs.project.properties.file.locations.glossaries.title"><option>Glossary
+			id="dialogs.project.properties.file.locations.glossaries.title">
+		  <option>Glossary
 		files folder</option></term>
 
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
 		  glossaries. OmegaT tries to read all the files at once, and compares
-			their contents to the segment you are translating.</para>
+		  their contents to the segment you are translating.</para>
 
 		  <para>See the <link linkend="project.folder.glossary"
 		  endterm="project.folder.glossary.title"/> section for details.</para>
@@ -543,7 +560,8 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.writable.glossary">
 		<term
-		id="dialogs.project.properties.file.locations.writable.glossary.title"><option>Writable
+			id="dialogs.project.properties.file.locations.writable.glossary.title">
+		  <option>Writable
 		Glossary File</option></term>
 
 		<listitem>
@@ -568,7 +586,8 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.dictionaries">
 		<term
-		id="dialogs.project.properties.file.locations.dictionaries.title"><option>Dictionaries
+			id="dialogs.project.properties.file.locations.dictionaries.title">
+		  <option>Dictionaries
 		folder</option></term>
 
 		<listitem>
@@ -588,7 +607,8 @@
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translated.files">
 		<term
-		id="dialogs.project.properties.file.locations.translated.files.title"><option>Translated
+			id="dialogs.project.properties.file.locations.translated.files.title">
+		  <option>Translated
 		files folder</option></term>
 
 		<listitem>
@@ -602,10 +622,10 @@
 		  <para>Segments that have been translated are replaced by their
 		  translation and untranslated segments remain in the source
 		  language.</para>
-		
+		  
 		  <para>The folder structure mirrors that of the
-			<link linkend="project.folder.source"
-		  endterm="project.folder.source.title"/> folder. Files that
+		  <link linkend="project.folder.source"
+				endterm="project.folder.source.title"/> folder. Files that
 		  are not supported by OmegaT’s file filters are copied without
 		  modification.</para>
 
@@ -617,12 +637,13 @@
 
 		  <para>See the <link linkend="project.folder.target"
 		  endterm="project.folder.target.title"/> section for
-		  details.</para></listitem>
+		details.</para></listitem>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.project.properties.file.locations.exported.tms">
 		<term
-		id="dialogs.project.properties.file.locations.exported.tms.title"><option>Exported
+			id="dialogs.project.properties.file.locations.exported.tms.title">
+		  <option>Exported
 		translation memories folder</option></term>
 
 		<listitem>
@@ -639,9 +660,9 @@
 			endterm="how.to.tm.share.translation.memories.title"/> how-to for
 			details.</para>
 		  </note>
-		
+		  
 		  <para>The TMX files contain only the segments from the files currently
-			stored in the <link linkend="project.folder.source"
+		  stored in the <link linkend="project.folder.source"
 		  endterm="project.folder.source.title"/> folder.</para>
 
 		  <para>Use <link linkend="menus.project.create.translated.documents"
@@ -653,7 +674,8 @@
 		  <variablelist>
 			<varlistentry id="dialogs.project.properties.file.locations.tms.to.export">
 			  <term
-			  id="dialogs.project.properties.file.locations.tms.to.export.title"><option>Translation
+				  id="dialogs.project.properties.file.locations.tms.to.export.title">
+				<option>Translation
 			  memories to export</option></term>
 			  <listitem>
 				<para>This checkbox lets you choose the formats in which you want
@@ -661,27 +683,30 @@
 
 				<para>See the <link linkend="how.to.use.tm"
 				endterm="how.to.use.tm.title"/> how-to for details.</para>
-		
+				
 				<variablelist>
-				  <varlistentry>
-					<term><option>OmegaT</option></term>
+				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.omegat">
+					<term id="dialogs.project.properties.file.locations.tms.to.export.omegat.title">
+					<option>OmegaT</option></term>
 					<listitem>
 					  <para>An “OmegaT” TMX contains the tags created by OmegaT
-						in a form that can only be used properly by an
+					  in a form that can only be used properly by an
 					  OmegaT project.</para>
 					</listitem>
 				  </varlistentry>
-		  
-				  <varlistentry>
-					<term><option>TMX Level 1</option></term>
+				  
+				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level1">
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level1.title">
+					<option>TMX Level 1</option></term>
 					<listitem>
 					  <para>A “level 1” TMX removes all tag information and contains only
-						textual data.</para>
+					  textual data.</para>
 					</listitem>
 				  </varlistentry>
-				
-				  <varlistentry>
-					<term><option>TMX Level 2</option></term>
+				  
+				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level2">
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level2.title">
+					<option>TMX Level 2</option></term>
 					<listitem>
 					  <para>A “level 2” TMX contains textual data along with
 					  tags encapsulated in a form compatible with other

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="dialogs.project.properties">
-  <title id="dialogs.project.properties.title">
-    <guilabel>Project
-  Properties</guilabel></title>
+  <title id="dialogs.project.properties.title"><link linkend="dialogs.project.properties"> </link><guilabel>Project Properties</guilabel></title>
 
   <para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
   linkend="menus.project.properties" endterm="menus.project.properties.title"/>
@@ -20,9 +18,7 @@
   
 
   <section id="dialogs.project.properties.languages">
-	<title
-		id="dialogs.project.properties.languages.title">
-    <guilabel>Languages</guilabel></title>
+	<title id="dialogs.project.properties.languages.title"><link linkend="dialogs.project.properties.languages"> </link><guilabel>Languages</guilabel></title>
 
     <para>Select the source and target languages from the drop-down list,
     or enter them manually.</para>
@@ -79,16 +75,11 @@
   </section>
 
   <section id="dialogs.project.properties.options">
-	<title
-		id="dialogs.project.properties.options.title">
-    <guilabel>Options</guilabel></title>
+	<title id="dialogs.project.properties.options.title"><link linkend="dialogs.project.properties.options"> </link><guilabel>Options</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.project.properties.options.segmentation">
-		<term
-			id="dialogs.project.properties.options.segmentation.title">
-		  <option>Sentence-level
-        segmenting</option></term>
+		<term id="dialogs.project.properties.options.segmentation.title"><link linkend="dialogs.project.properties.options.segmentation"> </link><option>Sentence-level segmenting</option></term>
 
 		<listitem>		  
           <para>Sentence-level segmentation splits paragraphs or other text
@@ -147,10 +138,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.local.segmentation">
-		<term
-			id="dialogs.project.properties.local.segmentation.title">
-		  <guibutton>Local
-        Segmentation Rules...</guibutton></term>
+		<term id="dialogs.project.properties.local.segmentation.title"><link linkend="dialogs.project.properties.local.segmentation"> </link><guibutton>Local Segmentation Rules...</guibutton></term>
 
 		<listitem>
 		  <para>By default, segmentation rules are global and apply to all
@@ -193,10 +181,7 @@
 	  
 	  
       <varlistentry id="dialogs.project.properties.auto.propagation">
-		<term
-			id="dialogs.project.properties.auto.propagation.title">
-		  <option>Auto-propagation
-        of translations</option></term>
+		<term id="dialogs.project.properties.auto.propagation.title"><link linkend="dialogs.project.properties.auto.propagation"> </link><option>Auto-propagation of translations</option></term>
 
 		<listitem>
           <para>If there are repeated segments in the source
@@ -217,9 +202,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.hide.tags">
-		<term id="dialogs.project.properties.hide.tags.title">
-		  <option>Hide
-        tags</option></term>
+		<term id="dialogs.project.properties.hide.tags.title"><link linkend="dialogs.project.properties.hide.tags"> </link><option>Hide tags</option></term>
 
 		<listitem>
           <para>Tags are generally useful to reproduce specific layouts or
@@ -256,10 +239,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.processing.command">
-		<term
-			id="dialogs.project.properties.external.processing.command.title">
-		  <option>Local
-        post-processing commands</option></term>
+		<term id="dialogs.project.properties.external.processing.command.title"><link linkend="dialogs.project.properties.external.processing.command"> </link><option>Local post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -313,9 +293,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.filters">
-		<term id="dialogs.project.properties.filters.title">
-		  <guibutton>Local
-        File Filters...</guibutton></term>
+		<term id="dialogs.project.properties.filters.title"><link linkend="dialogs.project.properties.filters"> </link><guibutton>Local File Filters...</guibutton></term>
 
         <listitem>
           <para>By default, file filter settings are global and shared by
@@ -345,10 +323,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.repository.mapping">
-		<term
-			id="dialogs.project.properties.repository.mapping.title">
-		  <guibutton>Repository
-        Mapping...</guibutton></term>
+		<term id="dialogs.project.properties.repository.mapping.title"><link linkend="dialogs.project.properties.repository.mapping"> </link><guibutton>Repository Mapping...</guibutton></term>
 
         <listitem>
           <para>When working on a team project, this window allows you to define
@@ -363,10 +338,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.project.properties.external.searches">
-		<term
-			id="dialogs.project.properties.external.searches.title">
-		  <guibutton>Local
-        External Searches</guibutton></term>
+		<term id="dialogs.project.properties.external.searches.title"><link linkend="dialogs.project.properties.external.searches"> </link><guibutton>Local External Searches</guibutton></term>
 
         <listitem>
           <para>By default, external searches are global and are shared by all
@@ -407,9 +379,7 @@
   </section>
 
   <section id="dialogs.project.properties.file.locations">
-	<title id="dialogs.project.properties.file.locations.title">
-      <guilabel>File
-    locations</guilabel></title>
+	<title id="dialogs.project.properties.file.locations.title"><link linkend="dialogs.project.properties.file.locations"> </link><guilabel>File locations</guilabel></title>
 
 	<para>An OmegaT translation project consists of a number of resources in
 	separate folders.</para>
@@ -435,9 +405,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialogs.project.properties.file.locations.browse">
-		<term
-			id="dialogs.project.properties.file.locations.browse.title">
-		<guibutton>Browse</guibutton></term>
+		<term id="dialogs.project.properties.file.locations.browse.title"><link linkend="dialogs.project.properties.file.locations.browse"> </link><guibutton>Browse</guibutton></term>
 
 		<listitem>
 		  <para>The <guibutton>Browse</guibutton> button is available for all
@@ -455,10 +423,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.source.files">
-		<term
-			id="dialogs.project.properties.file.locations.source.files.title">
-		  <option>Source
-		files folder</option></term>
+		<term id="dialogs.project.properties.file.locations.source.files.title"><link linkend="dialogs.project.properties.file.locations.source.files"> </link><option>Source files folder</option></term>
 
 		<listitem>
 		  <para>This folder contains the files that you want to
@@ -474,9 +439,7 @@
 
 		  <variablelist>
 			<varlistentry id="dialogs.project.properties.file.locations.exclusions">
-			  <term
-				  id="dialogs.project.properties.file.locations.exclusions.title">
-			  <guibutton>Exclusions...</guibutton></term>
+			  <term id="dialogs.project.properties.file.locations.exclusions.title"><link linkend="dialogs.project.properties.file.locations.exclusions"> </link><guibutton>Exclusions...</guibutton></term>
 
 			  <listitem>
 				<para>Click the <guibutton>Exclusions...</guibutton> button to specify 
@@ -518,10 +481,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translation.memories">
-		<term
-			id="dialogs.project.properties.file.locations.translation.memories.title">
-		  <option>Translation
-		memories folder</option></term>
+		<term id="dialogs.project.properties.file.locations.translation.memories.title"><link linkend="dialogs.project.properties.file.locations.translation.memories"> </link><option>Translation memories folder</option></term>
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
 		  translation memories. OmegaT tries to read all the files at once,
@@ -537,10 +497,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.glossaries">
-		<term
-			id="dialogs.project.properties.file.locations.glossaries.title">
-		  <option>Glossary
-		files folder</option></term>
+		<term id="dialogs.project.properties.file.locations.glossaries.title"><link linkend="dialogs.project.properties.file.locations.glossaries"> </link><option>Glossary files folder</option></term>
 
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
@@ -559,10 +516,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.writable.glossary">
-		<term
-			id="dialogs.project.properties.file.locations.writable.glossary.title">
-		  <option>Writable
-		Glossary File</option></term>
+		<term id="dialogs.project.properties.file.locations.writable.glossary.title"><link linkend="dialogs.project.properties.file.locations.writable.glossary"> </link><option>Writable Glossary File</option></term>
 
 		<listitem>
 		  <para>The writable glossary is the file that OmegaT uses when you add
@@ -585,10 +539,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.dictionaries">
-		<term
-			id="dialogs.project.properties.file.locations.dictionaries.title">
-		  <option>Dictionaries
-		folder</option></term>
+		<term id="dialogs.project.properties.file.locations.dictionaries.title"><link linkend="dialogs.project.properties.file.locations.dictionaries"> </link><option>Dictionaries folder</option></term>
 
 		<listitem>
 		  <para>This folder contains the files that you want to use as reference
@@ -606,10 +557,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.project.properties.file.locations.translated.files">
-		<term
-			id="dialogs.project.properties.file.locations.translated.files.title">
-		  <option>Translated
-		files folder</option></term>
+		<term id="dialogs.project.properties.file.locations.translated.files.title"><link linkend="dialogs.project.properties.file.locations.translated.files"> </link><option>Translated files folder</option></term>
 
 		<listitem>
 		  <para>This is the folder where OmegaT creates the translated
@@ -641,10 +589,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.project.properties.file.locations.exported.tms">
-		<term
-			id="dialogs.project.properties.file.locations.exported.tms.title">
-		  <option>Exported
-		translation memories folder</option></term>
+		<term id="dialogs.project.properties.file.locations.exported.tms.title"><link linkend="dialogs.project.properties.file.locations.exported.tms"> </link><option>Exported translation memories folder</option></term>
 
 		<listitem>
 		  <para>This is the folder where OmegaT copies the current state of the
@@ -673,10 +618,7 @@
 
 		  <variablelist>
 			<varlistentry id="dialogs.project.properties.file.locations.tms.to.export">
-			  <term
-				  id="dialogs.project.properties.file.locations.tms.to.export.title">
-				<option>Translation
-			  memories to export</option></term>
+			  <term id="dialogs.project.properties.file.locations.tms.to.export.title"><link linkend="dialogs.project.properties.file.locations.tms.to.export"> </link><option>Translation memories to export</option></term>
 			  <listitem>
 				<para>This checkbox lets you choose the formats in which you want
 				OmegaT to create the above TMX files.</para>
@@ -686,7 +628,7 @@
 				
 				<variablelist>
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.omegat">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.omegat.title"><option>OmegaT</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.omegat.title"><link linkend="dialogs.project.properties.file.locations.tms.to.export.omegat"> </link><option>OmegaT</option></term>
 					<listitem>
 					  <para>An “OmegaT” TMX contains the tags created by OmegaT
 					  in a form that can only be used properly by an
@@ -695,7 +637,7 @@
 				  </varlistentry>
 				  
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level1">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.level1.title"><option>TMX Level 1</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level1.title"><link linkend="dialogs.project.properties.file.locations.tms.to.export.level1"> </link><option>TMX Level 1</option></term>
 					<listitem>
 					  <para>A “level 1” TMX removes all tag information and contains only
 					  textual data.</para>
@@ -703,7 +645,7 @@
 				  </varlistentry>
 				  
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level2">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.level2.title"><option>TMX Level 2</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level2.title"><link linkend="dialogs.project.properties.file.locations.tms.to.export.level2"> </link><option>TMX Level 2</option></term>
 					<listitem>
 					  <para>A “level 2” TMX contains textual data along with
 					  tags encapsulated in a form compatible with other

--- a/doc_src/en/Dialogs_ProjectProperties.xml
+++ b/doc_src/en/Dialogs_ProjectProperties.xml
@@ -686,8 +686,7 @@
 				
 				<variablelist>
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.omegat">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.omegat.title">
-					<option>OmegaT</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.omegat.title"><option>OmegaT</option></term>
 					<listitem>
 					  <para>An “OmegaT” TMX contains the tags created by OmegaT
 					  in a form that can only be used properly by an
@@ -696,8 +695,7 @@
 				  </varlistentry>
 				  
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level1">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.level1.title">
-					<option>TMX Level 1</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level1.title"><option>TMX Level 1</option></term>
 					<listitem>
 					  <para>A “level 1” TMX removes all tag information and contains only
 					  textual data.</para>
@@ -705,8 +703,7 @@
 				  </varlistentry>
 				  
 				  <varlistentry id="dialogs.project.properties.file.locations.tms.to.export.level2">
-					<term id="dialogs.project.properties.file.locations.tms.to.export.level2.title">
-					<option>TMX Level 2</option></term>
+					<term id="dialogs.project.properties.file.locations.tms.to.export.level2.title"><option>TMX Level 2</option></term>
 					<listitem>
 					  <para>A “level 2” TMX contains textual data along with
 					  tags encapsulated in a form compatible with other

--- a/doc_src/en/First_Steps.xml
+++ b/doc_src/en/First_Steps.xml
@@ -5,7 +5,7 @@
 <article lang="en" id="first.steps">
   <title>OmegaT</title>
   <section>
-	<title id="first-steps">First steps</title>
+	<link linkend="first-steps"> </link><title id="first-steps">First steps</title>
 	<para>Hit <keycap>F1</keycap> or access the <guimenu>> Help</guimenu> menu
 	to open the user manual. It comes with a thorough introduction to OmegaT. To
 	start using OmegaT with minimal settings, do this:
@@ -61,7 +61,7 @@
   </section>
 
   <section>
-	<title id="freedoms">Freedoms</title>
+	<link linkend="freedoms"> </link><title id="freedoms">Freedoms</title>
 	<para>OmegaT is a free computer-assisted translation (CAT) solution for
 	professional translators. It is distributed under the terms of the
 	<emphasis>GNU General Public License, version 3.0</emphasis>. See

--- a/doc_src/en/First_Steps.xml
+++ b/doc_src/en/First_Steps.xml
@@ -5,7 +5,7 @@
 <article lang="en" id="first.steps">
   <title>OmegaT</title>
   <section>
-	<link linkend="first-steps"> </link><title id="first-steps">First steps</title>
+	<title id="first-steps">First steps</title>
 	<para>Hit <keycap>F1</keycap> or access the <guimenu>> Help</guimenu> menu
 	to open the user manual. It comes with a thorough introduction to OmegaT. To
 	start using OmegaT with minimal settings, do this:
@@ -61,7 +61,7 @@
   </section>
 
   <section>
-	<link linkend="freedoms"> </link><title id="freedoms">Freedoms</title>
+	<title id="freedoms">Freedoms</title>
 	<para>OmegaT is a free computer-assisted translation (CAT) solution for
 	professional translators. It is distributed under the terms of the
 	<emphasis>GNU General Public License, version 3.0</emphasis>. See

--- a/doc_src/en/HowTo_Install.xml
+++ b/doc_src/en/HowTo_Install.xml
@@ -5,23 +5,25 @@
 %manualvariables;
 ]>
 <section id="how.to.installing.omegat">
-  <title id="how.to.installing.omegat.title">Install
+  <title id="how.to.installing.omegat.title">
+    Install
   OmegaT</title>
 
   <para>OmegaT comes in two editions:</para>
 
   <variablelist>
-	<varlistentry>
-	  <term>Standard: OmegaT &vernb;</term>
+	<varlistentry id="how.to.installing.omegat.standard">
+	  <term id="how.to.installing.omegat.standard.title">
+      Standard</term>
 	  <listitem>
 		<para>This edition is recommended for everyday use.</para>
 	  </listitem>
 	</varlistentry>
-	<varlistentry>
-	  <term>Developer: OmegaT Weekly</term>
+	<varlistentry id="how.to.installing.omegat.weekly">
+	  <term id="how.to.installing.omegatweekly.title">OmegaT Weekly</term>
 	  <listitem>
 		<para>This is the edition of OmegaT in active development. It is automatically generated every week,
-			and serves as a beta version for testing purposes.</para>
+		and serves as a beta version for testing purposes.</para>
 	  </listitem>
 	</varlistentry>
   </variablelist>
@@ -41,7 +43,7 @@
 
 	<para>Due to licensing considerations, the OmegaT team recommends the Eclipse
 	Temurin Java runtime provided by the &preferedopenjdk;, but any Java 11 compatible runtime environment should work.
-		See <ulink
+	See <ulink
 	url="https://projects.eclipse.org/projects/adoptium.temurin">The Eclipse
 	Temurin™ project</ulink>.</para>
 
@@ -50,7 +52,8 @@
   </note>
 
   <section id="installing.omegat.windows">
-    <title id="installing.omegat.windows.title">On Windows</title>
+	<title id="installing.omegat.windows.title">
+    On Windows</title>
 
     <para>Double-click on the package you downloaded.</para>
 
@@ -60,7 +63,8 @@
   </section>
 
   <section id="installing.omegat.linux.intel">
-    <title id="installing.omegat.linux.intel.title">On Linux</title>
+	<title id="installing.omegat.linux.intel.title">
+    On Linux</title>
 
 	<para>Some Linux distributions offer OmegaT in their package manager. The
 	instructions given here apply to people who download the package from the
@@ -92,7 +96,8 @@
   </section>
 
   <section id="Installing.omegat.macos">
-    <title id="Installing.omegat.macos.title">On macOS</title>
+	<title id="Installing.omegat.macos.title">
+    On macOS</title>
 
     <para>Double click on the package you downloaded to unpack it.  This creates
     a folder called <filename>OmegaT</filename>. The folder contains two files:
@@ -108,12 +113,13 @@
   </section>
 
   <section id="installing.omegat.other.systems">
-    <title id="installing.omegat.other.systems.title">On other platforms</title>
+	<title id="installing.omegat.other.systems.title">
+    On other platforms</title>
 
     <para>This information applies to any system for a Java version
     compatible with &javaversionlong; is available. That includes the platforms
-		described above, as well as platforms for which no specific OmegaT package
-		is provided.</para>
+	described above, as well as platforms for which no specific OmegaT package
+	is provided.</para>
 
     <para>Download the <emphasis>Cross-platform without JRE</emphasis>
     version.</para>
@@ -126,7 +132,8 @@
   </section>
 
   <section id="update.and.delete.omegat">
-	<title id="update.and.delete.omegat.title">Upgrade</title>
+	<title id="update.and.delete.omegat.title">
+    Upgrade</title>
 
 	<para>OmegaT can tell you when a new version is available. See the <link
 	endterm="dialogs.preferences.updates.title"
@@ -146,7 +153,7 @@
 		  <para>OmegaT’s preferences are stored in the configuration folder and
 		  will <emphasis>not</emphasis> be modified by the new version.  See the
 		  <link endterm="configuration.folder.title"
-		  linkend="configuration.folder"/> chapter for details.</para>
+				linkend="configuration.folder"/> chapter for details.</para>
 		</listitem>
 
 		<listitem>
@@ -164,9 +171,9 @@
 		  <filename>Configuration.properties</filename> and
 		  <filename>Info.plist</filename> files for <link
 		  linkend="running.omegat.on.macos">macOS</link> packages) might be
-			overwritten or deleted, so you may want to create a backup before
-			upgrading, if you have been using these files to modify OmegaT’s
-			launch parameters.</para>
+		  overwritten or deleted, so you may want to create a backup before
+		  upgrading, if you have been using these files to modify OmegaT’s
+		  launch parameters.</para>
 		</listitem>
 
 		<listitem>
@@ -179,7 +186,8 @@
 
 	<variablelist>
 	  <varlistentry id="update.and.delete.omegat.over.existing.package">
-		<term id="update.and.delete.omegat.over.existing.package.title">Over an existing version</term>
+		<term id="update.and.delete.omegat.over.existing.package.title">
+		Over an existing version</term>
 
 		<listitem>
 		  <para>To do this, simply select the same installation folder as the
@@ -190,44 +198,47 @@
 		</listitem>
 	  </varlistentry>
 	  
-	<varlistentry id="update.and.delete.omegat.along.existing.package">
-	  <term  id="update.and.delete.omegat.along.existing.package.title">Alongside an existing version</term>
+	  <varlistentry id="update.and.delete.omegat.along.existing.package">
+		<term  id="update.and.delete.omegat.along.existing.package.title">
+		Alongside an existing version</term>
 
-	  <listitem>
-		<para>This will enable you to keep any number of versions side-by-side,
-		which you may wish to do until you feel comfortable with the new
-		version.</para>
+		<listitem>
+		  <para>This will enable you to keep any number of versions side-by-side,
+		  which you may wish to do until you feel comfortable with the new
+		  version.</para>
 
-	  <para>All the parameters located in the OmegaT configuration folder will
-	  be shared unless you specify a different configuration folder with the
-	  <literal>--config-dir=&lt;path&gt;</literal> option on the command
-	  line. See the <link
-	  endterm="launch.with.command.line.omegat.options.title"
-	  linkend="launch.with.command.line.omegat.options"/> section.</para>
+		  <para>All the parameters located in the OmegaT configuration folder will
+		  be shared unless you specify a different configuration folder with the
+		  <literal>--config-dir=&lt;path&gt;</literal> option on the command
+		  line. See the <link
+		  endterm="launch.with.command.line.omegat.options.title"
+		  linkend="launch.with.command.line.omegat.options"/> section.</para>
 
-	  <para>All the parameters located in a <link
-	  linkend="chapter.project.folder">project folder</link> will apply to that
-	  project regardless of which version of OmegaT opens it.</para>
-	  </listitem>
-	</varlistentry>
+		  <para>All the parameters located in a <link
+		  linkend="chapter.project.folder">project folder</link> will apply to that
+		  project regardless of which version of OmegaT opens it.</para>
+		</listitem>
+	  </varlistentry>
 	</variablelist>
   </section>
   
-	<section id="update.and.delete.omegat.delete">
-	  <title id="update.and.delete.omegat.delete.title">Delete OmegaT</title>
+  <section id="update.and.delete.omegat.delete">
+	<title id="update.and.delete.omegat.delete.title">
+    Delete OmegaT</title>
 
-	  <para>Use your operating system’s standard procedure to remove OmegaT.  If
-	  you want to remove OmegaT completely, you will also have to delete the
-	  configuration folder.</para>
+	<para>Use your operating system’s standard procedure to remove OmegaT.  If
+	you want to remove OmegaT completely, you will also have to delete the
+	configuration folder.</para>
 
-	  <para>If you performed a manual installation on Linux, you will have to
-	  manually delete the OmegaT folders in <filename>opt/</filename>, as well
-	  as the symlinks placed in <filename>/usr/local/bin/</filename> by the
-	  installation script.</para>
-	</section>
+	<para>If you performed a manual installation on Linux, you will have to
+	manually delete the OmegaT folders in <filename>opt/</filename>, as well
+	as the symlinks placed in <filename>/usr/local/bin/</filename> by the
+	installation script.</para>
+  </section>
 
   <section id="build.omegat.from.source">
-	<title id="build.omegat.from.source.title">Build OmegaT</title>
+	<title id="build.omegat.from.source.title">
+    Build OmegaT</title>
 
 	<para>The source code for the current version can either be downloaded
 	directly from the OmegaT <ulink url="https://omegat.org/download">download

--- a/doc_src/en/HowTo_Install.xml
+++ b/doc_src/en/HowTo_Install.xml
@@ -13,8 +13,7 @@
 
   <variablelist>
 	<varlistentry id="how.to.installing.omegat.standard">
-	  <term id="how.to.installing.omegat.standard.title">
-      Standard</term>
+	  <term id="how.to.installing.omegat.standard.title">Standard</term>
 	  <listitem>
 		<para>This edition is recommended for everyday use.</para>
 	  </listitem>
@@ -52,8 +51,7 @@
   </note>
 
   <section id="installing.omegat.windows">
-	<title id="installing.omegat.windows.title">
-    On Windows</title>
+	<title id="installing.omegat.windows.title">On Windows</title>
 
     <para>Double-click on the package you downloaded.</para>
 
@@ -63,8 +61,7 @@
   </section>
 
   <section id="installing.omegat.linux.intel">
-	<title id="installing.omegat.linux.intel.title">
-    On Linux</title>
+	<title id="installing.omegat.linux.intel.title">On Linux</title>
 
 	<para>Some Linux distributions offer OmegaT in their package manager. The
 	instructions given here apply to people who download the package from the
@@ -96,8 +93,7 @@
   </section>
 
   <section id="Installing.omegat.macos">
-	<title id="Installing.omegat.macos.title">
-    On macOS</title>
+	<title id="Installing.omegat.macos.title">On macOS</title>
 
     <para>Double click on the package you downloaded to unpack it.  This creates
     a folder called <filename>OmegaT</filename>. The folder contains two files:
@@ -113,8 +109,7 @@
   </section>
 
   <section id="installing.omegat.other.systems">
-	<title id="installing.omegat.other.systems.title">
-    On other platforms</title>
+	<title id="installing.omegat.other.systems.title">On other platforms</title>
 
     <para>This information applies to any system for a Java version
     compatible with &javaversionlong; is available. That includes the platforms
@@ -132,8 +127,7 @@
   </section>
 
   <section id="update.and.delete.omegat">
-	<title id="update.and.delete.omegat.title">
-    Upgrade</title>
+	<title id="update.and.delete.omegat.title">Upgrade</title>
 
 	<para>OmegaT can tell you when a new version is available. See the <link
 	endterm="dialogs.preferences.updates.title"
@@ -186,8 +180,7 @@
 
 	<variablelist>
 	  <varlistentry id="update.and.delete.omegat.over.existing.package">
-		<term id="update.and.delete.omegat.over.existing.package.title">
-		Over an existing version</term>
+		<term id="update.and.delete.omegat.over.existing.package.title">Over an existing version</term>
 
 		<listitem>
 		  <para>To do this, simply select the same installation folder as the
@@ -223,8 +216,7 @@
   </section>
   
   <section id="update.and.delete.omegat.delete">
-	<title id="update.and.delete.omegat.delete.title">
-    Delete OmegaT</title>
+	<title id="update.and.delete.omegat.delete.title">Delete OmegaT</title>
 
 	<para>Use your operating system’s standard procedure to remove OmegaT.  If
 	you want to remove OmegaT completely, you will also have to delete the
@@ -237,8 +229,7 @@
   </section>
 
   <section id="build.omegat.from.source">
-	<title id="build.omegat.from.source.title">
-    Build OmegaT</title>
+	<title id="build.omegat.from.source.title">Build OmegaT</title>
 
 	<para>The source code for the current version can either be downloaded
 	directly from the OmegaT <ulink url="https://omegat.org/download">download

--- a/doc_src/en/HowTo_Install.xml
+++ b/doc_src/en/HowTo_Install.xml
@@ -5,21 +5,19 @@
 %manualvariables;
 ]>
 <section id="how.to.installing.omegat">
-  <title id="how.to.installing.omegat.title">
-    Install
-  OmegaT</title>
+  <title id="how.to.installing.omegat.title"><link linkend="how.to.installing.omegat"> </link>Install OmegaT</title>
 
   <para>OmegaT comes in two editions:</para>
 
   <variablelist>
 	<varlistentry id="how.to.installing.omegat.standard">
-	  <term id="how.to.installing.omegat.standard.title">Standard</term>
+	  <term id="how.to.installing.omegat.standard.title"><link linkend="how.to.installing.omegat.standard"> </link>Standard</term>
 	  <listitem>
 		<para>This edition is recommended for everyday use.</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry id="how.to.installing.omegat.weekly">
-	  <term id="how.to.installing.omegatweekly.title">OmegaT Weekly</term>
+	  <term id="how.to.installing.omegat.weekly.title"><link linkend="how.to.installing.omegat.weekly"> </link>OmegaT Weekly</term>
 	  <listitem>
 		<para>This is the edition of OmegaT in active development. It is automatically generated every week,
 		and serves as a beta version for testing purposes.</para>
@@ -51,7 +49,7 @@
   </note>
 
   <section id="installing.omegat.windows">
-	<title id="installing.omegat.windows.title">On Windows</title>
+	<title id="installing.omegat.windows.title"><link linkend="installing.omegat.windows"> </link>On Windows</title>
 
     <para>Double-click on the package you downloaded.</para>
 
@@ -61,7 +59,7 @@
   </section>
 
   <section id="installing.omegat.linux.intel">
-	<title id="installing.omegat.linux.intel.title">On Linux</title>
+	<title id="installing.omegat.linux.intel.title"><link linkend="installing.omegat.linux.intel"> </link>On Linux</title>
 
 	<para>Some Linux distributions offer OmegaT in their package manager. The
 	instructions given here apply to people who download the package from the
@@ -93,7 +91,7 @@
   </section>
 
   <section id="Installing.omegat.macos">
-	<title id="Installing.omegat.macos.title">On macOS</title>
+	<title id="Installing.omegat.macos.title"><link linkend="Installing.omegat.macos"> </link>On macOS</title>
 
     <para>Double click on the package you downloaded to unpack it.  This creates
     a folder called <filename>OmegaT</filename>. The folder contains two files:
@@ -109,7 +107,7 @@
   </section>
 
   <section id="installing.omegat.other.systems">
-	<title id="installing.omegat.other.systems.title">On other platforms</title>
+	<title id="installing.omegat.other.systems.title"><link linkend="installing.omegat.other.systems"> </link>On other platforms</title>
 
     <para>This information applies to any system for a Java version
     compatible with &javaversionlong; is available. That includes the platforms
@@ -127,7 +125,7 @@
   </section>
 
   <section id="update.and.delete.omegat">
-	<title id="update.and.delete.omegat.title">Upgrade</title>
+	<title id="update.and.delete.omegat.title"><link linkend="update.and.delete.omegat"> </link>Upgrade</title>
 
 	<para>OmegaT can tell you when a new version is available. See the <link
 	endterm="dialogs.preferences.updates.title"
@@ -180,7 +178,7 @@
 
 	<variablelist>
 	  <varlistentry id="update.and.delete.omegat.over.existing.package">
-		<term id="update.and.delete.omegat.over.existing.package.title">Over an existing version</term>
+		<term id="update.and.delete.omegat.over.existing.package.title"><link linkend="update.and.delete.omegat.over.existing.package"> </link>Over an existing version</term>
 
 		<listitem>
 		  <para>To do this, simply select the same installation folder as the
@@ -192,8 +190,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="update.and.delete.omegat.along.existing.package">
-		<term  id="update.and.delete.omegat.along.existing.package.title">
-		Alongside an existing version</term>
+		<term  id="update.and.delete.omegat.along.existing.package.title"><link linkend="update.and.delete.omegat.along.existing.package"> </link>Alongside an existing version</term>
 
 		<listitem>
 		  <para>This will enable you to keep any number of versions side-by-side,
@@ -216,7 +213,7 @@
   </section>
   
   <section id="update.and.delete.omegat.delete">
-	<title id="update.and.delete.omegat.delete.title">Delete OmegaT</title>
+	<title id="update.and.delete.omegat.delete.title"><link linkend="update.and.delete.omegat.delete"> </link>Delete OmegaT</title>
 
 	<para>Use your operating system’s standard procedure to remove OmegaT.  If
 	you want to remove OmegaT completely, you will also have to delete the
@@ -229,7 +226,7 @@
   </section>
 
   <section id="build.omegat.from.source">
-	<title id="build.omegat.from.source.title">Build OmegaT</title>
+	<title id="build.omegat.from.source.title"><link linkend="build.omegat.from.source"> </link>Build OmegaT</title>
 
 	<para>The source code for the current version can either be downloaded
 	directly from the OmegaT <ulink url="https://omegat.org/download">download

--- a/doc_src/en/HowTo_RestoreYourData.xml
+++ b/doc_src/en/HowTo_RestoreYourData.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.restore.your.data">
-  <title id="how.to.restore.your.data.title">
-  Troubleshoot issues</title>
+  <title id="how.to.restore.your.data.title">Troubleshoot issues</title>
 
   <warning>
 	<para>OmegaT is a robust and trustworthy application, but even so, it is
@@ -350,8 +349,7 @@
   </section>
 
   <section id="how.to.restore.your.data.summary">
-	<title id="how.to.restore.your.data.summary.title">
-    Summary</title>
+	<title id="how.to.restore.your.data.summary.title">Summary</title>
 
 	<itemizedlist>
       <listitem>

--- a/doc_src/en/HowTo_RestoreYourData.xml
+++ b/doc_src/en/HowTo_RestoreYourData.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.restore.your.data">
-  <title id="how.to.restore.your.data.title">Troubleshoot issues</title>
+  <title id="how.to.restore.your.data.title"><link linkend="how.to.restore.your.data"> </link>Troubleshoot issues</title>
 
   <warning>
 	<para>OmegaT is a robust and trustworthy application, but even so, it is
@@ -11,9 +11,7 @@
   </warning>
 
   <section id="how.to.restore.your.data.automatic.backup">
-	<title id="how.to.restore.your.data.automatic.backup.title">
-      Automatic
-	backups</title>
+	<title id="how.to.restore.your.data.automatic.backup.title"><link linkend="how.to.restore.your.data.automatic.backup"> </link>Automatic backups</title>
 
 	<para>OmegaT creates backups of your project settings to ensure it can
 	retrieve them in case of problem. See the <link
@@ -90,9 +88,7 @@
   </section>
 
   <section id="how.to.restore.your.data.lost.in.translation">
-	<title id="how.to.restore.your.data.lost.in.translation.title">
-      You lost your
-	translation?</title>
+	<title id="how.to.restore.your.data.lost.in.translation.title"><link linkend="how.to.restore.your.data.lost.in.translation"> </link>You lost your translation?</title>
 
 	<para>Even if you fear you might have lost translation data, it is probably
 	safely stored in your most recent backup memory, which is usually less than
@@ -142,9 +138,7 @@
   </section>
 
   <section id="how.to.restore.your.data.project.locked">
-	<title id="how.to.restore.your.data.project.locked.title">
-      Your project is
-	locked?</title>
+	<title id="how.to.restore.your.data.project.locked.title"><link linkend="how.to.restore.your.data.project.locked"> </link>Your project is locked?</title>
 
 	<para>In the rare case where your computer freezes and OmegaT does not have
 	time to close properly, the <filename>omegat.project</filename> file can be
@@ -188,9 +182,7 @@
   </section>
   
   <section id="how.to.restore.your.data.project.wont.open">
-	<title id="how.to.restore.your.data.project.wont.open.title">
-      Your project
-	won’t open?</title>
+	<title id="how.to.restore.your.data.project.wont.open.title"><link linkend="how.to.restore.your.data.project.wont.open"> </link>Your project won’t open?</title>
 
 	<para>In the rare case where your computer freezes and OmegaT does not have
 	time to close properly, some important files can be corrupted and keep your
@@ -234,9 +226,7 @@
   </section>
 
   <section id="how.to.restore.your.data.translated.file.broken">
-	<title id="how.to.restore.your.data.translated.file.broken.title">
-      Your
-	translated file won’t open?</title>
+	<title id="how.to.restore.your.data.translated.file.broken.title"><link linkend="how.to.restore.your.data.translated.file.broken"> </link>Your translated file won’t open?</title>
 
 	<para>Very often, office suite files contain tags that must be copied into
 	the translation to ensure that the translated file can be opened in the
@@ -279,9 +269,7 @@
   </section>
 
   <section id="how.to.restore.your.data.omegat.wont.behave">
-	<title id="how.to.restore.your.data.omegat.wont.behave.title">
-      OmegaT won’t
-	behave?</title>
+	<title id="how.to.restore.your.data.omegat.wont.behave.title"><link linkend="how.to.restore.your.data.omegat.wont.behave"> </link>OmegaT won’t behave?</title>
 
 	<para>Something has happened and OmegaT won’t behave anymore. Whatever you
 	try, you can’t seem to be able to fix it. You want to try one last thing
@@ -349,7 +337,7 @@
   </section>
 
   <section id="how.to.restore.your.data.summary">
-	<title id="how.to.restore.your.data.summary.title">Summary</title>
+	<title id="how.to.restore.your.data.summary.title"><link linkend="how.to.restore.your.data.summary"> </link>Summary</title>
 
 	<itemizedlist>
       <listitem>

--- a/doc_src/en/HowTo_RestoreYourData.xml
+++ b/doc_src/en/HowTo_RestoreYourData.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.restore.your.data">
-  <title id="how.to.restore.your.data.title">Troubleshoot issues</title>
+  <title id="how.to.restore.your.data.title">
+  Troubleshoot issues</title>
 
   <warning>
 	<para>OmegaT is a robust and trustworthy application, but even so, it is
@@ -11,7 +12,8 @@
   </warning>
 
   <section id="how.to.restore.your.data.automatic.backup">
-	<title id="how.to.restore.your.data.automatic.backup.title">Automatic
+	<title id="how.to.restore.your.data.automatic.backup.title">
+      Automatic
 	backups</title>
 
 	<para>OmegaT creates backups of your project settings to ensure it can
@@ -19,10 +21,10 @@
 	linkend="project.folder.omegat.project.file"
 	endterm="project.folder.omegat.project.file.title"/> section for
 	details.</para>
-	  
+	
 	<para>OmegaT regularly and automatically stores all your progress in the
 	<link linkend="project.folder.project.save.tmx"
-	endterm="project.folder.project.save.tmx.title"/> file located in the
+		  endterm="project.folder.project.save.tmx.title"/> file located in the
 	project’s <link linkend="project.folder.omegat"
 	endterm="project.folder.omegat.title"/> folder. OmegaT also creates regular
 	backups of that file.</para>
@@ -89,7 +91,8 @@
   </section>
 
   <section id="how.to.restore.your.data.lost.in.translation">
-	<title id="how.to.restore.your.data.lost.in.translation.title">You lost your
+	<title id="how.to.restore.your.data.lost.in.translation.title">
+      You lost your
 	translation?</title>
 
 	<para>Even if you fear you might have lost translation data, it is probably
@@ -134,13 +137,14 @@
 	  <para>Exercise caution with changes made to files in the source folder,
 	  the segmentation rules, or the file filters, partway through a
 	  project. Modifying any of those after you have started your translation
-		could result in some segments disapparing or new segments appearing
-		unexpectedly.</para>
+	  could result in some segments disapparing or new segments appearing
+	  unexpectedly.</para>
 	</note>
   </section>
 
   <section id="how.to.restore.your.data.project.locked">
-	<title id="how.to.restore.your.data.project.locked.title">Your project is
+	<title id="how.to.restore.your.data.project.locked.title">
+      Your project is
 	locked?</title>
 
 	<para>In the rare case where your computer freezes and OmegaT does not have
@@ -185,7 +189,8 @@
   </section>
   
   <section id="how.to.restore.your.data.project.wont.open">
-	<title id="how.to.restore.your.data.project.wont.open.title">Your project
+	<title id="how.to.restore.your.data.project.wont.open.title">
+      Your project
 	won’t open?</title>
 
 	<para>In the rare case where your computer freezes and OmegaT does not have
@@ -230,7 +235,8 @@
   </section>
 
   <section id="how.to.restore.your.data.translated.file.broken">
-	<title id="how.to.restore.your.data.translated.file.broken.title">Your
+	<title id="how.to.restore.your.data.translated.file.broken.title">
+      Your
 	translated file won’t open?</title>
 
 	<para>Very often, office suite files contain tags that must be copied into
@@ -274,7 +280,8 @@
   </section>
 
   <section id="how.to.restore.your.data.omegat.wont.behave">
-	<title id="how.to.restore.your.data.omegat.wont.behave.title">OmegaT won’t
+	<title id="how.to.restore.your.data.omegat.wont.behave.title">
+      OmegaT won’t
 	behave?</title>
 
 	<para>Something has happened and OmegaT won’t behave anymore. Whatever you
@@ -343,7 +350,8 @@
   </section>
 
   <section id="how.to.restore.your.data.summary">
-	<title id="how.to.restore.your.data.summary.title">Summary</title>
+	<title id="how.to.restore.your.data.summary.title">
+    Summary</title>
 
 	<itemizedlist>
       <listitem>

--- a/doc_src/en/HowTo_Run.xml
+++ b/doc_src/en/HowTo_Run.xml
@@ -5,10 +5,10 @@
 %manualvariables;
 ]>
 <section id="how.to.running.omegat">
-  <title id="how.to.running.omegat.title">Run OmegaT</title>
+  <title id="how.to.running.omegat.title"><link linkend="how.to.running.omegat"> </link>Run OmegaT</title>
 
   <section id="running.omegat.on.windows">
-	<title id="running.omegat.on.windows.title">On Windows</title>
+	<title id="running.omegat.on.windows.title"><link linkend="running.omegat.on.windows"> </link>On Windows</title>
 	
 	<para>The simplest way to launch OmegaT is to execute the
 	<filename>OmegaT.exe</filename> program. The options for the program
@@ -35,7 +35,7 @@
   </section>
 
   <section id="running.omegat.on.linux">
-	<title id="running.omegat.on.linux.title">On Linux</title>
+	<title id="running.omegat.on.linux.title"><link linkend="running.omegat.on.linux"> </link>On Linux</title>
 
 	<para>You can launch OmegaT from the command line with a script that
 	includes start-up options. See the <link
@@ -53,7 +53,7 @@
   </section>
 
   <section id="running.omegat.on.macos">
-	<title id="running.omegat.on.macos.title">On macOS</title>
+	<title id="running.omegat.on.macos.title"><link linkend="running.omegat.on.macos"> </link>On macOS</title>
 
 	<para>Double-click on <filename>OmegaT.app</filename> or click on its
 	location in the Dock.</para>
@@ -95,7 +95,7 @@
 
 	<variablelist>
 	  <varlistentry id="running.omegat.on.macos.configuration.properties">
-		<term id="running.omegat.on.macos.configuration.properties.title">Configuration.properties</term>
+		<term id="running.omegat.on.macos.configuration.properties.title"><link linkend="running.omegat.on.macos.configuration.properties"> </link>Configuration.properties</term>
 
 		<listitem>
 		  <para>For predefined options, remove the <literal>#</literal> symbol 
@@ -105,7 +105,7 @@
 		</listitem>
 	  </varlistentry>
 	  <varlistentry id="running.omegat.on.macos.info.plist">
-		<term id="running.omegat.on.macosinfo.plist.title">Info.plist</term>
+		<term id="running.omegat.on.macos.info.plist.title"><link linkend="running.omegat.on.macos.info.plist"> </link>Info.plist</term>
 
 		<listitem>
 		  <para>For example, to change the amount of memory available uncomment
@@ -130,7 +130,7 @@
   </section>
 
   <section id="running.omegat.on.other.systems">
-	<title id="running.omegat.on.other.systems.title">On other platforms</title>
+	<title id="running.omegat.on.other.systems.title"><link linkend="running.omegat.on.other.systems"> </link>On other platforms</title>
 
 	<para>Methods vary from one system to another, but in general, once OmegaT
 	is installed, you can launch it directly from the command line.  See the <link
@@ -147,7 +147,7 @@
   </section>
   
   <section id="launch.with.command.line">
-	<title id="launch.with.command.line.title">Command line launch</title>
+	<title id="launch.with.command.line.title"><link linkend="launch.with.command.line"> </link>Command line launch</title>
 
 	<para>Using the command line allows you to set various options that control
 	or modify the behaviour of the application. You can also define and save sets
@@ -159,9 +159,7 @@
 	each with its own parameters.</para>
 
 	<section id="launch.with.command.line.tutorial">
-	  <title id="launch.with.command.line.tutorial.title">
-		Simplified
-	  Overview</title>
+	  <title id="launch.with.command.line.tutorial.title"><link linkend="launch.with.command.line.tutorial"> </link>Simplified Overview</title>
 
 	  <para>Before graphical interfaces became common, users interacted with
 	  computers via a command-line interface (CLI), which requires typing
@@ -226,10 +224,7 @@
 	</section>
 
 	<section id="launch.with.command.line.omegat.terminal.command.syntax">
-	  <title
-		  id="launch.with.command.line.omegat.terminal.command.syntax.title">
-		Command
-	  syntax</title>
+	  <title id="launch.with.command.line.omegat.terminal.command.syntax.title"><link linkend="launch.with.command.line.omegat.terminal.command.syntax"> </link>Command syntax</title>
 
 	  <para>The syntax to launch OmegaT from the terminal is:
 	  <programlisting>java -jar &lt;java parameters&gt; path/to/OmegaT.jar &lt;OmegaT options&gt; </programlisting></para>
@@ -245,7 +240,7 @@
 
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.java.jar">
-		  <term id="launch.with.command.line.java.jar.title"><option>java -jar</option></term>
+		  <term id="launch.with.command.line.java.jar.title"><link linkend="launch.with.command.line.java.jar"> </link><option>java -jar</option></term>
 		  <listitem>
 			<para>This command tells the Java Virtual Machine to run a Jar
 			package.</para>
@@ -253,10 +248,7 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.intro.java.parameters">
-		  <term
-			  id="launch.with.command.line.intro.java.parameters.title">
-			<option>&lt;java
-		  parameters&gt;</option></term>
+		  <term id="launch.with.command.line.intro.java.parameters.title"><link linkend="launch.with.command.line.intro.java.parameters"> </link><option>&lt;java parameters&gt;</option></term>
 		  <listitem>
 			<para>Optional parameters accepted by the <command>java</command>
 			command. The parameters relevant to running OmegaT are described
@@ -266,19 +258,14 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.intro.omegat.jar">
-		  <term
-			  id="launch.with.command.line.intro.omegat.jar.title">
-		  <option>path/to/OmegaT.jar</option></term>
+		  <term id="launch.with.command.line.intro.omegat.jar.title"><link linkend="launch.with.command.line.intro.omegat.jar"> </link><option>path/to/OmegaT.jar</option></term>
 		  <listitem>
 			<para>The location of the OmegaT java executable.</para>	  
 		  </listitem>
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.intro.omegat.options">
-		  <term
-			  id="launch.with.command.line.intro.omegat.options.title">
-			<emphasis><option>&lt;OmegaT
-		  options&gt;</option></emphasis></term>
+		  <term id="launch.with.command.line.intro.omegat.options.title"><link linkend="launch.with.command.line.intro.omegat.options"> </link><emphasis><option>&lt;OmegaT options&gt;</option></emphasis></term>
 		  <listitem>
 			<para>The options specific to OmegaT are described <link
 			linkend="launch.with.command.line.omegat.options">later in this
@@ -289,18 +276,14 @@
 	</section>
 
 	<section id="launch.with.command.line.java.parameters">
-	  <title id="launch.with.command.line.java.parameters.title">
-		Java
-	  parameters</title>
+	  <title id="launch.with.command.line.java.parameters.title"><link linkend="launch.with.command.line.java.parameters"> </link>Java parameters</title>
 
 	  <para>The list below presents parameters for the <command>java</command>
 	  command that can be useful when working with OmegaT.</para>
 	  
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.user.interface.language">
-		  <term id="launch.with.command.line.user.interface.language.title">
-			User
-		  interface language</term>
+		  <term id="launch.with.command.line.user.interface.language.title"><link linkend="launch.with.command.line.user.interface.language"> </link>User interface language</term>
 
 		  <listitem>
 			<para><option>-Duser.language=LL</option></para>
@@ -319,9 +302,7 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.user.country">
-		  <term id="launch.with.command.line.user.country.title">
-			User
-		  country</term>
+		  <term id="launch.with.command.line.user.country.title"><link linkend="launch.with.command.line.user.country"> </link>User country</term>
 		  <listitem>
 			<para><option>-Duser.country=CC</option></para>
 
@@ -338,10 +319,7 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.maximum.memory.assignment">
-		  <term
-			  id="launch.with.command.line.maximum.memory.assignment.title">
-			Maximum
-		  memory assignment</term>
+		  <term id="launch.with.command.line.maximum.memory.assignment.title"><link linkend="launch.with.command.line.maximum.memory.assignment"> </link>Maximum memory assignment</term>
 		  <listitem>
 			<para><option>-XmxSIZE</option></para>
 
@@ -353,9 +331,7 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.ip.address">
-		  <term id="launch.with.command.line.proxy.host.ip.address.title">
-			Proxy
-		  host ip address</term>
+		  <term id="launch.with.command.line.proxy.host.ip.address.title"><link linkend="launch.with.command.line.proxy.host.ip.address"> </link>Proxy host ip address</term>
 		  <listitem>
 			<para><option>-Dhttp.proxyHost=&lt;proxy IP&gt;</option></para>
 
@@ -365,9 +341,7 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.port.number">
-		  <term id="launch.with.command.line.proxy.host.port.number.title">
-			Proxy
-		  host port number</term>
+		  <term id="launch.with.command.line.proxy.host.port.number.title"><link linkend="launch.with.command.line.proxy.host.port.number"> </link>Proxy host port number</term>
 		  <listitem>
 			<para><option>-Dhttp.proxyPort=&lt;port number&gt;</option></para>
 
@@ -379,9 +353,7 @@
 	</section>
 
 	<section id="launch.with.command.line.omegat.options">
-	  <title id="launch.with.command.line.omegat.options.title">
-		OmegaT
-	  options</title>
+	  <title id="launch.with.command.line.omegat.options.title"><link linkend="launch.with.command.line.omegat.options"> </link>OmegaT options</title>
 
 	  <para>You can also get a list of these options in the terminal with the
 	  <command>java -jar OmegaT.jar --help</command>
@@ -389,32 +361,23 @@
 
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.general.options">
-		  <term id="launch.with.command.line.general.options.title">
-			General
-		  options:</term>
+		  <term id="launch.with.command.line.general.options.title"><link linkend="launch.with.command.line.general.options"> </link>General options:</term>
 		  <listitem>
 			<variablelist>
 			  <varlistentry id="launch.with.command.line.h.help">
-				<term
-					id="launch.with.command.line.h.help.title">
-				  <option>-h</option>,
-				<option>--help</option></term>
+				<term id="launch.with.command.line.h.help.title"><link linkend="launch.with.command.line.h.help"> </link><option>-h</option>, <option>--help</option></term>
 				<listitem>
 				  <para>Show usage information.</para>
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.path.to.an.omegat.project">
-				<term
-					id="launch.with.command.line.path.to.an.omegat.project.title">
-				  <emphasis>path
-				to an omegat project</emphasis></term>
+				<term id="launch.with.command.line.path.to.an.omegat.project.title"><link linkend="launch.with.command.line.path.to.an.omegat.project"> </link><emphasis>path to an omegat project</emphasis></term>
 				<listitem>
 				  <para>Launch the GUI and load the specified project</para>
 				</listitem>
 			  </varlistentry>
-			  <varlistentry id="launch.with.command.line.remote.project.">
-				<term id="launch.with.command.line.remote.project.title"><option>--remote-project</option>
-				<userinput>&lt;path-to-omegat-project-file&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.remote.project">
+				<term id="launch.with.command.line.remote.project.title"><link linkend="launch.with.command.line.remote.project"> </link><option>--remote-project</option><userinput>&lt;path-to-omegat-project-file&gt;</userinput></term>
 				<listitem>
 				  <para>Download the OmegaT project from the URL specified in
 				  <emphasis>&lt;path-to-omegat-project-file&gt;</emphasis>, and
@@ -422,7 +385,7 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.no.team">
-				<term id="launch.with.command.line.no.team.title"><option>--no-team</option></term>
+				<term id="launch.with.command.line.no.team.title"><link linkend="launch.with.command.line.no.team"> </link><option>--no-team</option></term>
 				<listitem>
 				  <para>Disable team project functionality. Use this option if
 				  you want to prevent OmegaT from synchronizing the project
@@ -430,10 +393,7 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.team.init">
-				<term id="launch.with.command.line.team.init.title">
-				  <option>team
-				  init</option> <userinput>SL</userinput>
-				<userinput>TL</userinput></term>
+				<term id="launch.with.command.line.team.init.title"><link linkend="launch.with.command.line.team.init"> </link><option>team init</option> <userinput>SL</userinput><userinput>TL</userinput></term>
 				<listitem>
 				  <para>Initialize a team project using <emphasis>SL</emphasis>
 				  and <emphasis>TL</emphasis> as the source and target
@@ -441,9 +401,7 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.disable.project.locking">
-				<term
-					id="launch.with.command.line.disable.project.locking.title">
-				<option>--disable-project-locking</option></term>
+				<term id="launch.with.command.line.disable.project.locking.title"><link linkend="launch.with.command.line.disable.project.locking"> </link><option>--disable-project-locking</option></term>
 				<listitem>
 				  <para>Do not lock the omegat.project file.</para>
 
@@ -454,16 +412,14 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.disable.location.save">
-				<term
-					id="launch.with.command.line.disable.location.save.title">
-				<option>--disable-location-save</option></term>
+				<term id="launch.with.command.line.disable.location.save.title"><link linkend="launch.with.command.line.disable.location.save"> </link><option>--disable-location-save</option></term>
 				<listitem>
 				  <para>Do not remember the last folder opened in the file
 				  picker.</para>
 				</listitem>
 			  </varlistentry>
-			  <varlistentry id="launch.with.command.line.itokenizer.lt.classname.gt.">
-				<term id="launch.with.command.line.itokenizer.lt.classname.gt.title"><option>--ITokenizer=</option><userinput>&lt;classname&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.itokenizer.lt.classname.gt">
+				<term id="launch.with.command.line.itokenizer.lt.classname.gt.title"><link linkend="launch.with.command.line.itokenizer.lt.classname.gt"> </link><option>--ITokenizer=</option><userinput>&lt;classname&gt;</userinput></term>
 				<term><option>--ITokenizerTarget=</option><userinput>&lt;classname&gt;</userinput></term>
 				<listitem>
 				  <para>Specify a source- or target-language tokenizer (using
@@ -471,16 +427,16 @@
 				  OmegaT.jar/META-INF/MANIFEST.MF for valid values.</para>
 				</listitem>
 			  </varlistentry>
-			  <varlistentry id="launch.with.command.line.config.dir.">
-				<term id="launch.with.command.line.config.dir.title"><option>--config-dir=</option><userinput>&lt;path&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.config.dir">
+				<term id="launch.with.command.line.config.dir.title"><link linkend="launch.with.command.line.config.dir"> </link><option>--config-dir=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>The folder used to read and write OmegaT configuration
 				  files. See the <link endterm="configuration.folder.title"
 				  linkend="configuration.folder"/> chapter for details.</para>
 				</listitem>
 			  </varlistentry>
-			  <varlistentry id="launch.with.command.line.config.file.">
-				<term id="launch.with.command.line.config.file.title"><option>--config-file=</option><userinput>&lt;path&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.config.file">
+				<term id="launch.with.command.line.config.file.title"><link linkend="launch.with.command.line.config.file"> </link><option>--config-file=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>A file written in the Java .properties format used to
 				  specify a batch of command line options.</para>
@@ -508,26 +464,23 @@ config-dir="path/to/new/configdir"</programlisting>
 				</listitem>
 			  </varlistentry>
 
-			  <varlistentry id="launch.with.command.line.resource.bundle.">
-				<term id="launch.with.command.line.resource.bundle.title"><option>--resource-bundle=</option><userinput>&lt;path&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.resource.bundle">
+				<term id="launch.with.command.line.resource.bundle.title"><link linkend="launch.with.command.line.resource.bundle"> </link><option>--resource-bundle=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>A Java .properties file to use for interface
 				  text.</para>
 				</listitem>
 			  </varlistentry>
 
-			  <varlistentry id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.">
-				<term id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title"><option>--mode=[console
-				mode name]</option> <userinput>&lt;project path&gt;</userinput> <userinput>&lt;mode option&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align">
+				<term id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title"><link linkend="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align"> </link><option>--mode=[console mode name]</option> <userinput>&lt;project path&gt;</userinput> <userinput>&lt;mode option&gt;</userinput></term>
 				<listitem>
 				  <para>Specify a mode other than the GUI default. The following
 				  options are available:</para>
 
 				  <variablelist>
 					<varlistentry id="launch.with.command.line.mode.console.translate">
-					  <term
-						  id="launch.with.command.line.mode.console.translate.title">
-					  <option>--mode=console-translate</option> <userinput>&lt;project path&gt;</userinput></term>
+					  <term id="launch.with.command.line.mode.console.translate.title"><link linkend="launch.with.command.line.mode.console.translate"> </link><option>--mode=console-translate</option> <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<para>In this mode, OmegaT attempts to translate the
 						files in the source folder with the available
@@ -538,7 +491,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt">
-							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title"><option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
+							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title"><link linkend="launch.with.command.line.source.pattern.lt.pattern.gt"> </link><option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
 							<listitem>
 							  <para>An allowlist of regular expressions defining
 							  the source files to process. Remember that in
@@ -550,13 +503,13 @@ config-dir="path/to/new/configdir"</programlisting>
 							  
 							  <variablelist>
 								<varlistentry id="launch.with.command.line.html">
-								  <term id="launch.with.command.line.html.title"><option>.*\.html</option></term>
+								  <term id="launch.with.command.line.html.title"><link linkend="launch.with.command.line.html"> </link><option>.*\.html</option></term>
 								  <listitem>
 									<para>Translate all HTML files.</para>
 								  </listitem>
 								</varlistentry>
 								<varlistentry id="launch.with.command.line.test.html">
-								  <term id="launch.with.command.line.test.html.title"><option>test\.html</option></term>
+								  <term id="launch.with.command.line.test.html.title"><link linkend="launch.with.command.line.test.html"> </link><option>test\.html</option></term>
 								  <listitem>
 									<para>Only translate
 									<filename>test.html</filename> file in the
@@ -567,9 +520,7 @@ config-dir="path/to/new/configdir"</programlisting>
 								</varlistentry>
 
 								<varlistentry id="launch.with.command.line.dir.test.html">
-								  <term
-									  id="launch.with.command.line.dir.test.html.title">
-								  <option>dir-10\\test\.html</option></term>
+								  <term id="launch.with.command.line.dir.test.html.title"><link linkend="launch.with.command.line.dir.test.html"> </link><option>dir-10\\test\.html</option></term>
 								  <listitem>
 									<para>Only translate the
 									<filename>test.html</filename> file in the
@@ -590,10 +541,7 @@ config-dir="path/to/new/configdir"</programlisting>
 					</varlistentry>
 
 					<varlistentry id="launch.with.command.line.mode.console.pseudotranslatetmx">
-					  <term
-						  id="launch.with.command.line.mode.console.pseudotranslatetmx.title">
-						<option>--mode=console-createpseudotranslatetmx</option>
-					  <userinput>&lt;project path&gt;</userinput></term>
+					  <term id="launch.with.command.line.mode.console.pseudotranslatetmx.title"><link linkend="launch.with.command.line.mode.console.pseudotranslatetmx"> </link><option>--mode=console-createpseudotranslatetmx</option> <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<para>In this mode OmegaT will create a TMX for the
 						whole project using only the source files.</para>
@@ -601,15 +549,15 @@ config-dir="path/to/new/configdir"</programlisting>
 						<para>Specify the TMX file to create with:</para>
 						
 						<variablelist>
-						  <varlistentry id="launch.with.command.line.pseudotranslatetmx.">
-							<term id="launch.with.command.line.pseudotranslatetmx.title"><option>--pseudotranslatetmx=</option><userinput>&lt;path&gt;</userinput></term>
+						  <varlistentry id="launch.with.command.line.pseudotranslatetmx">
+							<term id="launch.with.command.line.pseudotranslatetmx.title"><link linkend="launch.with.command.line.pseudotranslatetmx"> </link><option>--pseudotranslatetmx=</option><userinput>&lt;path&gt;</userinput></term>
 							<listitem>
 							  <para>The output pseudotranslated TMX file.</para>
 							</listitem>
 						  </varlistentry>
 
-						  <varlistentry id="launch.with.command.line.pseudotranslatetype.equal.empty.">
-							<term id="launch.with.command.line.pseudotranslatetype.equal.empty.title"><option>--pseudotranslatetype=[equal|empty]</option></term>
+						  <varlistentry id="launch.with.command.line.pseudotranslatetype.equal.empty">
+							<term id="launch.with.command.line.pseudotranslatetype.equal.empty.title"><link linkend="launch.with.command.line.pseudotranslatetype.equal.empty"> </link><option>--pseudotranslatetype=[equal|empty]</option></term>
 							<listitem>
 							  <para>What to fill the pseudotranslated TMX
 							  with.</para>
@@ -620,10 +568,7 @@ config-dir="path/to/new/configdir"</programlisting>
 					</varlistentry>
 					
 					<varlistentry id="launch.with.command.line.mode.console.align">
-					  <term
-						  id="launch.with.command.line.mode.console.align.title">
-						<option>--mode=console-align</option> 
-					  <userinput>&lt;project path&gt;</userinput></term>
+					  <term id="launch.with.command.line.mode.console.align.title"><link linkend="launch.with.command.line.mode.console.align"> </link><option>--mode=console-align</option> <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<para>In this mode, OmegaT will align the files in the
 						/source folder of the project with those at the location
@@ -632,7 +577,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.align.dir">
-							<term id="launch.with.command.line.align.dir.title"><option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
+							<term id="launch.with.command.line.align.dir.title"><link linkend="launch.with.command.line.align.dir"> </link><option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
 							<listitem>
 							  <para>The path containing the files translated in the target language.</para>
 
@@ -653,13 +598,11 @@ config-dir="path/to/new/configdir"</programlisting>
 					</varlistentry>
 
 					<varlistentry id="launch.with.command.line.mode.console.stats">
-					  <term id="launch.with.command.line.mode.console.stats.title">
-						<option>--mode=console-stats</option> 
-					  <userinput>&lt;project path&gt;</userinput></term>
+					  <term id="launch.with.command.line.mode.console.stats.title"><link linkend="launch.with.command.line.mode.console.stats"> </link><option>--mode=console-stats</option><userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.console.stats.output.file">
-							<term id="launch.with.command.line.console.stats.output.file.title"><option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
+							<term id="launch.with.command.line.console.stats.output.file.title"><link linkend="launch.with.command.line.console.stats.output.file"> </link><option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
 							<listitem>
 							  <para>Prints to that file, or to standard output
 							  if absent. Without
@@ -670,7 +613,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						  </varlistentry>
 						  
 						  <varlistentry id="launch.with.command.line.console.stats.output.format">
-							<term id="launch.with.command.line.console.stats.output.format.title"><option>--stats-type=[xml|text][txt][json]]]</option></term>
+							<term id="launch.with.command.line.console.stats.output.format.title"><link linkend="launch.with.command.line.console.stats.output.format"> </link><option>--stats-type=[xml|text][txt][json]]]</option></term>
 							<listitem>
 							  <para>Requires
 							  <emphasis>--output-file</emphasis>. Specifies the
@@ -693,28 +636,26 @@ config-dir="path/to/new/configdir"</programlisting>
 		</varlistentry>
 		
 		<varlistentry id="launch.with.command.line.non.gui.mode.options">
-		  <term id="launch.with.command.line.non.gui.mode.options.title">
-			Non-gui
-		  mode options:</term>
+		  <term id="launch.with.command.line.non.gui.mode.options.title"><link linkend="launch.with.command.line.non.gui.mode.options"> </link>Non-gui mode options:</term>
 		  <listitem>
 			<variablelist>
 			  <varlistentry id="launch.with.command.line.quiet">
-				<term id="launch.with.command.line.quiet.title"><option>--quiet</option></term>
+				<term id="launch.with.command.line.quiet.title"><link linkend="launch.with.command.line.quiet"> </link><option>--quiet</option></term>
 				<listitem>
 				  <para>Minimize the output shown on the command line.</para>
 				</listitem>
 			  </varlistentry>
 			  
-			  <varlistentry id="launch.with.command.line.script.">
-				<term id="launch.with.command.line.script.title"><option>--script=</option><userinput>&lt;path&gt;</userinput></term>
+			  <varlistentry id="launch.with.command.line.script">
+				<term id="launch.with.command.line.script.title"><link linkend="launch.with.command.line.script"> </link><option>--script=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>A script file to run when a project event is
 				  triggered.</para>
 				</listitem>
 			  </varlistentry>
 
-			  <varlistentry id="launch.with.command.line.tag.validation.abort.warn.">
-				<term id="launch.with.command.line.tag.validation.abort.warn.title"><option>--tag-validation=[abort|warn]</option></term>
+			  <varlistentry id="launch.with.command.line.tag.validation.abort.warn">
+				<term id="launch.with.command.line.tag.validation.abort.warn.title"><link linkend="launch.with.command.line.tag.validation.abort.warn"> </link><option>--tag-validation=[abort|warn]</option></term>
 				<listitem>
 				  <para>Check tag issues.</para>
 				  

--- a/doc_src/en/HowTo_Run.xml
+++ b/doc_src/en/HowTo_Run.xml
@@ -5,10 +5,12 @@
 %manualvariables;
 ]>
 <section id="how.to.running.omegat">
-  <title id="how.to.running.omegat.title">Run OmegaT</title>
+  <title id="how.to.running.omegat.title">
+  Run OmegaT</title>
 
   <section id="running.omegat.on.windows">
-	<title id="running.omegat.on.windows.title">On Windows</title>
+	<title id="running.omegat.on.windows.title">
+    On Windows</title>
 	
 	<para>The simplest way to launch OmegaT is to execute the
 	<filename>OmegaT.exe</filename> program. The options for the program
@@ -19,13 +21,13 @@
 	country:</para>
 
 	<programlisting># OmegaT.exe runtime configuration
-	# To use a parameter, remove the '#' before the '-'
-	# Memory
-	-Xmx1024M
-	# Language
-	-Duser.language=FR
-	# Country
-	-Duser.country=CA</programlisting>
+# To use a parameter, remove the '#' before the '-'
+# Memory
+-Xmx1024M
+# Language
+-Duser.language=FR
+# Country
+-Duser.country=CA</programlisting>
 
 
 	<para>Advice: if OmegaT works slowly in Remote Desktop sessions under
@@ -35,7 +37,8 @@
   </section>
 
   <section id="running.omegat.on.linux">
-	<title id="running.omegat.on.linux.title">On Linux</title>
+	<title id="running.omegat.on.linux.title">
+    On Linux</title>
 
 	<para>You can launch OmegaT from the command line with a script that
 	includes start-up options. See the <link
@@ -53,7 +56,8 @@
   </section>
 
   <section id="running.omegat.on.macos">
-	<title id="running.omegat.on.macos.title">On macOS</title>
+	<title id="running.omegat.on.macos.title">
+    On macOS</title>
 
 	<para>Double-click on <filename>OmegaT.app</filename> or click on its
 	location in the Dock.</para>
@@ -94,8 +98,9 @@
 	<para>Use your text editor of choice to modify the files.</para>
 
 	<variablelist>
-	  <varlistentry>
-		<term>Configuration.properties</term>
+	  <varlistentry id="running.omegat.on.macos.configuration.properties">
+		<term id="running.omegat.on.macos.configuration.properties.title">
+		Configuration.properties</term>
 
 		<listitem>
 		  <para>For predefined options, remove the <literal>#</literal> symbol 
@@ -104,8 +109,8 @@
 		  will launch OmegaT with the user interface in Japanese.</para>
 		</listitem>
 	  </varlistentry>
-	  <varlistentry>
-		<term>Info.plist</term>
+	  <varlistentry id="running.omegat.on.macos.info.plist">
+		<term id="running.omegat.on.macosinfo.plist.title">Info.plist</term>
 
 		<listitem>
 		  <para>For example, to change the amount of memory available uncomment
@@ -130,7 +135,8 @@
   </section>
 
   <section id="running.omegat.on.other.systems">
-	<title id="running.omegat.on.other.systems.title">On other platforms</title>
+	<title id="running.omegat.on.other.systems.title">
+    On other platforms</title>
 
 	<para>Methods vary from one system to another, but in general, once OmegaT
 	is installed, you can launch it directly from the command line.  See the <link
@@ -147,7 +153,8 @@
   </section>
   
   <section id="launch.with.command.line">
-	<title id="launch.with.command.line.title">Command line launch</title>
+	<title id="launch.with.command.line.title">
+    Command line launch</title>
 
 	<para>Using the command line allows you to set various options that control
 	or modify the behaviour of the application. You can also define and save sets
@@ -159,7 +166,8 @@
 	each with its own parameters.</para>
 
 	<section id="launch.with.command.line.tutorial">
-	  <title id="launch.with.command.line.tutorial.title">Simplified
+	  <title id="launch.with.command.line.tutorial.title">
+		Simplified
 	  Overview</title>
 
 	  <para>Before graphical interfaces became common, users interacted with
@@ -197,19 +205,22 @@
 		
 		<variablelist>
 		  <varlistentry id="launch.with.command.line.windows">
-			<term id="launch.with.command.line.windows.title">Windows</term>
+			<term id="launch.with.command.line.windows.title">
+			Windows</term>
 			<listitem>
 			  <para><filename>C:\Program Files\OmegaT\OmegaT.jar</filename></para>
 			</listitem>
 		  </varlistentry>
 		  <varlistentry id="launch.with.command.line.macos">
-			<term id="launch.with.command.line.macos.title">Macos</term>
+			<term id="launch.with.command.line.macos.title">
+			Macos</term>
 			<listitem>
 			  <para><filename>/Applications/OmegaT.app/Contents/Java/OmegaT.jar</filename></para>
 			</listitem>
 		  </varlistentry>
 		  <varlistentry id="launch.with.command.line.linux">
-			<term id="launch.with.command.line.linux.title">Linux</term>
+			<term id="launch.with.command.line.linux.title">
+			Linux</term>
 			<listitem>
 			  <para><filename>/opt/omegat/OmegaT.jar</filename></para>
 
@@ -226,7 +237,8 @@
 
 	<section id="launch.with.command.line.omegat.terminal.command.syntax">
 	  <title
-		  id="launch.with.command.line.omegat.terminal.command.syntax.title">Command
+		  id="launch.with.command.line.omegat.terminal.command.syntax.title">
+		Command
 	  syntax</title>
 
 	  <para>The syntax to launch OmegaT from the terminal is:
@@ -236,14 +248,15 @@
 		<para>On macOS, it is also possible to use
 		<filename>OmegaT.app</filename> directly in the terminal, in which case
 		java parameters cannot be added: <programlisting>open path/to/OmegaT.app
-		-n --args &lt;OmegaT options&gt;</programlisting> where
+-n --args &lt;OmegaT options&gt;</programlisting> where
 		<userinput>-n</userinput> is used to create a new instance of
 		OmegaT.</para>
 	  </note>
 
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.java.jar">
-		  <term id="launch.with.command.line.java.jar.title"><option>java -jar</option></term>
+		  <term id="launch.with.command.line.java.jar.title">
+		  <option>java -jar</option></term>
 		  <listitem>
 			<para>This command tells the Java Virtual Machine to run a Jar
 			package.</para>
@@ -252,7 +265,8 @@
 
 		<varlistentry id="launch.with.command.line.intro.java.parameters">
 		  <term
-			  id="launch.with.command.line.intro.java.parameters.title"><option>&lt;java
+			  id="launch.with.command.line.intro.java.parameters.title">
+			<option>&lt;java
 		  parameters&gt;</option></term>
 		  <listitem>
 			<para>Optional parameters accepted by the <command>java</command>
@@ -264,7 +278,8 @@
 
 		<varlistentry id="launch.with.command.line.intro.omegat.jar">
 		  <term
-			  id="launch.with.command.line.intro.omegat.jar.title"><option>path/to/OmegaT.jar</option></term>
+			  id="launch.with.command.line.intro.omegat.jar.title">
+		  <option>path/to/OmegaT.jar</option></term>
 		  <listitem>
 			<para>The location of the OmegaT java executable.</para>	  
 		  </listitem>
@@ -272,7 +287,8 @@
 
 		<varlistentry id="launch.with.command.line.intro.omegat.options">
 		  <term
-			  id="launch.with.command.line.intro.omegat.options.title"><emphasis><option>&lt;OmegaT
+			  id="launch.with.command.line.intro.omegat.options.title">
+			<emphasis><option>&lt;OmegaT
 		  options&gt;</option></emphasis></term>
 		  <listitem>
 			<para>The options specific to OmegaT are described <link
@@ -284,7 +300,8 @@
 	</section>
 
 	<section id="launch.with.command.line.java.parameters">
-	  <title id="launch.with.command.line.java.parameters.title">Java
+	  <title id="launch.with.command.line.java.parameters.title">
+		Java
 	  parameters</title>
 
 	  <para>The list below presents parameters for the <command>java</command>
@@ -292,7 +309,8 @@
 	  
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.user.interface.language">
-		  <term id="launch.with.command.line.user.interface.language.title">User
+		  <term id="launch.with.command.line.user.interface.language.title">
+			User
 		  interface language</term>
 
 		  <listitem>
@@ -312,7 +330,8 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.user.country">
-		  <term id="launch.with.command.line.user.country.title">User
+		  <term id="launch.with.command.line.user.country.title">
+			User
 		  country</term>
 		  <listitem>
 			<para><option>-Duser.country=CC</option></para>
@@ -331,7 +350,8 @@
 
 		<varlistentry id="launch.with.command.line.maximum.memory.assignment">
 		  <term
-			  id="launch.with.command.line.maximum.memory.assignment.title">Maximum
+			  id="launch.with.command.line.maximum.memory.assignment.title">
+			Maximum
 		  memory assignment</term>
 		  <listitem>
 			<para><option>-XmxSIZE</option></para>
@@ -344,7 +364,8 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.ip.address">
-		  <term id="launch.with.command.line.proxy.host.ip.address.title">Proxy
+		  <term id="launch.with.command.line.proxy.host.ip.address.title">
+			Proxy
 		  host ip address</term>
 		  <listitem>
 			<para><option>-Dhttp.proxyHost=&lt;proxy IP&gt;</option></para>
@@ -355,7 +376,8 @@
 		</varlistentry>
 
 		<varlistentry id="launch.with.command.line.proxy.host.port.number">
-		  <term id="launch.with.command.line.proxy.host.port.number.title">Proxy
+		  <term id="launch.with.command.line.proxy.host.port.number.title">
+			Proxy
 		  host port number</term>
 		  <listitem>
 			<para><option>-Dhttp.proxyPort=&lt;port number&gt;</option></para>
@@ -368,7 +390,8 @@
 	</section>
 
 	<section id="launch.with.command.line.omegat.options">
-	  <title id="launch.with.command.line.omegat.options.title">OmegaT
+	  <title id="launch.with.command.line.omegat.options.title">
+		OmegaT
 	  options</title>
 
 	  <para>You can also get a list of these options in the terminal with the
@@ -376,14 +399,16 @@
 	  command. The OmegaT GUI is launched if no option is specified.</para>
 
 	  <variablelist>
-		<varlistentry id="launch.with.command.line.general.options.">
-		  <term id="launch.with.command.line.general.options.title">General
+		<varlistentry id="launch.with.command.line.general.options">
+		  <term id="launch.with.command.line.general.options.title">
+			General
 		  options:</term>
 		  <listitem>
 			<variablelist>
 			  <varlistentry id="launch.with.command.line.h.help">
 				<term
-				id="launch.with.command.line.h.help.title"><option>-h</option>,
+					id="launch.with.command.line.h.help.title">
+				  <option>-h</option>,
 				<option>--help</option></term>
 				<listitem>
 				  <para>Show usage information.</para>
@@ -391,15 +416,15 @@
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.path.to.an.omegat.project">
 				<term
-					id="launch.with.command.line.path.to.an.omegat.project.title"><emphasis>path
+					id="launch.with.command.line.path.to.an.omegat.project.title">
+				  <emphasis>path
 				to an omegat project</emphasis></term>
 				<listitem>
 				  <para>Launch the GUI and load the specified project</para>
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.remote.project.">
-				<term
-				id="launch.with.command.line.remote.project.title"><option>--remote-project</option>
+				<term id="launch.with.command.line.remote.project.title"><option>--remote-project</option>
 				<userinput>&lt;path-to-omegat-project-file&gt;</userinput></term>
 				<listitem>
 				  <para>Download the OmegaT project from the URL specified in
@@ -408,7 +433,8 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.no.team">
-				<term id="launch.with.command.line.no.team.title"><option>--no-team</option></term>
+				<term id="launch.with.command.line.no.team.title">
+				<option>--no-team</option></term>
 				<listitem>
 				  <para>Disable team project functionality. Use this option if
 				  you want to prevent OmegaT from synchronizing the project
@@ -416,8 +442,9 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.team.init">
-				<term id="launch.with.command.line.team.init.title"><option>team
-				init</option> <userinput>SL</userinput>
+				<term id="launch.with.command.line.team.init.title">
+				  <option>team
+				  init</option> <userinput>SL</userinput>
 				<userinput>TL</userinput></term>
 				<listitem>
 				  <para>Initialize a team project using <emphasis>SL</emphasis>
@@ -427,7 +454,8 @@
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.disable.project.locking">
 				<term
-				id="launch.with.command.line.disable.project.locking.title"><option>--disable-project-locking</option></term>
+					id="launch.with.command.line.disable.project.locking.title">
+				<option>--disable-project-locking</option></term>
 				<listitem>
 				  <para>Do not lock the omegat.project file.</para>
 
@@ -439,15 +467,15 @@
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.disable.location.save">
 				<term
-					id="launch.with.command.line.disable.location.save.title"><option>--disable-location-save</option></term>
+					id="launch.with.command.line.disable.location.save.title">
+				<option>--disable-location-save</option></term>
 				<listitem>
 				  <para>Do not remember the last folder opened in the file
 				  picker.</para>
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.itokenizer.lt.classname.gt.">
-				<term
-				id="launch.with.command.line.itokenizer.lt.classname.gt.title"><option>--ITokenizer=</option><userinput>&lt;classname&gt;</userinput></term>
+				<term id="launch.with.command.line.itokenizer.lt.classname.gt.title"><option>--ITokenizer=</option><userinput>&lt;classname&gt;</userinput></term>
 				<term><option>--ITokenizerTarget=</option><userinput>&lt;classname&gt;</userinput></term>
 				<listitem>
 				  <para>Specify a source- or target-language tokenizer (using
@@ -456,8 +484,7 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.config.dir.">
-				<term
-					id="launch.with.command.line.config.dir.title"><option>--config-dir=</option><userinput>&lt;path&gt;</userinput></term>
+				<term id="launch.with.command.line.config.dir.title"><option>--config-dir=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>The folder used to read and write OmegaT configuration
 				  files. See the <link endterm="configuration.folder.title"
@@ -494,8 +521,7 @@ config-dir="path/to/new/configdir"</programlisting>
 			  </varlistentry>
 
 			  <varlistentry id="launch.with.command.line.resource.bundle.">
-				<term
-				id="launch.with.command.line.resource.bundle.title"><option>--resource-bundle=</option><userinput>&lt;path&gt;</userinput></term>
+				<term id="launch.with.command.line.resource.bundle.title"><option>--resource-bundle=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>A Java .properties file to use for interface
 				  text.</para>
@@ -503,8 +529,7 @@ config-dir="path/to/new/configdir"</programlisting>
 			  </varlistentry>
 
 			  <varlistentry id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.">
-				<term
-				id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title"><option>--mode=[console
+				<term id="launch.with.command.line.mode.console.translate.console.pseudotranslatetmx.console.align.title"><option>--mode=[console
 				mode name]</option> <userinput>&lt;project path&gt;</userinput> <userinput>&lt;mode option&gt;</userinput></term>
 				<listitem>
 				  <para>Specify a mode other than the GUI default. The following
@@ -513,7 +538,8 @@ config-dir="path/to/new/configdir"</programlisting>
 				  <variablelist>
 					<varlistentry id="launch.with.command.line.mode.console.translate">
 					  <term
-						  id="launch.with.command.line.mode.console.translate.title"><option>--mode=console-translate</option> <userinput>&lt;project path&gt;</userinput></term>
+						  id="launch.with.command.line.mode.console.translate.title">
+					  <option>--mode=console-translate</option> <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<para>In this mode, OmegaT attempts to translate the
 						files in the source folder with the available
@@ -521,10 +547,11 @@ config-dir="path/to/new/configdir"</programlisting>
 
 						<para>This is useful if OmegaT is run on a server with
 						TMX files automatically fed to a project.</para>
-						  
+						
 						<variablelist>
-						  <varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt.">
-							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title"><option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
+						  <varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt">
+							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title">
+							<option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
 							<listitem>
 							  <para>An allowlist of regular expressions defining
 							  the source files to process. Remember that in
@@ -536,13 +563,15 @@ config-dir="path/to/new/configdir"</programlisting>
 							  
 							  <variablelist>
 								<varlistentry id="launch.with.command.line.html">
-								  <term id="launch.with.command.line.html.title"><option>.*\.html</option></term>
+								  <term id="launch.with.command.line.html.title">
+								  <option>.*\.html</option></term>
 								  <listitem>
 									<para>Translate all HTML files.</para>
 								  </listitem>
 								</varlistentry>
 								<varlistentry id="launch.with.command.line.test.html">
-								  <term id="launch.with.command.line.test.html.title"><option>test\.html</option></term>
+								  <term id="launch.with.command.line.test.html.title">
+								  <option>test\.html</option></term>
 								  <listitem>
 									<para>Only translate
 									<filename>test.html</filename> file in the
@@ -554,7 +583,8 @@ config-dir="path/to/new/configdir"</programlisting>
 
 								<varlistentry id="launch.with.command.line.dir.test.html">
 								  <term
-									  id="launch.with.command.line.dir.test.html.title"><option>dir-10\\test\.html</option></term>
+									  id="launch.with.command.line.dir.test.html.title">
+								  <option>dir-10\\test\.html</option></term>
 								  <listitem>
 									<para>Only translate the
 									<filename>test.html</filename> file in the
@@ -576,8 +606,9 @@ config-dir="path/to/new/configdir"</programlisting>
 
 					<varlistentry id="launch.with.command.line.mode.console.pseudotranslatetmx">
 					  <term
-					  id="launch.with.command.line.mode.console.pseudotranslatetmx.title"><option>--mode=console-createpseudotranslatetmx</option>
-							<userinput>&lt;project path&gt;</userinput></term>
+						  id="launch.with.command.line.mode.console.pseudotranslatetmx.title">
+						<option>--mode=console-createpseudotranslatetmx</option>
+					  <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<para>In this mode OmegaT will create a TMX for the
 						whole project using only the source files.</para>
@@ -586,16 +617,14 @@ config-dir="path/to/new/configdir"</programlisting>
 						
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.pseudotranslatetmx.">
-							<term
-								id="launch.with.command.line.pseudotranslatetmx.title"><option>--pseudotranslatetmx=</option><userinput>&lt;path&gt;</userinput></term>
+							<term id="launch.with.command.line.pseudotranslatetmx.title"><option>--pseudotranslatetmx=</option><userinput>&lt;path&gt;</userinput></term>
 							<listitem>
 							  <para>The output pseudotranslated TMX file.</para>
 							</listitem>
 						  </varlistentry>
 
 						  <varlistentry id="launch.with.command.line.pseudotranslatetype.equal.empty.">
-							<term
-								id="launch.with.command.line.pseudotranslatetype.equal.empty.title"><option>--pseudotranslatetype=[equal|empty]</option></term>
+							<term id="launch.with.command.line.pseudotranslatetype.equal.empty.title"><option>--pseudotranslatetype=[equal|empty]</option></term>
 							<listitem>
 							  <para>What to fill the pseudotranslated TMX
 							  with.</para>
@@ -607,24 +636,26 @@ config-dir="path/to/new/configdir"</programlisting>
 					
 					<varlistentry id="launch.with.command.line.mode.console.align">
 					  <term
-					  id="launch.with.command.line.mode.console.align.title"><option>--mode=console-align</option> 
+						  id="launch.with.command.line.mode.console.align.title">
+						<option>--mode=console-align</option> 
 					  <userinput>&lt;project path&gt;</userinput></term>
-						<listitem>
+					  <listitem>
 						<para>In this mode, OmegaT will align the files in the
 						/source folder of the project with those at the location
 						specified by the <emphasis>--alignDir</emphasis>
 						parameter below.</para>
 						
 						<variablelist>
-							<varlistentry>
-								<term><option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
-								<listitem>
-									<para>The path containing the files translated in the target language.</para>
+						  <varlistentry id="launch.with.command.line.align.dir">
+							<term id="launch.with.command.line.align.dir.title">
+							<option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
+							<listitem>
+							  <para>The path containing the files translated in the target language.</para>
 
-									<para>That folder must contain a translation in the target language of the project. For instance, if
-									the project is EN-to-FR, the specified folder must contain a bundle ending with <filename>_fr</filename>.</para>
-								</listitem>
-							</varlistentry>							
+							  <para>That folder must contain a translation in the target language of the project. For instance, if
+							  the project is EN-to-FR, the specified folder must contain a bundle ending with <filename>_fr</filename>.</para>
+							</listitem>
+						  </varlistentry>							
 						</variablelist>
 
 						<para>The resulting TMX file is saved in the <filename role="directory">omegat/</filename>
@@ -638,14 +669,14 @@ config-dir="path/to/new/configdir"</programlisting>
 					</varlistentry>
 
 					<varlistentry id="launch.with.command.line.mode.console.stats">
-					  <term
-						  id="launch.with.command.line.mode.console.stats.title"><option>--mode=console-stats</option> 
+					  <term id="launch.with.command.line.mode.console.stats.title">
+						<option>--mode=console-stats</option> 
 					  <userinput>&lt;project path&gt;</userinput></term>
 					  <listitem>
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.console.stats.output.file">
-							<term
-							id="launch.with.command.line.console.stats.output.file.title"><option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
+							<term id="launch.with.command.line.console.stats.output.file.title">
+							<option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
 							<listitem>
 							  <para>Prints to that file, or to standard output
 							  if absent. Without
@@ -654,10 +685,10 @@ config-dir="path/to/new/configdir"</programlisting>
 							  xml.</para>
 							</listitem>
 						  </varlistentry>
-							
+						  
 						  <varlistentry id="launch.with.command.line.console.stats.output.format">
-							<term
-								id="launch.with.command.line.console.stats.output.format.title"><option>--stats-type=[xml|text][txt][json]]]</option></term>
+							<term id="launch.with.command.line.console.stats.output.format.title">
+							<option>--stats-type=[xml|text][txt][json]]]</option></term>
 							<listitem>
 							  <para>Requires
 							  <emphasis>--output-file</emphasis>. Specifies the
@@ -665,7 +696,7 @@ config-dir="path/to/new/configdir"</programlisting>
 							</listitem>
 						  </varlistentry>
 						</variablelist>
-						  
+						
 						<para>The data is the same as when using <link
 						linkend="menus.tools" endterm="menus.tools.title"/><link
 						linkend="menus.tools.statistics"
@@ -678,22 +709,23 @@ config-dir="path/to/new/configdir"</programlisting>
 			</variablelist>
 		  </listitem>
 		</varlistentry>
-		  
-		<varlistentry id="launch.with.command.line.non.gui.mode.options.">
-		  <term id="launch.with.command.line.non.gui.mode.options.title">Non-gui
+		
+		<varlistentry id="launch.with.command.line.non.gui.mode.options">
+		  <term id="launch.with.command.line.non.gui.mode.options.title">
+			Non-gui
 		  mode options:</term>
 		  <listitem>
 			<variablelist>
 			  <varlistentry id="launch.with.command.line.quiet">
-				<term id="launch.with.command.line.quiet.title"><option>--quiet</option></term>
+				<term id="launch.with.command.line.quiet.title">
+				<option>--quiet</option></term>
 				<listitem>
 				  <para>Minimize the output shown on the command line.</para>
 				</listitem>
 			  </varlistentry>
-				
+			  
 			  <varlistentry id="launch.with.command.line.script.">
-				<term
-					id="launch.with.command.line.script.title"><option>--script=</option><userinput>&lt;path&gt;</userinput></term>
+				<term id="launch.with.command.line.script.title"><option>--script=</option><userinput>&lt;path&gt;</userinput></term>
 				<listitem>
 				  <para>A script file to run when a project event is
 				  triggered.</para>
@@ -701,8 +733,7 @@ config-dir="path/to/new/configdir"</programlisting>
 			  </varlistentry>
 
 			  <varlistentry id="launch.with.command.line.tag.validation.abort.warn.">
-				<term
-					id="launch.with.command.line.tag.validation.abort.warn.title"><option>--tag-validation=[abort|warn]</option></term>
+				<term id="launch.with.command.line.tag.validation.abort.warn.title"><option>--tag-validation=[abort|warn]</option></term>
 				<listitem>
 				  <para>Check tag issues.</para>
 				  

--- a/doc_src/en/HowTo_Run.xml
+++ b/doc_src/en/HowTo_Run.xml
@@ -5,12 +5,10 @@
 %manualvariables;
 ]>
 <section id="how.to.running.omegat">
-  <title id="how.to.running.omegat.title">
-  Run OmegaT</title>
+  <title id="how.to.running.omegat.title">Run OmegaT</title>
 
   <section id="running.omegat.on.windows">
-	<title id="running.omegat.on.windows.title">
-    On Windows</title>
+	<title id="running.omegat.on.windows.title">On Windows</title>
 	
 	<para>The simplest way to launch OmegaT is to execute the
 	<filename>OmegaT.exe</filename> program. The options for the program
@@ -37,8 +35,7 @@
   </section>
 
   <section id="running.omegat.on.linux">
-	<title id="running.omegat.on.linux.title">
-    On Linux</title>
+	<title id="running.omegat.on.linux.title">On Linux</title>
 
 	<para>You can launch OmegaT from the command line with a script that
 	includes start-up options. See the <link
@@ -56,8 +53,7 @@
   </section>
 
   <section id="running.omegat.on.macos">
-	<title id="running.omegat.on.macos.title">
-    On macOS</title>
+	<title id="running.omegat.on.macos.title">On macOS</title>
 
 	<para>Double-click on <filename>OmegaT.app</filename> or click on its
 	location in the Dock.</para>
@@ -99,8 +95,7 @@
 
 	<variablelist>
 	  <varlistentry id="running.omegat.on.macos.configuration.properties">
-		<term id="running.omegat.on.macos.configuration.properties.title">
-		Configuration.properties</term>
+		<term id="running.omegat.on.macos.configuration.properties.title">Configuration.properties</term>
 
 		<listitem>
 		  <para>For predefined options, remove the <literal>#</literal> symbol 
@@ -135,8 +130,7 @@
   </section>
 
   <section id="running.omegat.on.other.systems">
-	<title id="running.omegat.on.other.systems.title">
-    On other platforms</title>
+	<title id="running.omegat.on.other.systems.title">On other platforms</title>
 
 	<para>Methods vary from one system to another, but in general, once OmegaT
 	is installed, you can launch it directly from the command line.  See the <link
@@ -153,8 +147,7 @@
   </section>
   
   <section id="launch.with.command.line">
-	<title id="launch.with.command.line.title">
-    Command line launch</title>
+	<title id="launch.with.command.line.title">Command line launch</title>
 
 	<para>Using the command line allows you to set various options that control
 	or modify the behaviour of the application. You can also define and save sets
@@ -205,22 +198,19 @@
 		
 		<variablelist>
 		  <varlistentry id="launch.with.command.line.windows">
-			<term id="launch.with.command.line.windows.title">
-			Windows</term>
+			<term id="launch.with.command.line.windows.title">Windows</term>
 			<listitem>
 			  <para><filename>C:\Program Files\OmegaT\OmegaT.jar</filename></para>
 			</listitem>
 		  </varlistentry>
 		  <varlistentry id="launch.with.command.line.macos">
-			<term id="launch.with.command.line.macos.title">
-			Macos</term>
+			<term id="launch.with.command.line.macos.title">Macos</term>
 			<listitem>
 			  <para><filename>/Applications/OmegaT.app/Contents/Java/OmegaT.jar</filename></para>
 			</listitem>
 		  </varlistentry>
 		  <varlistentry id="launch.with.command.line.linux">
-			<term id="launch.with.command.line.linux.title">
-			Linux</term>
+			<term id="launch.with.command.line.linux.title">Linux</term>
 			<listitem>
 			  <para><filename>/opt/omegat/OmegaT.jar</filename></para>
 
@@ -255,8 +245,7 @@
 
 	  <variablelist>
 		<varlistentry id="launch.with.command.line.java.jar">
-		  <term id="launch.with.command.line.java.jar.title">
-		  <option>java -jar</option></term>
+		  <term id="launch.with.command.line.java.jar.title"><option>java -jar</option></term>
 		  <listitem>
 			<para>This command tells the Java Virtual Machine to run a Jar
 			package.</para>
@@ -433,8 +422,7 @@
 				</listitem>
 			  </varlistentry>
 			  <varlistentry id="launch.with.command.line.no.team">
-				<term id="launch.with.command.line.no.team.title">
-				<option>--no-team</option></term>
+				<term id="launch.with.command.line.no.team.title"><option>--no-team</option></term>
 				<listitem>
 				  <para>Disable team project functionality. Use this option if
 				  you want to prevent OmegaT from synchronizing the project
@@ -550,8 +538,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.source.pattern.lt.pattern.gt">
-							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title">
-							<option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
+							<term id="launch.with.command.line.source.pattern.lt.pattern.gt.title"><option>--source-pattern=</option><userinput>&lt;pattern&gt;</userinput></term>
 							<listitem>
 							  <para>An allowlist of regular expressions defining
 							  the source files to process. Remember that in
@@ -563,15 +550,13 @@ config-dir="path/to/new/configdir"</programlisting>
 							  
 							  <variablelist>
 								<varlistentry id="launch.with.command.line.html">
-								  <term id="launch.with.command.line.html.title">
-								  <option>.*\.html</option></term>
+								  <term id="launch.with.command.line.html.title"><option>.*\.html</option></term>
 								  <listitem>
 									<para>Translate all HTML files.</para>
 								  </listitem>
 								</varlistentry>
 								<varlistentry id="launch.with.command.line.test.html">
-								  <term id="launch.with.command.line.test.html.title">
-								  <option>test\.html</option></term>
+								  <term id="launch.with.command.line.test.html.title"><option>test\.html</option></term>
 								  <listitem>
 									<para>Only translate
 									<filename>test.html</filename> file in the
@@ -647,8 +632,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.align.dir">
-							<term id="launch.with.command.line.align.dir.title">
-							<option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
+							<term id="launch.with.command.line.align.dir.title"><option>--alignDir=</option><userinput>&lt;project path&gt;</userinput></term>
 							<listitem>
 							  <para>The path containing the files translated in the target language.</para>
 
@@ -675,8 +659,7 @@ config-dir="path/to/new/configdir"</programlisting>
 					  <listitem>
 						<variablelist>
 						  <varlistentry id="launch.with.command.line.console.stats.output.file">
-							<term id="launch.with.command.line.console.stats.output.file.title">
-							<option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
+							<term id="launch.with.command.line.console.stats.output.file.title"><option>--output-file=</option><userinput>[stats-output-file]</userinput></term>
 							<listitem>
 							  <para>Prints to that file, or to standard output
 							  if absent. Without
@@ -687,8 +670,7 @@ config-dir="path/to/new/configdir"</programlisting>
 						  </varlistentry>
 						  
 						  <varlistentry id="launch.with.command.line.console.stats.output.format">
-							<term id="launch.with.command.line.console.stats.output.format.title">
-							<option>--stats-type=[xml|text][txt][json]]]</option></term>
+							<term id="launch.with.command.line.console.stats.output.format.title"><option>--stats-type=[xml|text][txt][json]]]</option></term>
 							<listitem>
 							  <para>Requires
 							  <emphasis>--output-file</emphasis>. Specifies the
@@ -717,8 +699,7 @@ config-dir="path/to/new/configdir"</programlisting>
 		  <listitem>
 			<variablelist>
 			  <varlistentry id="launch.with.command.line.quiet">
-				<term id="launch.with.command.line.quiet.title">
-				<option>--quiet</option></term>
+				<term id="launch.with.command.line.quiet.title"><option>--quiet</option></term>
 				<listitem>
 				  <para>Minimize the output shown on the command line.</para>
 				</listitem>

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.setup.team.project">
-  <title id="how.to.setup.team.project.title">Set up a team project</title>
+  <title id="how.to.setup.team.project.title"><link linkend="how.to.setup.team.project"> </link>Set up a team project</title>
 
   <para>Managing a team project calls for some knowledge of either the
   <emphasis>SVN</emphasis> or <emphasis>Git</emphasis> version control system
@@ -245,9 +245,7 @@
   </section>
 
   <section id="how.to.setup.team.project.mapping.parameters">
-	<title id="how.to.setup.team.project.mapping.parameters.title">
-      Repository
-	mappings</title>
+	<title id="how.to.setup.team.project.mapping.parameters.title"><link linkend="how.to.setup.team.project.mapping.parameters"> </link>Repository mappings</title>
 
 	<para>It is possible to map various remote locations to local files via the
 	OmegaT user interface using <link
@@ -265,7 +263,7 @@
 
 	<variablelist>
       <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.type">
-		<term id="how.to.setup.team.project.mapping.parameters.repository.type.title">repository type</term>
+		<term id="how.to.setup.team.project.mapping.parameters.repository.type.title"><link linkend="how.to.setup.team.project.mapping.parameters.repository.type"> </link>repository type</term>
 		<listitem>
           <para>This can be either <emphasis>http</emphasis> (which includes
           https), <emphasis>svn</emphasis>, <emphasis>git</emphasis>, or
@@ -274,14 +272,14 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.url">
-		<term id="how.to.setup.team.project.mapping.parameters.repository.url.title">repository url</term>
+		<term id="how.to.setup.team.project.mapping.parameters.repository.url.title"><link linkend="how.to.setup.team.project.mapping.parameters.repository.url"> </link>repository url</term>
 		<listitem>
           <para>Remote location or folder of the files to translate.</para>
 		</listitem>
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.local">
-		<term id="how.to.setup.team.project.mapping.parameters.mapping.local.title">mapping local</term>
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.local.title"><link linkend="how.to.setup.team.project.mapping.parameters.mapping.local"> </link>mapping local</term>
 		<listitem>
           <para>Name of the local folder or file, relative to the root of the
           OmegaT project.</para>
@@ -289,7 +287,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.repository">
-		<term id="how.to.setup.team.project.mapping.parameters.mapping.repository.title">mapping repository</term>
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.repository.title"><link linkend="how.to.setup.team.project.mapping.parameters.mapping.repository"> </link>mapping repository</term>
 		<listitem>
           <para>Name of the remote folder or file, relative to the repository
           url.</para>
@@ -297,7 +295,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.excludes">
-		<term id="how.to.setup.team.project.mapping.parameters.excludes.title">excludes</term>
+		<term id="how.to.setup.team.project.mapping.parameters.excludes.title"><link linkend="how.to.setup.team.project.mapping.parameters.excludes"> </link>excludes</term>
 		<listitem>
           <para>Use wildcards (following the Apache Ant style: *, ?, **) to add
           patterns for files that should not be part of the mapping. Use a
@@ -309,7 +307,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.includes">
-		<term id="how.to.setup.team.project.mapping.parameters.includes.title">includes</term>
+		<term id="how.to.setup.team.project.mapping.parameters.includes.title"><link linkend="how.to.setup.team.project.mapping.parameters.includes"> </link>includes</term>
 		<listitem>
           <para>As above, but for files that should be part of the mapping.
           Since files are included by default unless specifically excluded, this
@@ -324,9 +322,7 @@
   </section>
 
   <section id="how.to.setup.team.project.example.mappings">
-	<title id="how.to.setup.team.project.example.mappings.title">
-      Example
-	mappings</title>
+	<title id="how.to.setup.team.project.example.mappings.title"><link linkend="how.to.setup.team.project.example.mappings"> </link>Example mappings</title>
 
 	<para>Default project mapping:
 	<programlisting>&lt;repository type="svn" url="https://repo_for_OmegaT_team_project"&gt;
@@ -404,9 +400,7 @@
 
   </section>
   <section id="how.to.setup.team.project.selective.sharing">
-	<title id="how.to.setup.team.project.selective.sharing.title">
-      Selective
-	sharing</title>
+	<title id="how.to.setup.team.project.selective.sharing.title"><link linkend="how.to.setup.team.project.selective.sharing"> </link>Selective sharing</title>
 
 	<para>The above process describes the most common scenario, in which the
 	team project administrator has full control of the project and all files

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.setup.team.project">
-  <title id="how.to.setup.team.project.title">
-  Set up a team project</title>
+  <title id="how.to.setup.team.project.title">Set up a team project</title>
 
   <para>Managing a team project calls for some knowledge of either the
   <emphasis>SVN</emphasis> or <emphasis>Git</emphasis> version control system
@@ -266,8 +265,7 @@
 
 	<variablelist>
       <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.type">
-		<term id="how.to.setup.team.project.mapping.parameters.repository.type.title">
-		repository type</term>
+		<term id="how.to.setup.team.project.mapping.parameters.repository.type.title">repository type</term>
 		<listitem>
           <para>This can be either <emphasis>http</emphasis> (which includes
           https), <emphasis>svn</emphasis>, <emphasis>git</emphasis>, or
@@ -276,16 +274,14 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.url">
-		<term id="how.to.setup.team.project.mapping.parameters.repository.url.title">
-		repository url</term>
+		<term id="how.to.setup.team.project.mapping.parameters.repository.url.title">repository url</term>
 		<listitem>
           <para>Remote location or folder of the files to translate.</para>
 		</listitem>
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.local">
-		<term id="how.to.setup.team.project.mapping.parameters.mapping.local.title">
-		mapping local</term>
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.local.title">mapping local</term>
 		<listitem>
           <para>Name of the local folder or file, relative to the root of the
           OmegaT project.</para>
@@ -293,8 +289,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.repository">
-		<term id="how.to.setup.team.project.mapping.parameters.mapping.repository.title">
-		mapping repository</term>
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.repository.title">mapping repository</term>
 		<listitem>
           <para>Name of the remote folder or file, relative to the repository
           url.</para>
@@ -302,8 +297,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.excludes">
-		<term id="how.to.setup.team.project.mapping.parameters.excludes.title">
-		excludes</term>
+		<term id="how.to.setup.team.project.mapping.parameters.excludes.title">excludes</term>
 		<listitem>
           <para>Use wildcards (following the Apache Ant style: *, ?, **) to add
           patterns for files that should not be part of the mapping. Use a
@@ -315,8 +309,7 @@
       </varlistentry>
 
       <varlistentry id="how.to.setup.team.project.mapping.parameters.includes">
-		<term id="how.to.setup.team.project.mapping.parameters.includes.title">
-		includes</term>
+		<term id="how.to.setup.team.project.mapping.parameters.includes.title">includes</term>
 		<listitem>
           <para>As above, but for files that should be part of the mapping.
           Since files are included by default unless specifically excluded, this

--- a/doc_src/en/HowTo_SetUpTeamProject.xml
+++ b/doc_src/en/HowTo_SetUpTeamProject.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.setup.team.project">
-  <title id="how.to.setup.team.project.title">Set up a team project</title>
+  <title id="how.to.setup.team.project.title">
+  Set up a team project</title>
 
   <para>Managing a team project calls for some knowledge of either the
   <emphasis>SVN</emphasis> or <emphasis>Git</emphasis> version control system
@@ -15,7 +16,7 @@
   <note>
 	<para>An OmegaT team projects synchronizes the project translation memory
 	<link linkend="project.folder.project.save.tmx"
-	endterm="project.folder.project.save.tmx.title"/> and the project writable
+		  endterm="project.folder.project.save.tmx.title"/> and the project writable
 	glossary <link linkend="project.folder.glossary.txt"
 	endterm="project.folder.glossary.txt.title"/> between the hosting server and
 	all the participating team members, and manages all possible conflicts
@@ -23,15 +24,16 @@
   </note>
 
   <section id="how.to.setup.team.project.prepare.the.repository">
-    <title
-    id="how.to.setup.team.project.prepare.the.repository.title">Preparations</title>
+	<title
+		id="how.to.setup.team.project.prepare.the.repository.title">
+    Preparations</title>
 
 	<para>Here are the steps to set up a team project:</para>
 
 	<orderedlist>
       <listitem id="how.to.setup.team.project.create.empty.repository">
 		<para
-		id="how.to.setup.team.project.create.empty.repository.title">Create an
+			id="how.to.setup.team.project.create.empty.repository.title">Create an
 		empty repository on your VCS hosting server</para>
 
 		<para>This can normally be done through a web interface, a graphical
@@ -90,7 +92,7 @@
 
 			<para>Similarly add any relevant lists of spellchecker files you
 			want to make available to everyone working on the project. See <link
-			linkend="project.folder.omegat.spellcheck">spellchecker files</link>
+			linkend="project.folder.omegat.ignored.words">spellchecker files</link>
 			for details.</para>
 
 			<para>If you are converting an existing project, make sure you
@@ -244,7 +246,8 @@
   </section>
 
   <section id="how.to.setup.team.project.mapping.parameters">
-	<title id="how.to.setup.team.project.mapping.parameters.title">Repository
+	<title id="how.to.setup.team.project.mapping.parameters.title">
+      Repository
 	mappings</title>
 
 	<para>It is possible to map various remote locations to local files via the
@@ -262,8 +265,9 @@
 	use are provided in the next section.</para>
 
 	<variablelist>
-      <varlistentry>
-		<term>repository type</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.type">
+		<term id="how.to.setup.team.project.mapping.parameters.repository.type.title">
+		repository type</term>
 		<listitem>
           <para>This can be either <emphasis>http</emphasis> (which includes
           https), <emphasis>svn</emphasis>, <emphasis>git</emphasis>, or
@@ -271,31 +275,35 @@
 		</listitem>
       </varlistentry>
 
-      <varlistentry>
-		<term>repository url</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.repository.url">
+		<term id="how.to.setup.team.project.mapping.parameters.repository.url.title">
+		repository url</term>
 		<listitem>
           <para>Remote location or folder of the files to translate.</para>
 		</listitem>
       </varlistentry>
 
-      <varlistentry>
-		<term>mapping local</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.local">
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.local.title">
+		mapping local</term>
 		<listitem>
           <para>Name of the local folder or file, relative to the root of the
           OmegaT project.</para>
 		</listitem>
       </varlistentry>
 
-      <varlistentry>
-		<term>mapping repository</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.mapping.repository">
+		<term id="how.to.setup.team.project.mapping.parameters.mapping.repository.title">
+		mapping repository</term>
 		<listitem>
           <para>Name of the remote folder or file, relative to the repository
           url.</para>
 		</listitem>
       </varlistentry>
 
-      <varlistentry>
-		<term>excludes</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.excludes">
+		<term id="how.to.setup.team.project.mapping.parameters.excludes.title">
+		excludes</term>
 		<listitem>
           <para>Use wildcards (following the Apache Ant style: *, ?, **) to add
           patterns for files that should not be part of the mapping. Use a
@@ -306,8 +314,9 @@
 		</listitem>
       </varlistentry>
 
-      <varlistentry>
-		<term>includes</term>
+      <varlistentry id="how.to.setup.team.project.mapping.parameters.includes">
+		<term id="how.to.setup.team.project.mapping.parameters.includes.title">
+		includes</term>
 		<listitem>
           <para>As above, but for files that should be part of the mapping.
           Since files are included by default unless specifically excluded, this
@@ -322,7 +331,8 @@
   </section>
 
   <section id="how.to.setup.team.project.example.mappings">
-	<title id="how.to.setup.team.project.example.mappings.title">Example
+	<title id="how.to.setup.team.project.example.mappings.title">
+      Example
 	mappings</title>
 
 	<para>Default project mapping:
@@ -347,8 +357,8 @@
 	filters:
 	<programlisting>&lt;repository type="svn" url="https://repo_for_All_OmegaT_team_project_sources"&gt;
 	&lt;mapping local="source/subdir" repository=""&gt;
-	    &lt;excludes&gt;**/*.bak&lt;/excludes&gt;
-    	&lt;includes&gt;readme.bak&lt;/includes&gt;
+		&lt;excludes&gt;**/*.bak&lt;/excludes&gt;
+		&lt;includes&gt;readme.bak&lt;/includes&gt;
 	&lt;/mapping&gt;
 &lt;/repository&gt;</programlisting></para>
 
@@ -401,7 +411,8 @@
 
   </section>
   <section id="how.to.setup.team.project.selective.sharing">
-	<title id="how.to.setup.team.project.selective.sharing.title">Selective
+	<title id="how.to.setup.team.project.selective.sharing.title">
+      Selective
 	sharing</title>
 
 	<para>The above process describes the most common scenario, in which the

--- a/doc_src/en/HowTo_TranslateOtherFiles.xml
+++ b/doc_src/en/HowTo_TranslateOtherFiles.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.translate.other.files">
-  <title id="how.to.translate.other.files.title">Support other formats</title>
+  <title id="how.to.translate.other.files.title">
+  Support other formats</title>
 
   <para>OmegaT's file filters provide a wide range of support for common and
   less common file formats. If you need to support formats that are not covered
@@ -26,146 +27,148 @@
 	</listitem>
   </itemizedlist>
   
-	<section id="how.to.translate.other.files.associate">
-	  <title id="how.to.translate.other.files.associate.title">Association</title>
+  <section id="how.to.translate.other.files.associate">
+	<title id="how.to.translate.other.files.associate.title">
+    Association</title>
 
-	  <para>File filters have a list of file extensions that are associated to
-	  them. If the format you want to translate is structurally close to an
-	  already supported format, just add its file extension to the supported
-	  format extension list, or change the file extension to one that is
-	  accepted by the file filter that you want to use. See the <link
-	  linkend="file.filters" endterm="file.filters.title"/> chapter for
-	  details.</para>
-		
-	  <para>You can also use OmegaT's custom tag function to register format
-	  specific strings and have OmegaT handle them as if they were normal
-	  tags. See the <link
-	  linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"
-	  endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/>
-	  preferences for details.</para>
-	</section>
+	<para>File filters have a list of file extensions that are associated to
+	them. If the format you want to translate is structurally close to an
+	already supported format, just add its file extension to the supported
+	format extension list, or change the file extension to one that is
+	accepted by the file filter that you want to use. See the <link
+	linkend="file.filters" endterm="file.filters.title"/> chapter for
+	details.</para>
 	
-	<section id="how.to.translate.other.files.convert">
-	  <title id="how.to.translate.other.files.convert.title">Conversion</title>
-
-	  <para>To ensure that all the properties of a format are properly taken
-	  into account, it is sometimes preferable to convert the file to a
-	  supported format and then convert the translated file back to the original
-	  format.</para>
-
-	  <para>A number of free software third party utilities provide such
-		“round-trip” conversion, including:</para>
-	  
-	  <itemizedlist id="how.to.translate.other.files.third.party.utilities">
-		<listitem id="how.to.translate.other.files.third.party.utilities.rainbow">
-		  <para>Rainbow, from the <ulink url="https://okapiframework.org">Okapi
-		  Framework</ulink></para>
-
-		  <para>License: Apache License Version 2.0</para>
-
-		  <para>The Okapi Framework comes with a number of file filters,
-		  including some not supported natively by OmegaT. See <ulink
-		  url="https://okapiframework.org/wiki/index.php?title=Filters">List of
-		  file filters</ulink> for details.</para>
-
-		  <para>Rainbow can create XLIFF 1.2 compliant files or OmegaT projects
-		  from all the files set as “input” files. Rainbow-supported files are
-		  converted into XLIFF and inserted as source files into a full fledged
-		  OmegaT project that you can open with OmegaT right away. See <ulink
-		  url="https://okapiframework.org/wiki/index.php/Rainbow_TKit_-_OmegaT_Project">Rainbow
-		  TKit - OmegaT Project</ulink> for details.</para>
-		</listitem>
-
-		<listitem id="how.to.translate.other.files.third.party.utilities.po4a">
-		  <para><ulink url="https://po4a.org">po4a</ulink></para>
-
-		  <para>License: GNU General Public License v2</para>
-
-		  <para>po4a supports a number of free software documentation formats,
-		  listed on the site front page, and offers conversion tools to and from
-		  the po format. See the <link linkend="file.filters.po"
-		  endterm="file.filters.po.title"/> section for details.</para>
-		</listitem>
-
-		<listitem>
-		  <para>The converters from the <ulink
-		  url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/index.html">Translate
-		  Toolkit</ulink></para>
-
-		  <para>License: GNU General Public License v2</para>
-
-		  <para>The Translate Toolkit offers a number of convertion tools to and
-		  from the po format. See <ulink
-		  url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/index.html">Converters</ulink>
-		  for details.</para>
-		</listitem>
-
-		<listitem id="how.to.translate.other.files.third.party.utilities.openxliff">
-		  <para>OpenXLIFF from <ulink
-		  url="https://maxprograms.com/">Maxprograms</ulink></para>
-
-		  <para>License:  Eclipse Public License v1.0</para>
-
-		  <para>OpenXLIFF supports a number of file filters, including some
-		  not supported natively by OmegaT. See <ulink
-		  url="https://maxprograms.com/products/openxliff.html">OpenXLIFF
-		  Filters</ulink> for details. Maxprograms also distributes <ulink
-		  url="https://maxprograms.com/products/xliffmanager.html">XLIFF
-		  Manager</ulink>, a graphical user interface for the OpenXLIFF
-		  Filters.</para>
-
-		  <para>OpenXLIFF produces XLIFF 1.2 compliant files.</para>
-		</listitem>
-	  </itemizedlist>
-	  
-		<para>Some formats, like PDF, cannot be properly handled through “round
-		trip” conversions. They require an intermediate conversion to a supported
-		format that serves as a base to manually create a proper target language
-		document.</para>
-		
-		<para>You can find a number of online or offline utilities that convert PDF
-		to common office formats, but the conversion will always require extensive
-		manual adjustments to the target document before a proper PDF document can
-		be produced. Make sure you understand the format requirements when you
-		start working on a PDF or similar file.</para>
-	  </section>
-
-	  <section
-		  id="how.to.translate.other.files.third.party.plugins">
-		<title
-		id="how.to.translate.other.files.third.party.plugins.title">Third-party
-		plugins</title>
-
-		<itemizedlist>
-		  <listitem>
-			<para>The Okapi Filters Plugin for OmegaT, from the <ulink
-			url="https://okapiframework.org">Okapi Framework</ulink></para>
-
-			<para>License: Apache License Version 2.0</para>
-
-			<para>Not all of the Okapi Framework file filters are included into
-			the file filter plugin. See <ulink
-			url="https://okapiframework.org/wiki/index.php/Okapi_Filters_Plugin_for_OmegaT#Filters_Included">Filters
-			Included</ulink> for details.</para>
-
-			<para>When installed, the plugin offers direct access to the added
-			formats and also allows you to associate a custom filter parameters
-			file created in Rainbow. See <link
-			linkend="how.to.translate.other.files.third.party.utilities.rainbow">above</link>.</para>
-		  </listitem>
-		</itemizedlist>
-
-		<para>Other plugins for less common formats are listed on the OmegaT
-		wiki. See <ulink
-		url="https://sourceforge.net/p/omegat/wiki/Plugins/">Plugins</ulink>.</para>
-	</section>
-
-	<section id="how.to.translate.other.files.develop">
-	  <title id="how.to.translate.other.files.develop.title">Development</title>
-
-	  <para>OmegaT provides developers with thorough documentation to create
-	  file filter plugins. See <ulink
-	  url="https://omegat.readthedocs.io/en/latest/11.HowToCreateFilterPlugin/">How
-	  to create a file filter plugin for OmegaT</ulink> for details.</para>
-	</section>
+	<para>You can also use OmegaT's custom tag function to register format
+	specific strings and have OmegaT handle them as if they were normal
+	tags. See the <link
+	linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"
+	endterm="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"/>
+	preferences for details.</para>
   </section>
+  
+  <section id="how.to.translate.other.files.convert">
+	<title id="how.to.translate.other.files.convert.title">
+    Conversion</title>
+
+	<para>To ensure that all the properties of a format are properly taken
+	into account, it is sometimes preferable to convert the file to a
+	supported format and then convert the translated file back to the original
+	format.</para>
+
+	<para>A number of free software third party utilities provide such
+	“round-trip” conversion, including:</para>
+	
+	<itemizedlist id="how.to.translate.other.files.third.party.utilities">
+	  <listitem id="how.to.translate.other.files.third.party.utilities.rainbow">
+		<para>Rainbow, from the <ulink url="https://okapiframework.org">Okapi
+		Framework</ulink></para>
+
+		<para>License: Apache License Version 2.0</para>
+
+		<para>The Okapi Framework comes with a number of file filters,
+		including some not supported natively by OmegaT. See <ulink
+		url="https://okapiframework.org/wiki/index.php?title=Filters">List of
+		file filters</ulink> for details.</para>
+
+		<para>Rainbow can create XLIFF 1.2 compliant files or OmegaT projects
+		from all the files set as “input” files. Rainbow-supported files are
+		converted into XLIFF and inserted as source files into a full fledged
+		OmegaT project that you can open with OmegaT right away. See <ulink
+		url="https://okapiframework.org/wiki/index.php/Rainbow_TKit_-_OmegaT_Project">Rainbow
+		TKit - OmegaT Project</ulink> for details.</para>
+	  </listitem>
+
+	  <listitem id="how.to.translate.other.files.third.party.utilities.po4a">
+		<para><ulink url="https://po4a.org">po4a</ulink></para>
+
+		<para>License: GNU General Public License v2</para>
+
+		<para>po4a supports a number of free software documentation formats,
+		listed on the site front page, and offers conversion tools to and from
+		the po format. See the <link linkend="file.filters.po"
+		endterm="file.filters.po.title"/> section for details.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>The converters from the <ulink
+		url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/index.html">Translate
+		Toolkit</ulink></para>
+
+		<para>License: GNU General Public License v2</para>
+
+		<para>The Translate Toolkit offers a number of convertion tools to and
+		from the po format. See <ulink
+		url="http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/index.html">Converters</ulink>
+		for details.</para>
+	  </listitem>
+
+	  <listitem id="how.to.translate.other.files.third.party.utilities.openxliff">
+		<para>OpenXLIFF from <ulink
+		url="https://maxprograms.com/">Maxprograms</ulink></para>
+
+		<para>License:  Eclipse Public License v1.0</para>
+
+		<para>OpenXLIFF supports a number of file filters, including some
+		not supported natively by OmegaT. See <ulink
+		url="https://maxprograms.com/products/openxliff.html">OpenXLIFF
+		Filters</ulink> for details. Maxprograms also distributes <ulink
+		url="https://maxprograms.com/products/xliffmanager.html">XLIFF
+		Manager</ulink>, a graphical user interface for the OpenXLIFF
+		Filters.</para>
+
+		<para>OpenXLIFF produces XLIFF 1.2 compliant files.</para>
+	  </listitem>
+	</itemizedlist>
+	
+	<para>Some formats, like PDF, cannot be properly handled through “round
+	trip” conversions. They require an intermediate conversion to a supported
+	format that serves as a base to manually create a proper target language
+	document.</para>
+	
+	<para>You can find a number of online or offline utilities that convert PDF
+	to common office formats, but the conversion will always require extensive
+	manual adjustments to the target document before a proper PDF document can
+	be produced. Make sure you understand the format requirements when you
+	start working on a PDF or similar file.</para>
+  </section>
+
+  <section id="how.to.translate.other.files.third.party.plugins">
+	<title id="how.to.translate.other.files.third.party.plugins.title">
+      Third-party
+	plugins</title>
+
+	<itemizedlist>
+	  <listitem>
+		<para>The Okapi Filters Plugin for OmegaT, from the <ulink
+		url="https://okapiframework.org">Okapi Framework</ulink></para>
+
+		<para>License: Apache License Version 2.0</para>
+
+		<para>Not all of the Okapi Framework file filters are included into
+		the file filter plugin. See <ulink
+		url="https://okapiframework.org/wiki/index.php/Okapi_Filters_Plugin_for_OmegaT#Filters_Included">Filters
+		Included</ulink> for details.</para>
+
+		<para>When installed, the plugin offers direct access to the added
+		formats and also allows you to associate a custom filter parameters
+		file created in Rainbow. See <link
+		linkend="how.to.translate.other.files.third.party.utilities.rainbow">above</link>.</para>
+	  </listitem>
+	</itemizedlist>
+
+	<para>Other plugins for less common formats are listed on the OmegaT
+	wiki. See <ulink
+	url="https://sourceforge.net/p/omegat/wiki/Plugins/">Plugins</ulink>.</para>
+  </section>
+
+  <section id="how.to.translate.other.files.develop">
+	<title id="how.to.translate.other.files.develop.title">
+    Development</title>
+
+	<para>OmegaT provides developers with thorough documentation to create
+	file filter plugins. See <ulink
+	url="https://omegat.readthedocs.io/en/latest/11.HowToCreateFilterPlugin/">How
+	to create a file filter plugin for OmegaT</ulink> for details.</para>
+  </section>
+</section>

--- a/doc_src/en/HowTo_TranslateOtherFiles.xml
+++ b/doc_src/en/HowTo_TranslateOtherFiles.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.translate.other.files">
-  <title id="how.to.translate.other.files.title">Support other formats</title>
+  <title id="how.to.translate.other.files.title"><link linkend="how.to.translate.other.files"> </link>Support other formats</title>
 
   <para>OmegaT's file filters provide a wide range of support for common and
   less common file formats. If you need to support formats that are not covered
@@ -27,7 +27,7 @@
   </itemizedlist>
   
   <section id="how.to.translate.other.files.associate">
-	<title id="how.to.translate.other.files.associate.title">Association</title>
+	<title id="how.to.translate.other.files.associate.title"><link linkend="how.to.translate.other.files.associate"> </link>Association</title>
 
 	<para>File filters have a list of file extensions that are associated to
 	them. If the format you want to translate is structurally close to an
@@ -46,7 +46,7 @@
   </section>
   
   <section id="how.to.translate.other.files.convert">
-	<title id="how.to.translate.other.files.convert.title">Conversion</title>
+	<title id="how.to.translate.other.files.convert.title"><link linkend="how.to.translate.other.files.convert"> </link>Conversion</title>
 
 	<para>To ensure that all the properties of a format are properly taken
 	into account, it is sometimes preferable to convert the file to a
@@ -131,9 +131,7 @@
   </section>
 
   <section id="how.to.translate.other.files.third.party.plugins">
-	<title id="how.to.translate.other.files.third.party.plugins.title">
-      Third-party
-	plugins</title>
+	<title id="how.to.translate.other.files.third.party.plugins.title"><link linkend="how.to.translate.other.files.third.party.plugins"> </link>Third-party plugins</title>
 
 	<itemizedlist>
 	  <listitem>
@@ -160,7 +158,7 @@
   </section>
 
   <section id="how.to.translate.other.files.develop">
-	<title id="how.to.translate.other.files.develop.title">Development</title>
+	<title id="how.to.translate.other.files.develop.title"><link linkend="how.to.translate.other.files.develop"> </link>Development</title>
 
 	<para>OmegaT provides developers with thorough documentation to create
 	file filter plugins. See <ulink

--- a/doc_src/en/HowTo_TranslateOtherFiles.xml
+++ b/doc_src/en/HowTo_TranslateOtherFiles.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.translate.other.files">
-  <title id="how.to.translate.other.files.title">
-  Support other formats</title>
+  <title id="how.to.translate.other.files.title">Support other formats</title>
 
   <para>OmegaT's file filters provide a wide range of support for common and
   less common file formats. If you need to support formats that are not covered
@@ -28,8 +27,7 @@
   </itemizedlist>
   
   <section id="how.to.translate.other.files.associate">
-	<title id="how.to.translate.other.files.associate.title">
-    Association</title>
+	<title id="how.to.translate.other.files.associate.title">Association</title>
 
 	<para>File filters have a list of file extensions that are associated to
 	them. If the format you want to translate is structurally close to an
@@ -48,8 +46,7 @@
   </section>
   
   <section id="how.to.translate.other.files.convert">
-	<title id="how.to.translate.other.files.convert.title">
-    Conversion</title>
+	<title id="how.to.translate.other.files.convert.title">Conversion</title>
 
 	<para>To ensure that all the properties of a format are properly taken
 	into account, it is sometimes preferable to convert the file to a
@@ -163,8 +160,7 @@
   </section>
 
   <section id="how.to.translate.other.files.develop">
-	<title id="how.to.translate.other.files.develop.title">
-    Development</title>
+	<title id="how.to.translate.other.files.develop.title">Development</title>
 
 	<para>OmegaT provides developers with thorough documentation to create
 	file filter plugins. See <ulink

--- a/doc_src/en/HowTo_UseTM.xml
+++ b/doc_src/en/HowTo_UseTM.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.tm">
-  <title id="how.to.use.tm.title">Use translation memories</title>
+  <title id="how.to.use.tm.title"><link linkend="how.to.use.tm"> </link>Use translation memories</title>
 
   <para>When a project is initially created, it comes with its own empty project
   translation memory, the <link linkend="project.folder.project.save.tmx.title"
@@ -37,7 +37,7 @@
   </itemizedlist>
 
   <section id="how.to.use.tm.create.your.tm">
-	<title id="how.to.use.tm.create.your.tm.title">Create your own TMs</title>
+	<title id="how.to.use.tm.create.your.tm.title"><link linkend="how.to.use.tm.create.your.tm"> </link>Create your own TMs</title>
 	
 	<para>When you use <link linkend="menus.project"
 	endterm="menus.project.title"/><link
@@ -63,7 +63,7 @@
   </section>
 
   <section id="how.to.use.tm.reuse.tm">
-	<title id="how.to.use.tm.reuse.tm.title">Reuse TMs</title>
+	<title id="how.to.use.tm.reuse.tm.title"><link linkend="how.to.use.tm.reuse.tm"> </link>Reuse TMs</title>
 	
 	<para>To reuse translation memories from a previous project you have two
 	options:</para>
@@ -168,9 +168,7 @@
 	</itemizedlist>
 	
     <section id="how.to.tm.read.and.write">
-	  <title id="how.to.tm.read.and.write.title">
-		Reading TMs from other
-      tools</title>
+	  <title id="how.to.tm.read.and.write.title"><link linkend="how.to.tm.read.and.write"> </link>Reading TMs from other tools</title>
 
       <para>OmegaT can read TMX-standard compliant memories produced by other
       tools.</para>
@@ -184,7 +182,7 @@
 	</section>
 
 	<section id="how.to.use.tm.store.your.tm">
-	  <title id="how.to.use.tm.store.your.tm.title">Managing your TMs</title>
+	  <title id="how.to.use.tm.store.your.tm.title"><link linkend="how.to.use.tm.store.your.tm"> </link>Managing your TMs</title>
 
 	  <para>You may want to store translation memories in separate folders, by
 	  client or area of specialty so you can reuse them quickly when the need
@@ -196,9 +194,7 @@
 	</section>
 	
 	<section id="how.to.tm.creating.a.tm.for.selected.documents">
-	  <title id="how.to.tm.creating.a.tm.for.selected.documents.title">
-		Creating
-      a TM specific to selected documents</title>
+	  <title id="how.to.tm.creating.a.tm.for.selected.documents.title"><link linkend="how.to.tm.creating.a.tm.for.selected.documents"> </link>Creating a TM specific to selected documents</title>
 
       <para>In situations where you need to share a TMX that contain only the
       text from certain specific files and excludes other content, follow the
@@ -247,7 +243,7 @@
   </section>
 
   <section id="how.to.tm.share.translation.memories">
-	<title id="how.to.tm.share.translation.memories.title">Share TMs</title>
+	<title id="how.to.tm.share.translation.memories.title"><link linkend="how.to.tm.share.translation.memories"> </link>Share TMs</title>
 
 	<para>For large jobs involving a team of translators, it is easier for
 	everyone involved in sharing common translation memories rather than pass
@@ -257,7 +253,7 @@
 
 	<variablelist>
 	  <varlistentry id="how.to.tm.share.translation.memories.good.enough.way">
-		<term id="how.to.tm.share.translation.memories.good.enough.way.title">The good enough way</term>
+		<term id="how.to.tm.share.translation.memories.good.enough.way.title"><link linkend="how.to.tm.share.translation.memories.good.enough.way"> </link>The good enough way</term>
 		<listitem>
 		  
 		  <para>See the <link linkend="how.to.use.tm.create.your.tm"
@@ -298,7 +294,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="how.to.tm.share.translation.memories.technical.approach">
-		<term id="how.to.tm.share.translation.memories.technical.approach.title">The technical approach</term>
+		<term id="how.to.tm.share.translation.memories.technical.approach.title"><link linkend="how.to.tm.share.translation.memories.technical.approach"> </link>The technical approach</term>
 		<listitem>
 		  <para>OmegaT uses collaborative version control systems to share
 		  data.</para>
@@ -327,7 +323,7 @@
   </section>
 
   <section id="how.to.tm.bridge.two.languages">
-	<title id="how.to.tm.bridge.two.languages.title">Bridge two languages</title>
+	<title id="how.to.tm.bridge.two.languages.title"><link linkend="how.to.tm.bridge.two.languages"> </link>Bridge two languages</title>
 
 	<para>OmegaT displays fuzzy matches in the <link linkend="panes.fuzzy.matches"
 	endterm="panes.fuzzy.matches.title"/> pane. By default, those matches are limited to the source and target languages defined in the <link
@@ -390,9 +386,7 @@
 	</orderedlist>
 
 	<example id="bridge.english.and.french.with.japanese">
-	  <title id="bridge.english.and.french.with.japanese.title">
-		Using a Japanese reference under the
-	  English source</title>
+	  <title id="bridge.english.and.french.with.japanese.title"><link linkend="bridge.english.and.french.with.japanese"> </link>Using a Japanese reference under the English source</title>
 	  <para>If you have a TMX that contains the Japanese translation of an
 	  English document you are translating to French, you can use the Japanese
 	  translation as an alternative exact reference by displaying it under the

--- a/doc_src/en/HowTo_UseTM.xml
+++ b/doc_src/en/HowTo_UseTM.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.tm">
-  <title id="how.to.use.tm.title">Use translation memories</title>
+  <title id="how.to.use.tm.title">
+  Use translation memories</title>
 
   <para>When a project is initially created, it comes with its own empty project
   translation memory, the <link linkend="project.folder.project.save.tmx.title"
@@ -10,34 +11,35 @@
   linkend="project.folder.omegat" endterm="project.folder.omegat.title"/>
   folder. This memory is gradually filled as your translation progresses.</para>
 
-	<para>Existing translations are used to speed up the translation
-	process.</para>
+  <para>Existing translations are used to speed up the translation
+  process.</para>
 
-	<itemizedlist>
-	  <listitem>
-		<para>If a given sentence has already been translated once, there is no
-		need to retranslate it. See the <link
-		linkend="dialogs.project.properties.auto.propagation"
-		endterm="dialogs.project.properties.auto.propagation.title"/> project
-		property.</para>
-	  </listitem>
+  <itemizedlist>
+	<listitem>
+	  <para>If a given sentence has already been translated once, there is no
+	  need to retranslate it. See the <link
+	  linkend="dialogs.project.properties.auto.propagation"
+	  endterm="dialogs.project.properties.auto.propagation.title"/> project
+	  property.</para>
+	</listitem>
 
-	  <listitem>
-		<para>If an old translation is similar to the contents of the segment
-		you are translating, you can recycle it in your translation. See the
-		<link linkend="panes.fuzzy.matches"
-		endterm="panes.fuzzy.matches.title"/> pane for details.</para>
-	  </listitem>
+	<listitem>
+	  <para>If an old translation is similar to the contents of the segment
+	  you are translating, you can recycle it in your translation. See the
+	  <link linkend="panes.fuzzy.matches"
+			endterm="panes.fuzzy.matches.title"/> pane for details.</para>
+	</listitem>
 
-	  <listitem>
-		<para>You can also make use of reference translation memories by putting
-		them in the <link linkend="project.folder.tm"
-		endterm="project.folder.tm.title"/> folder of your project.</para>
-	  </listitem>
-	</itemizedlist>
+	<listitem>
+	  <para>You can also make use of reference translation memories by putting
+	  them in the <link linkend="project.folder.tm"
+	  endterm="project.folder.tm.title"/> folder of your project.</para>
+	</listitem>
+  </itemizedlist>
 
   <section id="how.to.use.tm.create.your.tm">
-	<title id="how.to.use.tm.create.your.tm.title">Create your own TMs</title>
+	<title id="how.to.use.tm.create.your.tm.title">
+    Create your own TMs</title>
 	
 	<para>When you use <link linkend="menus.project"
 	endterm="menus.project.title"/><link
@@ -63,7 +65,8 @@
   </section>
 
   <section id="how.to.use.tm.reuse.tm">
-	<title id="how.to.use.tm.reuse.tm.title">Reuse TMs</title>
+	<title id="how.to.use.tm.reuse.tm.title">
+    Reuse TMs</title>
 	
 	<para>To reuse translation memories from a previous project you have two
 	options:</para>
@@ -160,15 +163,16 @@
 		  </listitem>
 		</itemizedlist>
 
-	  <para>You can add such files to your project's <link
-	  linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder or
-	  one of its subfolders and the translated data will be immediately be
-	  available for matching purposes.</para>
+		<para>You can add such files to your project's <link
+		linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder or
+		one of its subfolders and the translated data will be immediately be
+		available for matching purposes.</para>
 	  </listitem>
 	</itemizedlist>
 	
     <section id="how.to.tm.read.and.write">
-      <title id="how.to.tm.read.and.write.title">Reading TMs from other
+	  <title id="how.to.tm.read.and.write.title">
+		Reading TMs from other
       tools</title>
 
       <para>OmegaT can read TMX-standard compliant memories produced by other
@@ -183,7 +187,8 @@
 	</section>
 
 	<section id="how.to.use.tm.store.your.tm">
-	  <title id="how.to.use.tm.store.your.tm.title">Managing your TMs</title>
+	  <title id="how.to.use.tm.store.your.tm.title">
+      Managing your TMs</title>
 
 	  <para>You may want to store translation memories in separate folders, by
 	  client or area of specialty so you can reuse them quickly when the need
@@ -193,9 +198,10 @@
 	  endterm="dialogs.project.properties.file.locations.title"/> section of the
 	  project property dialog.</para>
 	</section>
-  
+	
 	<section id="how.to.tm.creating.a.tm.for.selected.documents">
-      <title id="how.to.tm.creating.a.tm.for.selected.documents.title">Creating
+	  <title id="how.to.tm.creating.a.tm.for.selected.documents.title">
+		Creating
       a TM specific to selected documents</title>
 
       <para>In situations where you need to share a TMX that contain only the
@@ -239,109 +245,113 @@
       contain only the original and translated text from the files you copied
       into the source folder, in the selected language pair. See the
       <link linkend="dialogs.project.properties.file.locations.exported.tms"
-      endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
+			endterm="dialogs.project.properties.file.locations.exported.tms.title"/>
       project property for details.</para>
+	</section>
   </section>
-</section>
 
-<section id="how.to.tm.share.translation.memories">
-  <title id="how.to.tm.share.translation.memories.title">Share TMs</title>
+  <section id="how.to.tm.share.translation.memories">
+	<title id="how.to.tm.share.translation.memories.title">
+    Share TMs</title>
 
-  <para>For large jobs involving a team of translators, it is easier for
-  everyone involved in sharing common translation memories rather than pass
-  local versions back and forth.</para>
+	<para>For large jobs involving a team of translators, it is easier for
+	everyone involved in sharing common translation memories rather than pass
+	local versions back and forth.</para>
 
-  <para>There are two ways to share translation memories:</para>
+	<para>There are two ways to share translation memories:</para>
 
-  <variablelist>
-	<varlistentry>
-	  <term>The good enough way</term>
-	  <listitem>
-		
-		<para>See the <link linkend="how.to.use.tm.create.your.tm"
-		endterm="how.to.use.tm.create.your.tm.title"/> section above.</para>
+	<variablelist>
+	  <varlistentry id="how.to.tm.share.translation.memories.good.enough.way">
+		<term id="how.to.tm.share.translation.memories.good.enough.way.title">
+		The good enough way</term>
+		<listitem>
+		  
+		  <para>See the <link linkend="how.to.use.tm.create.your.tm"
+		  endterm="how.to.use.tm.create.your.tm.title"/> section above.</para>
 
-		<para>If you write the TMX file to a folder on a shared disk, you can
-		ask your partner to assign that folder as the <link
-		linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder
-		for the current translation.</para>
+		  <para>If you write the TMX file to a folder on a shared disk, you can
+		  ask your partner to assign that folder as the <link
+		  linkend="project.folder.tm" endterm="project.folder.tm.title"/> folder
+		  for the current translation.</para>
 
-		<para>Conversely, you can ask your partner to write the project TMX
-		files to a folder on a shared disk that you will assign as
-		your <link linkend="project.folder.tm"
-		endterm="project.folder.tm.title"/> folder for the current
-		translation.</para>
+		  <para>Conversely, you can ask your partner to write the project TMX
+		  files to a folder on a shared disk that you will assign as
+		  your <link linkend="project.folder.tm"
+		  endterm="project.folder.tm.title"/> folder for the current
+		  translation.</para>
 
-		<para>OmegaT instantaneously recognizes modifications to TMX files.
-		Therefore, any time one side creates or modifies such a TMX using <link
-		linkend="menus.project"
-		endterm="menus.project.title"/><link
-		linkend="menus.project.create.translated.documents"
-		endterm="menus.project.create.translated.documents.title"/>, the other
-		side does not need to do anything to have that TMX recognized
-		locally.</para>
+		  <para>OmegaT instantaneously recognizes modifications to TMX files.
+		  Therefore, any time one side creates or modifies such a TMX using <link
+		  linkend="menus.project"
+		  endterm="menus.project.title"/><link
+		  linkend="menus.project.create.translated.documents"
+		  endterm="menus.project.create.translated.documents.title"/>, the other
+		  side does not need to do anything to have that TMX recognized
+		  locally.</para>
 
-		<para>This approach also works just as well for sharing glossaries where
-		the project writable glossary (with a non-default name to avoid
-		overwriting the file) is located in a shared glossary folder. See the <link
-		linkend="app.glossaries" endterm="app.glossaries.title"/> appendix for
-		details.</para>
+		  <para>This approach also works just as well for sharing glossaries where
+		  the project writable glossary (with a non-default name to avoid
+		  overwriting the file) is located in a shared glossary folder. See the <link
+		  linkend="app.glossaries" endterm="app.glossaries.title"/> appendix for
+		  details.</para>
 
-		<note>
-		  <para>This approach to sharing works well when the lag between TMX
+		  <note>
+			<para>This approach to sharing works well when the lag between TMX
 			updates is not important: a translator sending data to a reviewer a few
-		  times a day, for example.</para>
-		</note>
-	  </listitem>
-	</varlistentry>
-	
-	<varlistentry>
-	  <term>The technical approach</term>
-	  <listitem>
-		<para>OmegaT uses collaborative version control systems to share
-		data.</para>
+			times a day, for example.</para>
+		  </note>
+		</listitem>
+	  </varlistentry>
+	  
+	  <varlistentry id="how.to.tm.share.translation.memories.technical.approach">
+		<term id="how.to.tm.share.translation.memories.technical.approach.title">
+		The technical approach</term>
+		<listitem>
+		  <para>OmegaT uses collaborative version control systems to share
+		  data.</para>
 
-		<para>Such systems are free to use, install and manage and are widely
-		used in the computer development world, making them extremely
-		robust.</para>
+		  <para>Such systems are free to use, install and manage and are widely
+		  used in the computer development world, making them extremely
+		  robust.</para>
 
-		<para>See the <link linkend="how.to.setup.team.project"
-		endterm="how.to.setup.team.project.title"/> how-to for details.</para>
-	  </listitem>
-	</varlistentry>
-  </variablelist>
-  <warning>
-	<para>Be cautious when you put a whole project in a file-sharing system like
-	DropBox, OneCloud and the likes.</para>
-	<para><emphasis>Such systems are not designed to keep track of the internal
-	modifications of a given file.</emphasis></para>
-	<para>An OmegaT project is a complex set of files. Such systems will not
-	always be able to provide you with the most recent version of your data, may
-	even lock some files for no obvious reasons and can even corrupt team
-	project related files.</para>
-	<para>Make sure that you have properly tested your project layout and set up
-	a separate data backup before sharing data in such a system.</para>
-  </warning>
-</section>
+		  <para>See the <link linkend="how.to.setup.team.project"
+		  endterm="how.to.setup.team.project.title"/> how-to for details.</para>
+		</listitem>
+	  </varlistentry>
+	</variablelist>
+	<warning>
+	  <para>Be cautious when you put a whole project in a file-sharing system like
+	  DropBox, OneCloud and the likes.</para>
+	  <para><emphasis>Such systems are not designed to keep track of the internal
+	  modifications of a given file.</emphasis></para>
+	  <para>An OmegaT project is a complex set of files. Such systems will not
+	  always be able to provide you with the most recent version of your data, may
+	  even lock some files for no obvious reasons and can even corrupt team
+	  project related files.</para>
+	  <para>Make sure that you have properly tested your project layout and set up
+	  a separate data backup before sharing data in such a system.</para>
+	</warning>
+  </section>
 
-<section id="how.to.tm.bridge.two.languages">
-  <title id="how.to.tm.bridge.two.languages.title">Bridge two languages</title>
+  <section id="how.to.tm.bridge.two.languages">
+	<title id="how.to.tm.bridge.two.languages.title">
+    Bridge two languages</title>
 
-  <para>OmegaT displays fuzzy matches in the <link linkend="panes.fuzzy.matches"
-  endterm="panes.fuzzy.matches.title"/> pane. By default, those matches are limited to the source and target languages defined in the <link
-  linkend="dialogs.project.properties"
-  endterm="dialogs.project.properties.title"/> dialog.</para>
+	<para>OmegaT displays fuzzy matches in the <link linkend="panes.fuzzy.matches"
+	endterm="panes.fuzzy.matches.title"/> pane. By default, those matches are limited to the source and target languages defined in the <link
+	linkend="dialogs.project.properties"
+	endterm="dialogs.project.properties.title"/> dialog.</para>
 
-  <para>You can add matches in languages that are not the target language. See
-  the <link linkend="dialog.preferences.tm.matches.other.languages"
-  endterm="dialog.preferences.tm.matches.other.languages.title"/> preference for
-  details.</para>
+	<para>You can add matches in languages that are not the target language. See
+	the <link linkend="dialog.preferences.tm.matches.other.languages"
+	endterm="dialog.preferences.tm.matches.other.languages.title"/> preference for
+	details.</para>
 
-  <para>If you have a TMX that corresponds to your source document and contains its translation to a different language, you can also display that
-  language <emphasis>right below</emphasis> the source segment for use as an
-  additional reference language.</para>
+	<para>If you have a TMX that corresponds to your source document and contains its translation to a different language, you can also display that
+	language <emphasis>right below</emphasis> the source segment for use as an
+	additional reference language.</para>
 
-  <para>To achieve this:</para>
+	<para>To achieve this:</para>
 
 	<orderedlist>
 	  <listitem>
@@ -387,28 +397,29 @@
 	  </listitem>
 	</orderedlist>
 
-  <example id="bridge.english.and.french.with.japanese">
-	<title id="replace.with.allemand.title">Using a Japanese reference under the
-	English source</title>
-	<para>If you have a TMX that contains the Japanese translation of an
-	English document you are translating to French, you can use the Japanese
-	translation as an alternative exact reference by displaying it under the
-	English text to translate.</para>
-	<para>Just put the English-Japanese file in <filename
-	class="directory">tm/tmx2source</filename> under the name
-	<filename>JA-JP.tmx</filename>. OmegaT will now show you the Japanese text
-	corresponding to the English source segment:</para>
-	<para>
-	  <programlisting>— ¶ —————————————————————
+	<example id="bridge.english.and.french.with.japanese">
+	  <title id="bridge.english.and.french.with.japanese.title">
+		Using a Japanese reference under the
+	  English source</title>
+	  <para>If you have a TMX that contains the Japanese translation of an
+	  English document you are translating to French, you can use the Japanese
+	  translation as an alternative exact reference by displaying it under the
+	  English text to translate.</para>
+	  <para>Just put the English-Japanese file in <filename
+	  class="directory">tm/tmx2source</filename> under the name
+	  <filename>JA-JP.tmx</filename>. OmegaT will now show you the Japanese text
+	  corresponding to the English source segment:</para>
+	  <para>
+		<programlisting>— ¶ —————————————————————
 <token>A whitespace character: [ \t\n\x0B\f\r]
 ja-JP: 空白文字：[ \t\n\x0B\f\r]</token>
 Un caractère d'espacement : [ \t\n\r\f\x0B]<token>&lt;segment 3075 ¶></token>
 — ¶ —————————————————————</programlisting></para>
-<para>The first line is the original English, the second line is the bridge
-language you expect to find useful when you create your translation, and the
-third line is the current translation to French.</para>
-  </example>
-  
+	  <para>The first line is the original English, the second line is the bridge
+	  language you expect to find useful when you create your translation, and the
+	  third line is the current translation to French.</para>
+	</example>
+	
     <note>
 	  <para>You can use any number of TMX files containing as many different bridge language pairs as you want.</para>	  
 	</note>

--- a/doc_src/en/HowTo_UseTM.xml
+++ b/doc_src/en/HowTo_UseTM.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.tm">
-  <title id="how.to.use.tm.title">
-  Use translation memories</title>
+  <title id="how.to.use.tm.title">Use translation memories</title>
 
   <para>When a project is initially created, it comes with its own empty project
   translation memory, the <link linkend="project.folder.project.save.tmx.title"
@@ -38,8 +37,7 @@
   </itemizedlist>
 
   <section id="how.to.use.tm.create.your.tm">
-	<title id="how.to.use.tm.create.your.tm.title">
-    Create your own TMs</title>
+	<title id="how.to.use.tm.create.your.tm.title">Create your own TMs</title>
 	
 	<para>When you use <link linkend="menus.project"
 	endterm="menus.project.title"/><link
@@ -65,8 +63,7 @@
   </section>
 
   <section id="how.to.use.tm.reuse.tm">
-	<title id="how.to.use.tm.reuse.tm.title">
-    Reuse TMs</title>
+	<title id="how.to.use.tm.reuse.tm.title">Reuse TMs</title>
 	
 	<para>To reuse translation memories from a previous project you have two
 	options:</para>
@@ -187,8 +184,7 @@
 	</section>
 
 	<section id="how.to.use.tm.store.your.tm">
-	  <title id="how.to.use.tm.store.your.tm.title">
-      Managing your TMs</title>
+	  <title id="how.to.use.tm.store.your.tm.title">Managing your TMs</title>
 
 	  <para>You may want to store translation memories in separate folders, by
 	  client or area of specialty so you can reuse them quickly when the need
@@ -251,8 +247,7 @@
   </section>
 
   <section id="how.to.tm.share.translation.memories">
-	<title id="how.to.tm.share.translation.memories.title">
-    Share TMs</title>
+	<title id="how.to.tm.share.translation.memories.title">Share TMs</title>
 
 	<para>For large jobs involving a team of translators, it is easier for
 	everyone involved in sharing common translation memories rather than pass
@@ -262,8 +257,7 @@
 
 	<variablelist>
 	  <varlistentry id="how.to.tm.share.translation.memories.good.enough.way">
-		<term id="how.to.tm.share.translation.memories.good.enough.way.title">
-		The good enough way</term>
+		<term id="how.to.tm.share.translation.memories.good.enough.way.title">The good enough way</term>
 		<listitem>
 		  
 		  <para>See the <link linkend="how.to.use.tm.create.your.tm"
@@ -304,8 +298,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="how.to.tm.share.translation.memories.technical.approach">
-		<term id="how.to.tm.share.translation.memories.technical.approach.title">
-		The technical approach</term>
+		<term id="how.to.tm.share.translation.memories.technical.approach.title">The technical approach</term>
 		<listitem>
 		  <para>OmegaT uses collaborative version control systems to share
 		  data.</para>
@@ -334,8 +327,7 @@
   </section>
 
   <section id="how.to.tm.bridge.two.languages">
-	<title id="how.to.tm.bridge.two.languages.title">
-    Bridge two languages</title>
+	<title id="how.to.tm.bridge.two.languages.title">Bridge two languages</title>
 
 	<para>OmegaT displays fuzzy matches in the <link linkend="panes.fuzzy.matches"
 	endterm="panes.fuzzy.matches.title"/> pane. By default, those matches are limited to the source and target languages defined in the <link

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.team.project">
-  <title id="how.to.use.team.project.title">Use a team project</title>
+  <title id="how.to.use.team.project.title"><link linkend="how.to.use.team.project"> </link>Use a team project</title>
 
   <para>Team projects use synchronization mechanisms between project members.</para>
 
@@ -34,7 +34,7 @@
   
   <variablelist>
     <varlistentry id="how.to.use.team.project.download">
-	  <term id="how.to.use.team.project.download.title">Downloading the project</term>
+	  <term id="how.to.use.team.project.download.title"><link linkend="how.to.use.team.project.download"> </link>Downloading the project</term>
       <listitem>
 		<orderedlist>
 		  <listitem>
@@ -90,7 +90,7 @@
 	</varlistentry>
 
     <varlistentry id="how.to.use.team.project.synchronization">
-	  <term id="how.to.use.team.project.synchronization.title">Synchronization</term>
+	  <term id="how.to.use.team.project.synchronization.title"><link linkend="how.to.use.team.project.synchronization"> </link>Synchronization</term>
 
       <listitem>
         <para>Synchronizing the project adds translations made by all team
@@ -122,7 +122,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.configuration">
-	  <term id="how.to.use.team.project.configuration.title">Team project configuration</term>
+	  <term id="how.to.use.team.project.configuration.title"><link linkend="how.to.use.team.project.configuration"> </link>Team project configuration</term>
 
       <listitem>
         <para>As in regular local projects, the configuration of the team
@@ -204,7 +204,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.source.files">
-	  <term id="how.to.use.team.project.source.files.title">Source files</term>
+	  <term id="how.to.use.team.project.source.files.title"><link linkend="how.to.use.team.project.source.files"> </link>Source files</term>
 
       <listitem>
         <warning>
@@ -217,7 +217,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.target.files">
-	  <term id="how.to.use.team.project.target.files.title">Target files</term>
+	  <term id="how.to.use.team.project.target.files.title"><link linkend="how.to.use.team.project.target.files"> </link>Target files</term>
 
       <listitem>
         <para>After you generate the target files use
@@ -230,7 +230,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.deleting.files">
-	  <term id="how.to.use.team.project.deleting.files.title">Deleting files</term>
+	  <term id="how.to.use.team.project.deleting.files.title"><link linkend="how.to.use.team.project.deleting.files"> </link>Deleting files</term>
 
       <listitem>
         <para>Files in a team project cannot be deleted from OmegaT or the local
@@ -241,7 +241,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.working.offline">
-	  <term id="how.to.use.team.project.working.offline.title">Working offline</term>
+	  <term id="how.to.use.team.project.working.offline.title"><link linkend="how.to.use.team.project.working.offline"> </link>Working offline</term>
 
       <listitem>
         <para>You can open a team project and work on it offline. All changes

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.team.project">
-  <title id="how.to.use.team.project.title">
-  Use a team project</title>
+  <title id="how.to.use.team.project.title">Use a team project</title>
 
   <para>Team projects use synchronization mechanisms between project members.</para>
 
@@ -35,8 +34,7 @@
   
   <variablelist>
     <varlistentry id="how.to.use.team.project.download">
-	  <term id="how.to.use.team.project.download.title">
-      Downloading the project</term>
+	  <term id="how.to.use.team.project.download.title">Downloading the project</term>
       <listitem>
 		<orderedlist>
 		  <listitem>
@@ -92,8 +90,7 @@
 	</varlistentry>
 
     <varlistentry id="how.to.use.team.project.synchronization">
-	  <term id="how.to.use.team.project.synchronization.title">
-      Synchronization</term>
+	  <term id="how.to.use.team.project.synchronization.title">Synchronization</term>
 
       <listitem>
         <para>Synchronizing the project adds translations made by all team
@@ -125,8 +122,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.configuration">
-	  <term id="how.to.use.team.project.configuration.title">
-      Team project configuration</term>
+	  <term id="how.to.use.team.project.configuration.title">Team project configuration</term>
 
       <listitem>
         <para>As in regular local projects, the configuration of the team
@@ -208,8 +204,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.source.files">
-	  <term id="how.to.use.team.project.source.files.title">
-      Source files</term>
+	  <term id="how.to.use.team.project.source.files.title">Source files</term>
 
       <listitem>
         <warning>
@@ -222,8 +217,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.target.files">
-	  <term id="how.to.use.team.project.target.files.title">
-      Target files</term>
+	  <term id="how.to.use.team.project.target.files.title">Target files</term>
 
       <listitem>
         <para>After you generate the target files use
@@ -236,8 +230,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.deleting.files">
-	  <term id="how.to.use.team.project.deleting.files.title">
-      Deleting files</term>
+	  <term id="how.to.use.team.project.deleting.files.title">Deleting files</term>
 
       <listitem>
         <para>Files in a team project cannot be deleted from OmegaT or the local
@@ -248,8 +241,7 @@
     </varlistentry>
 
     <varlistentry id="how.to.use.team.project.working.offline">
-	  <term id="how.to.use.team.project.working.offline.title">
-      Working offline</term>
+	  <term id="how.to.use.team.project.working.offline.title">Working offline</term>
 
       <listitem>
         <para>You can open a team project and work on it offline. All changes

--- a/doc_src/en/HowTo_UseTeamProject.xml
+++ b/doc_src/en/HowTo_UseTeamProject.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="how.to.use.team.project">
-  <title id="how.to.use.team.project.title">Use a team project</title>
+  <title id="how.to.use.team.project.title">
+  Use a team project</title>
 
   <para>Team projects use synchronization mechanisms between project members.</para>
 
@@ -33,8 +34,9 @@
   for example.</para>
   
   <variablelist>
-    <varlistentry>
-      <term>Downloading the project</term>
+    <varlistentry id="how.to.use.team.project.download">
+	  <term id="how.to.use.team.project.download.title">
+      Downloading the project</term>
       <listitem>
 		<orderedlist>
 		  <listitem>
@@ -89,8 +91,9 @@
 	  </listitem>
 	</varlistentry>
 
-    <varlistentry>
-      <term>Synchronization</term>
+    <varlistentry id="how.to.use.team.project.synchronization">
+	  <term id="how.to.use.team.project.synchronization.title">
+      Synchronization</term>
 
       <listitem>
         <para>Synchronizing the project adds translations made by all team
@@ -121,8 +124,9 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Team project configuration</term>
+    <varlistentry id="how.to.use.team.project.configuration">
+	  <term id="how.to.use.team.project.configuration.title">
+      Team project configuration</term>
 
       <listitem>
         <para>As in regular local projects, the configuration of the team
@@ -203,8 +207,9 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Source files</term>
+    <varlistentry id="how.to.use.team.project.source.files">
+	  <term id="how.to.use.team.project.source.files.title">
+      Source files</term>
 
       <listitem>
         <warning>
@@ -216,21 +221,23 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Target files</term>
+    <varlistentry id="how.to.use.team.project.target.files">
+	  <term id="how.to.use.team.project.target.files.title">
+      Target files</term>
 
       <listitem>
         <para>After you generate the target files use
         <link endterm="menus.project.title"
-        linkend="menus.project"/><link
-        endterm="menus.project.commit.target.files.title"
-        linkend="menus.project.commit.target.files"/> to add them to the
+			  linkend="menus.project"/><link
+			  endterm="menus.project.commit.target.files.title"
+			  linkend="menus.project.commit.target.files"/> to add them to the
         server, if the project administrator has requested you to do so.</para>
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Deleting files</term>
+    <varlistentry id="how.to.use.team.project.deleting.files">
+	  <term id="how.to.use.team.project.deleting.files.title">
+      Deleting files</term>
 
       <listitem>
         <para>Files in a team project cannot be deleted from OmegaT or the local
@@ -240,8 +247,9 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Working offline</term>
+    <varlistentry id="how.to.use.team.project.working.offline">
+	  <term id="how.to.use.team.project.working.offline.title">
+      Working offline</term>
 
       <listitem>
         <para>You can open a team project and work on it offline. All changes

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -1,23 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd"
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <chapter id="chapter.instant.start.guide">
-  <title id="chapter.instant.start.guide.title">Introduction to OmegaT</title>
+  <title id="chapter.instant.start.guide.title"><link linkend="chapter.instant.start.guide"> </link>Introduction to OmegaT</title>
   
   <section id="introduction.omegat.principles">
-	<title id="introduction.omegat.principles.title">Principles</title>
+	<title id="introduction.omegat.principles.title"><link linkend="introduction.omegat.principles"> </link>Principles</title>
 
     <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
     offers great flexibility, performance and robustness, as well as features
     beyond those of commercial offerings, even for beginning translators.</para>
 
 	<section id="introduction.omegat.principles.translation.project">
-	  <title
-		  id="introduction.omegat.principles.translation.project.title">
-		Translation
-      project</title>
+	  <title id="introduction.omegat.principles.translation.project.title"><link linkend="introduction.omegat.principles.translation.project"> </link>Translation project</title>
 
       <para>An OmegaT translation project consists of a number of resources
       stored in separate folders, of an <link
@@ -40,10 +37,7 @@
     </section>
 
 	<section id="introduction.omegat.principles.translation.memories">
-	  <title
-		  id="introduction.omegat.principles.translation.memories.title">
-		Translation
-      memories</title>
+	  <title id="introduction.omegat.principles.translation.memories.title"><link linkend="introduction.omegat.principles.translation.memories"> </link>Translation memories</title>
 
       <para>Translators do not have to <emphasis>create</emphasis> a translation
       memory or <emphasis>associate</emphasis> one to a new project. OmegaT
@@ -63,9 +57,7 @@
 	</section>
 
 	<section id="introduction.omegat.principles.collaboration">
-	  <title
-		  id="introduction.omegat.principles.collaboration.title">
-      Collaboration</title>
+	  <title id="introduction.omegat.principles.collaboration.title"><link linkend="introduction.omegat.principles.collaboration"> </link>Collaboration</title>
 
       <para>Simple settings enable translators to easily share resources and
       work together on a project.</para>
@@ -81,9 +73,7 @@
 	</section>
 
 	<section id="introduction.omegat.principles.made.for.translators">
-	  <title id="introduction.omegat.principles.made.for.translators.title">
-		Made
-      for translators</title>
+	  <title id="introduction.omegat.principles.made.for.translators.title"><link linkend="introduction.omegat.principles.made.for.translators"> </link>Made for translators</title>
 
 	  <para>OmegaT is designed not only to facilitate the translation process,
 	  but also to ensure the translator does not have to worry about losing
@@ -120,9 +110,7 @@
   </section>
 
   <section id="introduction.how.to.use.the.manual">
-	<title id="introduction.how.to.use.the.manual.title">
-      Conventions used in
-	this manual</title>
+	<title id="introduction.how.to.use.the.manual.title"><link linkend="introduction.how.to.use.the.manual"> </link>Conventions used in this manual</title>
 	<para>This section presents the conventions used to distinguish the elements
 	of the OmegaT user interface in this manual. They are displayed in a way
 	that makes it easier to identify their function. The action associated with
@@ -209,9 +197,7 @@
 		  details.</para>
 
 		  <example id="example.introduction.note.on.shortcuts">
-			<title id="example.introduction.note.on.shortcuts.title">
-			  Key
-			modifiers are identified by a single letter.</title>
+			<title id="example.introduction.note.on.shortcuts.title"><link linkend="example.introduction.note.on.shortcuts"> </link>Key modifiers are identified by a single letter.</title>
 
 			<para>On Windows and Linux:
 			<keycombo><keycap>Control</keycap><keycap>E</keycap></keycombo></para>
@@ -228,9 +214,7 @@
   </section>
 
   <section id="introduction.create.and.open.new.project">
-	<title id="introduction.create.and.open.new.project.title">
-      Create a new
-    project</title>
+	<title id="introduction.create.and.open.new.project.title"><link linkend="introduction.create.and.open.new.project"> </link>Create a new project</title>
 
 	<warning>
 	  <para>If you have not yet installed OmegaT, see the <link
@@ -314,9 +298,7 @@
   </section>
 
   <section id="introduction.install.spellchecker.dictionary">
-	<title id="introduction.install.spellchecker.dictionary.title">
-      Spellchecking
-	dictionaries</title>
+	<title id="introduction.install.spellchecker.dictionary.title"><link linkend="introduction.install.spellchecker.dictionary"> </link>Spellchecking dictionaries</title>
 
 	<para>Omegat provides a spellchecking system, but does not come with the
 	dictionaries required to actually spellcheck your translations.
@@ -356,9 +338,7 @@
 	  a dictionary if its name matches the target language code.</para>
 
 	  <example id="introduction.install.spellchecker.dictionary.warning">
-		<title id="introduction.install.spellchecker.dictionary.warning.title">
-		  Project target language code and spellchecking dictionary
-		name</title>
+		<title id="introduction.install.spellchecker.dictionary.warning.title"><link linkend="introduction.install.spellchecker.dictionary.warning"> </link>Project target language code and spellchecking dictionary name</title>
 		<para>If the project target language is <emphasis
 		role="bold">fr</emphasis> and the dictionary name is <emphasis
 		role="bold">fr_fr</emphasis> or <emphasis role="bold">fr-fr</emphasis>,
@@ -387,9 +367,7 @@
   </section>
 
   <section id="introduction.manage.your.segments">
-	<title id="introduction.manage.your.segments.title">
-      Manage your
-    segments</title>
+	<title id="introduction.manage.your.segments.title"><link linkend="introduction.manage.your.segments"> </link>Manage your segments</title>
 
 	<para>The default setting for a translation project is to create
 	<emphasis>sentences</emphasis> by splitting the <emphasis>paragraph
@@ -440,13 +418,12 @@
   </section>
 
   <section id="introduction.make.it.look.good">
-	<title id="introduction.make.it.look.good.title">Make it look good!</title>
+	<title id="introduction.make.it.look.good.title"><link linkend="introduction.make.it.look.good"> </link>Make it look good!</title>
 	<para>Once all that is done, the source files appear in OmegaT in a layout
 	that looks like this:</para>
 
 	<figure id="default.omegat.layout">
-      <title id="default.omegat.layout.title">Default OmegaT layout on
-      macOS</title>
+      <title id="default.omegat.layout.title"><link linkend="default.omegat.layout"> </link>Default OmegaT layout on macOS</title>
       <mediaobject>
         <imageobject role="html">
           <imagedata fileref="images/defaultOmegaTLayout.png"/>
@@ -507,9 +484,7 @@
   </section>
 
   <section id="introduction.translate.the.segments.one.by.one">
-	<title id="introduction.translate.the.segments.one.by.one.title">
-      Translate
-    your files</title>
+	<title id="introduction.translate.the.segments.one.by.one.title"><link linkend="introduction.translate.the.segments.one.by.one"> </link>Translate your files</title>
 
     <para>The <link linkend="panes.editor" endterm="panes.editor.title"/> pane
     is where you type your translation.</para>
@@ -626,7 +601,7 @@
   </section>
   
   <section id="introduction.manage.your.tags">
-	<title id="introduction.manage.your.tags.title">Manage your tags</title>
+	<title id="introduction.manage.your.tags.title"><link linkend="introduction.manage.your.tags"> </link>Manage your tags</title>
 
     <para>If the documents you translate use bold, italics, or other decorative
     elements, OmegaT will convert those elements into tags that enclose the
@@ -638,9 +613,7 @@
 	<para>A sentence might look like this in its original application:</para>
     
 	<example id="example.source.segment.with.decorations">
-	  <title id="example.source.segment.with.decorations.title">
-		Sentence with
-	  decorative formatting</title>
+	  <title id="example.source.segment.with.decorations.title"><link linkend="example.source.segment.with.decorations"> </link>Sentence with decorative formatting</title>
 	  <para>OmegaT is an <emphasis role="bold">easy-to-use</emphasis> program
 	  for <emphasis>eager</emphasis> translators</para>
 	</example>
@@ -649,9 +622,7 @@
     sentence in a fashion similar to this one:</para>
 
 	<example id="example.how.decorations.are.displayed">
-	  <title id="example.how.decorations.are.displayed.title">
-		How decorations
-	  are displayed in OmegaT</title>
+	  <title id="example.how.decorations.are.displayed.title"><link linkend="example.how.decorations.are.displayed"> </link>How decorations are displayed in OmegaT</title>
 	  <para>OmegaT is an <code role="tag">&lt;t0/&gt;</code>easy to use<code
 	  role="tag">&lt;t1/&gt;</code> program for <code
 	  role="tag">&lt;t2/&gt;</code>eager<code role="tag">&lt;t3/&gt;</code>
@@ -722,9 +693,7 @@
   </section>
 
   <section id="introduction.review.the.translation">
-	<title id="introduction.review.the.translation.title">
-      Review your
-    translation</title>
+	<title id="introduction.review.the.translation.title"><link linkend="introduction.review.the.translation"> </link>Review your translation</title>
 
 	<para>Feel free to modify the <link linkend="chapter.panes"
 	endterm="chapter.panes.title"/> layout and <link linkend="menus.view"
@@ -736,9 +705,7 @@
   </section>
   
   <section id="introduction.generate.the.translated.file">
-	<title id="introduction.generate.the.translated.file.title">
-      Create the
-    translated files</title>
+	<title id="introduction.generate.the.translated.file.title"><link linkend="introduction.generate.the.translated.file"> </link>Create the translated files</title>
 
 	<para>Whenever you want to see what your translation will look like in its
 	final format, use <link linkend="menus.project"
@@ -786,7 +753,7 @@
   </section>
 
   <section id="introduction.one.more.thing">
-	<title id="introduction.one.more.thing.title">Manage your projects</title>
+	<title id="introduction.one.more.thing.title"><link linkend="introduction.one.more.thing"> </link>Manage your projects</title>
 
     <itemizedlist>
       <listitem>
@@ -823,9 +790,7 @@
   </section>
 
   <section id="app.shortcuts.streamline.workflow">
-	<title id="app.shortcuts.streamline.workflow.title">
-      A shortcut based
-    workflow</title>
+	<title id="app.shortcuts.streamline.workflow.title"><link linkend="app.shortcuts.streamline.workflow"> </link>A shortcut based workflow</title>
 
     <para>Remembering the main editing and navigation shortcuts (or <link
     linkend="app.shortcuts.customization">modifying them to suit your
@@ -833,9 +798,7 @@
     <para>This is best illustrated with an example:</para>
 
     <example id="example.shortcuts.streamline.workflow">
-	  <title id="example.shortcuts.streamline.workflow.title">
-		Using shortcuts to
-      streamline the translation process</title>
+	  <title id="example.shortcuts.streamline.workflow.title"><link linkend="example.shortcuts.streamline.workflow"> </link>Using shortcuts to streamline the translation process</title>
 
       <para>Picture yourself tasked with translating an updated version of a
       manual from a previous job. See the <link linkend="how.to.use.tm.reuse.tm"

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -7,8 +7,7 @@
   <title id="chapter.instant.start.guide.title">Introduction to OmegaT</title>
   
   <section id="introduction.omegat.principles">
-	<title id="introduction.omegat.principles.title">
-    Principles</title>
+	<title id="introduction.omegat.principles.title">Principles</title>
 
     <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
     offers great flexibility, performance and robustness, as well as features
@@ -441,8 +440,7 @@
   </section>
 
   <section id="introduction.make.it.look.good">
-	<title id="introduction.make.it.look.good.title">
-    Make it look good!</title>
+	<title id="introduction.make.it.look.good.title">Make it look good!</title>
 	<para>Once all that is done, the source files appear in OmegaT in a layout
 	that looks like this:</para>
 
@@ -628,8 +626,7 @@
   </section>
   
   <section id="introduction.manage.your.tags">
-	<title id="introduction.manage.your.tags.title">
-    Manage your tags</title>
+	<title id="introduction.manage.your.tags.title">Manage your tags</title>
 
     <para>If the documents you translate use bold, italics, or other decorative
     elements, OmegaT will convert those elements into tags that enclose the
@@ -789,8 +786,7 @@
   </section>
 
   <section id="introduction.one.more.thing">
-	<title id="introduction.one.more.thing.title">
-    Manage your projects</title>
+	<title id="introduction.one.more.thing.title">Manage your projects</title>
 
     <itemizedlist>
       <listitem>

--- a/doc_src/en/Introduction.xml
+++ b/doc_src/en/Introduction.xml
@@ -7,15 +7,17 @@
   <title id="chapter.instant.start.guide.title">Introduction to OmegaT</title>
   
   <section id="introduction.omegat.principles">
-	<title id="introduction.omegat.principles.title">Principles</title>
+	<title id="introduction.omegat.principles.title">
+    Principles</title>
 
     <para>Welcome to OmegaT, a computer-assisted translation (CAT) tool that
     offers great flexibility, performance and robustness, as well as features
     beyond those of commercial offerings, even for beginning translators.</para>
 
 	<section id="introduction.omegat.principles.translation.project">
-      <title
-      id="introduction.omegat.principles.translation.project.title">Translation
+	  <title
+		  id="introduction.omegat.principles.translation.project.title">
+		Translation
       project</title>
 
       <para>An OmegaT translation project consists of a number of resources
@@ -39,8 +41,9 @@
     </section>
 
 	<section id="introduction.omegat.principles.translation.memories">
-      <title
-      id="introduction.omegat.principles.translation.memories.title">Translation
+	  <title
+		  id="introduction.omegat.principles.translation.memories.title">
+		Translation
       memories</title>
 
       <para>Translators do not have to <emphasis>create</emphasis> a translation
@@ -61,8 +64,9 @@
 	</section>
 
 	<section id="introduction.omegat.principles.collaboration">
-      <title
-      id="introduction.omegat.principles.collaboration.title">Collaboration</title>
+	  <title
+		  id="introduction.omegat.principles.collaboration.title">
+      Collaboration</title>
 
       <para>Simple settings enable translators to easily share resources and
       work together on a project.</para>
@@ -78,7 +82,8 @@
 	</section>
 
 	<section id="introduction.omegat.principles.made.for.translators">
-      <title id="introduction.omegat.principles.made.for.translators.title">Made
+	  <title id="introduction.omegat.principles.made.for.translators.title">
+		Made
       for translators</title>
 
 	  <para>OmegaT is designed not only to facilitate the translation process,
@@ -116,7 +121,8 @@
   </section>
 
   <section id="introduction.how.to.use.the.manual">
-	<title id="introduction.how.to.use.the.manual.title">Conventions used in
+	<title id="introduction.how.to.use.the.manual.title">
+      Conventions used in
 	this manual</title>
 	<para>This section presents the conventions used to distinguish the elements
 	of the OmegaT user interface in this manual. They are displayed in a way
@@ -204,7 +210,8 @@
 		  details.</para>
 
 		  <example id="example.introduction.note.on.shortcuts">
-			<title id="example.introduction.note.on.shortcuts.title">Key
+			<title id="example.introduction.note.on.shortcuts.title">
+			  Key
 			modifiers are identified by a single letter.</title>
 
 			<para>On Windows and Linux:
@@ -222,7 +229,8 @@
   </section>
 
   <section id="introduction.create.and.open.new.project">
-    <title id="introduction.create.and.open.new.project.title">Create a new
+	<title id="introduction.create.and.open.new.project.title">
+      Create a new
     project</title>
 
 	<warning>
@@ -307,7 +315,8 @@
   </section>
 
   <section id="introduction.install.spellchecker.dictionary">
-	<title id="introduction.install.spellchecker.dictionary.title">Spellchecking
+	<title id="introduction.install.spellchecker.dictionary.title">
+      Spellchecking
 	dictionaries</title>
 
 	<para>Omegat provides a spellchecking system, but does not come with the
@@ -317,7 +326,7 @@
 	<para>Use the <link linkend="dialog.preferences.spellchecker"
 	endterm="dialog.preferences.spellchecker.title"/> section in the general
 	<link linkend="chapter.dialogs.preferences"
-	endterm="chapter.dialogs.preferences.title"/> dialog to access the
+		  endterm="chapter.dialogs.preferences.title"/> dialog to access the
 	spellchecking preferences.</para>
 
 	<orderedlist>
@@ -347,8 +356,9 @@
 	  <para>OmegaT does not recognize languages automatically, and only uses
 	  a dictionary if its name matches the target language code.</para>
 
-	  <example>
-		<title>Project target language code and spellchecking dictionary
+	  <example id="introduction.install.spellchecker.dictionary.warning">
+		<title id="introduction.install.spellchecker.dictionary.warning.title">
+		  Project target language code and spellchecking dictionary
 		name</title>
 		<para>If the project target language is <emphasis
 		role="bold">fr</emphasis> and the dictionary name is <emphasis
@@ -378,7 +388,8 @@
   </section>
 
   <section id="introduction.manage.your.segments">
-    <title id="introduction.manage.your.segments.title">Manage your
+	<title id="introduction.manage.your.segments.title">
+      Manage your
     segments</title>
 
 	<para>The default setting for a translation project is to create
@@ -430,7 +441,8 @@
   </section>
 
   <section id="introduction.make.it.look.good">
-	<title id="introduction.make.it.look.good.title">Make it look good!</title>
+	<title id="introduction.make.it.look.good.title">
+    Make it look good!</title>
 	<para>Once all that is done, the source files appear in OmegaT in a layout
 	that looks like this:</para>
 
@@ -497,7 +509,8 @@
   </section>
 
   <section id="introduction.translate.the.segments.one.by.one">
-    <title id="introduction.translate.the.segments.one.by.one.title">Translate
+	<title id="introduction.translate.the.segments.one.by.one.title">
+      Translate
     your files</title>
 
     <para>The <link linkend="panes.editor" endterm="panes.editor.title"/> pane
@@ -601,9 +614,9 @@
 	translate, and go back to annotated segments with <link
 	linkend="menus.goto.next.note" endterm="menus.goto.next.note.title"/> or
 	<link linkend="menus.goto.previous.note"
-	endterm="menus.goto.previous.note.title"/> in the <link linkend="menus.goto"
-	endterm="menus.goto.title"/> menu, or from the <link
-	linkend="windows.text.search" endterm="windows.text.search.title"/>
+		  endterm="menus.goto.previous.note.title"/> in the <link linkend="menus.goto"
+		  endterm="menus.goto.title"/> menu, or from the <link
+		  linkend="windows.text.search" endterm="windows.text.search.title"/>
 	window.</para>
 
 	<para>The <link linkend="panes.editor.context.menu"
@@ -615,7 +628,8 @@
   </section>
   
   <section id="introduction.manage.your.tags">
-    <title id="introduction.manage.your.tags.title">Manage your tags</title>
+	<title id="introduction.manage.your.tags.title">
+    Manage your tags</title>
 
     <para>If the documents you translate use bold, italics, or other decorative
     elements, OmegaT will convert those elements into tags that enclose the
@@ -627,7 +641,8 @@
 	<para>A sentence might look like this in its original application:</para>
     
 	<example id="example.source.segment.with.decorations">
-	  <title id="example.source.segment.with.decorations.title">Sentence with
+	  <title id="example.source.segment.with.decorations.title">
+		Sentence with
 	  decorative formatting</title>
 	  <para>OmegaT is an <emphasis role="bold">easy-to-use</emphasis> program
 	  for <emphasis>eager</emphasis> translators</para>
@@ -637,7 +652,8 @@
     sentence in a fashion similar to this one:</para>
 
 	<example id="example.how.decorations.are.displayed">
-	  <title id="example.how.decorations.are.displayed.title">How decorations
+	  <title id="example.how.decorations.are.displayed.title">
+		How decorations
 	  are displayed in OmegaT</title>
 	  <para>OmegaT is an <code role="tag">&lt;t0/&gt;</code>easy to use<code
 	  role="tag">&lt;t1/&gt;</code> program for <code
@@ -677,9 +693,9 @@
 	<para>Use
     <link linkend="menus.edit" endterm="menus.edit.title"/>
     <link linkend="menus.edit.insert.missing.source.tag"
-    endterm="menus.edit.insert.missing.source.tag.title"/> and <link
-    linkend="menus.edit.insert.next.missing.tag"
-    endterm="menus.edit.insert.next.missing.tag.title"/> to insert the tags at
+		  endterm="menus.edit.insert.missing.source.tag.title"/> and <link
+		  linkend="menus.edit.insert.next.missing.tag"
+		  endterm="menus.edit.insert.next.missing.tag.title"/> to insert the tags at
     the cursor location.</para>
 
 	<para>You can define custom tags that will be managed in the same
@@ -709,7 +725,8 @@
   </section>
 
   <section id="introduction.review.the.translation">
-    <title id="introduction.review.the.translation.title">Review your
+	<title id="introduction.review.the.translation.title">
+      Review your
     translation</title>
 
 	<para>Feel free to modify the <link linkend="chapter.panes"
@@ -722,7 +739,8 @@
   </section>
   
   <section id="introduction.generate.the.translated.file">
-    <title id="introduction.generate.the.translated.file.title">Create the
+	<title id="introduction.generate.the.translated.file.title">
+      Create the
     translated files</title>
 
 	<para>Whenever you want to see what your translation will look like in its
@@ -737,10 +755,10 @@
 	  prevent from being overwritten after you create them. You can
 	  automate file name changes using the <link linkend="edit.filter.dialog"
 	  endterm="edit.filter.dialog.title"/> option for the file filter.</para>
-	
+	  
 	  <para>Your translations are <emphasis>always</emphasis> stored in the
 	  <link linkend="project.folder.project.save.tmx"
-	  endterm="project.folder.project.save.tmx.title"/> file, which is the
+			endterm="project.folder.project.save.tmx.title"/> file, which is the
 	  project translation memory, located in the <link
 	  linkend="project.folder.omegat" endterm="project.folder.omegat.title"/>
 	  folder of your project.</para>
@@ -771,7 +789,8 @@
   </section>
 
   <section id="introduction.one.more.thing">
-    <title id="introduction.one.more.thing.title">Manage your projects</title>
+	<title id="introduction.one.more.thing.title">
+    Manage your projects</title>
 
     <itemizedlist>
       <listitem>
@@ -808,7 +827,8 @@
   </section>
 
   <section id="app.shortcuts.streamline.workflow">
-    <title id="app.shortcuts.streamline.workflow.title">A shortcut based
+	<title id="app.shortcuts.streamline.workflow.title">
+      A shortcut based
     workflow</title>
 
     <para>Remembering the main editing and navigation shortcuts (or <link
@@ -817,13 +837,14 @@
     <para>This is best illustrated with an example:</para>
 
     <example id="example.shortcuts.streamline.workflow">
-      <title id="example.shortcuts.streamline.workflow.title">Using shortcuts to
+	  <title id="example.shortcuts.streamline.workflow.title">
+		Using shortcuts to
       streamline the translation process</title>
 
       <para>Picture yourself tasked with translating an updated version of a
       manual from a previous job. See the <link linkend="how.to.use.tm.reuse.tm"
       endterm="how.to.use.tm.reuse.tm.title"/> how-to for details.</para>
-        
+      
       <para>Since the first few pages have not changed, your are greeted with a
       screenful of already translated segments from the previous job's memory
       upon opening the project.</para>
@@ -852,7 +873,7 @@
 	  automatically display not only history predictions, but also glossary
 	  terms, and pre-defined short strings, which can be entered with simple
 	  arrow navigation.</para>
-		
+	  
       <para>You then reach a revised section of the text where the
       <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"/>
       pane shows a number of similar segments from the previous job.</para>
@@ -898,7 +919,7 @@
 	  <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo> to navigate the
 	  results. OmegaT synchronizes the Editor contents with the selected result,
 	  so you can edit the segments right away.</para>
-        
+      
       <para>Time for a break. As you savour your coffee, you reflect
       on how much more smoothly you were able to use the various OmegaT functions
       compared to when you had just gotten started and spent a lot of time
@@ -906,7 +927,7 @@
 
       <para>The smoother workfow, in turn, allowed you to better focus on the
       translation itself.</para>
-        
+      
       <para>At the same time, you realize that during you session,
       you used the <link linkend="menus.edit" endterm="menus.edit.title"/><link
       linkend="menus.edit.create.alternative.translation"

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -2,14 +2,12 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.edit">
-  <title id="menus.edit.title">
-  <guimenu>Edit</guimenu></title>
+  <title id="menus.edit.title"><guimenu>Edit</guimenu></title>
 
   <para>This menu gives you access to segment edition commands.</para>
 
   <example id="example.undo.last.action">
-	<title id="example.undo.last.action.title">
-    Shortcut description example</title>
+	<title id="example.undo.last.action.title">Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Z</keycap></keycombo></para>
 
@@ -302,8 +300,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.switch.case">
-	  <term id="menus.edit.switch.case.title">
-      <guisubmenu>Switch case to</guisubmenu></term>
+	  <term id="menus.edit.switch.case.title"><guisubmenu>Switch case to</guisubmenu></term>
       <listitem>
         <para>Changes the case of the selected text in the target segment to the
         selected option, or cycles through the options. If no text is selected,
@@ -349,8 +346,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.select.match">
-	  <term id="menus.edit.select.match.title">
-      <guisubmenu>Select Match</guisubmenu></term>
+	  <term id="menus.edit.select.match.title"><guisubmenu>Select Match</guisubmenu></term>
       <listitem>
 		<para>Selects the previous, next or <varname>n</varname>th fuzzy match
 		displayed in the fuzzy match pane to replace or insert it to the

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -2,12 +2,14 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.edit">
-  <title id="menus.edit.title"><guimenu>Edit</guimenu></title>
+  <title id="menus.edit.title">
+  <guimenu>Edit</guimenu></title>
 
   <para>This menu gives you access to segment edition commands.</para>
 
   <example id="example.undo.last.action">
-	<title id="example.undo.last.action.title">Shortcut description example</title>
+	<title id="example.undo.last.action.title">
+    Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Z</keycap></keycombo></para>
 
@@ -20,7 +22,8 @@
 
   <variablelist>
     <varlistentry id="menus.edit.undo.last.action">
-      <term id="menus.edit.undo.last.action.title"><guimenuitem>Undo</guimenuitem>
+	  <term id="menus.edit.undo.last.action.title">
+		<guimenuitem>Undo</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></term>
       <listitem>
         <para>Cancels modifications made to the segment while it is
@@ -29,8 +32,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.redo.last.action">
-      <term id="menus.edit.redo.last.action.title"><guimenuitem>Redo</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
+	  <term id="menus.edit.redo.last.action.title">
+		<guimenuitem>Redo</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Reapplies modifications that were cancelled while the segment
@@ -39,8 +43,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.match.or.selection">
-      <term id="menus.edit.replace.with.match.or.selection.title"><guimenuitem>Replace With Match or Selection</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>
+	  <term id="menus.edit.replace.with.match.or.selection.title">
+		<guimenuitem>Replace With Match or Selection</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Replaces the target segment with the currently selected fuzzy
@@ -57,8 +62,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.match.or.selection">
-      <term id="menus.edit.insert.match.or.selection.title"><guimenuitem>Insert
-      Match or Selection</guimenuitem>
+	  <term id="menus.edit.insert.match.or.selection.title">
+		<guimenuitem>Insert
+		Match or Selection</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo></term>
       <listitem>
         <para>Inserts the currently selected fuzzy match or the text selected in
@@ -76,8 +82,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.source">
-      <term id="menus.edit.replace.with.source.title"><guimenuitem>Replace with Source</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>
+	  <term id="menus.edit.replace.with.source.title">
+		<guimenuitem>Replace with Source</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Replaces the entire target segment with the segment source.</para>
@@ -85,8 +92,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.source">
-      <term id="menus.edit.insert.source.title"><guimenuitem>Insert Source</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>
+	  <term id="menus.edit.insert.source.title">
+		<guimenuitem>Insert Source</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Inserts the segment source at the cursor position. If a part of
@@ -96,8 +104,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.select.source.text">
-      <term id="menus.edit.select.source.text.title"><guimenuitem>Select Source Text</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>A</keycap></keycombo>
+	  <term id="menus.edit.select.source.text.title">
+		<guimenuitem>Select Source Text</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>A</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Selects the source text.</para>
@@ -113,8 +122,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.mt">
-      <term id="menus.edit.replace.with.mt.title"><guimenuitem>Replace with Machine Translation</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
+	  <term id="menus.edit.replace.with.mt.title">
+		<guimenuitem>Replace with Machine Translation</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Replaces the target segment with the translation provided by the
@@ -135,8 +145,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.missing.source.tag">
-      <term id="menus.edit.insert.missing.source.tag.title"><guimenuitem>Insert Missing Tags</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo>
+	  <term id="menus.edit.insert.missing.source.tag.title">
+		<guimenuitem>Insert Missing Tags</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Inserts the remaining missing source tags at the cursor
@@ -145,8 +156,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.next.missing.tag">
-      <term id="menus.edit.insert.next.missing.tag.title"><guimenuitem>Insert Next Missing Tag</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>T</keycap></keycombo>
+	  <term id="menus.edit.insert.next.missing.tag.title">
+		<guimenuitem>Insert Next Missing Tag</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>T</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Inserts the next missing tag at the cursor position.</para>
@@ -154,8 +166,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.export.selection">
-      <term id="menus.edit.export.selection.title"><guimenuitem>Export Selection</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>C</keycap></keycombo>
+	  <term id="menus.edit.export.selection.title">
+		<guimenuitem>Export Selection</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>C</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Exports the current selection to a text file for processing. If no
@@ -171,8 +184,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.create.glossary.entry">
-      <term id="menus.edit.create.glossary.entry.title"><guimenuitem>Create Glossary Entry...</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
+	  <term id="menus.edit.create.glossary.entry.title">
+		<guimenuitem>Create Glossary Entry...</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Allows the user to create an entry in the project writable
@@ -240,8 +254,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.project">
-      <term id="menus.edit.search.project.title"><guimenuitem>Search...</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>
+	  <term id="menus.edit.search.project.title">
+		<guimenuitem>Search...</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Opens a new <link linkend="windows.text.search"
@@ -258,8 +273,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.and.replace">
-      <term id="menus.edit.search.and.replace.title"><guimenuitem>Replace...</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>K</keycap></keycombo>
+	  <term id="menus.edit.search.and.replace.title">
+		<guimenuitem>Replace...</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>K</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Opens a new <link linkend="windows.text.replace"
@@ -272,8 +288,9 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.dictionaries">
-      <term id="menus.edit.search.dictionaries.title"><guimenuitem>Search Dictionaries</guimenuitem>
-	  <keycombo><keycap>A</keycap><keycap>S</keycap><keycap>D</keycap></keycombo>
+	  <term id="menus.edit.search.dictionaries.title">
+		<guimenuitem>Search Dictionaries</guimenuitem>
+		<keycombo><keycap>A</keycap><keycap>S</keycap><keycap>D</keycap></keycombo>
 	  </term>
       <listitem>
         <para>If the <link
@@ -285,7 +302,8 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.switch.case">
-      <term id="menus.edit.switch.case.title"><guisubmenu>Switch case to</guisubmenu></term>
+	  <term id="menus.edit.switch.case.title">
+      <guisubmenu>Switch case to</guisubmenu></term>
       <listitem>
         <para>Changes the case of the selected text in the target segment to the
         selected option, or cycles through the options. If no text is selected,
@@ -331,7 +349,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.select.match">
-      <term id="menus.edit.select.match.title"><guisubmenu>Select Match</guisubmenu></term>
+	  <term id="menus.edit.select.match.title">
+      <guisubmenu>Select Match</guisubmenu></term>
       <listitem>
 		<para>Selects the previous, next or <varname>n</varname>th fuzzy match
 		displayed in the fuzzy match pane to replace or insert it to the
@@ -378,19 +397,20 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.insert.unicode.control.character">
-      <term id="menus.edit.insert.unicode.control.character.title"><guisubmenu>Insert
+	  <term id="menus.edit.insert.unicode.control.character.title">
+		<guisubmenu>Insert
       Bidi Control Character</guisubmenu></term>
 	  <listitem>
 		<para>Inserts the selected Unicode directional formatting character. See
 		<ulink
-		url="https://www.unicode.org/reports/tr9/#Directional_Formatting_Characters">Unicode
+			url="https://www.unicode.org/reports/tr9/#Directional_Formatting_Characters">Unicode
 		Bidirectional Algorithm</ulink> for details.</para>
 
 		<itemizedlist>
 		  <listitem>
 			<para><guimenuitem>Left-to-Right Mark (LRM U+200E)</guimenuitem></para>
 		  </listitem>
-		
+		  
 		  <listitem>
 			<para><guimenuitem>Right-to-Left Mark (RLM U+200F)</guimenuitem></para>
 		  </listitem>
@@ -417,7 +437,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.use.as.default.translation">
-      <term id="menus.edit.use.as.default.translation.title"><guimenuitem>Use as Default
+	  <term id="menus.edit.use.as.default.translation.title">
+		<guimenuitem>Use as Default
       Translation</guimenuitem></term>
       <listitem>
 		<para>If several alternative translations are available for the active
@@ -428,8 +449,9 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.create.alternative.translation">
-      <term
-      id="menus.edit.create.alternative.translation.title"><guimenuitem>Create
+	  <term
+		  id="menus.edit.create.alternative.translation.title">
+		<guimenuitem>Create
       Alternative Translation</guimenuitem></term>
       <listitem>
 		<para>Segments that are one and the same segment may, depending on the
@@ -437,14 +459,14 @@
 		not apply, select this menu item and enter the alternative
 		translation.</para>
 		<warning>
-		<para>OmegaT differentiates between identical segments using either
+		  <para>OmegaT differentiates between identical segments using either
 		  an internal identifier provided by the file type, or by referring to
 		  their preceding and following segments. In such cases, alternative
 		  translations relies on the identical segments having different preceding
 		  or following segments. If the identical segments also have identical
 		  preceding and following segments, you will not be able to translate them
 		  differently and make one of them an alternative translation in OmegaT.</para>
-		<para>You can work around this issue by introducing a small change to one
+		  <para>You can work around this issue by introducing a small change to one
 		  of the preceding or following segments in the source file to distinguish
 		  between the various instances of the same preceding or following segment.</para>
 		</warning>
@@ -452,7 +474,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.remove.translation">
-      <term id="menus.edit.remove.translation.title"><guimenuitem>Remove
+	  <term id="menus.edit.remove.translation.title">
+		<guimenuitem>Remove
       Translation</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>X</keycap></keycombo></term>
       <listitem>
 		<para>Deletes the current translation and sets the segment as
@@ -461,7 +484,8 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.set.empty.translation">
-      <term id="menus.edit.set.empty.translation.title"><guimenuitem>Set Empty
+	  <term id="menus.edit.set.empty.translation.title">
+		<guimenuitem>Set Empty
       Translation</guimenuitem></term>
       <listitem>
 		<para>Define the translation as empty. The target document contains nothing
@@ -471,8 +495,9 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.register.identical.translation">
-      <term id="menus.edit.register.identical.translation.title"><guimenuitem>Register Identical Translation</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo>
+	  <term id="menus.edit.register.identical.translation.title">
+		<guimenuitem>Register Identical Translation</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo>
 	  </term>
       <listitem>
 		<para>Use this command to register a translation as identical to the

--- a/doc_src/en/Menus_Edit.xml
+++ b/doc_src/en/Menus_Edit.xml
@@ -2,12 +2,12 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.edit">
-  <title id="menus.edit.title"><guimenu>Edit</guimenu></title>
+  <title id="menus.edit.title"><link linkend="menus.edit"> </link><guimenu>Edit</guimenu></title>
 
   <para>This menu gives you access to segment edition commands.</para>
 
   <example id="example.undo.last.action">
-	<title id="example.undo.last.action.title">Shortcut description example</title>
+	<title id="example.undo.last.action.title"><link linkend="example.undo.last.action"> </link>Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Z</keycap></keycombo></para>
 
@@ -20,9 +20,7 @@
 
   <variablelist>
     <varlistentry id="menus.edit.undo.last.action">
-	  <term id="menus.edit.undo.last.action.title">
-		<guimenuitem>Undo</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></term>
+	  <term id="menus.edit.undo.last.action.title"><link linkend="menus.edit.undo.last.action"> </link><guimenuitem>Undo</guimenuitem><keycombo><keycap>C</keycap><keycap>Z</keycap></keycombo></term>
       <listitem>
         <para>Cancels modifications made to the segment while it is
         current. Modification history is lost upon leaving the segment.</para>
@@ -30,10 +28,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.redo.last.action">
-	  <term id="menus.edit.redo.last.action.title">
-		<guimenuitem>Redo</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.redo.last.action.title"><link linkend="menus.edit.redo.last.action"> </link><guimenuitem>Redo</guimenuitem><keycombo><keycap>C</keycap><keycap>Y</keycap></keycombo></term>
       <listitem>
         <para>Reapplies modifications that were cancelled while the segment
         is current. Modification history is lost upon leaving the segment.</para>
@@ -41,10 +36,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.match.or.selection">
-	  <term id="menus.edit.replace.with.match.or.selection.title">
-		<guimenuitem>Replace With Match or Selection</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.replace.with.match.or.selection.title"><link linkend="menus.edit.replace.with.match.or.selection"> </link><guimenuitem>Replace With Match or Selection</guimenuitem><keycombo><keycap>C</keycap><keycap>R</keycap></keycombo></term>
       <listitem>
         <para>Replaces the target segment with the currently selected fuzzy
         match (the first match by default) or with the text selected
@@ -60,10 +52,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.match.or.selection">
-	  <term id="menus.edit.insert.match.or.selection.title">
-		<guimenuitem>Insert
-		Match or Selection</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>I</keycap></keycombo></term>
+	  <term id="menus.edit.insert.match.or.selection.title"><link linkend="menus.edit.insert.match.or.selection"> </link><guimenuitem>Insert Match or Selection</guimenuitem><keycombo><keycap>C</keycap><keycap>I</keycap></keycombo></term>
       <listitem>
         <para>Inserts the currently selected fuzzy match or the text selected in
         the <link linkend="panes.fuzzy.matches"
@@ -80,20 +69,14 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.source">
-	  <term id="menus.edit.replace.with.source.title">
-		<guimenuitem>Replace with Source</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.replace.with.source.title"><link linkend="menus.edit.replace.with.source"> </link><guimenuitem>Replace with Source</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>R</keycap></keycombo></term>
       <listitem>
         <para>Replaces the entire target segment with the segment source.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.source">
-	  <term id="menus.edit.insert.source.title">
-		<guimenuitem>Insert Source</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.insert.source.title"><link linkend="menus.edit.insert.source"> </link><guimenuitem>Insert Source</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>I</keycap></keycombo></term>
       <listitem>
         <para>Inserts the segment source at the cursor position. If a part of
         the target segment has been selected, that part will be
@@ -102,10 +85,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.select.source.text">
-	  <term id="menus.edit.select.source.text.title">
-		<guimenuitem>Select Source Text</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>A</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.select.source.text.title"><link linkend="menus.edit.select.source.text"> </link><guimenuitem>Select Source Text</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>A</keycap></keycombo></term>
       <listitem>
         <para>Selects the source text.</para>
 
@@ -120,10 +100,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.replace.with.mt">
-	  <term id="menus.edit.replace.with.mt.title">
-		<guimenuitem>Replace with Machine Translation</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>M</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.replace.with.mt.title"><link linkend="menus.edit.replace.with.mt"> </link><guimenuitem>Replace with Machine Translation</guimenuitem><keycombo><keycap>C</keycap><keycap>M</keycap></keycombo></term>
       <listitem>
         <para>Replaces the target segment with the translation provided by the
         selected machine translation service.</para>
@@ -143,10 +120,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.missing.source.tag">
-	  <term id="menus.edit.insert.missing.source.tag.title">
-		<guimenuitem>Insert Missing Tags</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.insert.missing.source.tag.title"><link linkend="menus.edit.insert.missing.source.tag"> </link><guimenuitem>Insert Missing Tags</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>T</keycap></keycombo></term>
       <listitem>
         <para>Inserts the remaining missing source tags at the cursor
         position.</para>
@@ -154,20 +128,14 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.insert.next.missing.tag">
-	  <term id="menus.edit.insert.next.missing.tag.title">
-		<guimenuitem>Insert Next Missing Tag</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>T</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.insert.next.missing.tag.title"><link linkend="menus.edit.insert.next.missing.tag"> </link><guimenuitem>Insert Next Missing Tag</guimenuitem><keycombo><keycap>C</keycap><keycap>T</keycap></keycombo></term>
       <listitem>
         <para>Inserts the next missing tag at the cursor position.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.edit.export.selection">
-	  <term id="menus.edit.export.selection.title">
-		<guimenuitem>Export Selection</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>C</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.export.selection.title"><link linkend="menus.edit.export.selection"> </link><guimenuitem>Export Selection</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>C</keycap></keycombo></term>
       <listitem>
         <para>Exports the current selection to a text file for processing. If no
         text has been selected, the current source segment is written to this
@@ -182,10 +150,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.create.glossary.entry">
-	  <term id="menus.edit.create.glossary.entry.title">
-		<guimenuitem>Create Glossary Entry...</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.create.glossary.entry.title"><link linkend="menus.edit.create.glossary.entry"> </link><guimenuitem>Create Glossary Entry...</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>G</keycap></keycombo></term>
       <listitem>
         <para>Allows the user to create an entry in the project writable
         glossary (the <link linkend="project.folder.glossary.txt"
@@ -252,10 +217,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.project">
-	  <term id="menus.edit.search.project.title">
-		<guimenuitem>Search...</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>F</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.search.project.title"><link linkend="menus.edit.search.project"> </link><guimenuitem>Search...</guimenuitem><keycombo><keycap>C</keycap><keycap>F</keycap></keycombo></term>
       <listitem>
         <para>Opens a new <link linkend="windows.text.search"
         endterm="windows.text.search.title"/> window.</para>
@@ -271,10 +233,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.and.replace">
-	  <term id="menus.edit.search.and.replace.title">
-		<guimenuitem>Replace...</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>K</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.search.and.replace.title"><link linkend="menus.edit.search.and.replace"> </link><guimenuitem>Replace...</guimenuitem><keycombo><keycap>C</keycap><keycap>K</keycap></keycombo></term>
       <listitem>
         <para>Opens a new <link linkend="windows.text.replace"
         endterm="windows.text.replace.title"/> window.</para>
@@ -286,10 +245,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.search.dictionaries">
-	  <term id="menus.edit.search.dictionaries.title">
-		<guimenuitem>Search Dictionaries</guimenuitem>
-		<keycombo><keycap>A</keycap><keycap>S</keycap><keycap>D</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.search.dictionaries.title"><link linkend="menus.edit.search.dictionaries"> </link><guimenuitem>Search Dictionaries</guimenuitem><keycombo><keycap>A</keycap><keycap>S</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
         <para>If the <link
         linkend="dialogs.preferences.dictionary.automatically.search.segment"
@@ -300,7 +256,7 @@
     </varlistentry>
 
     <varlistentry id="menus.edit.switch.case">
-	  <term id="menus.edit.switch.case.title"><guisubmenu>Switch case to</guisubmenu></term>
+	  <term id="menus.edit.switch.case.title"><link linkend="menus.edit.switch.case"> </link><guisubmenu>Switch case to</guisubmenu></term>
       <listitem>
         <para>Changes the case of the selected text in the target segment to the
         selected option, or cycles through the options. If no text is selected,
@@ -346,7 +302,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.select.match">
-	  <term id="menus.edit.select.match.title"><guisubmenu>Select Match</guisubmenu></term>
+	  <term id="menus.edit.select.match.title"><link linkend="menus.edit.select.match"> </link><guisubmenu>Select Match</guisubmenu></term>
       <listitem>
 		<para>Selects the previous, next or <varname>n</varname>th fuzzy match
 		displayed in the fuzzy match pane to replace or insert it to the
@@ -393,9 +349,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.insert.unicode.control.character">
-	  <term id="menus.edit.insert.unicode.control.character.title">
-		<guisubmenu>Insert
-      Bidi Control Character</guisubmenu></term>
+	  <term id="menus.edit.insert.unicode.control.character.title"><link linkend="menus.edit.insert.unicode.control.character"> </link><guisubmenu>Insert Bidi Control Character</guisubmenu></term>
 	  <listitem>
 		<para>Inserts the selected Unicode directional formatting character. See
 		<ulink
@@ -433,9 +387,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.use.as.default.translation">
-	  <term id="menus.edit.use.as.default.translation.title">
-		<guimenuitem>Use as Default
-      Translation</guimenuitem></term>
+	  <term id="menus.edit.use.as.default.translation.title"><link linkend="menus.edit.use.as.default.translation"> </link><guimenuitem>Use as Default Translation</guimenuitem></term>
       <listitem>
 		<para>If several alternative translations are available for the active
 		segment, you can label the alternative selected as the default
@@ -445,10 +397,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.create.alternative.translation">
-	  <term
-		  id="menus.edit.create.alternative.translation.title">
-		<guimenuitem>Create
-      Alternative Translation</guimenuitem></term>
+	  <term id="menus.edit.create.alternative.translation.title"><link linkend="menus.edit.create.alternative.translation"> </link><guimenuitem>Create Alternative Translation</guimenuitem></term>
       <listitem>
 		<para>Segments that are one and the same segment may, depending on the
 		context, require different translations. If the current translation does
@@ -470,9 +419,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.remove.translation">
-	  <term id="menus.edit.remove.translation.title">
-		<guimenuitem>Remove
-      Translation</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>X</keycap></keycombo></term>
+	  <term id="menus.edit.remove.translation.title"><link linkend="menus.edit.remove.translation"> </link><guimenuitem>Remove Translation</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>X</keycap></keycombo></term>
       <listitem>
 		<para>Deletes the current translation and sets the segment as
 		untranslated.</para>
@@ -480,9 +427,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.set.empty.translation">
-	  <term id="menus.edit.set.empty.translation.title">
-		<guimenuitem>Set Empty
-      Translation</guimenuitem></term>
+	  <term id="menus.edit.set.empty.translation.title"><link linkend="menus.edit.set.empty.translation"> </link><guimenuitem>Set Empty Translation</guimenuitem></term>
       <listitem>
 		<para>Define the translation as empty. The target document contains nothing
 		for this segment, while the Editor marks it with the
@@ -491,10 +436,7 @@
 	</varlistentry>
 
 	<varlistentry id="menus.edit.register.identical.translation">
-	  <term id="menus.edit.register.identical.translation.title">
-		<guimenuitem>Register Identical Translation</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo>
-	  </term>
+	  <term id="menus.edit.register.identical.translation.title"><link linkend="menus.edit.register.identical.translation"> </link><guimenuitem>Register Identical Translation</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>S</keycap></keycombo></term>
       <listitem>
 		<para>Use this command to register a translation as identical to the
 		source, even if the <link

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.goto">
-  <title id="menus.goto.title"><guimenu>Go To</guimenu></title>
+<section id="menus.goto"><title id="menus.goto.title">
+  <guimenu>Go To</guimenu></title>
 
   <para>This menu gives you access to the segment and pane navigation commands.</para>
 
   <example id="example.next.untranslated.segment">
-	<title id="example.next.untranslated.segment.title">Shortcut description
+	<title id="example.next.untranslated.segment.title">
+      Shortcut description
 	example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>U</keycap></keycombo></para>
@@ -21,8 +22,9 @@
 
   <variablelist>
     <varlistentry id="menus.goto.next.untranslated.segment">
-      <term id="menus.goto.next.untranslated.segment.title"><guimenuitem>Next
-      Untranslated Segment</guimenuitem>
+	  <term id="menus.goto.next.untranslated.segment.title">
+		<guimenuitem>Next
+		Untranslated Segment</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
@@ -32,8 +34,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.translated.segment">
-      <term id="menus.goto.next.translated.segment.title"><guimenuitem>Next
-      Translated Segment</guimenuitem>
+	  <term id="menus.goto.next.translated.segment.title">
+		<guimenuitem>Next
+		Translated Segment</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
@@ -43,8 +46,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.segment">
-      <term id="menus.goto.next.segment.title"><guimenuitem>Next
-      Segment</guimenuitem>
+	  <term id="menus.goto.next.segment.title">
+		<guimenuitem>Next
+		Segment</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
 
       <listitem>
@@ -57,17 +61,18 @@
 		  <para>You can use <keycap>TAB</keycap> as an alternative shortcut by
 		  enabling the
 		  <link linkend="dialogs.preferences.general.use.tab.to.advance"
-		  endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
+				endterm="dialogs.preferences.general.use.tab.to.advance.title"/>
 		  preference.</para>
 		  
 		  <para>This is useful with character entry systems that use
-		  <keycap>Enter</keycap> to validate input.</para></note>
+		<keycap>Enter</keycap> to validate input.</para></note>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.segment">
-      <term id="menus.goto.previous.segment.title"><guimenuitem>Previous
-      Segment</guimenuitem>
+	  <term id="menus.goto.previous.segment.title">
+		<guimenuitem>Previous
+		Segment</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Also:
@@ -91,8 +96,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.segment.number">
-      <term id="menus.goto.segment.number.title"><guimenuitem>Segment
-      number...</guimenuitem>
+	  <term id="menus.goto.segment.number.title">
+		<guimenuitem>Segment
+		number...</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
       <listitem>
         <para>Jumps to the segment whose call-out or number is entered.</para>
@@ -100,8 +106,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.note">
-      <term id="menus.goto.next.note.title"><guimenuitem>Next
-      Note</guimenuitem>
+	  <term id="menus.goto.next.note.title">
+		<guimenuitem>Next
+		Note</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the next segment with a note.</para>
@@ -109,8 +116,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.note">
-      <term id="menus.goto.previous.note.title"><guimenuitem>Previous
-      Note</guimenuitem>
+	  <term id="menus.goto.previous.note.title">
+		<guimenuitem>Previous
+		Note</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the previous segment with a note.</para>
@@ -118,8 +126,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.unique.segment">
-      <term id="menus.goto.next.unique.segment.title"><guimenuitem>Next Unique
-      Segment</guimenuitem>
+	  <term id="menus.goto.next.unique.segment.title">
+		<guimenuitem>Next Unique
+		Segment</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>K</keycap></keycombo></term>
       <listitem>
         <para>Moves to the next unique segment.</para>
@@ -127,8 +136,9 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.source.of.selected.match">
-      <term id="menus.goto.source.of.selected.match.title"><guimenuitem>Source
-      of Selected Match</guimenuitem>
+	  <term id="menus.goto.source.of.selected.match.title">
+		<guimenuitem>Source
+		of Selected Match</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>M</keycap></keycombo></term>
       <listitem>
         <para>Moves to the segment that corresponds to the currently
@@ -138,7 +148,8 @@
 
 	<varlistentry id="menus.goto.auto.populated.segments">
 	  <term
-	  id="menus.goto.auto.populated.segments.title"><guisubmenu>Auto-Populated
+		  id="menus.goto.auto.populated.segments.title">
+		<guisubmenu>Auto-Populated
 	  Segments</guisubmenu></term>
 	  <listitem>
         <para>Navigate between segments that were automatically populated by
@@ -153,7 +164,7 @@
 		<itemizedlist>
 		  <listitem id="menus.goto.auto.populated.segments.next.auto">
 			<para
-			id="menus.goto.auto.populated.segments.next.auto.title"><guimenuitem>Next
+				id="menus.goto.auto.populated.segments.next.auto.title"><guimenuitem>Next
 			Segment from tm/auto/</guimenuitem>
 			<keycombo><keycap>C</keycap><keycap>A</keycap><keycap>,</keycap></keycombo></para>
 
@@ -163,7 +174,7 @@
 
 		  <listitem id="menus.goto.auto.populated.segments.prev.auto">
 			<para
-			id="menus.goto.auto.populated.segments.prev.auto.title"><guimenuitem>Previous
+				id="menus.goto.auto.populated.segments.prev.auto.title"><guimenuitem>Previous
 			Segment from tm/auto/</guimenuitem>
 			<keycombo><keycap>S</keycap><keycap>C</keycap><keycap>A</keycap><keycap>,</keycap></keycombo></para>
 
@@ -173,7 +184,7 @@
 
 		  <listitem id="menus.goto.auto.populated.segments.next.enforce">
 			<para
-			id="menus.goto.auto.populated.segments.next.enforce.title"><guimenuitem>Next
+				id="menus.goto.auto.populated.segments.next.enforce.title"><guimenuitem>Next
 			Segment from tm/enforce/</guimenuitem>
 			<keycombo><keycap>C</keycap><keycap>A</keycap><keycap>.</keycap></keycombo></para>
 
@@ -183,7 +194,7 @@
 
 		  <listitem id="menus.goto.auto.populated.segments.prev.enforce">
 			<para
-			id="menus.goto.auto.populated.segments.prev.enforce.title"><guimenuitem>Previous
+				id="menus.goto.auto.populated.segments.prev.enforce.title"><guimenuitem>Previous
 			Segment from tm/enforce/</guimenuitem>
 			<keycombo><keycap>S</keycap><keycap>C</keycap><keycap>A</keycap><keycap>.</keycap></keycombo></para>
 
@@ -195,8 +206,9 @@
 	</varlistentry>
 
     <varlistentry id="menus.goto.back.in.history">
-      <term id="menus.goto.back.in.history.title"><guimenuitem>Back in
-      History</guimenuitem>
+	  <term id="menus.goto.back.in.history.title">
+		<guimenuitem>Back in
+		History</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
@@ -206,8 +218,9 @@
     </varlistentry>
     
     <varlistentry id="menus.goto.forward.in.history">
-      <term id="menus.goto.forward.in.history.title"><guimenuitem>Forward in
-      History</guimenuitem>
+	  <term id="menus.goto.forward.in.history.title">
+		<guimenuitem>Forward in
+		History</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
@@ -222,7 +235,8 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.notes.pane">
-      <term id="menus.goto.notes.pane.title"><guimenuitem>Notepad</guimenuitem>
+	  <term id="menus.goto.notes.pane.title">
+		<guimenuitem>Notepad</guimenuitem>
 	  <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.notes"
@@ -232,7 +246,8 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.editor.pane">
-      <term id="menus.goto.editor.pane.title"><guimenuitem>Editor</guimenuitem>
+	  <term id="menus.goto.editor.pane.title">
+		<guimenuitem>Editor</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>E</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.editor"

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.goto"><title id="menus.goto.title"><guimenu>Go To</guimenu></title>
+<section id="menus.goto"><title id="menus.goto.title"><link linkend="menus.goto"> </link><guimenu>Go To</guimenu></title>
 
   <para>This menu gives you access to the segment and pane navigation commands.</para>
 
   <example id="example.next.untranslated.segment">
-	<title id="example.next.untranslated.segment.title">
-      Shortcut description
-	example</title>
+	<title id="example.next.untranslated.segment.title"><link linkend="example.next.untranslated.segment"> </link>Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>U</keycap></keycombo></para>
 
@@ -21,10 +19,7 @@
 
   <variablelist>
     <varlistentry id="menus.goto.next.untranslated.segment">
-	  <term id="menus.goto.next.untranslated.segment.title">
-		<guimenuitem>Next
-		Untranslated Segment</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>U</keycap></keycombo></term>
+	  <term id="menus.goto.next.untranslated.segment.title"><link linkend="menus.goto.next.untranslated.segment"> </link><guimenuitem>Next Untranslated Segment</guimenuitem><keycombo><keycap>C</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
         <para>Moves to the next segment with no target language entry in the
@@ -33,10 +28,7 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.translated.segment">
-	  <term id="menus.goto.next.translated.segment.title">
-		<guimenuitem>Next
-		Translated Segment</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>U</keycap></keycombo></term>
+	  <term id="menus.goto.next.translated.segment.title"><link linkend="menus.goto.next.translated.segment"> </link><guimenuitem>Next Translated Segment</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>U</keycap></keycombo></term>
 
       <listitem>
         <para>Moves to the next already translated segment, ignoring
@@ -45,10 +37,7 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.next.segment">
-	  <term id="menus.goto.next.segment.title">
-		<guimenuitem>Next
-		Segment</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
+	  <term id="menus.goto.next.segment.title"><link linkend="menus.goto.next.segment"> </link><guimenuitem>Next Segment</guimenuitem><keycombo><keycap>C</keycap><keycap>N</keycap></keycombo></term>
 
       <listitem>
 		<para>Also: <keycombo><keycap>Enter</keycap></keycombo></para>
@@ -69,10 +58,7 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.segment">
-	  <term id="menus.goto.previous.segment.title">
-		<guimenuitem>Previous
-		Segment</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
+	  <term id="menus.goto.previous.segment.title"><link linkend="menus.goto.previous.segment"> </link><guimenuitem>Previous Segment</guimenuitem><keycombo><keycap>C</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Also:
 		<keycombo><keycap>C</keycap><keycap>Enter</keycap></keycombo></para>
@@ -95,50 +81,35 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.segment.number">
-	  <term id="menus.goto.segment.number.title">
-		<guimenuitem>Segment
-		number...</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
+	  <term id="menus.goto.segment.number.title"><link linkend="menus.goto.segment.number"> </link><guimenuitem>Segment number...</guimenuitem><keycombo><keycap>C</keycap><keycap>J</keycap></keycombo></term>
       <listitem>
         <para>Jumps to the segment whose call-out or number is entered.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.next.note">
-	  <term id="menus.goto.next.note.title">
-		<guimenuitem>Next
-		Note</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
+	  <term id="menus.goto.next.note.title"><link linkend="menus.goto.next.note"> </link><guimenuitem>Next Note</guimenuitem>     <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the next segment with a note.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.previous.note">
-	  <term id="menus.goto.previous.note.title">
-		<guimenuitem>Previous
-		Note</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>P</keycap></keycombo></term>
+	  <term id="menus.goto.previous.note.title"><link linkend="menus.goto.previous.note"> </link><guimenuitem>Previous Note</guimenuitem><keycombo><keycap>C</keycap><keycap>A</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
 		<para>Moves to the previous segment with a note.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.next.unique.segment">
-	  <term id="menus.goto.next.unique.segment.title">
-		<guimenuitem>Next Unique
-		Segment</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>K</keycap></keycombo></term>
+	  <term id="menus.goto.next.unique.segment.title"><link linkend="menus.goto.next.unique.segment"> </link><guimenuitem>Next Unique Segment</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>K</keycap></keycombo></term>
       <listitem>
         <para>Moves to the next unique segment.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.goto.source.of.selected.match">
-	  <term id="menus.goto.source.of.selected.match.title">
-		<guimenuitem>Source
-		of Selected Match</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>M</keycap></keycombo></term>
+	  <term id="menus.goto.source.of.selected.match.title"><link linkend="menus.goto.source.of.selected.match"> </link><guimenuitem>Source of Selected Match</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>M</keycap></keycombo></term>
       <listitem>
         <para>Moves to the segment that corresponds to the currently
         selected match in the <guilabel>Fuzzy matches</guilabel> pane.</para>
@@ -146,10 +117,7 @@
     </varlistentry>
 
 	<varlistentry id="menus.goto.auto.populated.segments">
-	  <term
-		  id="menus.goto.auto.populated.segments.title">
-		<guisubmenu>Auto-Populated
-	  Segments</guisubmenu></term>
+	  <term id="menus.goto.auto.populated.segments.title"><link linkend="menus.goto.auto.populated.segments"> </link><guisubmenu>Auto-Populated Segments</guisubmenu></term>
 	  <listitem>
         <para>Navigate between segments that were automatically populated by
         exact matches from the <link linkend="project.folder.tm.auto"
@@ -205,10 +173,7 @@
 	</varlistentry>
 
     <varlistentry id="menus.goto.back.in.history">
-	  <term id="menus.goto.back.in.history.title">
-		<guimenuitem>Back in
-		History</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
+	  <term id="menus.goto.back.in.history.title"><link linkend="menus.goto.back.in.history"> </link><guimenuitem>Back in History</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>P</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
         <para>This command allows you to move backward one segment at a time to
@@ -217,10 +182,7 @@
     </varlistentry>
     
     <varlistentry id="menus.goto.forward.in.history">
-	  <term id="menus.goto.forward.in.history.title">
-		<guimenuitem>Forward in
-		History</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></term>
+	  <term id="menus.goto.forward.in.history.title"><link linkend="menus.goto.forward.in.history"> </link><guimenuitem>Forward in History</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>OmegaT remembers your segment navigation history.</para>
 
@@ -234,9 +196,7 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.notes.pane">
-	  <term id="menus.goto.notes.pane.title">
-		<guimenuitem>Notepad</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
+	  <term id="menus.goto.notes.pane.title"><link linkend="menus.goto.notes.pane"> </link><guimenuitem>Notepad</guimenuitem><keycombo><keycap>C</keycap><keycap>A</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.notes"
         endterm="panes.notes.title"/> to write or modify a note associated
@@ -245,9 +205,7 @@
     </varlistentry>
 
     <varlistentry id="menus.goto.editor.pane">
-	  <term id="menus.goto.editor.pane.title">
-		<guimenuitem>Editor</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>A</keycap><keycap>E</keycap></keycombo></term>
+	  <term id="menus.goto.editor.pane.title"><link linkend="menus.goto.editor.pane"> </link><guimenuitem>Editor</guimenuitem><keycombo><keycap>C</keycap><keycap>A</keycap><keycap>E</keycap></keycombo></term>
       <listitem>
         <para>Enter the <link linkend="panes.editor"
         endterm="panes.editor.title"/> to proceed with your translation.</para>

--- a/doc_src/en/Menus_GoTo.xml
+++ b/doc_src/en/Menus_GoTo.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.goto"><title id="menus.goto.title">
-  <guimenu>Go To</guimenu></title>
+<section id="menus.goto"><title id="menus.goto.title"><guimenu>Go To</guimenu></title>
 
   <para>This menu gives you access to the segment and pane navigation commands.</para>
 

--- a/doc_src/en/Menus_Help.xml
+++ b/doc_src/en/Menus_Help.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.help"><title id="menus.help.title">
-  <guimenu>Help</guimenu></title>
+<section id="menus.help"><title id="menus.help.title"><guimenu>Help</guimenu></title>
 
   <para>This menu gives you access to information that will help you make the
   best of OmegaT.</para>
@@ -37,8 +36,7 @@
     </varlistentry>
 
     <varlistentry id="menus.help.log">
-	  <term id="menus.help.log.title">
-      <guimenuitem>Log...</guimenuitem></term>
+	  <term id="menus.help.log.title"><guimenuitem>Log...</guimenuitem></term>
       <listitem>
         <para>Displays the current log file. The title of the dialog reflects
         the file currently in use (which depends on the number of concurrently

--- a/doc_src/en/Menus_Help.xml
+++ b/doc_src/en/Menus_Help.xml
@@ -1,34 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.help"><title id="menus.help.title"><guimenu>Help</guimenu></title>
+<section id="menus.help"><title id="menus.help.title"><link linkend="menus.help"> </link><guimenu>Help</guimenu></title>
 
   <para>This menu gives you access to information that will help you make the
   best of OmegaT.</para>
 
   <variablelist>
     <varlistentry id="menus.help.user.manual">
-	  <term id="menus.help.user.manual.title">
-		<guimenuitem>User
-      Manual...</guimenuitem> <keycombo><keycap>F1</keycap></keycombo></term>
+	  <term id="menus.help.user.manual.title"><link linkend="menus.help.user.manual"> </link><guimenuitem>User Manual...</guimenuitem> <keycombo><keycap>F1</keycap></keycombo></term>
       <listitem>
         <para>Opens this manual in the default browser.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.about">
-	  <term
-		  id="menus.help.about.title">
-      <guimenuitem>About...</guimenuitem></term>
+	  <term id="menus.help.about.title"><link linkend="menus.help.about"> </link><guimenuitem>About...</guimenuitem></term>
       <listitem>
         <para>Displays copyright, credits and license information.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.last.changes">
-	  <term id="menus.help.last.changes.title">
-		<guimenuitem>Last
-      Changes...</guimenuitem></term>
+	  <term id="menus.help.last.changes.title"><link linkend="menus.help.last.changes"> </link><guimenuitem>Last Changes...</guimenuitem></term>
       <listitem>
         <para>Displays the list of new functionality, enhancements and bug fixes
         for each new release.</para>
@@ -36,7 +30,7 @@
     </varlistentry>
 
     <varlistentry id="menus.help.log">
-	  <term id="menus.help.log.title"><guimenuitem>Log...</guimenuitem></term>
+	  <term id="menus.help.log.title"><link linkend="menus.help.log"> </link><guimenuitem>Log...</guimenuitem></term>
       <listitem>
         <para>Displays the current log file. The title of the dialog reflects
         the file currently in use (which depends on the number of concurrently
@@ -45,9 +39,7 @@
     </varlistentry>
 
     <varlistentry id="menus.help.check.for.updates">
-	  <term id="menus.help.check.for.updates.title">
-		<guimenuitem>Check for
-      Updates...</guimenuitem></term>
+	  <term id="menus.help.check.for.updates.title"><link linkend="menus.help.check.for.updates"> </link><guimenuitem>Check for Updates...</guimenuitem></term>
       <listitem>
         <para>Checks to see if a newer version of OmegaT is available.</para>
       </listitem>

--- a/doc_src/en/Menus_Help.xml
+++ b/doc_src/en/Menus_Help.xml
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
-<section id="menus.help">
-  <title id="menus.help.title"><guimenu>Help</guimenu></title>
+<section id="menus.help"><title id="menus.help.title">
+  <guimenu>Help</guimenu></title>
 
   <para>This menu gives you access to information that will help you make the
   best of OmegaT.</para>
 
   <variablelist>
     <varlistentry id="menus.help.user.manual">
-      <term id="menus.help.user.manual.title"><guimenuitem>User
+	  <term id="menus.help.user.manual.title">
+		<guimenuitem>User
       Manual...</guimenuitem> <keycombo><keycap>F1</keycap></keycombo></term>
       <listitem>
         <para>Opens this manual in the default browser.</para>
-    </listitem>
+      </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.about">
-      <term
-      id="menus.help.about.title"><guimenuitem>About...</guimenuitem></term>
+	  <term
+		  id="menus.help.about.title">
+      <guimenuitem>About...</guimenuitem></term>
       <listitem>
         <para>Displays copyright, credits and license information.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.help.last.changes">
-      <term id="menus.help.last.changes.title"><guimenuitem>Last
+	  <term id="menus.help.last.changes.title">
+		<guimenuitem>Last
       Changes...</guimenuitem></term>
       <listitem>
         <para>Displays the list of new functionality, enhancements and bug fixes
@@ -34,7 +37,8 @@
     </varlistentry>
 
     <varlistentry id="menus.help.log">
-      <term id="menus.help.log.title"><guimenuitem>Log...</guimenuitem></term>
+	  <term id="menus.help.log.title">
+      <guimenuitem>Log...</guimenuitem></term>
       <listitem>
         <para>Displays the current log file. The title of the dialog reflects
         the file currently in use (which depends on the number of concurrently
@@ -43,7 +47,8 @@
     </varlistentry>
 
     <varlistentry id="menus.help.check.for.updates">
-      <term id="menus.help.check.for.updates.title"><guimenuitem>Check for
+	  <term id="menus.help.check.for.updates.title">
+		<guimenuitem>Check for
       Updates...</guimenuitem></term>
       <listitem>
         <para>Checks to see if a newer version of OmegaT is available.</para>

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -2,14 +2,14 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.options">
-  <title id="menus.options.title"><guimenu>Options</guimenu></title>
+  <title id="menus.options.title"><link linkend="menus.options"> </link><guimenu>Options</guimenu></title>
 
   <para>This menu gives quick access to a few frequently used
   preferences.</para>
   
   <variablelist>
     <varlistentry id="menus.options.preferences">
-	  <term id="menus.options.preferences.title"><guimenuitem>Preferences...</guimenuitem></term>
+	  <term id="menus.options.preferences.title"><link linkend="menus.options.preferences"> </link><guimenuitem>Preferences...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="chapter.dialogs.preferences"
         endterm="chapter.dialogs.preferences.title"/> dialog.</para>
@@ -22,7 +22,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.mt">
-	  <term id="menus.options.mt.title"><guisubmenu>Machine Translation</guisubmenu></term>
+	  <term id="menus.options.mt.title"><link linkend="menus.options.mt"> </link><guisubmenu>Machine Translation</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
@@ -43,9 +43,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.glossary">
-	  <term
-		  id="menus.options.glossary.title">
-      <guisubmenu>Glossary</guisubmenu></term>
+	  <term id="menus.options.glossary.title"><link linkend="menus.options.glossary"> </link><guisubmenu>Glossary</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
@@ -63,9 +61,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.dictionary">
-	  <term
-		  id="menus.options.dictionary.title">
-      <guisubmenu>Dictionary</guisubmenu></term>
+	  <term id="menus.options.dictionary.title"><link linkend="menus.options.dictionary"> </link><guisubmenu>Dictionary</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
@@ -83,9 +79,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.autocompletion">
-	  <term
-		  id="menus.options.autocompletion.title">
-      <guisubmenu>Auto-Completion</guisubmenu></term>
+	  <term id="menus.options.autocompletion.title"><link linkend="menus.options.autocompletion"> </link><guisubmenu>Auto-Completion</guisubmenu></term>
       <listitem>
 		<para>Select the various options to activate or deactivate them. See the
 		<link linkend="dialog.preferences.auto.completion"
@@ -95,9 +89,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.file.filters">
-	  <term id="menus.options.file.filters.title">
-		<guimenuitem>Global File
-      Filters...</guimenuitem></term>
+	  <term id="menus.options.file.filters.title"><link linkend="menus.options.file.filters"> </link><guimenuitem>Global File Filters...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.file.filters"
         endterm="dialogs.preferences.file.filters.title"/> preferences.</para>
@@ -110,9 +102,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.segmentation">
-	  <term id="menus.options.segmentation.title">
-		<guimenuitem>Global
-      Segmentation Rules...</guimenuitem></term>
+	  <term id="menus.options.segmentation.title"><link linkend="menus.options.segmentation"> </link><guimenuitem>Global Segmentation Rules...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.segmentation.setup"
         endterm="dialogs.preferences.segmentation.setup.title"/>
@@ -126,9 +116,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.editor">
-	  <term
-		  id="menus.options.editor.title">
-      <guimenuitem>Editor...</guimenuitem></term>
+	  <term id="menus.options.editor.title"><link linkend="menus.options.editor"> </link><guimenuitem>Editor...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.editor"
         endterm="dialogs.preferences.editor.title"/> preferences.</para>
@@ -136,10 +124,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.access.configuration.folder">
-	  <term
-		  id="menus.options.access.configuration.folder.title">
-		<guimenuitem>Access
-      Configuration Folder</guimenuitem></term>
+	  <term id="menus.options.access.configuration.folder.title"><link linkend="menus.options.access.configuration.folder"> </link><guimenuitem>Access Configuration Folder</guimenuitem></term>
       <listitem>
         <para>Opens the local folder where OmegaT configuration files are
         stored.</para>

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -2,16 +2,14 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.options">
-  <title id="menus.options.title">
-  <guimenu>Options</guimenu></title>
+  <title id="menus.options.title"><guimenu>Options</guimenu></title>
 
   <para>This menu gives quick access to a few frequently used
   preferences.</para>
   
   <variablelist>
     <varlistentry id="menus.options.preferences">
-	  <term id="menus.options.preferences.title">
-      <guimenuitem>Preferences...</guimenuitem></term>
+	  <term id="menus.options.preferences.title"><guimenuitem>Preferences...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="chapter.dialogs.preferences"
         endterm="chapter.dialogs.preferences.title"/> dialog.</para>
@@ -24,8 +22,7 @@
     </varlistentry>
 
     <varlistentry id="menus.options.mt">
-	  <term id="menus.options.mt.title">
-      <guisubmenu>Machine Translation</guisubmenu></term>
+	  <term id="menus.options.mt.title"><guisubmenu>Machine Translation</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>

--- a/doc_src/en/Menus_Options.xml
+++ b/doc_src/en/Menus_Options.xml
@@ -2,14 +2,16 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.options">
-  <title id="menus.options.title"><guimenu>Options</guimenu></title>
+  <title id="menus.options.title">
+  <guimenu>Options</guimenu></title>
 
   <para>This menu gives quick access to a few frequently used
   preferences.</para>
   
   <variablelist>
     <varlistentry id="menus.options.preferences">
-      <term id="menus.options.preferences.title"><guimenuitem>Preferences...</guimenuitem></term>
+	  <term id="menus.options.preferences.title">
+      <guimenuitem>Preferences...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="chapter.dialogs.preferences"
         endterm="chapter.dialogs.preferences.title"/> dialog.</para>
@@ -22,17 +24,18 @@
     </varlistentry>
 
     <varlistentry id="menus.options.mt">
-      <term id="menus.options.mt.title"><guisubmenu>Machine Translation</guisubmenu></term>
+	  <term id="menus.options.mt.title">
+      <guisubmenu>Machine Translation</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
 			<para><link linkend="dialogs.preferences.mt.automatically.fetch.translations"
-        endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/></para>
+			endterm="dialogs.preferences.mt.automatically.fetch.translations.title"/></para>
 		  </listitem>
 		</itemizedlist>
 
         <para>Allows you to activate or deactivate enabled and properly configured
-          machine translation engines.</para>
+        machine translation engines.</para>
 
         <para>If several translation engines are selected, you can also use
         <keycombo><keycap>C</keycap><keycap>M</keycap></keycombo> to switch
@@ -43,8 +46,9 @@
     </varlistentry>
 
     <varlistentry id="menus.options.glossary">
-      <term
-      id="menus.options.glossary.title"><guisubmenu>Glossary</guisubmenu></term>
+	  <term
+		  id="menus.options.glossary.title">
+      <guisubmenu>Glossary</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
@@ -62,8 +66,9 @@
     </varlistentry>
 
     <varlistentry id="menus.options.dictionary">
-      <term
-      id="menus.options.dictionary.title"><guisubmenu>Dictionary</guisubmenu></term>
+	  <term
+		  id="menus.options.dictionary.title">
+      <guisubmenu>Dictionary</guisubmenu></term>
       <listitem>
 		<itemizedlist>
 		  <listitem>
@@ -81,18 +86,20 @@
     </varlistentry>
 
     <varlistentry id="menus.options.autocompletion">
-      <term
-      id="menus.options.autocompletion.title"><guisubmenu>Auto-Completion</guisubmenu></term>
+	  <term
+		  id="menus.options.autocompletion.title">
+      <guisubmenu>Auto-Completion</guisubmenu></term>
       <listitem>
 		<para>Select the various options to activate or deactivate them. See the
 		<link linkend="dialog.preferences.auto.completion"
-		endterm="dialog.preferences.auto.completion.title"/> preferences for
+			  endterm="dialog.preferences.auto.completion.title"/> preferences for
 		details.</para>
 	  </listitem>
     </varlistentry>
 
     <varlistentry id="menus.options.file.filters">
-      <term id="menus.options.file.filters.title"><guimenuitem>Global File
+	  <term id="menus.options.file.filters.title">
+		<guimenuitem>Global File
       Filters...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.file.filters"
@@ -106,7 +113,8 @@
     </varlistentry>
 
     <varlistentry id="menus.options.segmentation">
-      <term id="menus.options.segmentation.title"><guimenuitem>Global
+	  <term id="menus.options.segmentation.title">
+		<guimenuitem>Global
       Segmentation Rules...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.segmentation.setup"
@@ -121,8 +129,9 @@
     </varlistentry>
 
     <varlistentry id="menus.options.editor">
-      <term
-      id="menus.options.editor.title"><guimenuitem>Editor...</guimenuitem></term>
+	  <term
+		  id="menus.options.editor.title">
+      <guimenuitem>Editor...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="dialogs.preferences.editor"
         endterm="dialogs.preferences.editor.title"/> preferences.</para>
@@ -130,8 +139,9 @@
     </varlistentry>
 
     <varlistentry id="menus.options.access.configuration.folder">
-      <term
-      id="menus.options.access.configuration.folder.title"><guimenuitem>Access
+	  <term
+		  id="menus.options.access.configuration.folder.title">
+		<guimenuitem>Access
       Configuration Folder</guimenuitem></term>
       <listitem>
         <para>Opens the local folder where OmegaT configuration files are

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -2,11 +2,13 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.project">
-  <title id="menus.project.title"><guimenu>Project</guimenu></title>
+  <title id="menus.project.title">
+  <guimenu>Project</guimenu></title>
   <para>This menu gives you access to project management commands.</para>
 
   <example id="example.new.project.shortcut">
-	<title id="example.new.project.shortcut.title">Shortcut description
+	<title id="example.new.project.shortcut.title">
+      Shortcut description
 	example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo>
@@ -23,8 +25,9 @@
   
   <variablelist>
     <varlistentry id="menus.project.new">
-      <term id="menus.project.new.title"><guimenuitem>New...</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
+	  <term id="menus.project.new.title">
+		<guimenuitem>New...</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
 	  </term>
       <listitem>
         <para>Creates and opens a new project. See the <link
@@ -35,7 +38,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.download.team.project">
-      <term id="menus.project.download.team.project.title"><guimenuitem>Download
+	  <term id="menus.project.download.team.project.title">
+		<guimenuitem>Download
       Team Project...</guimenuitem></term>
       <listitem>
         <para>Creates a local copy of a remote OmegaT project. See the <link
@@ -45,7 +49,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open">
-      <term id="menus.project.open.title"><guimenuitem>Open...</guimenuitem>
+	  <term id="menus.project.open.title">
+		<guimenuitem>Open...</guimenuitem>
 	  <keycombo><keycap>C</keycap><keycap>O</keycap></keycombo></term>
       <listitem>
         <para>Opens a previously created project.</para>
@@ -53,7 +58,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open.recent">
-      <term id="menus.project.open.recent.title"><guimenuitem>Open
+	  <term id="menus.project.open.recent.title">
+		<guimenuitem>Open
       Recent...</guimenuitem></term>
       <listitem>
         <para>Gives access to the last ten edited projects. Clicking one will
@@ -64,7 +70,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.reload">
-      <term id="menus.project.reload.title"><guimenuitem>Reload</guimenuitem>
+	  <term id="menus.project.reload.title">
+		<guimenuitem>Reload</guimenuitem>
 	  <keycombo><keycap>F5</keycap></keycombo></term>
       <listitem>
         <para>Reloads the project to take external changes in source files and
@@ -84,7 +91,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.close">
-      <term id="menus.project.close.title"><guimenuitem>Close</guimenuitem>
+	  <term id="menus.project.close.title">
+		<guimenuitem>Close</guimenuitem>
 	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>W</keycap></keycombo></term>
       <listitem>
         <para>Saves the project translation memory (<link
@@ -95,7 +103,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.save">
-      <term id="menus.project.save.title"><guimenuitem>Save</guimenuitem>
+	  <term id="menus.project.save.title">
+		<guimenuitem>Save</guimenuitem>
 	  <keycombo><keycap>C</keycap><keycap>S</keycap></keycombo></term>
       <listitem>
         <para>Saves the project translation memory (<link
@@ -111,8 +120,9 @@
     </varlistentry>
 
     <varlistentry id="menus.project.copy.files.to.source.folder">
-      <term
-		  id="menus.project.copy.files.to.source.folder.title"><guimenuitem>Add
+	  <term
+		  id="menus.project.copy.files.to.source.folder.title">
+		<guimenuitem>Add
       Files...</guimenuitem></term>
       <listitem>
         <para>Copies the selected files to the <link
@@ -123,7 +133,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.download.mediawiki.page">
-      <term id="menus.project.download.mediawiki.page.title"><guimenuitem>Add
+	  <term id="menus.project.download.mediawiki.page.title">
+		<guimenuitem>Add
       MediaWiki Page...</guimenuitem></term>
       <listitem>
 		<para>Opens a dialog where you can paste the URL of the MediaWiki page
@@ -135,7 +146,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.commit.source.files">
-      <term id="menus.project.commit.source.files.title"><guimenuitem>Commit
+	  <term id="menus.project.commit.source.files.title">
+		<guimenuitem>Commit
       Source Files</guimenuitem></term>
       <listitem>
         <warning><para>This function is specific to team
@@ -149,7 +161,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.commit.target.files">
-      <term id="menus.project.commit.target.files.title"><guimenuitem>Commit
+	  <term id="menus.project.commit.target.files.title">
+		<guimenuitem>Commit
       Target Files</guimenuitem></term>
       <listitem>
         <warning><para>This function is specific to team projects. <emphasis>Use
@@ -163,9 +176,10 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.translated.documents">
-      <term
-		  id="menus.project.create.translated.documents.title"><guimenuitem>Create
-      Translated Files</guimenuitem>
+	  <term
+		  id="menus.project.create.translated.documents.title">
+		<guimenuitem>Create
+		Translated Files</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
         <para>Creates the target files based on your translation. The created
@@ -185,9 +199,10 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.current.translated.document">
-      <term
-		  id="menus.project.create.current.translated.document.title"><guimenuitem>Create
-      Current Translated File</guimenuitem>
+	  <term
+		  id="menus.project.create.current.translated.document.title">
+		<guimenuitem>Create
+		Current Translated File</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
         <para>Creates the target file corresponding to source file currently
@@ -203,7 +218,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open.med.project">
-      <term id="menus.project.open.med.project.title"><guimenuitem>Open MED
+	  <term id="menus.project.open.med.project.title">
+		<guimenuitem>Open MED
       Project...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
@@ -213,7 +229,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.med.project">
-      <term id="menus.project.create.med.project.title"><guimenuitem>Create MED
+	  <term id="menus.project.create.med.project.title">
+		<guimenuitem>Create MED
       Projects...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
@@ -222,8 +239,9 @@
     </varlistentry>
 
     <varlistentry id="menus.project.properties">
-      <term
-		  id="menus.project.properties.title"><guimenuitem>Properties...</guimenuitem>
+	  <term
+		  id="menus.project.properties.title">
+		<guimenuitem>Properties...</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>E</keycap></keycombo></term>
       <listitem>
         <para>Displays the <link linkend="dialogs.project.properties"
@@ -235,8 +253,9 @@
     </varlistentry>
 
     <varlistentry id="menus.project.source.files.list">
-      <term id="menus.project.source.files.list.title"><guimenuitem>Source
-      Files...</guimenuitem>
+	  <term id="menus.project.source.files.list.title">
+		<guimenuitem>Source
+		Files...</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>L</keycap></keycombo></term>
       <listitem>
         <para>Opens the <link linkend="windows.source.files.list"
@@ -247,7 +266,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.access.project.contents">
-      <term id="menus.project.access.project.contents.title"><guisubmenu>Access
+	  <term id="menus.project.access.project.contents.title">
+		<guisubmenu>Access
       Project Contents</guisubmenu></term>
       <listitem>
         <para>Gives access to the various project folders. See the <link
@@ -260,93 +280,102 @@
         options are grayed out if the files do not exist.</para>
 
 		<variablelist>
-		  <varlistentry>
-			<term><link linkend="chapter.project.folder"><guimenuitem>Project
+		  <varlistentry id="menus.project.access.project.contents.project.folder">
+			<term id="menus.project.access.project.contents.project.folder.title">
+			  <link linkend="chapter.project.folder"><guimenuitem>Project
 			Folder</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><link
-			linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
-			<listitem>
-			  <para>Opens the folder in your default file manager.</para>
-			</listitem>
+		  <varlistentry id="menus.project.access.project.contents.dictionaries">
+			<term id="menus.project.access.project.contents.dictionaries.title">
+			  <link
+				  linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
+			  <listitem>
+				<para>Opens the folder in your default file manager.</para>
+			  </listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><link
-			linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
-			<listitem>
-			  <para>Opens the folder in your default file manager.</para>
-			</listitem>
+		  <varlistentry id="menus.project.access.project.contents.glossaries">
+			<term id="menus.project.access.project.contents.glossaries.title">
+			  <link
+				  linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
+			  <listitem>
+				<para>Opens the folder in your default file manager.</para>
+			  </listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><link linkend="project.folder.source"><guimenuitem>Source
+		  <varlistentry id="menus.project.access.project.contents.source.files">
+			<term id="menus.project.access.project.contents.source.files.title">
+			  <link linkend="project.folder.source"><guimenuitem>Source
 			Files</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><link linkend="project.folder.target"><guimenuitem>Target
+		  <varlistentry id="menus.project.access.project.contents.target.files">
+			<term id="menus.project.access.project.contents.target.files.title">
+			  <link linkend="project.folder.target"><guimenuitem>Target
 			Files</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><link
-			linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
-			<listitem>
-			  <para>Opens the folder in your default file manager.</para>
-			</listitem>
+		  <varlistentry id="menus.project.access.project.contents.tm">
+			<term id="menus.project.access.project.contents.tm.title">
+			  <link
+				  linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
+			  <listitem>
+				<para>Opens the folder in your default file manager.</para>
+			  </listitem>
 		  </varlistentry>
 		  
-		  <varlistentry>
-			<term><link
-			linkend="project.folder.exported.tm"><guimenuitem>Exported
+		  <varlistentry id="menus.project.access.project.contents.exported.tm">
+			<term id="menus.project.access.project.contents.exported.tm.title">
+			  <link
+				  linkend="project.folder.exported.tm"><guimenuitem>Exported
 			TMs</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><guimenuitem>Current Source File</guimenuitem></term>
+		  <varlistentry id="menus.project.access.project.contents.current.source.file">
+			<term id="menus.project.access.project.contents.current.source.file.title">
+			<guimenuitem>Current Source File</guimenuitem></term>
 			<listitem>
 			  <para>The current source file is located in the <link
 			  linkend="project.folder.source"
 			  endterm="project.folder.source.title"/> folder.</para>
 
               <para>Opens the file in the associated application if the file exists.
-               If you press down ALT key during selecting the menu item, opens a folder enclosing the file, by
-               OS standard file manager such as finder or file explorer, instead of opening the file.
+              If you press down ALT key during selecting the menu item, opens a folder enclosing the file, by
+              OS standard file manager such as finder or file explorer, instead of opening the file.
               </para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><guimenuitem>Current Target File</guimenuitem></term>
+		  <varlistentry id="menus.project.access.project.contents..current.target.file">
+			<term id="menus.project.access.project.contents.current.target.file.title"><guimenuitem>Current Target File</guimenuitem></term>
 			<listitem>
 			  <para>The current target file is located in the <link
 			  linkend="project.folder.target"
 			  endterm="project.folder.target.title"/> folder.</para>
 
 			  <para>Opens the file in the associated application if the file exists.
-                If you press down ALT key during selecting the menu item, opens a folder enclosing the file, by
-                OS standard file manager such as finder or file explorer, instead of opening the file.
+              If you press down ALT key during selecting the menu item, opens a folder enclosing the file, by
+              OS standard file manager such as finder or file explorer, instead of opening the file.
               </para>
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry>
-			<term><guimenuitem>Writable Glossary</guimenuitem></term>
+		  <varlistentry id="menus.project.access.project.contents.writable.glossary">
+			<term id="menus.project.access.project.contents.writable.glossary.title">
+			<guimenuitem>Writable Glossary</guimenuitem></term>
 			<listitem>
 			  <para>The writable glossary is located in the <link
 			  linkend="project.folder.glossary"
@@ -363,8 +392,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.restart">
-      <term
-      id="menus.project.restart.title"><guimenuitem>Restart</guimenuitem></term>
+	  <term id="menus.project.restart.title">
+      <guimenuitem>Restart</guimenuitem></term>
       <listitem>
         <para>Saves the project and restarts OmegaT. You are asked to confirm
         that you really want to quit if you have not yet saved the
@@ -373,7 +402,8 @@
     </varlistentry>
 
     <varlistentry id="menus.project.quit">
-      <term id="menus.project.quit.title"><guimenuitem>Quit</guimenuitem>
+	  <term id="menus.project.quit.title">
+		<guimenuitem>Quit</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>Q</keycap></keycombo></term>
       <listitem>
         <para>Saves the project and quits OmegaT. You are asked to confirm that

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.project">
-  <title id="menus.project.title">
-  <guimenu>Project</guimenu></title>
+  <title id="menus.project.title"><guimenu>Project</guimenu></title>
   <para>This menu gives you access to project management commands.</para>
 
   <example id="example.new.project.shortcut">
@@ -345,8 +344,7 @@
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.current.source.file">
-			<term id="menus.project.access.project.contents.current.source.file.title">
-			<guimenuitem>Current Source File</guimenuitem></term>
+			<term id="menus.project.access.project.contents.current.source.file.title"><guimenuitem>Current Source File</guimenuitem></term>
 			<listitem>
 			  <para>The current source file is located in the <link
 			  linkend="project.folder.source"
@@ -374,8 +372,7 @@
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.writable.glossary">
-			<term id="menus.project.access.project.contents.writable.glossary.title">
-			<guimenuitem>Writable Glossary</guimenuitem></term>
+			<term id="menus.project.access.project.contents.writable.glossary.title"><guimenuitem>Writable Glossary</guimenuitem></term>
 			<listitem>
 			  <para>The writable glossary is located in the <link
 			  linkend="project.folder.glossary"
@@ -392,8 +389,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.restart">
-	  <term id="menus.project.restart.title">
-      <guimenuitem>Restart</guimenuitem></term>
+	  <term id="menus.project.restart.title"><guimenuitem>Restart</guimenuitem></term>
       <listitem>
         <para>Saves the project and restarts OmegaT. You are asked to confirm
         that you really want to quit if you have not yet saved the

--- a/doc_src/en/Menus_Project.xml
+++ b/doc_src/en/Menus_Project.xml
@@ -2,13 +2,11 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.project">
-  <title id="menus.project.title"><guimenu>Project</guimenu></title>
+  <title id="menus.project.title"><link linkend="menus.project"> </link><guimenu>Project</guimenu></title>
   <para>This menu gives you access to project management commands.</para>
 
   <example id="example.new.project.shortcut">
-	<title id="example.new.project.shortcut.title">
-      Shortcut description
-	example</title>
+	<title id="example.new.project.shortcut.title"><link linkend="example.new.project.shortcut"> </link>Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>N</keycap></keycombo>
 	</para>
@@ -24,10 +22,8 @@
   
   <variablelist>
     <varlistentry id="menus.project.new">
-	  <term id="menus.project.new.title">
-		<guimenuitem>New...</guimenuitem>
-		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo>
-	  </term>
+	  <term id="menus.project.new.title"><link linkend="menus.project.new"> </link><guimenuitem>New...</guimenuitem>
+		<keycombo><keycap>C</keycap><keycap>S</keycap><keycap>N</keycap></keycombo></term>
       <listitem>
         <para>Creates and opens a new project. See the <link
         linkend="introduction.create.and.open.new.project"
@@ -37,9 +33,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.download.team.project">
-	  <term id="menus.project.download.team.project.title">
-		<guimenuitem>Download
-      Team Project...</guimenuitem></term>
+	  <term id="menus.project.download.team.project.title"><link linkend="menus.project.download.team.project"> </link><guimenuitem>Download Team Project...</guimenuitem></term>
       <listitem>
         <para>Creates a local copy of a remote OmegaT project. See the <link
         linkend="how.to.use.team.project"
@@ -48,18 +42,14 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open">
-	  <term id="menus.project.open.title">
-		<guimenuitem>Open...</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>O</keycap></keycombo></term>
+	  <term id="menus.project.open.title"><link linkend="menus.project.open"> </link><guimenuitem>Open...</guimenuitem><keycombo><keycap>C</keycap><keycap>O</keycap></keycombo></term>
       <listitem>
         <para>Opens a previously created project.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.project.open.recent">
-	  <term id="menus.project.open.recent.title">
-		<guimenuitem>Open
-      Recent...</guimenuitem></term>
+	  <term id="menus.project.open.recent.title"><link linkend="menus.project.open.recent"> </link><guimenuitem>Open Recent...</guimenuitem></term>
       <listitem>
         <para>Gives access to the last ten edited projects. Clicking one will
         save the current project, close it and open the selected project.</para>
@@ -69,9 +59,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.reload">
-	  <term id="menus.project.reload.title">
-		<guimenuitem>Reload</guimenuitem>
-	  <keycombo><keycap>F5</keycap></keycombo></term>
+	  <term id="menus.project.reload.title"><link linkend="menus.project.reload"> </link><guimenuitem>Reload</guimenuitem><keycombo><keycap>F5</keycap></keycombo></term>
       <listitem>
         <para>Reloads the project to take external changes in source files and
         project settings into account.</para>
@@ -90,9 +78,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.close">
-	  <term id="menus.project.close.title">
-		<guimenuitem>Close</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>W</keycap></keycombo></term>
+	  <term id="menus.project.close.title"><link linkend="menus.project.close"> </link><guimenuitem>Close</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>W</keycap></keycombo></term>
       <listitem>
         <para>Saves the project translation memory (<link
         linkend="project.folder.project.save.tmx"
@@ -102,9 +88,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.save">
-	  <term id="menus.project.save.title">
-		<guimenuitem>Save</guimenuitem>
-	  <keycombo><keycap>C</keycap><keycap>S</keycap></keycombo></term>
+	  <term id="menus.project.save.title"><link linkend="menus.project.save"> </link><guimenuitem>Save</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap></keycombo></term>
       <listitem>
         <para>Saves the project translation memory (<link
         linkend="project.folder.project.save.tmx"
@@ -119,10 +103,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.copy.files.to.source.folder">
-	  <term
-		  id="menus.project.copy.files.to.source.folder.title">
-		<guimenuitem>Add
-      Files...</guimenuitem></term>
+	  <term id="menus.project.copy.files.to.source.folder.title"><link linkend="menus.project.copy.files.to.source.folder"> </link><guimenuitem>Add Files...</guimenuitem></term>
       <listitem>
         <para>Copies the selected files to the <link
         linkend="project.folder.source" endterm="project.folder.source.title"/>
@@ -132,9 +113,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.download.mediawiki.page">
-	  <term id="menus.project.download.mediawiki.page.title">
-		<guimenuitem>Add
-      MediaWiki Page...</guimenuitem></term>
+	  <term id="menus.project.download.mediawiki.page.title"><link linkend="menus.project.download.mediawiki.page"> </link><guimenuitem>Add MediaWiki Page...</guimenuitem></term>
       <listitem>
 		<para>Opens a dialog where you can paste the URL of the MediaWiki page
 		you want to translate. The source data of the page will be copied into
@@ -145,9 +124,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.commit.source.files">
-	  <term id="menus.project.commit.source.files.title">
-		<guimenuitem>Commit
-      Source Files</guimenuitem></term>
+	  <term id="menus.project.commit.source.files.title"><link linkend="menus.project.commit.source.files"> </link><guimenuitem>Commit Source Files</guimenuitem></term>
       <listitem>
         <warning><para>This function is specific to team
         projects. <emphasis>Only the team project manager should use this
@@ -160,9 +137,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.commit.target.files">
-	  <term id="menus.project.commit.target.files.title">
-		<guimenuitem>Commit
-      Target Files</guimenuitem></term>
+	  <term id="menus.project.commit.target.files.title"><link linkend="menus.project.commit.target.files"> </link><guimenuitem>Commit Target Files</guimenuitem></term>
       <listitem>
         <warning><para>This function is specific to team projects. <emphasis>Use
         this function only if the team project manager asked you to
@@ -175,11 +150,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.translated.documents">
-	  <term
-		  id="menus.project.create.translated.documents.title">
-		<guimenuitem>Create
-		Translated Files</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>D</keycap></keycombo></term>
+	  <term id="menus.project.create.translated.documents.title"><link linkend="menus.project.create.translated.documents"> </link><guimenuitem>Create Translated Files</guimenuitem><keycombo><keycap>C</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
         <para>Creates the target files based on your translation. The created
         target files are located in the <link linkend="project.folder.target"
@@ -198,11 +169,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.current.translated.document">
-	  <term
-		  id="menus.project.create.current.translated.document.title">
-		<guimenuitem>Create
-		Current Translated File</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>D</keycap></keycombo></term>
+	  <term id="menus.project.create.current.translated.document.title"><link linkend="menus.project.create.current.translated.document"> </link><guimenuitem>Create Current Translated File</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>D</keycap></keycombo></term>
       <listitem>
         <para>Creates the target file corresponding to source file currently
         being translated. The resulting file is located in the <link
@@ -217,9 +184,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.open.med.project">
-	  <term id="menus.project.open.med.project.title">
-		<guimenuitem>Open MED
-      Project...</guimenuitem></term>
+	  <term id="menus.project.open.med.project.title"><link linkend="menus.project.open.med.project"> </link><guimenuitem>Open MED Project...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
         <para>Opens a project package in the MED format defined by the EU
@@ -228,9 +193,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.create.med.project">
-	  <term id="menus.project.create.med.project.title">
-		<guimenuitem>Create MED
-      Projects...</guimenuitem></term>
+	  <term id="menus.project.create.med.project.title"><link linkend="menus.project.create.med.project"> </link><guimenuitem>Create MED Projects...</guimenuitem></term>
 	  <!-- TODO add link to a format description -->
       <listitem>
         <para>Converts the current project into a MED package.</para>
@@ -238,10 +201,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.properties">
-	  <term
-		  id="menus.project.properties.title">
-		<guimenuitem>Properties...</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>E</keycap></keycombo></term>
+	  <term id="menus.project.properties.title"><link linkend="menus.project.properties"> </link><guimenuitem>Properties...</guimenuitem><keycombo><keycap>C</keycap><keycap>E</keycap></keycombo></term>
       <listitem>
         <para>Displays the <link linkend="dialogs.project.properties"
         endterm="dialogs.project.properties.title"/> dialog to edit the project
@@ -252,10 +212,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.source.files.list">
-	  <term id="menus.project.source.files.list.title">
-		<guimenuitem>Source
-		Files...</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>L</keycap></keycombo></term>
+	  <term id="menus.project.source.files.list.title"><link linkend="menus.project.source.files.list"> </link><guimenuitem>Source Files...</guimenuitem><keycombo><keycap>C</keycap><keycap>L</keycap></keycombo></term>
       <listitem>
         <para>Opens the <link linkend="windows.source.files.list"
         endterm="windows.source.files.list.title"/> window.</para>
@@ -265,9 +222,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.access.project.contents">
-	  <term id="menus.project.access.project.contents.title">
-		<guisubmenu>Access
-      Project Contents</guisubmenu></term>
+	  <term id="menus.project.access.project.contents.title"><link linkend="menus.project.access.project.contents"> </link><guisubmenu>Access Project Contents</guisubmenu></term>
       <listitem>
         <para>Gives access to the various project folders. See the <link
         linkend="chapter.project.folder"
@@ -280,71 +235,56 @@
 
 		<variablelist>
 		  <varlistentry id="menus.project.access.project.contents.project.folder">
-			<term id="menus.project.access.project.contents.project.folder.title">
-			  <link linkend="chapter.project.folder"><guimenuitem>Project
-			Folder</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.project.folder.title"><link linkend="chapter.project.folder"><guimenuitem>Project Folder</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.dictionaries">
-			<term id="menus.project.access.project.contents.dictionaries.title">
-			  <link
-				  linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.dictionaries.title"><link linkend="project.folder.dictionary"><guimenuitem>Dictionaries</guimenuitem></link></term>
 			  <listitem>
 				<para>Opens the folder in your default file manager.</para>
 			  </listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.glossaries">
-			<term id="menus.project.access.project.contents.glossaries.title">
-			  <link
-				  linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.glossaries.title"><link linkend="project.folder.glossary"><guimenuitem>Glossaries</guimenuitem></link></term>
 			  <listitem>
 				<para>Opens the folder in your default file manager.</para>
 			  </listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.source.files">
-			<term id="menus.project.access.project.contents.source.files.title">
-			  <link linkend="project.folder.source"><guimenuitem>Source
-			Files</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.source.files.title"><link linkend="project.folder.source"><guimenuitem>Source Files</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.target.files">
-			<term id="menus.project.access.project.contents.target.files.title">
-			  <link linkend="project.folder.target"><guimenuitem>Target
-			Files</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.target.files.title"><link linkend="project.folder.target"><guimenuitem>Target Files</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.tm">
-			<term id="menus.project.access.project.contents.tm.title">
-			  <link
-				  linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.tm.title"><link linkend="project.folder.tm"><guimenuitem>TMs</guimenuitem></link></term>
 			  <listitem>
 				<para>Opens the folder in your default file manager.</para>
 			  </listitem>
 		  </varlistentry>
 		  
 		  <varlistentry id="menus.project.access.project.contents.exported.tm">
-			<term id="menus.project.access.project.contents.exported.tm.title">
-			  <link
-				  linkend="project.folder.exported.tm"><guimenuitem>Exported
-			TMs</guimenuitem></link></term>
+			<term id="menus.project.access.project.contents.exported.tm.title"><link linkend="project.folder.exported.tm"><guimenuitem>Exported TMs</guimenuitem></link></term>
 			<listitem>
 			  <para>Opens the folder in your default file manager.</para>
 			</listitem>
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.current.source.file">
-			<term id="menus.project.access.project.contents.current.source.file.title"><guimenuitem>Current Source File</guimenuitem></term>
+			<term id="menus.project.access.project.contents.current.source.file.title"><link linkend="menus.project.access.project.contents.current.source.file"> </link><guimenuitem>Current Source File</guimenuitem></term>
 			<listitem>
 			  <para>The current source file is located in the <link
 			  linkend="project.folder.source"
@@ -357,8 +297,8 @@
 			</listitem>
 		  </varlistentry>
 
-		  <varlistentry id="menus.project.access.project.contents..current.target.file">
-			<term id="menus.project.access.project.contents.current.target.file.title"><guimenuitem>Current Target File</guimenuitem></term>
+		  <varlistentry id="menus.project.access.project.contents.current.target.file">
+			<term id="menus.project.access.project.contents.current.target.file.title"><link linkend="menus.project.access.project.contents.current.target.file"> </link><guimenuitem>Current Target File</guimenuitem></term>
 			<listitem>
 			  <para>The current target file is located in the <link
 			  linkend="project.folder.target"
@@ -372,7 +312,7 @@
 		  </varlistentry>
 
 		  <varlistentry id="menus.project.access.project.contents.writable.glossary">
-			<term id="menus.project.access.project.contents.writable.glossary.title"><guimenuitem>Writable Glossary</guimenuitem></term>
+			<term id="menus.project.access.project.contents.writable.glossary.title"><link linkend="menus.project.access.project.contents.writable.glossary"> </link><guimenuitem>Writable Glossary</guimenuitem></term>
 			<listitem>
 			  <para>The writable glossary is located in the <link
 			  linkend="project.folder.glossary"
@@ -389,7 +329,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.restart">
-	  <term id="menus.project.restart.title"><guimenuitem>Restart</guimenuitem></term>
+	  <term id="menus.project.restart.title"><link linkend="menus.project.restart"> </link><guimenuitem>Restart</guimenuitem></term>
       <listitem>
         <para>Saves the project and restarts OmegaT. You are asked to confirm
         that you really want to quit if you have not yet saved the
@@ -398,9 +338,7 @@
     </varlistentry>
 
     <varlistentry id="menus.project.quit">
-	  <term id="menus.project.quit.title">
-		<guimenuitem>Quit</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>Q</keycap></keycombo></term>
+	  <term id="menus.project.quit.title"><link linkend="menus.project.quit"> </link><guimenuitem>Quit</guimenuitem><keycombo><keycap>C</keycap><keycap>Q</keycap></keycombo></term>
       <listitem>
         <para>Saves the project and quits OmegaT. You are asked to confirm that
         you really want to quit if you have not yet saved the project.</para>

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -2,13 +2,15 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.tools">
-  <title id="menus.tools.title"><guimenu>Tools</guimenu></title>
+  <title id="menus.tools.title">
+  <guimenu>Tools</guimenu></title>
 
   <para>This menu gives you access to a number of tools, including QA
   validation, match reports, an aligner, and scripting.</para>
 
   <example id="example.check.issues">
-	<title id="example.check.issues.title">Shortcut description example</title>
+	<title id="example.check.issues.title">
+    Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>V</keycap></keycombo></para>
 
@@ -21,8 +23,9 @@
 
   <variablelist>
     <varlistentry id="menus.tools.check.issues">
-      <term id="menus.tools.check.issues.title"><guimenuitem>Check
-      Issues...</guimenuitem>
+	  <term id="menus.tools.check.issues.title">
+		<guimenuitem>Check
+		Issues...</guimenuitem>
       <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo></term>
       <listitem>
         <para>This quality assurance tool carries out all automatic checks in
@@ -56,7 +59,7 @@
             <para><guilabel>Terminology Issues</guilabel> (optional): detects
             all the glossary items that are not properly translated. See the
             <link linkend="dialogs.preferences.glossary"
-            endterm="dialogs.preferences.glossary.title"/> preferences for
+				  endterm="dialogs.preferences.glossary.title"/> preferences for
             details.</para>
           </listitem>
 
@@ -105,8 +108,9 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.check.issues.for.current.document">
-      <term
-      id="menus.tools.check.issues.for.current.document.title"><guimenuitem>Check
+	  <term
+		  id="menus.tools.check.issues.for.current.document.title">
+		<guimenuitem>Check
       Issues for Current File</guimenuitem></term>
       <listitem>
         <para>As above, but only for the document currently displayed in the
@@ -115,8 +119,9 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.statistics">
-      <term
-      id="menus.tools.statistics.title"><guimenuitem>Statistics</guimenuitem></term>
+	  <term
+		  id="menus.tools.statistics.title">
+      <guimenuitem>Statistics</guimenuitem></term>
       <listitem>
         <para>Opens a new window and displays project statistics such as the
         overall project word count or segment totals, and totals for every file
@@ -172,7 +177,8 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.match.statistics">
-      <term id="menus.tools.match.statistics.title"><guimenuitem>Match
+	  <term id="menus.tools.match.statistics.title">
+		<guimenuitem>Match
       Statistics</guimenuitem></term>
       <listitem>
         <para>Displays the match statistics for the project, which consist of 
@@ -189,7 +195,8 @@
     </varlistentry>
 	
     <varlistentry id="menus.tools.match.statistics.per.file">
-      <term id="menus.tools.match.statistics.per.file.title"><guimenuitem>Match
+	  <term id="menus.tools.match.statistics.per.file.title">
+		<guimenuitem>Match
       Statistics per File</guimenuitem></term>
       <listitem>
         <para>Displays the individual match statistics, which consist of the
@@ -206,7 +213,8 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.align.files">
-      <term id="menus.tools.align.files.title"><guimenuitem>Align
+	  <term id="menus.tools.align.files.title">
+		<guimenuitem>Align
       Files...</guimenuitem></term>
       <listitem>
         <para>Select the two files to align (the source file and its
@@ -224,8 +232,9 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.scripting">
-      <term
-      id="menus.tools.scripting.title"><guimenuitem>Scripting...</guimenuitem></term>
+	  <term
+		  id="menus.tools.scripting.title">
+      <guimenuitem>Scripting...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="windows.scripts"
         endterm="windows.scripts.title"/> window, which allows you to set the
@@ -257,7 +266,8 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.external.search.commands">
-      <term id="menus.tools.external.search.commands.title">External search
+	  <term id="menus.tools.external.search.commands.title">
+		External search
       commands</term>
       <listitem>
         <para>If you have defined external searches in the <link

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.tools">
-  <title id="menus.tools.title"><guimenu>Tools</guimenu></title>
+  <title id="menus.tools.title"><link linkend="menus.tools"> </link><guimenu>Tools</guimenu></title>
 
   <para>This menu gives you access to a number of tools, including QA
   validation, match reports, an aligner, and scripting.</para>
 
   <example id="example.check.issues">
-	<title id="example.check.issues.title">Shortcut description example</title>
+	<title id="example.check.issues.title"><link linkend="example.check.issues"> </link>Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>V</keycap></keycombo></para>
 
@@ -21,10 +21,7 @@
 
   <variablelist>
     <varlistentry id="menus.tools.check.issues">
-	  <term id="menus.tools.check.issues.title">
-		<guimenuitem>Check
-		Issues...</guimenuitem>
-      <keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo></term>
+	  <term id="menus.tools.check.issues.title"><link linkend="menus.tools.check.issues"> </link><guimenuitem>Check Issues...</guimenuitem><keycombo><keycap>C</keycap><keycap>S</keycap><keycap>V</keycap></keycombo></term>
       <listitem>
         <para>This quality assurance tool carries out all automatic checks in
         one go and displays the results in a window.</para>
@@ -106,10 +103,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.check.issues.for.current.document">
-	  <term
-		  id="menus.tools.check.issues.for.current.document.title">
-		<guimenuitem>Check
-      Issues for Current File</guimenuitem></term>
+	  <term id="menus.tools.check.issues.for.current.document.title"><link linkend="menus.tools.check.issues.for.current.document"> </link><guimenuitem>Check Issues for Current File</guimenuitem></term>
       <listitem>
         <para>As above, but only for the document currently displayed in the
         Editor pane.</para>
@@ -117,9 +111,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.statistics">
-	  <term
-		  id="menus.tools.statistics.title">
-      <guimenuitem>Statistics</guimenuitem></term>
+	  <term id="menus.tools.statistics.title"><link linkend="menus.tools.statistics"> </link><guimenuitem>Statistics</guimenuitem></term>
       <listitem>
         <para>Opens a new window and displays project statistics such as the
         overall project word count or segment totals, and totals for every file
@@ -175,9 +167,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.match.statistics">
-	  <term id="menus.tools.match.statistics.title">
-		<guimenuitem>Match
-      Statistics</guimenuitem></term>
+	  <term id="menus.tools.match.statistics.title"><link linkend="menus.tools.match.statistics"> </link><guimenuitem>Match Statistics</guimenuitem></term>
       <listitem>
         <para>Displays the match statistics for the project, which consist of 
         the number of repetitions, exact matches, fuzzy matches and no-matches 
@@ -193,9 +183,7 @@
     </varlistentry>
 	
     <varlistentry id="menus.tools.match.statistics.per.file">
-	  <term id="menus.tools.match.statistics.per.file.title">
-		<guimenuitem>Match
-      Statistics per File</guimenuitem></term>
+	  <term id="menus.tools.match.statistics.per.file.title"><link linkend="menus.tools.match.statistics.per.file"> </link><guimenuitem>Match Statistics per File</guimenuitem></term>
       <listitem>
         <para>Displays the individual match statistics, which consist of the
         number of repetitions, exact matches, fuzzy matches and no-matches for
@@ -211,9 +199,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.align.files">
-	  <term id="menus.tools.align.files.title">
-		<guimenuitem>Align
-      Files...</guimenuitem></term>
+	  <term id="menus.tools.align.files.title"><link linkend="menus.tools.align.files"> </link><guimenuitem>Align Files...</guimenuitem></term>
       <listitem>
         <para>Select the two files to align (the source file and its
         translation) and click <guibutton>OK</guibutton> to open the <link
@@ -230,9 +216,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.scripting">
-	  <term
-		  id="menus.tools.scripting.title">
-      <guimenuitem>Scripting...</guimenuitem></term>
+	  <term id="menus.tools.scripting.title"><link linkend="menus.tools.scripting"> </link><guimenuitem>Scripting...</guimenuitem></term>
       <listitem>
         <para>Opens the <link linkend="windows.scripts"
         endterm="windows.scripts.title"/> window, which allows you to set the
@@ -264,9 +248,7 @@
     </varlistentry>
 
     <varlistentry id="menus.tools.external.search.commands">
-	  <term id="menus.tools.external.search.commands.title">
-		External search
-      commands</term>
+	  <term id="menus.tools.external.search.commands.title"><link linkend="menus.tools.external.search.commands"> </link>External search commands</term>
       <listitem>
         <para>If you have defined external searches in the <link
         linkend="dialogs.preferences.external.searches"

--- a/doc_src/en/Menus_Tools.xml
+++ b/doc_src/en/Menus_Tools.xml
@@ -2,15 +2,13 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.tools">
-  <title id="menus.tools.title">
-  <guimenu>Tools</guimenu></title>
+  <title id="menus.tools.title"><guimenu>Tools</guimenu></title>
 
   <para>This menu gives you access to a number of tools, including QA
   validation, match reports, an aligner, and scripting.</para>
 
   <example id="example.check.issues">
-	<title id="example.check.issues.title">
-    Shortcut description example</title>
+	<title id="example.check.issues.title">Shortcut description example</title>
 	<para>On Windows and Linux:
 	<keycombo><keycap>Control</keycap><keycap>Shift</keycap><keycap>V</keycap></keycombo></para>
 

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.view">
-  <title id="menus.view.title"><guimenu>View</guimenu></title>
+  <title id="menus.view.title">
+  <guimenu>View</guimenu></title>
 
   <para>This menu allows you to select the information you want to OmegaT to
   display.</para>
 
   <para>All the colours indicated in the descriptions can be modified in the
   <link linkend="dialogs.preferences.colours"
-  endterm="dialogs.preferences.colours.title"/> preference.</para>
+		endterm="dialogs.preferences.colours.title"/> preference.</para>
 
   <variablelist>
     <varlistentry id="menus.view.mark.translated.segments">
-      <term
-      id="menus.view.mark.translated.segments.title"><guimenuitem>Highlight
+	  <term
+		  id="menus.view.mark.translated.segments.title">
+		<guimenuitem>Highlight
       Translated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, translated segments are highlighted in yellow.</para>
@@ -21,8 +23,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.untranslated.segments">
-      <term
-      id="menus.view.mark.untranslated.segments.title"><guimenuitem>Highlight
+	  <term
+		  id="menus.view.mark.untranslated.segments.title">
+		<guimenuitem>Highlight
       Untranslated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, untranslated segments are highlighted in violet.</para>
@@ -30,8 +33,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.paragraph.delimitations">
-      <term
-      id="menus.view.mark.paragraph.delimitations.title"><guimenuitem>Display
+	  <term
+		  id="menus.view.mark.paragraph.delimitations.title">
+		<guimenuitem>Display
       Paragraph Delimitations</guimenuitem></term>
       <listitem>
         <para>If checked, separations between paragraphs in the source document
@@ -44,7 +48,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.display.source.segments">
-      <term id="menus.view.display.source.segments.title"><guimenuitem>Display
+	  <term id="menus.view.display.source.segments.title">
+		<guimenuitem>Display
       Source Segments</guimenuitem></term>
       <listitem>
         <para>If checked, all the source segments are shown and highlighted
@@ -54,8 +59,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.unique.segments">
-      <term
-      id="menus.view.mark.non.unique.segments.title"><guimenuitem>Highlight
+	  <term
+		  id="menus.view.mark.non.unique.segments.title">
+		<guimenuitem>Highlight
       Repeated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, repeated segments are highlighted in pale
@@ -64,8 +70,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.segments.with.notes">
-      <term
-      id="menus.view.mark.segments.with.notes.title"><guimenuitem>Highlight
+	  <term
+		  id="menus.view.mark.segments.with.notes.title">
+		<guimenuitem>Highlight
       Segments with Notes</guimenuitem></term>
       <listitem>
         <para>If checked, segments with notes are highlighted in cyan. This
@@ -76,7 +83,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.breakable.space">
-      <term id="menus.view.mark.non.breakable.space.title"><guimenuitem>Display
+	  <term id="menus.view.mark.non.breakable.space.title">
+		<guimenuitem>Display
       Non-Breakable Spaces</guimenuitem></term>
       <listitem>
         <para>If checked, non-breakable spaces are displayed with a gray
@@ -85,7 +93,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.white.space">
-      <term id="menus.view.mark.white.space.title"><guimenuitem>Display
+	  <term id="menus.view.mark.white.space.title">
+		<guimenuitem>Display
       Whitespace</guimenuitem></term>
       <listitem>
         <para>If checked, white spaces are displayed as a small
@@ -94,8 +103,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.bidirectional.algorithm.control.character">
-      <term
-      id="menus.view.mark.bidirectional.algorithm.control.character.title"><guimenuitem>Display
+	  <term
+		  id="menus.view.mark.bidirectional.algorithm.control.character.title">
+		<guimenuitem>Display
       Bidi Control Characters</guimenuitem></term>
       <listitem>
         <para>This option displays Unicode directional formatting characters. See <ulink
@@ -110,8 +120,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.auto.populated.segments">
-      <term
-      id="menus.view.mark.auto.populated.segments.title"><guimenuitem>Highlight
+	  <term
+		  id="menus.view.mark.auto.populated.segments.title">
+		<guimenuitem>Highlight
       Auto-Populated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, segments that have been auto-populated are
@@ -125,7 +136,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.glossary.matches">
-      <term id="menus.view.mark.glossary.matches.title"><guimenuitem>Mark
+	  <term id="menus.view.mark.glossary.matches.title">
+		<guimenuitem>Mark
       Glossary Matches</guimenuitem></term>
       <listitem>
         <para>Underlines source terms that have a match in the
@@ -137,7 +149,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.language.checker">
-      <term id="menus.view.mark.language.checker.title"><guimenuitem>Mark
+	  <term id="menus.view.mark.language.checker.title">
+		<guimenuitem>Mark
       Language Checker Issues</guimenuitem></term>
       <listitem>
         <para>Underlines parts of the target where LanguageTool has found
@@ -148,7 +161,8 @@
     </varlistentry>
 	
     <varlistentry id="menus.view.aggressive.font.fallback">
-      <term id="menus.view.aggressive.font.fallback.title"><guimenuitem>Use
+	  <term id="menus.view.aggressive.font.fallback.title">
+		<guimenuitem>Use
       Aggressive Font Fallback</guimenuitem></term>
       <listitem>
         <para>Check this option if OmegaT does not display certain glyphs
@@ -164,7 +178,8 @@
     </varlistentry>
 
     <varlistentry id="menus.view.modification.info">
-      <term id="menus.view.modification.info.title"><guisubmenu>Display
+	  <term id="menus.view.modification.info.title">
+		<guisubmenu>Display
       Modification Info</guisubmenu></term>
       <listitem>
         <para>Displays the time and the author of the last change made to a
@@ -182,7 +197,8 @@
     </varlistentry>
 	
 	<varlistentry id="menus.view.restore.main.window">
-      <term id="menus.view.restore.main.window.title"><guimenuitem>Restore OmegaT
+	  <term id="menus.view.restore.main.window.title">
+		<guimenuitem>Restore OmegaT
       Window</guimenuitem></term>
       <listitem>
         <para>Restores the OmegaT window layout to its default

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.view">
-  <title id="menus.view.title"><guimenu>View</guimenu></title>
+  <title id="menus.view.title"><link linkend="menus.view"> </link><guimenu>View</guimenu></title>
 
   <para>This menu allows you to select the information you want to OmegaT to
   display.</para>
@@ -12,30 +12,21 @@
 
   <variablelist>
     <varlistentry id="menus.view.mark.translated.segments">
-	  <term
-		  id="menus.view.mark.translated.segments.title">
-		<guimenuitem>Highlight
-      Translated Segments</guimenuitem></term>
+	  <term id="menus.view.mark.translated.segments.title"><link linkend="menus.view.mark.translated.segments"> </link><guimenuitem>Highlight Translated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, translated segments are highlighted in yellow.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.untranslated.segments">
-	  <term
-		  id="menus.view.mark.untranslated.segments.title">
-		<guimenuitem>Highlight
-      Untranslated Segments</guimenuitem></term>
+	  <term id="menus.view.mark.untranslated.segments.title"><link linkend="menus.view.mark.untranslated.segments"> </link><guimenuitem>Highlight Untranslated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, untranslated segments are highlighted in violet.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.paragraph.delimitations">
-	  <term
-		  id="menus.view.mark.paragraph.delimitations.title">
-		<guimenuitem>Display
-      Paragraph Delimitations</guimenuitem></term>
+	  <term id="menus.view.mark.paragraph.delimitations.title"><link linkend="menus.view.mark.paragraph.delimitations"> </link><guimenuitem>Display Paragraph Delimitations</guimenuitem></term>
       <listitem>
         <para>If checked, separations between paragraphs in the source document
         are indicated visually. You can change the paragraph delimitation string
@@ -47,21 +38,16 @@
     </varlistentry>
 
     <varlistentry id="menus.view.display.source.segments">
-	  <term id="menus.view.display.source.segments.title">
-		<guimenuitem>Display
-      Source Segments</guimenuitem></term>
-      <listitem>
-        <para>If checked, all the source segments are shown and highlighted
+	  <term id="menus.view.display.source.segments.title"><link linkend="menus.view.display.source.segments"> </link><guimenuitem>Display Source Segments</guimenuitem></term>
+	  <listitem>
+	    <para>If checked, all the source segments are shown and highlighted
         in green.  If not checked, only the current source segments is
         shown.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.unique.segments">
-	  <term
-		  id="menus.view.mark.non.unique.segments.title">
-		<guimenuitem>Highlight
-      Repeated Segments</guimenuitem></term>
+	  <term id="menus.view.mark.non.unique.segments.title"><link linkend="menus.view.mark.non.unique.segments"> </link><guimenuitem>Highlight Repeated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, repeated segments are highlighted in pale
         gray.</para>
@@ -69,10 +55,7 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.segments.with.notes">
-	  <term
-		  id="menus.view.mark.segments.with.notes.title">
-		<guimenuitem>Highlight
-      Segments with Notes</guimenuitem></term>
+	  <term id="menus.view.mark.segments.with.notes.title"><link linkend="menus.view.mark.segments.with.notes"> </link><guimenuitem>Highlight Segments with Notes</guimenuitem></term>
       <listitem>
         <para>If checked, segments with notes are highlighted in cyan. This
         marking has priority over <guimenuitem>Highlight Translated
@@ -82,30 +65,23 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.non.breakable.space">
-	  <term id="menus.view.mark.non.breakable.space.title">
-		<guimenuitem>Display
-      Non-Breakable Spaces</guimenuitem></term>
-      <listitem>
-        <para>If checked, non-breakable spaces are displayed with a gray
+	  <term id="menus.view.mark.non.breakable.space.title"><link linkend="menus.view.mark.non.breakable.space"> </link><guimenuitem>Display Non-Breakable Spaces</guimenuitem></term>
+	  <listitem>
+	   <para>If checked, non-breakable spaces are displayed with a gray
         background.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.white.space">
-	  <term id="menus.view.mark.white.space.title">
-		<guimenuitem>Display
-      Whitespace</guimenuitem></term>
-      <listitem>
-        <para>If checked, white spaces are displayed as a small
+	  <term id="menus.view.mark.white.space.title"><link linkend="menus.view.mark.white.space"> </link><guimenuitem>Display Whitespace</guimenuitem></term>
+	  <listitem>
+	   <para>If checked, white spaces are displayed as a small
         dot.</para>
       </listitem>
     </varlistentry>
 
     <varlistentry id="menus.view.mark.bidirectional.algorithm.control.character">
-	  <term
-		  id="menus.view.mark.bidirectional.algorithm.control.character.title">
-		<guimenuitem>Display
-      Bidi Control Characters</guimenuitem></term>
+	  <term id="menus.view.mark.bidirectional.algorithm.control.character.title"><link linkend="menus.view.mark.bidirectional.algorithm.control.character"> </link><guimenuitem>Display Bidi Control Characters</guimenuitem></term>
       <listitem>
         <para>This option displays Unicode directional formatting characters. See <ulink
         url="https://www.unicode.org/reports/tr9/">Unicode Bidirectional
@@ -119,10 +95,7 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.auto.populated.segments">
-	  <term
-		  id="menus.view.mark.auto.populated.segments.title">
-		<guimenuitem>Highlight
-      Auto-Populated Segments</guimenuitem></term>
+	  <term id="menus.view.mark.auto.populated.segments.title"><link linkend="menus.view.mark.auto.populated.segments"> </link><guimenuitem>Highlight Auto-Populated Segments</guimenuitem></term>
       <listitem>
         <para>If checked, segments that have been auto-populated are
         highlighted in various colours.</para>
@@ -135,11 +108,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.glossary.matches">
-	  <term id="menus.view.mark.glossary.matches.title">
-		<guimenuitem>Mark
-      Glossary Matches</guimenuitem></term>
-      <listitem>
-        <para>Underlines source terms that have a match in the
+	  <term id="menus.view.mark.glossary.matches.title"><link linkend="menus.view.mark.glossary.matches"> </link><guimenuitem>Mark Glossary Matches</guimenuitem></term>
+	  <listitem>
+	   <para>Underlines source terms that have a match in the
         glossaries. Hovering on an underlined term displays the matching target
         term. Right-clicking on an underlined term displays the matching target
         term, which can be selected and inserted at the cursor position in the
@@ -148,11 +119,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.mark.language.checker">
-	  <term id="menus.view.mark.language.checker.title">
-		<guimenuitem>Mark
-      Language Checker Issues</guimenuitem></term>
-      <listitem>
-        <para>Underlines parts of the target where LanguageTool has found
+	  <term id="menus.view.mark.language.checker.title"><link linkend="menus.view.mark.language.checker"> </link><guimenuitem>Mark Language Checker Issues</guimenuitem></term>
+	  <listitem>
+	   <para>Underlines parts of the target where LanguageTool has found
         errors. See the <link linkend="dialog.preferences.languagetool.plugin"
         endterm="dialog.preferences.languagetool.plugin.title"/> preferences for
         details.</para>
@@ -160,11 +129,9 @@
     </varlistentry>
 	
     <varlistentry id="menus.view.aggressive.font.fallback">
-	  <term id="menus.view.aggressive.font.fallback.title">
-		<guimenuitem>Use
-      Aggressive Font Fallback</guimenuitem></term>
-      <listitem>
-        <para>Check this option if OmegaT does not display certain glyphs
+	  <term id="menus.view.aggressive.font.fallback.title"><link linkend="menus.view.aggressive.font.fallback"> </link><guimenuitem>Use Aggressive Font Fallback</guimenuitem></term>
+	  <listitem>
+	   <para>Check this option if OmegaT does not display certain glyphs
         properly (even if the fonts containing the relevant glyphs are installed
         on your machine).</para>
 
@@ -177,11 +144,9 @@
     </varlistentry>
 
     <varlistentry id="menus.view.modification.info">
-	  <term id="menus.view.modification.info.title">
-		<guisubmenu>Display
-      Modification Info</guisubmenu></term>
-      <listitem>
-        <para>Displays the time and the author of the last change made to a
+	  <term id="menus.view.modification.info.title"><link linkend="menus.view.modification.info"> </link><guisubmenu>Display Modification Info</guisubmenu></term>
+	  <listitem>
+	   <para>Displays the time and the author of the last change made to a
         segment.</para>
 		
 		<para>The default value is <guimenuitem>Current segment</guimenuitem>
@@ -196,11 +161,7 @@
     </varlistentry>
 	
 	<varlistentry id="menus.view.restore.main.window">
-	  <term id="menus.view.restore.main.window.title">
-		<guimenuitem>Restore OmegaT
-      Window</guimenuitem></term>
-      <listitem>
-        <para>Restores the OmegaT window layout to its default
+	  <term id="menus.view.restore.main.window.title"><link linkend="menus.view.restore.main.window"> </link><guimenuitem>Restore OmegaT Window</guimenuitem></term><listitem> <para>Restores the OmegaT window layout to its default
         values.</para>
 
 		<note>

--- a/doc_src/en/Menus_View.xml
+++ b/doc_src/en/Menus_View.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="menus.view">
-  <title id="menus.view.title">
-  <guimenu>View</guimenu></title>
+  <title id="menus.view.title"><guimenu>View</guimenu></title>
 
   <para>This menu allows you to select the information you want to OmegaT to
   display.</para>

--- a/doc_src/en/OmegaT_Appendices.xml
+++ b/doc_src/en/OmegaT_Appendices.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.appendices">
-  <title id="chapter.appendices.title">Appendices</title>
+  <title id="chapter.appendices.title"><link linkend="chapter.appendices"> </link>Appendices</title>
 
   <xi:include href="App_FileFilters.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -5,12 +5,13 @@
   <title id="chapter.panes.title">Panes</title>
 
   <section id="panes.default.layout">
-	<title id="panes.default.layout.title">Default layout</title>
+    <title id="panes.default.layout.title">
+    Default layout</title>
 
 	<para>The first time you start OmegaT, the main window displays the
 	following default layout:</para>
 
-		<figure id="default.omegat.layout.macos">
+	<figure id="default.omegat.layout.macos">
       <title id="default.omegat.layout.macos.title">Default OmegaT layout on
       macOS</title>
       <mediaobject>
@@ -79,11 +80,13 @@
   </section>
 
   <section id="panes.principles">
-    <title id="panes.principles.title">Principles</title>
+    <title id="panes.principles.title">
+    Principles</title>
 
     <variablelist>
       <varlistentry id="panes.manipulation">
-        <term id="panes.manipulation.title">Manipulation</term>
+		<term id="panes.manipulation.title">
+        Manipulation</term>
 
         <listitem>
           <para>The main window consists of several panes, described here, menus,
@@ -97,20 +100,21 @@
           depending on the type of pane and its current status:</para>
 
           <table id="table.pane.widgets">
-            <title id="table.pane.widgets.title">Pane widgets</title>
+            <title id="table.pane.widgets.title">
+            Pane widgets</title>
 
             <tgroup cols="2">
               <tbody>
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Settings.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Settings.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Settings.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Settings.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry>Lists the various extra <emphasis
                   role="bold">actions</emphasis> available in the pane.</entry>
@@ -118,14 +122,14 @@
 
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Minimize.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Minimize.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Minimize.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Minimize.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry><emphasis role="bold">Minimizes</emphasis> the
                   pane to a tab at the bottom of the window.</entry>
@@ -133,28 +137,28 @@
 
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Maximize.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Maximize.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Maximize.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Maximize.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry><emphasis role="bold">Maximizes</emphasis> the pane</entry>
                 </row>
 
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Restore.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Restore.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Restore.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Restore.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry><emphasis role="bold">Restores</emphasis> a maximized
                   pane to its previous layout.</entry>
@@ -162,14 +166,14 @@
 
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Undock.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Undock.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Undock.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Undock.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry><emphasis role="bold">Undocks</emphasis> the pane from
                   the main window.</entry>
@@ -177,14 +181,14 @@
 
                 <row>
                   <entry><inlinemediaobject>
-                      <imageobject role="html">
-                        <imagedata fileref="images/Dock.png" width="60%"/>
-                      </imageobject>
+                    <imageobject role="html">
+                      <imagedata fileref="images/Dock.png" width="60%"/>
+                    </imageobject>
 
-                      <imageobject role="fo">
-                        <imagedata fileref="images/Dock.png" width="40%"/>
-                      </imageobject>
-                    </inlinemediaobject></entry>
+                    <imageobject role="fo">
+                      <imagedata fileref="images/Dock.png" width="40%"/>
+                    </imageobject>
+                  </inlinemediaobject></entry>
 
                   <entry><emphasis role="bold">Returns</emphasis> the pane to
                   the main window.</entry>
@@ -209,37 +213,40 @@
       </varlistentry>
 
       <varlistentry id="panes.context.menus">
-        <term id="panes.context.menus.title">Context menus</term>
+		<term id="panes.context.menus.title">
+        Context menus</term>
 
         <listitem>
           <para>Some panes have a context menu. You can call that menu using
           the standard method for your OS, or with the OmegaT defined
           shortcuts: <itemizedlist>
-              <listitem>
-                <para>On Windows and Linux: <keycap>Menu</keycap></para>
-              </listitem>
+          <listitem>
+            <para>On Windows and Linux: <keycap>Menu</keycap></para>
+          </listitem>
 
-              <listitem>
-                <para>On macOS: <keycombo>
-                    <keycap>S</keycap>
+          <listitem>
+            <para>On macOS: <keycombo>
+            <keycap>S</keycap>
 
-                    <keycap>Esc</keycap>
-                  </keycombo></para>
-              </listitem>
-            </itemizedlist></para>
+            <keycap>Esc</keycap>
+            </keycombo></para>
+          </listitem>
+          </itemizedlist></para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="panes.drag.and.drop">
-        <term id="panes.drag.and.drop.title">Dragging and dropping</term>
+		<term id="panes.drag.and.drop.title">
+        Dragging and dropping</term>
 
         <listitem>
           <para>Files can be dragged and dropped on certain panes, with the
           following results:</para>
 
           <variablelist>
-            <varlistentry>
-              <term>Editor pane</term>
+            <varlistentry id="panes.drag.and.drop.editor">
+			  <term id="panes.drag.and.drop.editor.title">
+              Editor pane</term>
 
               <listitem>
                 <para>Dropping an OmegaT project file
@@ -254,8 +261,9 @@
               </listitem>
             </varlistentry>
 
-            <varlistentry>
-              <term>Fuzzy Matches pane</term>
+            <varlistentry id="panes.drag.and.drop.fuzzies">
+			  <term id="panes.drag.and.drop.fuzzies.title">
+              Fuzzy Matches pane</term>
 
               <listitem>
                 <para>Dropping <filename>.tmx</filename> files here will copy
@@ -264,8 +272,9 @@
               </listitem>
             </varlistentry>
 
-            <varlistentry>
-              <term>Glossaries pane</term>
+            <varlistentry id="panes.drag.and.drop.glossaries">
+			  <term id="panes.drag.and.drop.glossaries.title">
+              Glossaries pane</term>
 
               <listitem>
                 <para>Dropping files with a recognized glossary extension
@@ -279,7 +288,8 @@
       </varlistentry>
 
 	  <varlistentry id="panes.notifications">
-        <term id="panes.notifications.title">Notifications</term>
+		<term id="panes.notifications.title">
+        Notifications</term>
 		
         <listitem>
           <para>If a pane is closed but has contents to display, OmegaT can
@@ -357,7 +367,8 @@
   </section>
 
   <section id="panes.editor">
-    <title id="panes.editor.title"><guilabel>Editor</guilabel></title>
+    <title id="panes.editor.title">
+    <guilabel>Editor</guilabel></title>
 
     <para>This is where you type and edit your translations.</para>
 
@@ -365,11 +376,11 @@
     document and double-click on any segment to open and edit it.</para>
 
 	<example id="panes.editor.default.editor.writing.space">
-	  <title id="panes.editor.default.editor.writing.space.title">Default editor
+      <title id="panes.editor.default.editor.writing.space.title">
+        Default editor
 	  writing space</title>
 	  <para>
 		<programlisting>— ¶ —————————————————————
-
 <token>Hide Tags</token>
 |Dissimuler les balises<token>&lt;segment 2148 ¶></token>
 
@@ -503,7 +514,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 
 		<listitem>
 		  <para>Automatically inserting the source text in the translation
-      field by disabling the <link
+          field by disabling the <link
 		  endterm="dialogs.preferences.editor.leave.the.segment.empty.title"
 		  linkend="dialogs.preferences.editor.leave.the.segment.empty"/>
 		  preference.</para>
@@ -512,8 +523,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 		<listitem>
 		  <para>Inserting the best fuzzy match above the threshold defined in
 		  <link
-		  endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"
-		  linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"/>
+		      endterm="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"
+		      linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"/>
 		  preference.</para>
 		</listitem>
 
@@ -533,8 +544,9 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     </note>
 
     <variablelist>
-      <varlistentry>
-        <term>Empty translations</term>
+      <varlistentry id="panes.editor.empty">
+		<term id="panes.editor.empty.title">
+        Empty translations</term>
 
         <listitem>
           <para>If you leave the translation field empty, OmegaT will treat the
@@ -543,8 +555,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Translations equal to the source</term>
+      <varlistentry id="panes.editor.equal">
+        <term id="panes.editorequal.title">Translations equal to the source</term>
 
         <listitem>
           <para>OmegaT can store translations that are identical to the source
@@ -554,8 +566,9 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Dragging text</term>
+      <varlistentry id="panes.editor.drag">
+		<term id="panes.editor.drag.title">
+        Dragging text</term>
 
         <listitem>
           <para>It is possible to drag text from anywhere in the main window and
@@ -566,7 +579,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.overwriting">
-        <term id="panes.editor.overwriting.title">Overwriting</term>
+		<term id="panes.editor.overwriting.title">
+        Overwriting</term>
 
         <listitem>
           <para>By default, typing text inserts the new text after the cursor in
@@ -592,7 +606,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.cursor.lock">
-        <term id="panes.editor.cursor.lock.title">Cursor lock</term>
+		<term id="panes.editor.cursor.lock.title">
+        Cursor lock</term>
 
         <listitem>
           <para>By default, the cursor is locked in the translation field, and
@@ -611,7 +626,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.context.menu">
-        <term id="panes.editor.context.menu.title">Context menu</term>
+		<term id="panes.editor.context.menu.title">
+        Context menu</term>
 
         <listitem>
           <para>Default shortcut:</para>
@@ -637,7 +653,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 		  <itemizedlist>
 			<listitem>
 			  <para>Matched glossary items, with comments, if any presented as a
-        tooltip. Use <link endterm="menus.view.title"
+              tooltip. Use <link endterm="menus.view.title"
 			  linkend="menus.view"/><link
 			  endterm="menus.view.mark.glossary.matches.title"
 			  linkend="menus.view.mark.glossary.matches"/> to enable this
@@ -645,28 +661,28 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 			</listitem>
 
 			<listitem>
-        <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
-        <guilabel>Paste</guilabel> functions,</para>
-      </listitem>
+              <para><guilabel>Cut</guilabel>, <guilabel>Copy</guilabel>,
+              <guilabel>Paste</guilabel> functions,</para>
+            </listitem>
 
-      <listitem>
-        <para><guilabel>Go To Segment</guilabel> (to jump to the segment
-        under the pointer).</para>
-      </listitem>
+            <listitem>
+              <para><guilabel>Go To Segment</guilabel> (to jump to the segment
+              under the pointer).</para>
+            </listitem>
 
-      <listitem>
-        <para><guilabel>Search Dictionaries</guilabel> (to search for the
-        selected term in an installed dictionary).</para>
-      </listitem>
+            <listitem>
+              <para><guilabel>Search Dictionaries</guilabel> (to search for the
+              selected term in an installed dictionary).</para>
+            </listitem>
 
-      <listitem>
-        <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
-        <link endterm="menus.edit.title" linkend="menus.edit"/><link
-        endterm="menus.edit.create.glossary.entry.title"
-        linkend="menus.edit.create.glossary.entry"/>).</para>
-      </listitem>
+            <listitem>
+              <para><guilabel>Add Glossary Entry</guilabel> (equivalent to using
+              <link endterm="menus.edit.title" linkend="menus.edit"/><link
+              endterm="menus.edit.create.glossary.entry.title"
+              linkend="menus.edit.create.glossary.entry"/>).</para>
+            </listitem>
 
-      </itemizedlist>
+          </itemizedlist>
 
           <para>If you have selected text and defined entries in the <link
           endterm="dialogs.preferences.external.searches.title"
@@ -676,7 +692,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.auto.completion.menu">
-        <term id="panes.editor.auto.completion.menu.title">Auto-completion
+		<term id="panes.editor.auto.completion.menu.title">
+          Auto-completion
         menu</term>
 
         <listitem>
@@ -692,7 +709,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
               <para>On macOS: <keycap>Esc</keycap></para>
 			</listitem>
           </itemizedlist>
-		  			
+		  
           <para>This menu offers the auto-completion options set in the <link
           endterm="dialog.preferences.auto.completion.title"
           linkend="dialog.preferences.auto.completion"/> preferences.</para>
@@ -700,7 +717,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.navigation">
-        <term id="panes.editor.navigation.title">Navigation</term>
+		<term id="panes.editor.navigation.title">
+        Navigation</term>
         <listitem>
 		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
 		  linkend="menus.goto.notes.pane"
@@ -717,7 +735,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
   </section>
 
   <section id="panes.fuzzy.matches">
-    <title id="panes.fuzzy.matches.title"><guilabel>Fuzzy Matches</guilabel></title>
+    <title id="panes.fuzzy.matches.title">
+    <guilabel>Fuzzy Matches</guilabel></title>
 
     <para>The match viewer shows the segments from your translation memories that
     are most similar to the segment you are currently translating.</para>
@@ -738,7 +757,8 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     to select a different match.</para>
 
 	<example id="the.first.match">
-	  <title id="the.first.match.title">An empty segment and its first two matches</title>
+      <title id="the.first.match.title">
+      An empty segment and its first two matches</title>
       <para>
 		<informaltable id="table.pane.matches">
           <tgroup cols="2">
@@ -772,7 +792,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 							<programlisting>1. <token>Top</token> Folder
 Dossier racine
 &lt;50/50/66% Orphan segments (+1 more)&gt;</programlisting>
-<programlisting>2. Configuration Folder
+                            <programlisting>2. Configuration Folder
 Dossier de configuration
 &lt;50/50/66% &gt;</programlisting></entry>
 						</row>
@@ -821,7 +841,7 @@ Dossier de configuration
 		</note>
       </listitem>
     </itemizedlist>
-  
+    
     <para>You can change how matches are displayed or sorted. See the <link
     endterm="dialog.preferences.tm.matches.title"
     linkend="dialog.preferences.tm.matches"/> preferences for details.</para>
@@ -837,7 +857,8 @@ Dossier de configuration
   </section>
 
   <section id="panes.glossary">
-    <title id="panes.glossary.title"><guilabel>Glossaries</guilabel></title>
+    <title id="panes.glossary.title">
+    <guilabel>Glossaries</guilabel></title>
 
     <para>This pane shows terms from your glossary files that correspond
     to terms in the current segment. The glossary files are located in the
@@ -851,7 +872,8 @@ Dossier de configuration
     text.</para>
 
 	<example id="glossary.matches">
-	  <title id="glossary.matches.title">Glossary matches</title>
+      <title id="glossary.matches.title">
+      Glossary matches</title>
 	  <para>
 		<programlisting>Project = <token>Projet</token>
 1. Projet de traduction
@@ -901,7 +923,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.dictionary">
-    <title id="panes.dictionary.title"><guilabel>Dictionaries</guilabel></title>
+    <title id="panes.dictionary.title">
+    <guilabel>Dictionaries</guilabel></title>
 
 	<para>This pane shows terms from your dictionary files that
 	correspond to terms in the current segment. The dictionary files are located
@@ -912,13 +935,14 @@ Folder = <token>Dossier</token></programlisting>
   </section>
   
   <section id="panes.machinetranslation">
-    <title id="panes.machinetranslation.title"><guilabel>Machine
+    <title id="panes.machinetranslation.title">
+      <guilabel>Machine
     Translations</guilabel></title>
 
     <para>If you have enabled and configured at least one machine translation
-      engine this pane shows the suggestions for the current segment produced
-      by the available engines. When suggestions from more than one translation
-      engine are available,</para>
+    engine this pane shows the suggestions for the current segment produced
+    by the available engines. When suggestions from more than one translation
+    engine are available,</para>
 	
     <itemizedlist>
       <listitem>
@@ -957,7 +981,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.multipletranslations">
-    <title id="panes.multipletranslations.title"><guilabel>Multiple
+    <title id="panes.multipletranslations.title">
+      <guilabel>Multiple
     Translations</guilabel></title>
 
     <para>A source segment that appears in multiple locations in the project may
@@ -978,7 +1003,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.notes">
-    <title id="panes.notes.title"><guilabel>Notepad</guilabel></title>
+    <title id="panes.notes.title">
+    <guilabel>Notepad</guilabel></title>
 
     <para>This pane is an <emphasis>editable</emphasis> space where you can
     add notes to the currently active segment.</para>
@@ -1007,7 +1033,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.comments">
-    <title id="panes.comments.title"><guilabel>Comments</guilabel></title>
+    <title id="panes.comments.title">
+    <guilabel>Comments</guilabel></title>
 
     <para>Some file formats, such as the PO format, can contain comments
     for the translator to add context to the translation. Such comments
@@ -1023,7 +1050,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.segment.properties">
-    <title id="panes.segment.properties.title"><guilabel>Segment
+    <title id="panes.segment.properties.title">
+      <guilabel>Segment
     properties</guilabel></title>
 
     <para>All segments have properties. The properties are displayed in this
@@ -1031,15 +1059,18 @@ Folder = <token>Dossier</token></programlisting>
 	<para>Common properties include:</para>
 	
 	<variablelist>
-	  <varlistentry>
-		<term>Is repetition</term>
+	  <varlistentry id="panes.segment.properties.repetition">
+		<term id="panes.segment.properties.repetition.title">
+        Is repetition</term>
 		<listitem>
 		  <para>Indicates that a segment is a repetition and specifies whether
 		  it is the FIRST instance.</para>
 		</listitem>
 	  </varlistentry>
-	  <varlistentry>
-		<term>File</term>
+	  
+	  <varlistentry id="panes.segment.properties.file">
+		<term id="panes.segment.properties.file.title">
+        File</term>
 		<listitem>
 		  <para>Indicates which file contains the segment.</para>
 		</listitem>
@@ -1053,7 +1084,8 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.statusbar">
-    <title id="panes.statusbar.title"><guilabel>Status bar</guilabel></title>
+    <title id="panes.statusbar.title">
+    <guilabel>Status bar</guilabel></title>
 
     <para>The bottom of the main window is the status bar.</para>
 
@@ -1061,7 +1093,8 @@ Folder = <token>Dossier</token></programlisting>
 	actions or error messages.</para>
 
 	<example id="panes.statusbar.messages">
-      <title id="panes.statusbar.messages.title">Status bar messages
+      <title id="panes.statusbar.messages.title">
+        Status bar messages
       examples</title>
 	  <para><literal>Synchronization of repositories</literal></para>
 
@@ -1093,7 +1126,8 @@ Folder = <token>Dossier</token></programlisting>
     percentages.</para>
 
 	<example id="panes.statusbar.widgets">
-      <title id="panes.statusbar.widgets.title">Status bar information</title>
+      <title id="panes.statusbar.widgets.title">
+      Status bar information</title>
 	  <para><literal>LCK | OVR <token>257/271 (12292/154896,
 	  177692)</token><token> 35/0 </token></literal></para>
 
@@ -1141,7 +1175,8 @@ Folder = <token>Dossier</token></programlisting>
 	</example>
 	
 	<example id="panes.statusbar.widgets.percentage">
-      <title id="panes.statusbar.widgets.percentage.title">Status bar
+      <title id="panes.statusbar.widgets.percentage.title">
+        Status bar
       information, percentage mode</title>
 	  <para><literal>UNL | INS <token>94.8% (14 left) / 7.9% (142,604 left),
 	  177,692</token> <token>35/0</token></literal></para>

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -5,8 +5,7 @@
   <title id="chapter.panes.title">Panes</title>
 
   <section id="panes.default.layout">
-    <title id="panes.default.layout.title">
-    Default layout</title>
+    <title id="panes.default.layout.title">Default layout</title>
 
 	<para>The first time you start OmegaT, the main window displays the
 	following default layout:</para>
@@ -80,13 +79,11 @@
   </section>
 
   <section id="panes.principles">
-    <title id="panes.principles.title">
-    Principles</title>
+    <title id="panes.principles.title">Principles</title>
 
     <variablelist>
       <varlistentry id="panes.manipulation">
-		<term id="panes.manipulation.title">
-        Manipulation</term>
+		<term id="panes.manipulation.title">Manipulation</term>
 
         <listitem>
           <para>The main window consists of several panes, described here, menus,
@@ -100,8 +97,7 @@
           depending on the type of pane and its current status:</para>
 
           <table id="table.pane.widgets">
-            <title id="table.pane.widgets.title">
-            Pane widgets</title>
+            <title id="table.pane.widgets.title">Pane widgets</title>
 
             <tgroup cols="2">
               <tbody>
@@ -213,8 +209,7 @@
       </varlistentry>
 
       <varlistentry id="panes.context.menus">
-		<term id="panes.context.menus.title">
-        Context menus</term>
+		<term id="panes.context.menus.title">Context menus</term>
 
         <listitem>
           <para>Some panes have a context menu. You can call that menu using
@@ -236,8 +231,7 @@
       </varlistentry>
 
       <varlistentry id="panes.drag.and.drop">
-		<term id="panes.drag.and.drop.title">
-        Dragging and dropping</term>
+		<term id="panes.drag.and.drop.title">Dragging and dropping</term>
 
         <listitem>
           <para>Files can be dragged and dropped on certain panes, with the
@@ -245,8 +239,7 @@
 
           <variablelist>
             <varlistentry id="panes.drag.and.drop.editor">
-			  <term id="panes.drag.and.drop.editor.title">
-              Editor pane</term>
+			  <term id="panes.drag.and.drop.editor.title">Editor pane</term>
 
               <listitem>
                 <para>Dropping an OmegaT project file
@@ -262,8 +255,7 @@
             </varlistentry>
 
             <varlistentry id="panes.drag.and.drop.fuzzies">
-			  <term id="panes.drag.and.drop.fuzzies.title">
-              Fuzzy Matches pane</term>
+			  <term id="panes.drag.and.drop.fuzzies.title">Fuzzy Matches pane</term>
 
               <listitem>
                 <para>Dropping <filename>.tmx</filename> files here will copy
@@ -273,8 +265,7 @@
             </varlistentry>
 
             <varlistentry id="panes.drag.and.drop.glossaries">
-			  <term id="panes.drag.and.drop.glossaries.title">
-              Glossaries pane</term>
+			  <term id="panes.drag.and.drop.glossaries.title">Glossaries pane</term>
 
               <listitem>
                 <para>Dropping files with a recognized glossary extension
@@ -288,8 +279,7 @@
       </varlistentry>
 
 	  <varlistentry id="panes.notifications">
-		<term id="panes.notifications.title">
-        Notifications</term>
+		<term id="panes.notifications.title">Notifications</term>
 		
         <listitem>
           <para>If a pane is closed but has contents to display, OmegaT can
@@ -367,8 +357,7 @@
   </section>
 
   <section id="panes.editor">
-    <title id="panes.editor.title">
-    <guilabel>Editor</guilabel></title>
+    <title id="panes.editor.title"><guilabel>Editor</guilabel></title>
 
     <para>This is where you type and edit your translations.</para>
 
@@ -545,8 +534,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 
     <variablelist>
       <varlistentry id="panes.editor.empty">
-		<term id="panes.editor.empty.title">
-        Empty translations</term>
+		<term id="panes.editor.empty.title">Empty translations</term>
 
         <listitem>
           <para>If you leave the translation field empty, OmegaT will treat the
@@ -567,8 +555,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.drag">
-		<term id="panes.editor.drag.title">
-        Dragging text</term>
+		<term id="panes.editor.drag.title">Dragging text</term>
 
         <listitem>
           <para>It is possible to drag text from anywhere in the main window and
@@ -579,8 +566,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.overwriting">
-		<term id="panes.editor.overwriting.title">
-        Overwriting</term>
+		<term id="panes.editor.overwriting.title">Overwriting</term>
 
         <listitem>
           <para>By default, typing text inserts the new text after the cursor in
@@ -606,8 +592,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.cursor.lock">
-		<term id="panes.editor.cursor.lock.title">
-        Cursor lock</term>
+		<term id="panes.editor.cursor.lock.title">Cursor lock</term>
 
         <listitem>
           <para>By default, the cursor is locked in the translation field, and
@@ -626,8 +611,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.context.menu">
-		<term id="panes.editor.context.menu.title">
-        Context menu</term>
+		<term id="panes.editor.context.menu.title">Context menu</term>
 
         <listitem>
           <para>Default shortcut:</para>
@@ -717,8 +701,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.navigation">
-		<term id="panes.editor.navigation.title">
-        Navigation</term>
+		<term id="panes.editor.navigation.title">Navigation</term>
         <listitem>
 		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
 		  linkend="menus.goto.notes.pane"
@@ -735,8 +718,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
   </section>
 
   <section id="panes.fuzzy.matches">
-    <title id="panes.fuzzy.matches.title">
-    <guilabel>Fuzzy Matches</guilabel></title>
+    <title id="panes.fuzzy.matches.title"><guilabel>Fuzzy Matches</guilabel></title>
 
     <para>The match viewer shows the segments from your translation memories that
     are most similar to the segment you are currently translating.</para>
@@ -757,8 +739,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     to select a different match.</para>
 
 	<example id="the.first.match">
-      <title id="the.first.match.title">
-      An empty segment and its first two matches</title>
+      <title id="the.first.match.title">An empty segment and its first two matches</title>
       <para>
 		<informaltable id="table.pane.matches">
           <tgroup cols="2">
@@ -857,8 +838,7 @@ Dossier de configuration
   </section>
 
   <section id="panes.glossary">
-    <title id="panes.glossary.title">
-    <guilabel>Glossaries</guilabel></title>
+    <title id="panes.glossary.title"><guilabel>Glossaries</guilabel></title>
 
     <para>This pane shows terms from your glossary files that correspond
     to terms in the current segment. The glossary files are located in the
@@ -872,8 +852,7 @@ Dossier de configuration
     text.</para>
 
 	<example id="glossary.matches">
-      <title id="glossary.matches.title">
-      Glossary matches</title>
+      <title id="glossary.matches.title">Glossary matches</title>
 	  <para>
 		<programlisting>Project = <token>Projet</token>
 1. Projet de traduction
@@ -923,8 +902,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.dictionary">
-    <title id="panes.dictionary.title">
-    <guilabel>Dictionaries</guilabel></title>
+    <title id="panes.dictionary.title"><guilabel>Dictionaries</guilabel></title>
 
 	<para>This pane shows terms from your dictionary files that
 	correspond to terms in the current segment. The dictionary files are located
@@ -1003,8 +981,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.notes">
-    <title id="panes.notes.title">
-    <guilabel>Notepad</guilabel></title>
+    <title id="panes.notes.title"><guilabel>Notepad</guilabel></title>
 
     <para>This pane is an <emphasis>editable</emphasis> space where you can
     add notes to the currently active segment.</para>
@@ -1033,8 +1010,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.comments">
-    <title id="panes.comments.title">
-    <guilabel>Comments</guilabel></title>
+    <title id="panes.comments.title"><guilabel>Comments</guilabel></title>
 
     <para>Some file formats, such as the PO format, can contain comments
     for the translator to add context to the translation. Such comments
@@ -1060,8 +1036,7 @@ Folder = <token>Dossier</token></programlisting>
 	
 	<variablelist>
 	  <varlistentry id="panes.segment.properties.repetition">
-		<term id="panes.segment.properties.repetition.title">
-        Is repetition</term>
+		<term id="panes.segment.properties.repetition.title">Is repetition</term>
 		<listitem>
 		  <para>Indicates that a segment is a repetition and specifies whether
 		  it is the FIRST instance.</para>
@@ -1069,8 +1044,7 @@ Folder = <token>Dossier</token></programlisting>
 	  </varlistentry>
 	  
 	  <varlistentry id="panes.segment.properties.file">
-		<term id="panes.segment.properties.file.title">
-        File</term>
+		<term id="panes.segment.properties.file.title">File</term>
 		<listitem>
 		  <para>Indicates which file contains the segment.</para>
 		</listitem>
@@ -1084,8 +1058,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.statusbar">
-    <title id="panes.statusbar.title">
-    <guilabel>Status bar</guilabel></title>
+    <title id="panes.statusbar.title"><guilabel>Status bar</guilabel></title>
 
     <para>The bottom of the main window is the status bar.</para>
 
@@ -1126,8 +1099,7 @@ Folder = <token>Dossier</token></programlisting>
     percentages.</para>
 
 	<example id="panes.statusbar.widgets">
-      <title id="panes.statusbar.widgets.title">
-      Status bar information</title>
+      <title id="panes.statusbar.widgets.title">Status bar information</title>
 	  <para><literal>LCK | OVR <token>257/271 (12292/154896,
 	  177692)</token><token> 35/0 </token></literal></para>
 

--- a/doc_src/en/OmegaT_EditorsPanes.xml
+++ b/doc_src/en/OmegaT_EditorsPanes.xml
@@ -2,17 +2,16 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.panes">
-  <title id="chapter.panes.title">Panes</title>
+  <title id="chapter.panes.title"><link linkend="chapter.panes"> </link>Panes</title>
 
   <section id="panes.default.layout">
-    <title id="panes.default.layout.title">Default layout</title>
+    <title id="panes.default.layout.title"><link linkend="panes.default.layout"> </link>Default layout</title>
 
 	<para>The first time you start OmegaT, the main window displays the
 	following default layout:</para>
 
 	<figure id="default.omegat.layout.macos">
-      <title id="default.omegat.layout.macos.title">Default OmegaT layout on
-      macOS</title>
+      <title id="default.omegat.layout.macos.title"><link linkend="default.omegat.layout.macos"> </link>Default OmegaT layout on macOS</title>
       <mediaobject>
         <imageobject role="html">
           <imagedata fileref="images/defaultOmegaTLayout.png"/>
@@ -79,11 +78,11 @@
   </section>
 
   <section id="panes.principles">
-    <title id="panes.principles.title">Principles</title>
+    <title id="panes.principles.title"><link linkend="panes.principles"> </link>Principles</title>
 
     <variablelist>
       <varlistentry id="panes.manipulation">
-		<term id="panes.manipulation.title">Manipulation</term>
+		<term id="panes.manipulation.title"><link linkend="panes.manipulation"> </link>Manipulation</term>
 
         <listitem>
           <para>The main window consists of several panes, described here, menus,
@@ -97,7 +96,7 @@
           depending on the type of pane and its current status:</para>
 
           <table id="table.pane.widgets">
-            <title id="table.pane.widgets.title">Pane widgets</title>
+            <title id="table.pane.widgets.title"><link linkend="table.pane.widgets"> </link>Pane widgets</title>
 
             <tgroup cols="2">
               <tbody>
@@ -209,7 +208,7 @@
       </varlistentry>
 
       <varlistentry id="panes.context.menus">
-		<term id="panes.context.menus.title">Context menus</term>
+		<term id="panes.context.menus.title"><link linkend="panes.context.menus"> </link>Context menus</term>
 
         <listitem>
           <para>Some panes have a context menu. You can call that menu using
@@ -231,7 +230,7 @@
       </varlistentry>
 
       <varlistentry id="panes.drag.and.drop">
-		<term id="panes.drag.and.drop.title">Dragging and dropping</term>
+		<term id="panes.drag.and.drop.title"><link linkend="panes.drag.and.drop"> </link>Dragging and dropping</term>
 
         <listitem>
           <para>Files can be dragged and dropped on certain panes, with the
@@ -239,7 +238,7 @@
 
           <variablelist>
             <varlistentry id="panes.drag.and.drop.editor">
-			  <term id="panes.drag.and.drop.editor.title">Editor pane</term>
+			  <term id="panes.drag.and.drop.editor.title"><link linkend="panes.drag.and.drop.editor"> </link>Editor pane</term>
 
               <listitem>
                 <para>Dropping an OmegaT project file
@@ -255,7 +254,7 @@
             </varlistentry>
 
             <varlistentry id="panes.drag.and.drop.fuzzies">
-			  <term id="panes.drag.and.drop.fuzzies.title">Fuzzy Matches pane</term>
+			  <term id="panes.drag.and.drop.fuzzies.title"><link linkend="panes.drag.and.drop.fuzzies"> </link>Fuzzy Matches pane</term>
 
               <listitem>
                 <para>Dropping <filename>.tmx</filename> files here will copy
@@ -265,7 +264,7 @@
             </varlistentry>
 
             <varlistentry id="panes.drag.and.drop.glossaries">
-			  <term id="panes.drag.and.drop.glossaries.title">Glossaries pane</term>
+			  <term id="panes.drag.and.drop.glossaries.title"><link linkend="panes.drag.and.drop.glossaries"> </link>Glossaries pane</term>
 
               <listitem>
                 <para>Dropping files with a recognized glossary extension
@@ -279,7 +278,7 @@
       </varlistentry>
 
 	  <varlistentry id="panes.notifications">
-		<term id="panes.notifications.title">Notifications</term>
+		<term id="panes.notifications.title"><link linkend="panes.notifications"> </link>Notifications</term>
 		
         <listitem>
           <para>If a pane is closed but has contents to display, OmegaT can
@@ -357,7 +356,7 @@
   </section>
 
   <section id="panes.editor">
-    <title id="panes.editor.title"><guilabel>Editor</guilabel></title>
+    <title id="panes.editor.title"><link linkend="panes.editor"> </link><guilabel>Editor</guilabel></title>
 
     <para>This is where you type and edit your translations.</para>
 
@@ -365,9 +364,7 @@
     document and double-click on any segment to open and edit it.</para>
 
 	<example id="panes.editor.default.editor.writing.space">
-      <title id="panes.editor.default.editor.writing.space.title">
-        Default editor
-	  writing space</title>
+      <title id="panes.editor.default.editor.writing.space.title"><link linkend="panes.editor.default.editor.writing.space"> </link>Default editor writing space</title>
 	  <para>
 		<programlisting>— ¶ —————————————————————
 <token>Hide Tags</token>
@@ -440,8 +437,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       <para>Modify the Editor display to suit your workflow.</para>
 
 	  <!--   <example id="panes.editor.modified.editor.target.field"> -->
-	  <!-- 	<title id="panes.editor.modified.editor.target.field.title">Example of modified -->
-	  <!--         editor writing space</title> -->
+	  <!-- 	<title id="panes.editor.modified.editor.target.field.title">Example of modified --> <!--         editor writing space</title> -->
 	  <!-- 	<para> -->
 	  <!-- 	  <programlisting>— ¶ ————————————————————— -->
 
@@ -534,7 +530,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
 
     <variablelist>
       <varlistentry id="panes.editor.empty">
-		<term id="panes.editor.empty.title">Empty translations</term>
+		<term id="panes.editor.empty.title"><link linkend="panes.editor.empty"> </link>Empty translations</term>
 
         <listitem>
           <para>If you leave the translation field empty, OmegaT will treat the
@@ -544,7 +540,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.equal">
-        <term id="panes.editorequal.title">Translations equal to the source</term>
+        <term id="panes.editor.equal.title"><link linkend="panes.editor.equal"> </link>Translations equal to the source</term>
 
         <listitem>
           <para>OmegaT can store translations that are identical to the source
@@ -555,7 +551,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.drag">
-		<term id="panes.editor.drag.title">Dragging text</term>
+		<term id="panes.editor.drag.title"><link linkend="panes.editor.drag"> </link>Dragging text</term>
 
         <listitem>
           <para>It is possible to drag text from anywhere in the main window and
@@ -566,7 +562,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.overwriting">
-		<term id="panes.editor.overwriting.title">Overwriting</term>
+		<term id="panes.editor.overwriting.title"><link linkend="panes.editor.overwriting"> </link>Overwriting</term>
 
         <listitem>
           <para>By default, typing text inserts the new text after the cursor in
@@ -592,7 +588,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.cursor.lock">
-		<term id="panes.editor.cursor.lock.title">Cursor lock</term>
+		<term id="panes.editor.cursor.lock.title"><link linkend="panes.editor.cursor.lock"> </link>Cursor lock</term>
 
         <listitem>
           <para>By default, the cursor is locked in the translation field, and
@@ -611,7 +607,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.context.menu">
-		<term id="panes.editor.context.menu.title">Context menu</term>
+		<term id="panes.editor.context.menu.title"><link linkend="panes.editor.context.menu"> </link>Context menu</term>
 
         <listitem>
           <para>Default shortcut:</para>
@@ -676,9 +672,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.auto.completion.menu">
-		<term id="panes.editor.auto.completion.menu.title">
-          Auto-completion
-        menu</term>
+		<term id="panes.editor.auto.completion.menu.title"><link linkend="panes.editor.auto.completion.menu"> </link>Auto-completion menu</term>
 
         <listitem>
           <para>Default shortcut:</para>
@@ -701,7 +695,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
       </varlistentry>
 
       <varlistentry id="panes.editor.navigation">
-		<term id="panes.editor.navigation.title">Navigation</term>
+		<term id="panes.editor.navigation.title"><link linkend="panes.editor.navigation"> </link>Navigation</term>
         <listitem>
 		  <para>Use <link linkend="menus.goto" endterm="menus.goto.title"/><link
 		  linkend="menus.goto.notes.pane"
@@ -718,7 +712,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
   </section>
 
   <section id="panes.fuzzy.matches">
-    <title id="panes.fuzzy.matches.title"><guilabel>Fuzzy Matches</guilabel></title>
+    <title id="panes.fuzzy.matches.title"><link linkend="panes.fuzzy.matches"> </link><guilabel>Fuzzy Matches</guilabel></title>
 
     <para>The match viewer shows the segments from your translation memories that
     are most similar to the segment you are currently translating.</para>
@@ -739,7 +733,7 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
     to select a different match.</para>
 
 	<example id="the.first.match">
-      <title id="the.first.match.title">An empty segment and its first two matches</title>
+      <title id="the.first.match.title"><link linkend="the.first.match"> </link>An empty segment and its first two matches</title>
       <para>
 		<informaltable id="table.pane.matches">
           <tgroup cols="2">
@@ -838,7 +832,7 @@ Dossier de configuration
   </section>
 
   <section id="panes.glossary">
-    <title id="panes.glossary.title"><guilabel>Glossaries</guilabel></title>
+    <title id="panes.glossary.title"><link linkend="panes.glossary"> </link><guilabel>Glossaries</guilabel></title>
 
     <para>This pane shows terms from your glossary files that correspond
     to terms in the current segment. The glossary files are located in the
@@ -852,7 +846,7 @@ Dossier de configuration
     text.</para>
 
 	<example id="glossary.matches">
-      <title id="glossary.matches.title">Glossary matches</title>
+      <title id="glossary.matches.title"><link linkend="glossary.matches"> </link>Glossary matches</title>
 	  <para>
 		<programlisting>Project = <token>Projet</token>
 1. Projet de traduction
@@ -902,7 +896,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.dictionary">
-    <title id="panes.dictionary.title"><guilabel>Dictionaries</guilabel></title>
+    <title id="panes.dictionary.title"><link linkend="panes.dictionary"> </link><guilabel>Dictionaries</guilabel></title>
 
 	<para>This pane shows terms from your dictionary files that
 	correspond to terms in the current segment. The dictionary files are located
@@ -913,9 +907,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
   
   <section id="panes.machinetranslation">
-    <title id="panes.machinetranslation.title">
-      <guilabel>Machine
-    Translations</guilabel></title>
+    <title id="panes.machinetranslation.title"><link linkend="panes.machinetranslation"> </link><guilabel>Machine Translations</guilabel></title>
 
     <para>If you have enabled and configured at least one machine translation
     engine this pane shows the suggestions for the current segment produced
@@ -959,9 +951,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.multipletranslations">
-    <title id="panes.multipletranslations.title">
-      <guilabel>Multiple
-    Translations</guilabel></title>
+    <title id="panes.multipletranslations.title"><link linkend="panes.multipletranslations"> </link><guilabel>Multiple Translations</guilabel></title>
 
     <para>A source segment that appears in multiple locations in the project may
     require several different translations depending on context.</para>
@@ -981,7 +971,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.notes">
-    <title id="panes.notes.title"><guilabel>Notepad</guilabel></title>
+    <title id="panes.notes.title"><link linkend="panes.notes"> </link><guilabel>Notepad</guilabel></title>
 
     <para>This pane is an <emphasis>editable</emphasis> space where you can
     add notes to the currently active segment.</para>
@@ -1010,7 +1000,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.comments">
-    <title id="panes.comments.title"><guilabel>Comments</guilabel></title>
+    <title id="panes.comments.title"><link linkend="panes.comments"> </link><guilabel>Comments</guilabel></title>
 
     <para>Some file formats, such as the PO format, can contain comments
     for the translator to add context to the translation. Such comments
@@ -1026,9 +1016,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.segment.properties">
-    <title id="panes.segment.properties.title">
-      <guilabel>Segment
-    properties</guilabel></title>
+    <title id="panes.segment.properties.title"><link linkend="panes.segment.properties"> </link><guilabel>Segment properties</guilabel></title>
 
     <para>All segments have properties. The properties are displayed in this
     pane.</para>
@@ -1036,7 +1024,7 @@ Folder = <token>Dossier</token></programlisting>
 	
 	<variablelist>
 	  <varlistentry id="panes.segment.properties.repetition">
-		<term id="panes.segment.properties.repetition.title">Is repetition</term>
+		<term id="panes.segment.properties.repetition.title"><link linkend="panes.segment.properties.repetition"> </link>Is repetition</term>
 		<listitem>
 		  <para>Indicates that a segment is a repetition and specifies whether
 		  it is the FIRST instance.</para>
@@ -1044,7 +1032,7 @@ Folder = <token>Dossier</token></programlisting>
 	  </varlistentry>
 	  
 	  <varlistentry id="panes.segment.properties.file">
-		<term id="panes.segment.properties.file.title">File</term>
+		<term id="panes.segment.properties.file.title"><link linkend="panes.segment.properties.file"> </link>File</term>
 		<listitem>
 		  <para>Indicates which file contains the segment.</para>
 		</listitem>
@@ -1058,7 +1046,7 @@ Folder = <token>Dossier</token></programlisting>
   </section>
 
   <section id="panes.statusbar">
-    <title id="panes.statusbar.title"><guilabel>Status bar</guilabel></title>
+    <title id="panes.statusbar.title"><link linkend="panes.statusbar"> </link><guilabel>Status bar</guilabel></title>
 
     <para>The bottom of the main window is the status bar.</para>
 
@@ -1066,9 +1054,7 @@ Folder = <token>Dossier</token></programlisting>
 	actions or error messages.</para>
 
 	<example id="panes.statusbar.messages">
-      <title id="panes.statusbar.messages.title">
-        Status bar messages
-      examples</title>
+      <title id="panes.statusbar.messages.title"><link linkend="panes.statusbar.messages"> </link>Status bar messages examples</title>
 	  <para><literal>Synchronization of repositories</literal></para>
 
 	  <para>→ OmegaT is opening a team project and synchronizes with the remote
@@ -1099,7 +1085,7 @@ Folder = <token>Dossier</token></programlisting>
     percentages.</para>
 
 	<example id="panes.statusbar.widgets">
-      <title id="panes.statusbar.widgets.title">Status bar information</title>
+      <title id="panes.statusbar.widgets.title"><link linkend="panes.statusbar.widgets"> </link>Status bar information</title>
 	  <para><literal>LCK | OVR <token>257/271 (12292/154896,
 	  177692)</token><token> 35/0 </token></literal></para>
 
@@ -1147,9 +1133,7 @@ Folder = <token>Dossier</token></programlisting>
 	</example>
 	
 	<example id="panes.statusbar.widgets.percentage">
-      <title id="panes.statusbar.widgets.percentage.title">
-        Status bar
-      information, percentage mode</title>
+      <title id="panes.statusbar.widgets.percentage.title"><link linkend="panes.statusbar.widgets.percentage"> </link>Status bar information, percentage mode</title>
 	  <para><literal>UNL | INS <token>94.8% (14 left) / 7.9% (142,604 left),
 	  177,692</token> <token>35/0</token></literal></para>
 	  <variablelist>

--- a/doc_src/en/OmegaT_HowTo.xml
+++ b/doc_src/en/OmegaT_HowTo.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.how.to">
-  <title id="chapter.how.to.title">How To...</title>
+  <title id="chapter.how.to.title"><link linkend="chapter.how.to"> </link>How To...</title>
 
   <xi:include href="HowTo_RestoreYourData.xml"
               xmlns:xi="http://www.w3.org/2001/XInclude"/>

--- a/doc_src/en/OmegaT_Menus.xml
+++ b/doc_src/en/OmegaT_Menus.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.menus">
-  <title id="chapter.menus.title">Menus</title>
+  <title id="chapter.menus.title"><link linkend="chapter.menus"> </link>Menus</title>
 
   <para>OmegaT has very few buttons and looks a bit stern, if not outright
   unfriendly, to people who are used to button-based interfaces. Most of
@@ -23,7 +23,7 @@
 
   <note><para>Key shortcut description reminder:
   <table id="menus.shortcut.description">
-    <title id="menus.shortcut.description.title">Modifier key identifiers</title>
+    <title id="menus.shortcut.description.title"><link linkend="menus.shortcut.description"> </link>Modifier key identifiers</title>
 
     <tgroup cols="3">
       <thead>

--- a/doc_src/en/OmegaT_Menus.xml
+++ b/doc_src/en/OmegaT_Menus.xml
@@ -4,64 +4,65 @@
 <chapter id="chapter.menus">
   <title id="chapter.menus.title">Menus</title>
 
-  	<para>OmegaT has very few buttons and looks a bit stern, if not outright
-    unfriendly, to people who are used to button-based interfaces. Most of
-  	the action takes place with the help of shortcuts associated to menu
-  	items.</para>
+  <para>OmegaT has very few buttons and looks a bit stern, if not outright
+  unfriendly, to people who are used to button-based interfaces. Most of
+  the action takes place with the help of shortcuts associated to menu
+  items.</para>
 
-	<para>Shortcuts are ubiquitous in this manual and you should be able very
-	shortly to remember the few that are useful in the course of a standard
-	translation day.</para>
+  <para>Shortcuts are ubiquitous in this manual and you should be able very
+  shortly to remember the few that are useful in the course of a standard
+  translation day.</para>
 
-	<para>Menus are where you access most of OmegaT's functions. Most 
-	menu items have an associated keyboard shortcut.</para>
+  <para>Menus are where you access most of OmegaT's functions. Most 
+  menu items have an associated keyboard shortcut.</para>
 
-	<para>Menu items that do not indicate a shortcut do not have one assigned by
-	default. See the <link linkend="app.shortcuts.customization"
-	endterm="app.shortcuts.customization.title"/> appendix if you want to modify
-	or add shortcuts.</para>
+  <para>Menu items that do not indicate a shortcut do not have one assigned by
+  default. See the <link linkend="app.shortcuts.customization"
+  endterm="app.shortcuts.customization.title"/> appendix if you want to modify
+  or add shortcuts.</para>
 
   <note><para>Key shortcut description reminder:
-    <table id="menus.shortcut.description">
-      <title id="menus.shortcut.description.title">Modifier key identifiers</title>
+  <table id="menus.shortcut.description">
+    <title id="menus.shortcut.description.title">
+    Modifier key identifiers</title>
 
-      <tgroup cols="3">
-        <thead>
-          <row>
-            <entry>Linux/Windows</entry>
-            <entry>Key identifier</entry>
-            <entry>macOS</entry>
-          </row>
-        </thead>
+    <tgroup cols="3">
+      <thead>
+        <row>
+          <entry>Linux/Windows</entry>
+          <entry>Key identifier</entry>
+          <entry>macOS</entry>
+        </row>
+      </thead>
 
-        <tbody>
-          <row>
-            <entry><keycap>Shift</keycap></entry>
-            <entry><keycap>S</keycap></entry>
-            <entry><keycap>shift</keycap> or <keycap>⇧</keycap></entry>
-          </row>
+      <tbody>
+        <row>
+          <entry><keycap>Shift</keycap></entry>
+          <entry><keycap>S</keycap></entry>
+          <entry><keycap>shift</keycap> or <keycap>⇧</keycap></entry>
+        </row>
 
-          <row>
-            <entry><keycap>Ctrl</keycap> or <keycap>Control</keycap></entry>
-            <entry><keycap>C</keycap></entry>
-            <entry><keycap>command</keycap> or <keycap>⌘</keycap></entry>
-          </row>
+        <row>
+          <entry><keycap>Ctrl</keycap> or <keycap>Control</keycap></entry>
+          <entry><keycap>C</keycap></entry>
+          <entry><keycap>command</keycap> or <keycap>⌘</keycap></entry>
+        </row>
 
-          <row>
-            <entry><keycap>Alt</keycap></entry>
-            <entry><keycap>A</keycap></entry>
-            <entry><keycap>alt / option</keycap> or
-            <keycap>⌥</keycap></entry>
-          </row>
+        <row>
+          <entry><keycap>Alt</keycap></entry>
+          <entry><keycap>A</keycap></entry>
+          <entry><keycap>alt / option</keycap> or
+          <keycap>⌥</keycap></entry>
+        </row>
 
-          <row>
-            <entry/>
-            <entry><keycap>Ctrl</keycap></entry>
-            <entry><keycap>control</keycap> or <keycap>⌃</keycap></entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table></para>
+        <row>
+          <entry/>
+          <entry><keycap>Ctrl</keycap></entry>
+          <entry><keycap>control</keycap> or <keycap>⌃</keycap></entry>
+        </row>
+      </tbody>
+    </tgroup>
+  </table></para>
   </note>
 
   <xi:include href="Menus_Project.xml"

--- a/doc_src/en/OmegaT_Menus.xml
+++ b/doc_src/en/OmegaT_Menus.xml
@@ -23,8 +23,7 @@
 
   <note><para>Key shortcut description reminder:
   <table id="menus.shortcut.description">
-    <title id="menus.shortcut.description.title">
-    Modifier key identifiers</title>
+    <title id="menus.shortcut.description.title">Modifier key identifiers</title>
 
     <tgroup cols="3">
       <thead>

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -29,13 +29,11 @@
   </note>
 
   <section id="dialogs.preferences.general">
-    <title id="dialogs.preferences.general.title">
-    <guilabel>General</guilabel></title>
+    <title id="dialogs.preferences.general.title"><guilabel>General</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.general.use.tab.to.advance">
-        <term id="dialogs.preferences.general.use.tab.to.advance.title">
-        <option>Use TAB to Advance</option></term>
+        <term id="dialogs.preferences.general.use.tab.to.advance.title"><option>Use TAB to Advance</option></term>
 
         <listitem>
 		  <para>The default key to validate and leave a segment is
@@ -49,8 +47,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.always.confirm.quit">
-        <term id="dialogs.preferences.general.always.confirm.quit.title">
-        <option>Always Confirm Quit</option></term>
+        <term id="dialogs.preferences.general.always.confirm.quit.title"><option>Always Confirm Quit</option></term>
 
         <listitem>
           <para>The program will ask for confirmation before closing.</para>
@@ -58,8 +55,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.access.configuration.folder">
-        <term id="dialogs.preferences.general.access.configuration.folder.title">
-        <option>Access Configuration Folder</option></term>
+        <term id="dialogs.preferences.general.access.configuration.folder.title"><option>Access Configuration Folder</option></term>
 		<listitem>
           <para>Opens the local folder where OmegaT configuration files are
           stored.</para>
@@ -75,13 +71,11 @@
   </section>
 
   <section id="dialogs.preferences.mt">
-    <title id="dialogs.preferences.mt.title">
-    <guilabel>Machine Translation</guilabel></title>
+    <title id="dialogs.preferences.mt.title"><guilabel>Machine Translation</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.mt.automatically.fetch.translations">
-        <term id="dialogs.preferences.mt.automatically.fetch.translations.title">
-        <option>Automatically fetch translations</option></term>
+        <term id="dialogs.preferences.mt.automatically.fetch.translations.title"><option>Automatically fetch translations</option></term>
 
 		<listitem>
 		  <para>Enable this option to automatically fetch machine translations from
@@ -96,8 +90,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.untranslated.segments.only">
-        <term id="dialogs.preferences.mt.untranslated.segments.only.title">
-        <option>Untranslated segments only</option></term>
+        <term id="dialogs.preferences.mt.untranslated.segments.only.title"><option>Untranslated segments only</option></term>
 
         <listitem>
           <para>Check this box to send only untranslated segments to the machine
@@ -106,8 +99,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.provider.list">
-        <term id="dialogs.preferences.mt.provider.list.title">
-        <option>Provider list</option></term>
+        <term id="dialogs.preferences.mt.provider.list.title"><option>Provider list</option></term>
 
         <listitem>
           <para>In the list of machine translation available in OmegaT, check
@@ -187,13 +179,11 @@
   </section>
 
   <section id="dialogs.preferences.glossary">
-	<title id="dialogs.preferences.glossary.title">
-    <guilabel>Glossaries</guilabel></title>
+	<title id="dialogs.preferences.glossary.title"><guilabel>Glossaries</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries">
-        <term id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title">
-        <option>Display TBX glossaries context description (TBX 2)</option></term>
+        <term id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title"><option>Display TBX glossaries context description (TBX 2)</option></term>
 
         <listitem>
           <para>Uncheck this option if the context description shown for each
@@ -213,8 +203,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.use.stemming.for.glossary.entries">
-        <term id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title">
-        <option>Use stemming</option></term>
+        <term id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title"><option>Use stemming</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -222,8 +211,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text">
-        <term id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title">
-        <option>Replace matches when inserting source text</option></term>
+        <term id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title"><option>Replace matches when inserting source text</option></term>
         <listitem>
           <para>When you use</para>
 		  
@@ -265,8 +253,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.glossary.layout">
-        <term id="dialogs.preferences.glossary.glossary.layout.title">
-        <option>Layout</option></term>
+        <term id="dialogs.preferences.glossary.glossary.layout.title"><option>Layout</option></term>
 
         <listitem>
           <para>Select a layout for the glossaries pane contents. Additional
@@ -275,8 +262,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term">
-        <term id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title">
-        <option>Merge alternate definition of the same term</option></term>
+        <term id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title"><option>Merge alternate definition of the same term</option></term>
 
         <listitem>
           <para>If a glossary item has multiple definitions, they will be
@@ -285,8 +271,7 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.glossary.sort.by.source.term.length">
-        <term id="dialogs.preferences.glossary.sort.by.source.term.length.title">
-        <option>Sort by source text term length</option></term>
+        <term id="dialogs.preferences.glossary.sort.by.source.term.length.title"><option>Sort by source text term length</option></term>
 		<listitem>
 		  <para>If some glossary items are similar in a source term text,
 		  and one contains another term text, sort by a length of source text.</para>
@@ -294,8 +279,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.glossary.sort.by.target.term.length">
-        <term id="dialogs.preferences.glossary.sort.by.target.term.length.title">
-        <option>Sort by source text term length</option></term>
+        <term id="dialogs.preferences.glossary.sort.by.target.term.length.title"><option>Sort by source text term length</option></term>
 		<listitem>
 		  <para>If a glossary item has multiple definitions, sort by a length of definition text.</para>
 		</listitem>
@@ -304,8 +288,7 @@
   </section>
 
   <section id="dialogs.preferences.dictionary">
-	<title id="dialogs.preferences.dictionary.title">
-    <guilabel>Dictionaries</guilabel></title>
+	<title id="dialogs.preferences.dictionary.title"><guilabel>Dictionaries</guilabel></title>
 
 	<para>Preferences here define how the contents of the <link
 	linkend="project.folder.dictionary"
@@ -315,8 +298,7 @@
 	
     <variablelist>
       <varlistentry id="dialogs.preferences.dictionary.automatically.search.segment">
-        <term id="dialogs.preferences.dictionary.automatically.search.segment.title">
-        <option>Search automatically</option></term>
+        <term id="dialogs.preferences.dictionary.automatically.search.segment.title"><option>Search automatically</option></term>
 
         <listitem>
           <para>While the option is disabled, use <link linkend="menus.edit"
@@ -331,8 +313,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries">
-        <term id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title">
-        <option>Use fuzzy matching</option></term>
+        <term id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"><option>Use fuzzy matching</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -340,8 +321,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.condensed.view">
-        <term id="dialogs.preferences.dictionary.use.condensed.view.title">
-        <option>Use condensed view</option></term>
+        <term id="dialogs.preferences.dictionary.use.condensed.view.title"><option>Use condensed view</option></term>
 
         <listitem>
           <para>Some dictionary drivers provided as plugins do not support this
@@ -352,13 +332,11 @@
   </section>
 
   <section id="dialogs.preferences.appearance">
-	<title id="dialogs.preferences.appearance.title">
-    <guilabel>Appearance</guilabel></title>
+	<title id="dialogs.preferences.appearance.title"><guilabel>Appearance</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.appearance.theme">
-        <term id="dialogs.preferences.appearance.theme.title">
-        <option>Theme</option></term>
+        <term id="dialogs.preferences.appearance.theme.title"><option>Theme</option></term>
 
         <listitem>
           <para>Select a theme for the OmegaT user interface.</para>
@@ -372,8 +350,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.appearance.restore.main.window">
-        <term id="dialogs.preferences.appearance.restore.main.window.title">
-        <option>Restore Main Window</option></term>
+        <term id="dialogs.preferences.appearance.restore.main.window.title"><option>Restore Main Window</option></term>
 
         <listitem>
           <para>Restores the OmegaT window panes to their default
@@ -388,8 +365,7 @@
     </variablelist>
 	
 	<section id="dialogs.preferences.fonts">
-	  <title id="dialogs.preferences.fonts.title">
-      <guilabel>Font</guilabel></title>
+	  <title id="dialogs.preferences.fonts.title"><guilabel>Font</guilabel></title>
 
       <para>Select the font and font size used to display the text in the main
       window panes.</para>
@@ -427,8 +403,7 @@
 	</section>
 
 	<section id="dialogs.preferences.colours">
-	  <title id="dialogs.preferences.colours.title">
-      <guilabel>Colours</guilabel></title>
+	  <title id="dialogs.preferences.colours.title"><guilabel>Colours</guilabel></title>
 
       <para>You can assign different colours for the various parts of the user
       interface.</para>
@@ -550,8 +525,7 @@
 	</section>
 
 	<section id="segmentation.rules">
-	  <title id="segmentation.rules.title">
-      <guilabel>Set contents</guilabel></title>
+	  <title id="segmentation.rules.title"><guilabel>Set contents</guilabel></title>
 	  <warning>
 		<para>Exception rules should be listed <emphasis>above</emphasis> break
 		rules.</para>
@@ -563,8 +537,7 @@
 	  
 	  <variablelist>
 		<varlistentry id="segmentation.rules.exceptionrule">
-          <term id="segmentation.rules.exceptionrule.title">
-          <option>Exceptions</option></term>
+          <term id="segmentation.rules.exceptionrule.title"><option>Exceptions</option></term>
 
 		  <listitem>
 			<para>To define an exception rule, leave the <guilabel>Break/Exception
@@ -579,8 +552,7 @@
 		</varlistentry>
 
 		<varlistentry id="segmentation.rules.breakrule">
-          <term id="segmentation.rules.breakrule.title">
-          <option>Breaks</option></term>
+          <term id="segmentation.rules.breakrule.title"><option>Breaks</option></term>
 
 		  <listitem>
 			<para>To define a break rule, check the
@@ -593,8 +565,7 @@
 		</varlistentry>
 
 		<varlistentry id="creating.new.rule">
-          <term id="creating.new.rule.title">
-          <guibutton>Add</guibutton></term>
+          <term id="creating.new.rule.title"><guibutton>Add</guibutton></term>
 		  <listitem>
 			<para>The <emphasis role="bold">Before</emphasis> pattern identifies
 			the parts that are before the break or exception point.</para>
@@ -670,8 +641,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.spellchecker.automatic.check">
-        <term id="dialog.preferences.spellchecker.automatic.check.title">
-        <option>Spellcheck the translation</option></term>
+        <term id="dialog.preferences.spellchecker.automatic.check.title"><option>Spellcheck the translation</option></term>
 		<listitem>
 		  <para>Enable after installing a spellchecking dictionary. OmegaT will
 		  underline spelling mistakes with red wavy-lines.</para>
@@ -685,8 +655,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.dictionary.folder">
-        <term id="dialog.preferences.spellchecker.dictionary.folder.title">
-        <option>Spellchecking dictionaries location</option></term>
+        <term id="dialog.preferences.spellchecker.dictionary.folder.title"><option>Spellchecking dictionaries location</option></term>
 		<listitem>
 		  <para>The folder where OmegaT will install and search for spelling
 		  dictionaries. It is generally in the <link
@@ -702,8 +671,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.already.installed">
-        <term id="dialog.preferences.spellchecker.already.installed.title">
-        <option>Available languages</option></term>
+        <term id="dialog.preferences.spellchecker.already.installed.title"><option>Available languages</option></term>
 		<listitem>
 		  <para>The list of dictionaries that are present in the above
 		  folder.</para>
@@ -716,8 +684,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.url">
-        <term id="dialog.preferences.spellchecker.url.title">
-        <option>URL of downloadable spellchecking dictionaries</option></term>
+        <term id="dialog.preferences.spellchecker.url.title"><option>URL of downloadable spellchecking dictionaries</option></term>
 		<listitem>
 		  <para>The default URL where OmegaT will look for dictionaries to
 		  install.</para>
@@ -727,8 +694,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.spellchecker.install.new">
-        <term id="dialog.preferences.spellchecker.install.new.title">
-        <guibutton>Install new language...</guibutton></term>
+        <term id="dialog.preferences.spellchecker.install.new.title"><guibutton>Install new language...</guibutton></term>
 		<listitem>
 		  <para>Displays the list of available dictionaries from the above
 		  URL.</para>
@@ -746,13 +712,11 @@
   </section>
   
   <section id="dialog.preferences.languagetool.plugin">
-    <title id="dialog.preferences.languagetool.plugin.title">
-    <guilabel>LanguageTool</guilabel></title>
+    <title id="dialog.preferences.languagetool.plugin.title"><guilabel>LanguageTool</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.languagetool.plugin.servicetype">
-        <term id="dialog.preferences.languagetool.plugin.servicetype.title">
-        <option>Service type</option></term>
+        <term id="dialog.preferences.languagetool.plugin.servicetype.title"><option>Service type</option></term>
 
 		<listitem>
 		  <para>Select the location of the language checker.</para>
@@ -764,8 +728,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.languagetool.plugin.rules">
-        <term id="dialog.preferences.languagetool.plugin.rules.title">
-        <option>Rules</option></term>
+        <term id="dialog.preferences.languagetool.plugin.rules.title"><option>Rules</option></term>
 
 		<listitem>
 		  <para>Select the rules depending on whether they are relevant to the
@@ -786,8 +749,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
-        <term id="dialogs.preferences.external.search.enable.project.specific.commands.title">
-        <option>Allow local external search commands</option></term>
+        <term id="dialogs.preferences.external.search.enable.project.specific.commands.title"><option>Allow local external search commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -804,8 +766,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.external.search.context.menu.priority">
-        <term id="dialogs.preferences.external.search.context.menu.priority.title">
-        <option>Context Menu Priority</option></term>
+        <term id="dialogs.preferences.external.search.context.menu.priority.title"><option>Context Menu Priority</option></term>
 
 		<listitem>
 		  <para>This option enables you to change the order of the commands in
@@ -820,8 +781,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.external.search.items">
-        <term id="dialogs.preferences.external.search.items.title">
-        <option>Sets</option></term>
+        <term id="dialogs.preferences.external.search.items.title"><option>Sets</option></term>
 		<listitem>
 		  <para>Each set represents a group of web searches or local commands
 		  that are launched simultaneously.</para>
@@ -871,14 +831,12 @@
   </section>
 
   <section id="dialogs.preferences.editor">
-	<title id="dialogs.preferences.editor.title">
-    <guilabel>Editor</guilabel></title>
+	<title id="dialogs.preferences.editor.title"><guilabel>Editor</guilabel></title>
 
 	<para>When entering an empty segment:</para>
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.insert.the.source.text">
-        <term id="dialogs.preferences.editor.insert.the.source.text.title">
-        <option>Insert the source text</option></term>
+        <term id="dialogs.preferences.editor.insert.the.source.text.title"><option>Insert the source text</option></term>
 
 		<listitem>
 		  <para>Use this option temporarily for parts of the translation that do
@@ -887,8 +845,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.leave.the.segment.empty">
-        <term id="dialogs.preferences.editor.leave.the.segment.empty.title">
-        <option>Leave the segment empty</option></term>
+        <term id="dialogs.preferences.editor.leave.the.segment.empty.title"><option>Leave the segment empty</option></term>
 
 		<listitem>
 		  <para>You can enter your translation right away.</para>
@@ -896,8 +853,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.insert.the.best.fuzzy.match">
-        <term id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title">
-        <option>Insert the best fuzzy match</option></term>
+        <term id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"><option>Insert the best fuzzy match</option></term>
 
 		<listitem>
 		  <para>OmegaT inserts the translation with the highest match percentage
@@ -915,8 +871,7 @@
 	
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match">
-        <term id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title">
-        <option>Attempt to replace fuzzy match numbers</option></term>
+        <term id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title"><option>Attempt to replace fuzzy match numbers</option></term>
 
 		<listitem>
 		  <para>When a fuzzy match is inserted, OmegaT tries to replace the numbers
@@ -928,8 +883,7 @@
 		  </note>
 
 		  <example id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers">
-			<title id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers.title">
-            Fuzzy match number conversion</title>
+			<title id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers.title">Fuzzy match number conversion</title>
 			<para><token>2001</token> in the source:</para>
 			<para>
 			<programlisting>[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
@@ -947,8 +901,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source">
-        <term id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title">
-        <option>Allow translation to be equal to source</option></term>
+        <term id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"><option>Allow translation to be equal to source</option></term>
 
 		<listitem>
 		  <para>A translation that is identical to the source text is not
@@ -961,8 +914,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.export.the.segment.to.text.files">
-        <term id="dialogs.preferences.editor.export.the.segment.to.text.files.title">
-        <option>Export the segment to a text file</option></term>
+        <term id="dialogs.preferences.editor.export.the.segment.to.text.files.title"><option>Export the segment to a text file</option></term>
 
 		<listitem>
 		  <para>When OmegaT enters a segment,</para>
@@ -1017,8 +969,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.tag.editing">
-        <term id="dialogs.preferences.editor.allow.tag.editing.title">
-        <option>Allow tag editing</option></term>
+        <term id="dialogs.preferences.editor.allow.tag.editing.title"><option>Allow tag editing</option></term>
 
 		<listitem>
 		  <para>Tags should generally not be modified, but that is possible when
@@ -1027,8 +978,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment">
-        <term id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title">
-        <option>Check issues when leaving a segment</option></term>
+        <term id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"><option>Check issues when leaving a segment</option></term>
 
 		<listitem>
 		  <para>OmegaT runs an issues check on the segment as you leave it. The
@@ -1039,8 +989,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.save.auto-populated.status">
-        <term id="dialogs.preferences.editor.save.auto-populated.status.title">
-        <option>Save auto-populated status</option></term>
+        <term id="dialogs.preferences.editor.save.auto-populated.status.title"><option>Save auto-populated status</option></term>
 
 		<listitem>
 		  <para>Translation memories located in <link
@@ -1060,8 +1009,7 @@
 	  </varlistentry>
 
       <varlistentry id="dialogs.preferences.editor.save.orgin.of.translation">
-        <term id="dialogs.preferences.editor.save.orgin.of.translation.title">
-        <option>Save origin of translation</option></term>
+        <term id="dialogs.preferences.editor.save.orgin.of.translation.title"><option>Save origin of translation</option></term>
 
 		<listitem>
           <para>When machine translation is enabled, OmegaT registers the name
@@ -1070,8 +1018,7 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.initially.load.this.many.segments">
-        <term id="dialogs.preferences.editor.initially.load.this.many.segments.title">
-        <option>Initial number of loaded segments</option></term>
+        <term id="dialogs.preferences.editor.initially.load.this.many.segments.title"><option>Initial number of loaded segments</option></term>
 
 		<listitem>
 		  <para>The editor initially loads and displays 2,000 segments, and
@@ -1081,8 +1028,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.paragraph.delimitation.format">
-        <term id="dialogs.preferences.editor.paragraph.delimitation.format.title">
-        <option>Paragraph delimitation format</option></term>
+        <term id="dialogs.preferences.editor.paragraph.delimitation.format.title"><option>Paragraph delimitation format</option></term>
 
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
@@ -1095,13 +1041,11 @@
   </section>
 
   <section id="dialogs.preferences.tag.processing">
-	<title id="dialogs.preferences.tag.processing.title">
-    <guilabel>Tag Processing</guilabel></title>
+	<title id="dialogs.preferences.tag.processing.title"><guilabel>Tag Processing</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.tag.processing.programming.variables">
-        <term id="dialogs.preferences.tag.processing.programming.variables.title">
-        <option>Check printf function variables</option></term>
+        <term id="dialogs.preferences.tag.processing.programming.variables.title"><option>Check printf function variables</option></term>
 		<listitem>
 		  <para>Check printf variables in file formats other than the PO
 		  format. The PO filter already handles variables marked with
@@ -1111,24 +1055,21 @@
 		  
 		  <variablelist>
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.none">
-              <term id="dialogs.preferences.tag.processing.programming.variables.none.title">
-              <option>None</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.none.title"><option>None</option></term>
 			  <listitem>
 				<para>None of the variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 			
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.simple">
-              <term id="dialogs.preferences.tag.processing.programming.variables.simple.title">
-              <option>Simple variables (e.g., %s, %d)</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.simple.title"><option>Simple variables (e.g., %s, %d)</option></term>
 			  <listitem>
 				<para>Only the simple variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.all">
-              <term id="dialogs.preferences.tag.processing.programming.variables.all.title">
-              <option>All variables (e.g., %s, %-s)</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.all.title"><option>All variables (e.g., %s, %-s)</option></term>
 			  <listitem>
 				<para>This can result in false positives in some files.</para>
 			  </listitem>
@@ -1138,8 +1079,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.simple.java.messageformat">
-        <term id="dialogs.preferences.tag.processing.simple.java.messageformat.title">
-        <option>Check simple Java MessageFormat placeholders</option></term>
+        <term id="dialogs.preferences.tag.processing.simple.java.messageformat.title"><option>Check simple Java MessageFormat placeholders</option></term>
 		<listitem>
 		  <para>Check Java MessageFormat placeholders in file formats other than
 		  the Java Bundles format. The Java Bundles filter already handles
@@ -1149,8 +1089,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order">
-        <term id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title">
-        <option>Allow translated tags to be in a different order</option></term>
+        <term id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title"><option>Allow translated tags to be in a different order</option></term>
 		<listitem>
 		  <para>Tags in a different order than the source will not appear in the
 		  list of tag issues. See the <link linkend="menus.tools"
@@ -1173,8 +1112,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics">
-        <term id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title">
-        <option>Count flagged text and custom tags in statistics</option></term>
+        <term id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"><option>Count flagged text and custom tags in statistics</option></term>
 		<listitem>
 		  <para>Unlike OmegaT tags, flagged text and custom tags are by default
 		  counted in the statistics. See the <link
@@ -1186,8 +1124,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags">
-        <term id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title">
-        <option>Custom tags</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"><option>Custom tags</option></term>
 		<listitem>
 		  <para>Use regular expressions to define custom tags. To define a list
 		  of tags, group each tag between parentheses and separate the groups
@@ -1211,8 +1148,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation">
-        <term id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title">
-        <option>Flagged text</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"><option>Flagged text</option></term>
 		<listitem>
 		  <para>Text in the target segment matching this expression is marked in
 		  red and identified as an extraneous tag for issue checking
@@ -1226,16 +1162,14 @@
   </section>
 
   <section id="dialog.preferences.team">
-	<title id="dialog.preferences.team.title">
-    <guilabel>Team</guilabel></title>
+	<title id="dialog.preferences.team.title"><guilabel>Team</guilabel></title>
 
 	<para>The name you enter here will be attached to all the segments you
 	translate.</para>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.team.title.repository.credentials">
-        <term id="dialog.preferences.team.title.repository.credentials.title">
-        <option>Repository Credentials</option></term>
+        <term id="dialog.preferences.team.title.repository.credentials.title"><option>Repository Credentials</option></term>
 		<listitem>
 		  <para>List of projects for which login details have been stored in
 		  OmegaT. Remove a project from this list if you want OmegaT to ask you
@@ -1246,13 +1180,11 @@
   </section>
 
   <section id="dialog.preferences.tm.matches">
-	<title id="dialog.preferences.tm.matches.title">
-    <option>TM Matches</option></title>
+	<title id="dialog.preferences.tm.matches.title"><option>TM Matches</option></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.tm.matches.sort.fuzzy.matches.by">
-        <term id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title">
-        <option>Sort fuzzy matches by:</option></term>
+        <term id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title"><option>Sort fuzzy matches by:</option></term>
 
 		<listitem>
 		  <para>By default, stemming is used to determine the closest matches
@@ -1265,8 +1197,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.minimum.threshold">
-        <term id="dialog.preferences.tm.matches.minimum.threshold.title">
-        <option>Minimal threshold to show a fuzzy match</option></term>
+        <term id="dialog.preferences.tm.matches.minimum.threshold.title"><option>Minimal threshold to show a fuzzy match</option></term>
 		<listitem>
 		  <para>OmegaT displays the five best fuzzy matches above 30% by
 		  default. You can change that threshold here.</para>
@@ -1295,8 +1226,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.other.languages">
-        <term id="dialog.preferences.tm.matches.other.languages.title">
-        <option>Include matches from other languages</option></term>
+        <term id="dialog.preferences.tm.matches.other.languages.title"><option>Include matches from other languages</option></term>
 		<listitem>
 		  <para>Segments that have matches in different target languages can
 		  also be displayed in the <link linkend="panes.fuzzy.matches"
@@ -1307,8 +1237,7 @@
 
 	  
 	  <varlistentry id="dialog.preferences.tm.matches.match.display.template">
-        <term id="dialog.preferences.tm.matches.match.display.template.title">
-        <option>Match display template</option></term>
+        <term id="dialog.preferences.tm.matches.match.display.template.title"><option>Match display template</option></term>
 
 		<listitem>
 		  <para>Change how fuzzy matches are displayed, through the use of
@@ -1334,8 +1263,7 @@ ${filePath}></programlisting></para>
 		  and can be inserted with a button.</para>
 
 		  <table id="table.match.pane.setup" colsep="0" rowsep="0">
-			<title id="table.match.pane.setup.title">
-            Match template variables</title>
+			<title id="table.match.pane.setup.title">Match template variables</title>
 
 			<tgroup cols="2" colsep="1" rowsep="1">
 			  <colspec align="left"/>
@@ -1482,13 +1410,11 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialog.preferences.view">
-	<title id="dialog.preferences.view.title">
-    <guilabel>View</guilabel></title>
+	<title id="dialog.preferences.view.title"><guilabel>View</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.view.display.all.source.segments.in.bold">
-        <term id="dialog.preferences.view.display.all.source.segments.in.bold.title">
-        <option>Display all source segments in bold</option></term>
+        <term id="dialog.preferences.view.display.all.source.segments.in.bold.title"><option>Display all source segments in bold</option></term>
 		<listitem>
 		  <para>By default, only the current segment is displayed in bold
 		  face.</para>
@@ -1496,8 +1422,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.display.active.source.segment.in.bold">
-        <term id="dialog.preferences.view.display.active.source.segment.in.bold.title">
-        <option>Display active source segment in bold</option></term>
+        <term id="dialog.preferences.view.display.active.source.segment.in.bold.title"><option>Display active source segment in bold</option></term>
 		<listitem>
 		  <para>If source segments are displayed in normal face, you can use
 		  this option to display only the current source segment in bold.</para>
@@ -1505,8 +1430,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments">
-        <term id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title">
-        <option>Mark all repeated segments</option></term>
+        <term id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title"><option>Mark all repeated segments</option></term>
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
 		  linkend="menus.view.mark.non.unique.segments"
@@ -1517,8 +1441,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.simplify.tooltip.on.protected.parts">
-        <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title">
-        <option>Simplify tag tooltips</option></term>
+        <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title"><option>Simplify tag tooltips</option></term>
 		<listitem>
 		  <para>OmegaT tags are protected text that represents format-specific
 		  tags in the source document. When hovering on an OmegaT tag, OmegaT
@@ -1529,8 +1452,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.use.custom.templates.for.modification.info">
-        <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title">
-        <option>Customize segment modification information</option></term>
+        <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title"><option>Customize segment modification information</option></term>
 		<listitem>
 		  <para>Segment modification information is displayed over the
 		  segment. the default setting shows who last modified the translation
@@ -1558,8 +1480,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.view.modification.info.template">
-        <term id="dialog.preferences.view.modification.info.template.title">
-        <option>Standard template</option></term>
+        <term id="dialog.preferences.view.modification.info.template.title"><option>Standard template</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1567,8 +1488,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.modification.info.template.for.segments.without.date">
-        <term id="dialog.preferences.view.modification.info.template.for.segments.without.date.title">
-        <option>Template for segments without date</option></term>
+        <term id="dialog.preferences.view.modification.info.template.for.segments.without.date.title"><option>Template for segments without date</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1584,8 +1504,7 @@ ${filePath}></programlisting></para>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.saving.and.output.interval">
-        <term id="dialog.preferences.saving.and.output.interval.title">
-        <option>Project data saving interval</option></term>
+        <term id="dialog.preferences.saving.and.output.interval.title"><option>Project data saving interval</option></term>
 		<listitem>
 		  <para>Allows the user to select the interval between automatic project
 		  data saves.  See the <link
@@ -1611,8 +1530,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
-        <term id="dialogs.preferences.saving.and.output.external.post-processing.command.title">
-        <option>Global post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>Global post-processing commands</option></term>
 
 		<listitem>
 		  <para>OmegaT can automatically run commands after you use <link
@@ -1640,8 +1558,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
-        <term id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title">
-        <option>Allow local post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><option>Allow local post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -1671,16 +1588,14 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.proxy.login">
-	<title id="dialogs.preferences.proxy.login.title">
-    <guilabel>Proxy Login</guilabel></title>
+	<title id="dialogs.preferences.proxy.login.title"><guilabel>Proxy Login</guilabel></title>
 
 	<para>If you use an authenticated proxy server to access the Internet, enter
 	your credentials here.</para>
   </section>
 
   <section id="dialogs.preferences.secure.store">
-	<title id="dialogs.preferences.secure.store.title">
-    <guilabel>Secure store</guilabel></title>
+	<title id="dialogs.preferences.secure.store.title"><guilabel>Secure store</guilabel></title>
 
 	<para>Define or reset the master password used to protect login credentials
 	as well as access keys for machine translation services.</para>
@@ -1691,8 +1606,7 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.plugins">
-	<title id="dialogs.preferences.plugins.title">
-    <guilabel>Plugins</guilabel></title>
+	<title id="dialogs.preferences.plugins.title"><guilabel>Plugins</guilabel></title>
 
 	<para>Displays the list of all the installed plugins.</para>
 
@@ -1718,8 +1632,7 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.updates">
-	<title id="dialogs.preferences.updates.title">
-    <guilabel>Updates</guilabel></title>
+	<title id="dialogs.preferences.updates.title"><guilabel>Updates</guilabel></title>
 
 	<para>Use this option to choose whether to be automatically notified of
 	updates to OmegaT.</para>

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -4,8 +4,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <chapter id="chapter.dialogs.preferences">
-  <title
-  id="chapter.dialogs.preferences.title"><guilabel>Preferences</guilabel></title>
+  <title id="chapter.dialogs.preferences.title"><guilabel>Preferences</guilabel></title>
 
   <para>Use <link endterm="menus.options.title" linkend="menus.options"/><link
   endterm="menus.options.preferences.title"
@@ -30,12 +29,13 @@
   </note>
 
   <section id="dialogs.preferences.general">
-    <title id="dialogs.preferences.general.title"><guilabel>General</guilabel></title>
+    <title id="dialogs.preferences.general.title">
+    <guilabel>General</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.general.use.tab.to.advance">
-        <term id="dialogs.preferences.general.use.tab.to.advance.title"><option>Use TAB
-        to Advance</option></term>
+        <term id="dialogs.preferences.general.use.tab.to.advance.title">
+        <option>Use TAB to Advance</option></term>
 
         <listitem>
 		  <para>The default key to validate and leave a segment is
@@ -49,8 +49,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.always.confirm.quit">
-        <term id="dialogs.preferences.general.always.confirm.quit.title"><option>Always
-        Confirm Quit</option></term>
+        <term id="dialogs.preferences.general.always.confirm.quit.title">
+        <option>Always Confirm Quit</option></term>
 
         <listitem>
           <para>The program will ask for confirmation before closing.</para>
@@ -58,9 +58,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.access.configuration.folder">
-        <term
-			id="dialogs.preferences.general.access.configuration.folder.title"><option>Access
-        Configuration Folder</option></term>
+        <term id="dialogs.preferences.general.access.configuration.folder.title">
+        <option>Access Configuration Folder</option></term>
 		<listitem>
           <para>Opens the local folder where OmegaT configuration files are
           stored.</para>
@@ -76,30 +75,29 @@
   </section>
 
   <section id="dialogs.preferences.mt">
-    <title id="dialogs.preferences.mt.title"><guilabel>Machine Translation</guilabel></title>
+    <title id="dialogs.preferences.mt.title">
+    <guilabel>Machine Translation</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.mt.automatically.fetch.translations">
-        <term
-			id="dialogs.preferences.mt.automatically.fetch.translations.title"><option>Automatically
-        fetch translations</option></term>
+        <term id="dialogs.preferences.mt.automatically.fetch.translations.title">
+        <option>Automatically fetch translations</option></term>
 
-				<listitem>
-					<para>Enable this option to automatically fetch machine translations from
-						the providers you have enabled and configured. If you leave this option
-						disabled, machine translations are only fetched when you use <link
-						linkend="menus.edit" endterm="menus.edit.title"/>
-						<link linkend="menus.edit.replace.with.mt"
-						endterm="menus.edit.replace.with.mt.title"/> in the current
-						segment. You then have to press that combination again to insert
-						the suggestion.</para>
-				</listitem>
+		<listitem>
+		  <para>Enable this option to automatically fetch machine translations from
+		  the providers you have enabled and configured. If you leave this option
+		  disabled, machine translations are only fetched when you use <link
+		  linkend="menus.edit" endterm="menus.edit.title"/>
+		  <link linkend="menus.edit.replace.with.mt"
+				endterm="menus.edit.replace.with.mt.title"/> in the current
+		  segment. You then have to press that combination again to insert
+		  the suggestion.</para>
+		</listitem>
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.untranslated.segments.only">
-        <term
-			id="dialogs.preferences.mt.untranslated.segments.only.title"><option>Untranslated
-        segments only</option></term>
+        <term id="dialogs.preferences.mt.untranslated.segments.only.title">
+        <option>Untranslated segments only</option></term>
 
         <listitem>
           <para>Check this box to send only untranslated segments to the machine
@@ -108,8 +106,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.provider.list">
-        <term id="dialogs.preferences.mt.provider.list.title"><option>Provider
-        list</option></term>
+        <term id="dialogs.preferences.mt.provider.list.title">
+        <option>Provider list</option></term>
 
         <listitem>
           <para>In the list of machine translation available in OmegaT, check
@@ -125,7 +123,8 @@
 
 		  <table id="dialogs.preferences.mt.provider.list.configuration">
 			<title
-			id="dialogs.preferences.mt.provider.list.configuration.title"><option>Required
+			    id="dialogs.preferences.mt.provider.list.configuration.title">
+              <option>Required
 			credentials</option></title>
 
 			<tgroup align="left" cols="3" rowsep="1">
@@ -148,19 +147,19 @@
 				  <entry>Requires a Deepl Pro Advanced plan available only in
 				  some countries</entry>
 				  <entry><ulink
-				  url="https://www.deepl.com/en/pro">https://www.deepl.com/en/pro</ulink></entry>
+				             url="https://www.deepl.com/en/pro">https://www.deepl.com/en/pro</ulink></entry>
 				</row>
 				<row>
 				  <entry>MyMemory (machine translation)</entry>
 				  <entry></entry>
 				  <entry><ulink
-				  url="https://mymemory.translated.net/doc/cat.php">https://mymemory.translated.net/</ulink></entry>
+				             url="https://mymemory.translated.net/doc/cat.php">https://mymemory.translated.net/</ulink></entry>
 				</row>
 				<row>
 				  <entry>Apertium</entry>
 				  <entry>URL, key</entry>
 				  <entry><ulink
-				  url="http://www.apertium.org">http://www.apertium.org</ulink></entry>
+				             url="http://www.apertium.org">http://www.apertium.org</ulink></entry>
 				</row>
 				<row>
 				  <entry>MyMemory (human translation)</entry>
@@ -171,13 +170,13 @@
 				  <entry>IBM Watson</entry>
 				  <entry>URL, Model ID, Login ID, Password</entry>
 				  <entry><ulink
-				  url="https://www.ibm.com/watson">https://www.ibm.com/watson</ulink></entry>
+				             url="https://www.ibm.com/watson">https://www.ibm.com/watson</ulink></entry>
 				</row>
 				<row>
 				  <entry>Google Translate v2</entry>
 				  <entry>API key</entry>
 				  <entry><ulink
-				  url="https://cloud.google.com/translate/docs/reference/rest/">https://cloud.google.com/translate/</ulink></entry>
+				             url="https://cloud.google.com/translate/docs/reference/rest/">https://cloud.google.com/translate/</ulink></entry>
 				</row>
 			  </tbody>
 			</tgroup>
@@ -188,13 +187,13 @@
   </section>
 
   <section id="dialogs.preferences.glossary">
-    <title id="dialogs.preferences.glossary.title"><guilabel>Glossaries</guilabel></title>
+	<title id="dialogs.preferences.glossary.title">
+    <guilabel>Glossaries</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries">
-        <term
-        id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title"><option>Display
-        TBX glossaries context description (TBX 2)</option></term>
+        <term id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title">
+        <option>Display TBX glossaries context description (TBX 2)</option></term>
 
         <listitem>
           <para>Uncheck this option if the context description shown for each
@@ -203,9 +202,9 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text">
-        <term
-			id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title"><option>Match
-        term groups even if the terms appear separately</option></term>
+        <term id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title">
+          <option>Match term groups even if the terms appear
+        separately</option></term>
 
         <listitem>
           <para>When a glossary term is a compound word, the term will match
@@ -214,9 +213,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.use.stemming.for.glossary.entries">
-        <term
-			id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title"><option>Use
-        stemming</option></term>
+        <term id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title">
+        <option>Use stemming</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -224,9 +222,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text">
-        <term
-        id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title"><option>Replace
-        matches when inserting source text</option></term>
+        <term id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title">
+        <option>Replace matches when inserting source text</option></term>
         <listitem>
           <para>When you use</para>
 		  
@@ -258,9 +255,9 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.ignore.hits.with.very.different.case">
-        <term
-        id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title"><option>Ignore
-        matches with very different case (e.g., USER vs user)</option></term>
+        <term id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title">
+          <option>Ignore matches with very different case (e.g., USER vs
+        user)</option></term>
 
         <listitem>
           <para>Matches with very different case are not displayed.</para>
@@ -268,7 +265,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.glossary.layout">
-        <term id="dialogs.preferences.glossary.glossary.layout.title"><option>Layout</option></term>
+        <term id="dialogs.preferences.glossary.glossary.layout.title">
+        <option>Layout</option></term>
 
         <listitem>
           <para>Select a layout for the glossaries pane contents. Additional
@@ -277,9 +275,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term">
-        <term
-        id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title"><option>Merge
-        alternate definition of the same term</option></term>
+        <term id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title">
+        <option>Merge alternate definition of the same term</option></term>
 
         <listitem>
           <para>If a glossary item has multiple definitions, they will be
@@ -288,26 +285,27 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.glossary.sort.by.source.term.length">
-		  <term id="dialogs.preference.glossary.sort.by.source.term.length.title"><option>Sort by source
-			  text term length</option></term>
-		  <listitem>
-			  <para>If some glossary items are similar in a source term text,
-				  and one contains another term text, sort by a length of source text.</para>
-		  </listitem>
+        <term id="dialogs.preferences.glossary.sort.by.source.term.length.title">
+        <option>Sort by source text term length</option></term>
+		<listitem>
+		  <para>If some glossary items are similar in a source term text,
+		  and one contains another term text, sort by a length of source text.</para>
+		</listitem>
 	  </varlistentry>
 
-		<varlistentry id="dialogs.preferences.glossary.sort.by.target.term.length">
-			<term id="dialogs.preference.glossary.sort.by.target.term.length.title"><option>Sort by source
-				text term length</option></term>
-			<listitem>
-				<para>If a glossary item has multiple definitions, sort by a length of definition text.</para>
-			</listitem>
-		</varlistentry>
+	  <varlistentry id="dialogs.preferences.glossary.sort.by.target.term.length">
+        <term id="dialogs.preferences.glossary.sort.by.target.term.length.title">
+        <option>Sort by source text term length</option></term>
+		<listitem>
+		  <para>If a glossary item has multiple definitions, sort by a length of definition text.</para>
+		</listitem>
+	  </varlistentry>
 	</variablelist>
   </section>
 
   <section id="dialogs.preferences.dictionary">
-    <title id="dialogs.preferences.dictionary.title"><guilabel>Dictionaries</guilabel></title>
+	<title id="dialogs.preferences.dictionary.title">
+    <guilabel>Dictionaries</guilabel></title>
 
 	<para>Preferences here define how the contents of the <link
 	linkend="project.folder.dictionary"
@@ -317,9 +315,8 @@
 	
     <variablelist>
       <varlistentry id="dialogs.preferences.dictionary.automatically.search.segment">
-        <term
-			id="dialogs.preferences.dictionary.automatically.search.segment.title"><option>Search
-        automatically</option></term>
+        <term id="dialogs.preferences.dictionary.automatically.search.segment.title">
+        <option>Search automatically</option></term>
 
         <listitem>
           <para>While the option is disabled, use <link linkend="menus.edit"
@@ -334,9 +331,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries">
-        <term
-			id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"><option>Use
-        fuzzy matching</option></term>
+        <term id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title">
+        <option>Use fuzzy matching</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -344,8 +340,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.condensed.view">
-        <term id="dialogs.preferences.dictionary.use.condensed.view.title"><option>Use
-        condensed view</option></term>
+        <term id="dialogs.preferences.dictionary.use.condensed.view.title">
+        <option>Use condensed view</option></term>
 
         <listitem>
           <para>Some dictionary drivers provided as plugins do not support this
@@ -356,11 +352,13 @@
   </section>
 
   <section id="dialogs.preferences.appearance">
-    <title id="dialogs.preferences.appearance.title"><guilabel>Appearance</guilabel></title>
+	<title id="dialogs.preferences.appearance.title">
+    <guilabel>Appearance</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.appearance.theme">
-        <term id="dialogs.preferences.appearance.theme.title"><option>Theme</option></term>
+        <term id="dialogs.preferences.appearance.theme.title">
+        <option>Theme</option></term>
 
         <listitem>
           <para>Select a theme for the OmegaT user interface.</para>
@@ -374,9 +372,8 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.appearance.restore.main.window">
-        <term
-			id="dialogs.preferences.appearance.restore.main.window.title"><option>Restore
-        Main Window</option></term>
+        <term id="dialogs.preferences.appearance.restore.main.window.title">
+        <option>Restore Main Window</option></term>
 
         <listitem>
           <para>Restores the OmegaT window panes to their default
@@ -391,7 +388,8 @@
     </variablelist>
 	
 	<section id="dialogs.preferences.fonts">
-      <title id="dialogs.preferences.fonts.title"><guilabel>Font</guilabel></title>
+	  <title id="dialogs.preferences.fonts.title">
+      <guilabel>Font</guilabel></title>
 
       <para>Select the font and font size used to display the text in the main
       window panes.</para>
@@ -405,9 +403,10 @@
 	  </note>
 
 	  <variablelist>
-		<varlistentry>
-		  <term><option>Apply this font to tabular data (project files, statistics,
-		  etc.)</option></term>
+		<varlistentry id="dialogs.preferences.fonts.apply.font.to.tabular.data">
+          <term id="dialogs.preferences.fonts.apply.font.to.tabular.data.title">
+			<option>Apply this font to tabular data (project files, statistics,
+          etc.)</option></term>
 		  <listitem>
 			<para>Tabular data is by default displayed in a monospaced font that
 			keeps columns properly aligned. Using a proportional font will break
@@ -415,8 +414,10 @@
 		  </listitem>
 		</varlistentry>
 
-		<varlistentry>
-		  <term><option>Apply a different font size to the dictionaries pane</option></term>
+		<varlistentry id="dialogs.preferences.fonts.apply.different.font.to.dictionaries">
+          <term id="dialogs.preferences.fonts.apply.different.font.to.dictionaries.title">
+			<option>Apply a different font size to the dictionaries
+          pane</option></term>
 		  <listitem>
 			<para>By default, the dictionaries pane uses the same font size as
 			the main window panes.</para>
@@ -426,7 +427,8 @@
 	</section>
 
 	<section id="dialogs.preferences.colours">
-      <title id="dialogs.preferences.colours.title"><guilabel>Colours</guilabel></title>
+	  <title id="dialogs.preferences.colours.title">
+      <guilabel>Colours</guilabel></title>
 
       <para>You can assign different colours for the various parts of the user
       interface.</para>
@@ -448,7 +450,8 @@
   </section>
 
   <section id="dialogs.preferences.file.filters">
-	<title id="dialogs.preferences.file.filters.title"><guilabel>Global File
+	<title id="dialogs.preferences.file.filters.title">
+      <guilabel>Global File
 	Filters</guilabel></title>
 
 	<para>This dialog lists the file filters available to projects that do not
@@ -467,7 +470,8 @@
 
 
   <section id="dialogs.preferences.segmentation.setup">
-	<title id="dialogs.preferences.segmentation.setup.title"><guilabel>Global
+	<title id="dialogs.preferences.segmentation.setup.title">
+      <guilabel>Global
 	Segmentation Rules</guilabel></title>
 
 	<para>See the <link linkend="app.segmentation"
@@ -482,7 +486,8 @@
 	</warning>
 	
 	<section id="dialogs.preferences.segmentation.setup.scope">
-	  <title id="dialogs.preferences.segmentation.setup.scope.title">Language
+	  <title id="dialogs.preferences.segmentation.setup.scope.title">
+		Language
 	  sets</title>
 
 	  <para>Only the rules associated to language patterns that correspond to
@@ -493,7 +498,8 @@
 
 	  <example id="dialogs.preferences.segmentation.setup.scope.example">
 		<title
-		id="dialogs.preferences.segmentation.setup.scope.example.title">Rules
+		    id="dialogs.preferences.segmentation.setup.scope.example.title">
+          Rules
 		for Japanese</title>
 		<para>For a translation from Japanese, <emphasis>only</emphasis> the
 		rule set associated to the <code>JA.*</code> pattern and the generic
@@ -511,7 +517,8 @@
 
 	  <example id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example">
 		<title
-			id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example.title">Cascading
+			id="dialogs.preferences.segmentation.setup.scope.cascading.proprieties.example.title">
+          Cascading
 		priorities</title>
 		<para>The rules for <emphasis>FR-CA</emphasis> should be set higher than
 		those for <emphasis>FR.*</emphasis>, which should themselves be higher
@@ -543,7 +550,8 @@
 	</section>
 
 	<section id="segmentation.rules">
-	  <title id="segmentation.rules.title"><guilabel>Set contents</guilabel></title>
+	  <title id="segmentation.rules.title">
+      <guilabel>Set contents</guilabel></title>
 	  <warning>
 		<para>Exception rules should be listed <emphasis>above</emphasis> break
 		rules.</para>
@@ -555,7 +563,8 @@
 	  
 	  <variablelist>
 		<varlistentry id="segmentation.rules.exceptionrule">
-		  <term id="segmentation.rules.exceptionrule.title"><option>Exceptions</option></term>
+          <term id="segmentation.rules.exceptionrule.title">
+          <option>Exceptions</option></term>
 
 		  <listitem>
 			<para>To define an exception rule, leave the <guilabel>Break/Exception
@@ -570,7 +579,8 @@
 		</varlistentry>
 
 		<varlistentry id="segmentation.rules.breakrule">
-		  <term id="segmentation.rules.breakrule.title"><option>Breaks</option></term>
+          <term id="segmentation.rules.breakrule.title">
+          <option>Breaks</option></term>
 
 		  <listitem>
 			<para>To define a break rule, check the
@@ -583,7 +593,8 @@
 		</varlistentry>
 
 		<varlistentry id="creating.new.rule">
-		  <term id="creating.new.rule.title"><guibutton>Add</guibutton></term>
+          <term id="creating.new.rule.title">
+          <guibutton>Add</guibutton></term>
 		  <listitem>
 			<para>The <emphasis role="bold">Before</emphasis> pattern identifies
 			the parts that are before the break or exception point.</para>
@@ -605,7 +616,8 @@
 
   <section id="dialog.preferences.auto.completion">
 	<title
-	id="dialog.preferences.auto.completion.title"><guilabel>Auto-Completion</guilabel></title>
+	    id="dialog.preferences.auto.completion.title">
+    <guilabel>Auto-Completion</guilabel></title>
 
 	<para>The auto-completion menu is available in the <link
 	linkend="panes.editor" endterm="panes.editor.title"/> pane. See the <link
@@ -640,7 +652,8 @@
 
   <section id="dialog.preferences.spellchecker">
 	<title
-	id="dialog.preferences.spellchecker.title"><guilabel>Spellchecker</guilabel></title>
+	    id="dialog.preferences.spellchecker.title">
+    <guilabel>Spellchecker</guilabel></title>
 
 	<para>OmegaT has a built-in spellchecker but requires you to install
 	spellchecking dictionaries based on your target languages.</para>
@@ -657,9 +670,8 @@
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.spellchecker.automatic.check">
-		<term
-		id="dialog.preferences.spellchecker.automatic.check.title"><option>Spellcheck
-		the translation</option></term>
+        <term id="dialog.preferences.spellchecker.automatic.check.title">
+        <option>Spellcheck the translation</option></term>
 		<listitem>
 		  <para>Enable after installing a spellchecking dictionary. OmegaT will
 		  underline spelling mistakes with red wavy-lines.</para>
@@ -667,15 +679,14 @@
 		  menu</link> to correct the mistake, to <guimenuitem>Ignore
 		  All</guimenuitem> or to <guimenuitem>Add to
 		  Dictionary</guimenuitem>. See <link
-		  linkend="project.folder.omegat.spellcheck">spellchecker files</link>
+		  linkend="project.folder.omegat.ignored.words">spellchecker files</link>
 		  for details.</para>
 		</listitem>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.dictionary.folder">
-		<term
-		id="dialog.preferences.spellchecker.dictionary.folder.title"><option>Spellchecking
-		dictionaries location</option></term>
+        <term id="dialog.preferences.spellchecker.dictionary.folder.title">
+        <option>Spellchecking dictionaries location</option></term>
 		<listitem>
 		  <para>The folder where OmegaT will install and search for spelling
 		  dictionaries. It is generally in the <link
@@ -691,9 +702,8 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.already.installed">
-		<term
-		id="dialog.preferences.spellchecker.already.installed.title"><option>Available
-		languages</option></term>
+        <term id="dialog.preferences.spellchecker.already.installed.title">
+        <option>Available languages</option></term>
 		<listitem>
 		  <para>The list of dictionaries that are present in the above
 		  folder.</para>
@@ -706,8 +716,8 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.url">
-		<term id="dialog.preferences.spellchecker.url.title"><option>URL of
-		downloadable spellchecking dictionaries</option></term>
+        <term id="dialog.preferences.spellchecker.url.title">
+        <option>URL of downloadable spellchecking dictionaries</option></term>
 		<listitem>
 		  <para>The default URL where OmegaT will look for dictionaries to
 		  install.</para>
@@ -717,9 +727,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.spellchecker.install.new">
-		<term
-		id="dialog.preferences.spellchecker.install.new.title"><guibutton>Install
-		new language...</guibutton></term>
+        <term id="dialog.preferences.spellchecker.install.new.title">
+        <guibutton>Install new language...</guibutton></term>
 		<listitem>
 		  <para>Displays the list of available dictionaries from the above
 		  URL.</para>
@@ -737,14 +746,13 @@
   </section>
   
   <section id="dialog.preferences.languagetool.plugin">
-	<title
-	id="dialog.preferences.languagetool.plugin.title"><guilabel>LanguageTool</guilabel></title>
+    <title id="dialog.preferences.languagetool.plugin.title">
+    <guilabel>LanguageTool</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.languagetool.plugin.servicetype">
-		<term
-		id="dialog.preferences.languagetool.plugin.servicetype.title"><option>Service
-		type</option></term>
+        <term id="dialog.preferences.languagetool.plugin.servicetype.title">
+        <option>Service type</option></term>
 
 		<listitem>
 		  <para>Select the location of the language checker.</para>
@@ -756,8 +764,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.languagetool.plugin.rules">
-		<term
-		id="dialog.preferences.languagetool.plugin.rules.title"><option>Rules</option></term>
+        <term id="dialog.preferences.languagetool.plugin.rules.title">
+        <option>Rules</option></term>
 
 		<listitem>
 		  <para>Select the rules depending on whether they are relevant to the
@@ -768,7 +776,8 @@
   </section>
 
   <section id="dialogs.preferences.external.searches">
-	<title id="dialogs.preferences.external.searches.title"><guilabel>Global External
+	<title id="dialogs.preferences.external.searches.title">
+      <guilabel>Global External
 	Searches</guilabel></title>
 	<para>External searches are either web searches or local commands that take
 	the string selected in the Editor as a parameter. The web searches are
@@ -777,9 +786,8 @@
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
-		<term
-		id="dialogs.preferences.external.search.enable.project.specific.commands.title"><option>Allow
-		local external search commands</option></term>
+        <term id="dialogs.preferences.external.search.enable.project.specific.commands.title">
+        <option>Allow local external search commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -796,9 +804,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.external.search.context.menu.priority">
-		<term
-		id="dialogs.preferences.external.search.context.menu.priority.title"><option>Context
-		Menu Priority</option></term>
+        <term id="dialogs.preferences.external.search.context.menu.priority.title">
+        <option>Context Menu Priority</option></term>
 
 		<listitem>
 		  <para>This option enables you to change the order of the commands in
@@ -812,8 +819,9 @@
 		</listitem>
 	  </varlistentry>
 	  
-	  <varlistentry  id="dialogs.preferences.external.search.items">
-		<term id="dialogs.preferences.external.search.items.title"><option>Sets</option></term>
+	  <varlistentry id="dialogs.preferences.external.search.items">
+        <term id="dialogs.preferences.external.search.items.title">
+        <option>Sets</option></term>
 		<listitem>
 		  <para>Each set represents a group of web searches or local commands
 		  that are launched simultaneously.</para>
@@ -835,44 +843,42 @@
 		  <para>URLs are opened with the default web browser, one per
 		  tab.</para>
 
-		  <example
-			  id="dialogs.preferences.external.search.items.url.search.example">
-			<title
-			id="dialogs.preferences.external.search.items.url.search.example.title">URL
+		  <example id="dialogs.preferences.external.search.items.url.search.example">
+			<title id="dialogs.preferences.external.search.items.url.search.example.title">
+              URL
 			search example</title>
 			<programlisting>https://duckduckgo.com/?q=%22{target}%22+site%3A.fr+-linguee</programlisting>
 
 			<para>This opens a search for the {target} term on DuckDuckGo with a
-			number of search parameters.</para></example>
+		  number of search parameters.</para></example>
 
-			<para>Commands are opened on the command line. The
-			<guilabel>Delimiter</guilabel>defines the delimiter between command
-			parameters. The default delimiter is <code>|</code>.</para>
+		  <para>Commands are opened on the command line. The
+		  <guilabel>Delimiter</guilabel>defines the delimiter between command
+		  parameters. The default delimiter is <code>|</code>.</para>
 
-		  <example
-			  id="dialogs.preferences.external.search.items.command.example">
-			<title
-			id="dialogs.preferences.external.search.items.command.example.title">Command
+		  <example id="dialogs.preferences.external.search.items.command.example">
+			<title id="dialogs.preferences.external.search.items.command.example.title">
+              Command
 			example</title>
 			<programlisting>/usr/bin/open|dict://{target}</programlisting>
 
 			<para>This opens the dictionary application that implements the
 			<code>dict</code> protocol on your machine looking for the {target}
-			term.</para></example>
+		  term.</para></example>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
   </section>
 
   <section id="dialogs.preferences.editor">
-	<title id="dialogs.preferences.editor.title"><guilabel>Editor</guilabel></title>
+	<title id="dialogs.preferences.editor.title">
+    <guilabel>Editor</guilabel></title>
 
 	<para>When entering an empty segment:</para>
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.insert.the.source.text">
-		<term
-		id="dialogs.preferences.editor.insert.the.source.text.title"><option>Insert the
-		source text</option></term>
+        <term id="dialogs.preferences.editor.insert.the.source.text.title">
+        <option>Insert the source text</option></term>
 
 		<listitem>
 		  <para>Use this option temporarily for parts of the translation that do
@@ -881,9 +887,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.leave.the.segment.empty">
-		<term
-		id="dialogs.preferences.editor.leave.the.segment.empty.title"><option>Leave the
-		segment empty</option></term>
+        <term id="dialogs.preferences.editor.leave.the.segment.empty.title">
+        <option>Leave the segment empty</option></term>
 
 		<listitem>
 		  <para>You can enter your translation right away.</para>
@@ -891,9 +896,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.insert.the.best.fuzzy.match">
-		<term
-		id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"><option>Insert
-		the best fuzzy match</option></term>
+        <term id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title">
+        <option>Insert the best fuzzy match</option></term>
 
 		<listitem>
 		  <para>OmegaT inserts the translation with the highest match percentage
@@ -911,9 +915,8 @@
 	
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match">
-		<term
-		id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title"><option>Attempt
-		to replace fuzzy match numbers</option></term>
+        <term id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title">
+        <option>Attempt to replace fuzzy match numbers</option></term>
 
 		<listitem>
 		  <para>When a fuzzy match is inserted, OmegaT tries to replace the numbers
@@ -924,15 +927,16 @@
 			considered.</para>
 		  </note>
 
-		  <example id="convert.match.numbers">
-			<title>Fuzzy match number conversion</title>
+		  <example id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers">
+			<title id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers.title">
+            Fuzzy match number conversion</title>
 			<para><token>2001</token> in the source:</para>
 			<para>
-			  <programlisting>[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
+			<programlisting>[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
 			
 			<para><token>2003</token> in the fuzzy match:</para>
 			<para><programlisting>[[<token>2003</token>年]]、ドイツの永住権を取得。
-[[<token>2003</token>]], elle acquiert la nationalité allemande.</programlisting></para>
+            [[<token>2003</token>]], elle acquiert la nationalité allemande.</programlisting></para>
 
 			<para>When the match is inserted, OmegaT will convert
 			<token>2003</token> to <token>2001</token>:</para>
@@ -943,9 +947,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source">
-		<term
-		id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"><option>Allow
-		translation to be equal to source</option></term>
+        <term id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title">
+        <option>Allow translation to be equal to source</option></term>
 
 		<listitem>
 		  <para>A translation that is identical to the source text is not
@@ -958,9 +961,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.export.the.segment.to.text.files">
-		<term
-		id="dialogs.preferences.editor.export.the.segment.to.text.files.title"><option>Export
-		the segment to a text file</option></term>
+        <term id="dialogs.preferences.editor.export.the.segment.to.text.files.title">
+        <option>Export the segment to a text file</option></term>
 
 		<listitem>
 		  <para>When OmegaT enters a segment,</para>
@@ -1002,9 +1004,9 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation">
-		<term
-		id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title"><option>Stop
-		at untranslated and alternatives translations</option></term>
+        <term id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title">
+          <option>Stop at untranslated and alternatives
+        translations</option></term>
 
 		<listitem>
 		  <para><link linkend="menus.goto" endterm="menus.goto.title"/><link
@@ -1015,8 +1017,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.tag.editing">
-		<term id="dialogs.preferences.editor.allow.tag.editing.title"><option>Allow tag
-		editing</option></term>
+        <term id="dialogs.preferences.editor.allow.tag.editing.title">
+        <option>Allow tag editing</option></term>
 
 		<listitem>
 		  <para>Tags should generally not be modified, but that is possible when
@@ -1025,9 +1027,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment">
-		<term
-		id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"><option>Check
-		issues when leaving a segment</option></term>
+        <term id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title">
+        <option>Check issues when leaving a segment</option></term>
 
 		<listitem>
 		  <para>OmegaT runs an issues check on the segment as you leave it. The
@@ -1038,8 +1039,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.save.auto-populated.status">
-		<term id="dialogs.preferences.editor.save.auto-populated.status.title"><option>Save
-		auto-populated status</option></term>
+        <term id="dialogs.preferences.editor.save.auto-populated.status.title">
+        <option>Save auto-populated status</option></term>
 
 		<listitem>
 		  <para>Translation memories located in <link
@@ -1059,9 +1060,8 @@
 	  </varlistentry>
 
       <varlistentry id="dialogs.preferences.editor.save.orgin.of.translation">
-		<term
-		id="dialogs.preferences.editor.save.orgin.of.translation.title"><option>Save
-		origin of translation</option></term>
+        <term id="dialogs.preferences.editor.save.orgin.of.translation.title">
+        <option>Save origin of translation</option></term>
 
 		<listitem>
           <para>When machine translation is enabled, OmegaT registers the name
@@ -1070,9 +1070,8 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.initially.load.this.many.segments">
-		<term
-		id="dialogs.preferences.editor.initially.load.this.many.segments.title"><option>Initial
-		number of loaded segments</option></term>
+        <term id="dialogs.preferences.editor.initially.load.this.many.segments.title">
+        <option>Initial number of loaded segments</option></term>
 
 		<listitem>
 		  <para>The editor initially loads and displays 2,000 segments, and
@@ -1082,9 +1081,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.paragraph.delimitation.format">
-		<term
-		id="dialogs.preferences.editor.paragraph.delimitation.format.title"><option>Paragraph
-		delimitation format</option></term>
+        <term id="dialogs.preferences.editor.paragraph.delimitation.format.title">
+        <option>Paragraph delimitation format</option></term>
 
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
@@ -1097,13 +1095,13 @@
   </section>
 
   <section id="dialogs.preferences.tag.processing">
-	<title id="dialogs.preferences.tag.processing.title"><guilabel>Tag Processing</guilabel></title>
+	<title id="dialogs.preferences.tag.processing.title">
+    <guilabel>Tag Processing</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.tag.processing.programming.variables">
-		<term
-		id="dialogs.preferences.tag.processing.programming.variables.title"><option>Check
-		printf function variables</option></term>
+        <term id="dialogs.preferences.tag.processing.programming.variables.title">
+        <option>Check printf function variables</option></term>
 		<listitem>
 		  <para>Check printf variables in file formats other than the PO
 		  format. The PO filter already handles variables marked with
@@ -1112,22 +1110,25 @@
 		  <para>You can select</para>
 		  
 		  <variablelist>
-			<varlistentry>
-			  <term><option>None</option></term>
+			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.none">
+              <term id="dialogs.preferences.tag.processing.programming.variables.none.title">
+              <option>None</option></term>
 			  <listitem>
 				<para>None of the variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 			
-			<varlistentry>
-			  <term><option>Simple variables (e.g., %s, %d)</option></term>
+			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.simple">
+              <term id="dialogs.preferences.tag.processing.programming.variables.simple.title">
+              <option>Simple variables (e.g., %s, %d)</option></term>
 			  <listitem>
 				<para>Only the simple variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 
-			<varlistentry>
-			  <term><option>All variables (e.g., %s, %-s)</option></term>
+			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.all">
+              <term id="dialogs.preferences.tag.processing.programming.variables.all.title">
+              <option>All variables (e.g., %s, %-s)</option></term>
 			  <listitem>
 				<para>This can result in false positives in some files.</para>
 			  </listitem>
@@ -1137,9 +1138,8 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.simple.java.messageformat">
-		<term
-		id="dialogs.preferences.tag.processing.simple.java.messageformat.title"><option>Check
-		simple Java MessageFormat placeholders</option></term>
+        <term id="dialogs.preferences.tag.processing.simple.java.messageformat.title">
+        <option>Check simple Java MessageFormat placeholders</option></term>
 		<listitem>
 		  <para>Check Java MessageFormat placeholders in file formats other than
 		  the Java Bundles format. The Java Bundles filter already handles
@@ -1149,9 +1149,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order">
-		<term
-		id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title"><option>Allow
-		translated tags to be in a different order</option></term>
+        <term id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title">
+        <option>Allow translated tags to be in a different order</option></term>
 		<listitem>
 		  <para>Tags in a different order than the source will not appear in the
 		  list of tag issues. See the <link linkend="menus.tools"
@@ -1161,9 +1160,9 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues">
-		<term
-		id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"><option>Block
-		the creation of translated files with tag issues</option></term>
+        <term id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title">
+          <option>Block the creation of translated files with tag
+        issues</option></term>
 		<listitem>
 		  <para>If you try to create the translated files, OmegaT will display
 		  the issues dialog until no issues are found. See the <link
@@ -1174,9 +1173,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics">
-		<term
-		id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"><option>Count
-		flagged text and custom tags in statistics</option></term>
+        <term id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title">
+        <option>Count flagged text and custom tags in statistics</option></term>
 		<listitem>
 		  <para>Unlike OmegaT tags, flagged text and custom tags are by default
 		  counted in the statistics. See the <link
@@ -1188,9 +1186,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags">
-		<term
-		id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"><option>Custom
-		tags</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title">
+        <option>Custom tags</option></term>
 		<listitem>
 		  <para>Use regular expressions to define custom tags. To define a list
 		  of tags, group each tag between parentheses and separate the groups
@@ -1214,9 +1211,8 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation">
-		<term
-		id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"><option>Flagged
-		text</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title">
+        <option>Flagged text</option></term>
 		<listitem>
 		  <para>Text in the target segment matching this expression is marked in
 		  red and identified as an extraneous tag for issue checking
@@ -1230,16 +1226,16 @@
   </section>
 
   <section id="dialog.preferences.team">
-	<title id="dialog.preferences.team.title"><guilabel>Team</guilabel></title>
+	<title id="dialog.preferences.team.title">
+    <guilabel>Team</guilabel></title>
 
 	<para>The name you enter here will be attached to all the segments you
 	translate.</para>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.team.title.repository.credentials">
-		<term
-		id="dialog.preferences.team.title.repository.credentials.title"><option>Repository
-		Credentials</option></term>
+        <term id="dialog.preferences.team.title.repository.credentials.title">
+        <option>Repository Credentials</option></term>
 		<listitem>
 		  <para>List of projects for which login details have been stored in
 		  OmegaT. Remove a project from this list if you want OmegaT to ask you
@@ -1250,13 +1246,13 @@
   </section>
 
   <section id="dialog.preferences.tm.matches">
-	<title id="dialog.preferences.tm.matches.title"><option>TM Matches</option></title>
+	<title id="dialog.preferences.tm.matches.title">
+    <option>TM Matches</option></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.tm.matches.sort.fuzzy.matches.by">
-		<term
-		id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title"><option>Sort
-		fuzzy matches by:</option></term>
+        <term id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title">
+        <option>Sort fuzzy matches by:</option></term>
 
 		<listitem>
 		  <para>By default, stemming is used to determine the closest matches
@@ -1269,24 +1265,25 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.minimum.threshold">
-		<term id="dialog.preferences.tm.matches.minimum.threshold.title"><option>Minimal threshold to show a fuzzy match</option></term>
+        <term id="dialog.preferences.tm.matches.minimum.threshold.title">
+        <option>Minimal threshold to show a fuzzy match</option></term>
 		<listitem>
 		  <para>OmegaT displays the five best fuzzy matches above 30% by
 		  default. You can change that threshold here.</para>
-			<note>
-				<para>Each of the three types of matching percentages presented in the <link linkend="panes.fuzzy.matches"
-				endterm="panes.fuzzy.matches.title"/> pane are taken into
-				account to determine whether a match is displayed. Potential
-				matches are rejected if all three percentages are below
-				the threshold.</para>
-			</note>
+		  <note>
+			<para>Each of the three types of matching percentages presented in the <link linkend="panes.fuzzy.matches"
+			endterm="panes.fuzzy.matches.title"/> pane are taken into
+			account to determine whether a match is displayed. Potential
+			matches are rejected if all three percentages are below
+			the threshold.</para>
+		  </note>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs">
-		<term
-		id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title"><option>Select
-		how tags of non-OmegaT TMXs should be displayed</option></term>
+        <term id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title">
+          <option>Select how tags of non-OmegaT TMXs should be
+        displayed</option></term>
 
 		<listitem>
 		  <para>Determine how to handle tags in TMX files generated by other
@@ -1298,9 +1295,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.other.languages">
-		<term
-		id="dialog.preferences.tm.matches.other.languages.title"><option>Include
-		matches from other languages</option></term>
+        <term id="dialog.preferences.tm.matches.other.languages.title">
+        <option>Include matches from other languages</option></term>
 		<listitem>
 		  <para>Segments that have matches in different target languages can
 		  also be displayed in the <link linkend="panes.fuzzy.matches"
@@ -1311,9 +1307,8 @@
 
 	  
 	  <varlistentry id="dialog.preferences.tm.matches.match.display.template">
-		<term
-		id="dialog.preferences.tm.matches.match.display.template.title"><option>Match
-		display template</option></term>
+        <term id="dialog.preferences.tm.matches.match.display.template.title">
+        <option>Match display template</option></term>
 
 		<listitem>
 		  <para>Change how fuzzy matches are displayed, through the use of
@@ -1332,14 +1327,15 @@ ${filePath}></programlisting></para>
 [NEW]▷ ${diff}
 			
 [OLD]◀ ${diffReversed}
-◀ ${targetText}</programlisting></para>
+     ◀ ${targetText}</programlisting></para>
 
 
 		  <para>The template variables are also available from a drop-down menu
 		  and can be inserted with a button.</para>
 
 		  <table id="table.match.pane.setup" colsep="0" rowsep="0">
-			<title id="table.match.pane.setup.title">Match template variables</title>
+			<title id="table.match.pane.setup.title">
+            Match template variables</title>
 
 			<tgroup cols="2" colsep="1" rowsep="1">
 			  <colspec align="left"/>
@@ -1486,13 +1482,13 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialog.preferences.view">
-	<title id="dialog.preferences.view.title"><guilabel>View</guilabel></title>
+	<title id="dialog.preferences.view.title">
+    <guilabel>View</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.view.display.all.source.segments.in.bold">
-		<term
-		id="dialog.preferences.view.display.all.source.segments.in.bold.title"><option>Display
-		all source segments in bold</option></term>
+        <term id="dialog.preferences.view.display.all.source.segments.in.bold.title">
+        <option>Display all source segments in bold</option></term>
 		<listitem>
 		  <para>By default, only the current segment is displayed in bold
 		  face.</para>
@@ -1500,9 +1496,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.display.active.source.segment.in.bold">
-		<term
-		id="dialog.preferences.view.display.active.source.segment.in.bold.title"><option>Display
-		active source segment in bold</option></term>
+        <term id="dialog.preferences.view.display.active.source.segment.in.bold.title">
+        <option>Display active source segment in bold</option></term>
 		<listitem>
 		  <para>If source segments are displayed in normal face, you can use
 		  this option to display only the current source segment in bold.</para>
@@ -1510,9 +1505,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments">
-		<term
-		id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title"><option>Mark
-		all repeated segments</option></term>
+        <term id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title">
+        <option>Mark all repeated segments</option></term>
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
 		  linkend="menus.view.mark.non.unique.segments"
@@ -1523,9 +1517,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.simplify.tooltip.on.protected.parts">
-		<term
-		id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title"><option>Simplify
-		tag tooltips</option></term>
+        <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title">
+        <option>Simplify tag tooltips</option></term>
 		<listitem>
 		  <para>OmegaT tags are protected text that represents format-specific
 		  tags in the source document. When hovering on an OmegaT tag, OmegaT
@@ -1536,9 +1529,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.use.custom.templates.for.modification.info">
-		<term
-		id="dialog.preferences.view.use.custom.templates.for.modification.info.title"><option>Customize
-		segment modification information</option></term>
+        <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title">
+        <option>Customize segment modification information</option></term>
 		<listitem>
 		  <para>Segment modification information is displayed over the
 		  segment. the default setting shows who last modified the translation
@@ -1546,7 +1538,8 @@ ${filePath}></programlisting></para>
 
 		  <example id="dialog.preferences.view.use.custom.templates.for.modification.info.example">
 			<title
-			id="dialog.preferences.view.use.custom.templates.for.modification.info.example.title">Default
+			    id="dialog.preferences.view.use.custom.templates.for.modification.info.example.title">
+              Default
 			display</title>
 			<para>
 			  <programlisting>Translation last modified by suzume on Oct 6, 2022 at 2:18:27 PM
@@ -1565,9 +1558,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.view.modification.info.template">
-		<term
-		id="dialog.preferences.view.modification.info.template.title"><option>Standard
-		template</option></term>
+        <term id="dialog.preferences.view.modification.info.template.title">
+        <option>Standard template</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1575,9 +1567,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.modification.info.template.for.segments.without.date">
-		<term
-		id="dialog.preferences.view.modification.info.template.for.segments.without.date.title"><option>Template
-		for segments without date</option></term>
+        <term id="dialog.preferences.view.modification.info.template.for.segments.without.date.title">
+        <option>Template for segments without date</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1587,13 +1578,14 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.saving.and.output">
-	<title id="dialogs.preferences.saving.and.output.title"><guilabel>Saving and
+	<title id="dialogs.preferences.saving.and.output.title">
+      <guilabel>Saving and
 	Output</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.saving.and.output.interval">
-		<term id="dialog.preferences.saving.and.output.interval.title"><option>Project
-		data saving interval</option></term>
+        <term id="dialog.preferences.saving.and.output.interval.title">
+        <option>Project data saving interval</option></term>
 		<listitem>
 		  <para>Allows the user to select the interval between automatic project
 		  data saves.  See the <link
@@ -1619,9 +1611,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
-		<term
-		id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>Global
-		post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.external.post-processing.command.title">
+        <option>Global post-processing commands</option></term>
 
 		<listitem>
 		  <para>OmegaT can automatically run commands after you use <link
@@ -1649,9 +1640,8 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
-		<term
-		id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><option>Allow
-		local post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title">
+        <option>Allow local post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -1681,14 +1671,16 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.proxy.login">
-	<title id="dialogs.preferences.proxy.login.title"><guilabel>Proxy Login</guilabel></title>
+	<title id="dialogs.preferences.proxy.login.title">
+    <guilabel>Proxy Login</guilabel></title>
 
 	<para>If you use an authenticated proxy server to access the Internet, enter
 	your credentials here.</para>
   </section>
 
   <section id="dialogs.preferences.secure.store">
-	<title id="dialogs.preferences.secure.store.title"><guilabel>Secure store</guilabel></title>
+	<title id="dialogs.preferences.secure.store.title">
+    <guilabel>Secure store</guilabel></title>
 
 	<para>Define or reset the master password used to protect login credentials
 	as well as access keys for machine translation services.</para>
@@ -1699,7 +1691,8 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.plugins">
-	<title id="dialogs.preferences.plugins.title"><guilabel>Plugins</guilabel></title>
+	<title id="dialogs.preferences.plugins.title">
+    <guilabel>Plugins</guilabel></title>
 
 	<para>Displays the list of all the installed plugins.</para>
 
@@ -1719,13 +1712,14 @@ ${filePath}></programlisting></para>
 	itself, as well as README and LICENSE files.
 	</para>
 	<warning>
-		<para>The plugin installer only accepts archives containing a JAR plugin.
-		 It does not recognize plugin files renamed with a <filename>.zip</filename> extension.</para>
+	  <para>The plugin installer only accepts archives containing a JAR plugin.
+	  It does not recognize plugin files renamed with a <filename>.zip</filename> extension.</para>
 	</warning>
   </section>
 
   <section id="dialogs.preferences.updates">
-	<title id="dialogs.preferences.updates.title"><guilabel>Updates</guilabel></title>
+	<title id="dialogs.preferences.updates.title">
+    <guilabel>Updates</guilabel></title>
 
 	<para>Use this option to choose whether to be automatically notified of
 	updates to OmegaT.</para>

--- a/doc_src/en/OmegaT_Preferences.xml
+++ b/doc_src/en/OmegaT_Preferences.xml
@@ -4,7 +4,7 @@
 [<!ENTITY % manualvariables SYSTEM "manualvariables.mod"> %manualvariables;]>
 
 <chapter id="chapter.dialogs.preferences">
-  <title id="chapter.dialogs.preferences.title"><guilabel>Preferences</guilabel></title>
+  <title id="chapter.dialogs.preferences.title"><link linkend="chapter.dialogs.preferences"> </link><guilabel>Preferences</guilabel></title>
 
   <para>Use <link endterm="menus.options.title" linkend="menus.options"/><link
   endterm="menus.options.preferences.title"
@@ -29,11 +29,11 @@
   </note>
 
   <section id="dialogs.preferences.general">
-    <title id="dialogs.preferences.general.title"><guilabel>General</guilabel></title>
+    <title id="dialogs.preferences.general.title"><link linkend="dialogs.preferences.general"> </link><guilabel>General</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.general.use.tab.to.advance">
-        <term id="dialogs.preferences.general.use.tab.to.advance.title"><option>Use TAB to Advance</option></term>
+        <term id="dialogs.preferences.general.use.tab.to.advance.title"><link linkend="dialogs.preferences.general.use.tab.to.advance"> </link><option>Use TAB to Advance</option></term>
 
         <listitem>
 		  <para>The default key to validate and leave a segment is
@@ -47,7 +47,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.always.confirm.quit">
-        <term id="dialogs.preferences.general.always.confirm.quit.title"><option>Always Confirm Quit</option></term>
+        <term id="dialogs.preferences.general.always.confirm.quit.title"><link linkend="dialogs.preferences.general.always.confirm.quit"> </link><option>Always Confirm Quit</option></term>
 
         <listitem>
           <para>The program will ask for confirmation before closing.</para>
@@ -55,7 +55,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.general.access.configuration.folder">
-        <term id="dialogs.preferences.general.access.configuration.folder.title"><option>Access Configuration Folder</option></term>
+        <term id="dialogs.preferences.general.access.configuration.folder.title"><link linkend="dialogs.preferences.general.access.configuration.folder"> </link><option>Access Configuration Folder</option></term>
 		<listitem>
           <para>Opens the local folder where OmegaT configuration files are
           stored.</para>
@@ -71,11 +71,11 @@
   </section>
 
   <section id="dialogs.preferences.mt">
-    <title id="dialogs.preferences.mt.title"><guilabel>Machine Translation</guilabel></title>
+    <title id="dialogs.preferences.mt.title"><link linkend="dialogs.preferences.mt"> </link><guilabel>Machine Translation</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.mt.automatically.fetch.translations">
-        <term id="dialogs.preferences.mt.automatically.fetch.translations.title"><option>Automatically fetch translations</option></term>
+        <term id="dialogs.preferences.mt.automatically.fetch.translations.title"><link linkend="dialogs.preferences.mt.automatically.fetch.translations"> </link><option>Automatically fetch translations</option></term>
 
 		<listitem>
 		  <para>Enable this option to automatically fetch machine translations from
@@ -90,7 +90,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.untranslated.segments.only">
-        <term id="dialogs.preferences.mt.untranslated.segments.only.title"><option>Untranslated segments only</option></term>
+        <term id="dialogs.preferences.mt.untranslated.segments.only.title"><link linkend="dialogs.preferences.mt.untranslated.segments.only"> </link><option>Untranslated segments only</option></term>
 
         <listitem>
           <para>Check this box to send only untranslated segments to the machine
@@ -99,7 +99,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.mt.provider.list">
-        <term id="dialogs.preferences.mt.provider.list.title"><option>Provider list</option></term>
+        <term id="dialogs.preferences.mt.provider.list.title"><link linkend="dialogs.preferences.mt.provider.list"> </link><option>Provider list</option></term>
 
         <listitem>
           <para>In the list of machine translation available in OmegaT, check
@@ -179,11 +179,11 @@
   </section>
 
   <section id="dialogs.preferences.glossary">
-	<title id="dialogs.preferences.glossary.title"><guilabel>Glossaries</guilabel></title>
+	<title id="dialogs.preferences.glossary.title"><link linkend="dialogs.preferences.glossary"> </link><guilabel>Glossaries</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries">
-        <term id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title"><option>Display TBX glossaries context description (TBX 2)</option></term>
+        <term id="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries.title"><link linkend="dialogs.preferences.glossary.display.context.description.for.tbx.glossaries"> </link><option>Display TBX glossaries context description (TBX 2)</option></term>
 
         <listitem>
           <para>Uncheck this option if the context description shown for each
@@ -192,9 +192,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text">
-        <term id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title">
-          <option>Match term groups even if the terms appear
-        separately</option></term>
+        <term id="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text.title"><link linkend="dialogs.preferences.glossary.use.terms.appearing.separately.in.the.source.text"> </link><option>Match term groups even if the terms appear separately</option></term>
 
         <listitem>
           <para>When a glossary term is a compound word, the term will match
@@ -203,7 +201,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.use.stemming.for.glossary.entries">
-        <term id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title"><option>Use stemming</option></term>
+        <term id="dialogs.preferences.glossary.use.stemming.for.glossary.entries.title"><link linkend="dialogs.preferences.glossary.use.stemming.for.glossary.entries"> </link><option>Use stemming</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -211,7 +209,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text">
-        <term id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title"><option>Replace matches when inserting source text</option></term>
+        <term id="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text.title"><link linkend="dialogs.preferences.glossary.replace.glossary.hits.when.inserting.source.text"> </link><option>Replace matches when inserting source text</option></term>
         <listitem>
           <para>When you use</para>
 		  
@@ -243,9 +241,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.ignore.hits.with.very.different.case">
-        <term id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title">
-          <option>Ignore matches with very different case (e.g., USER vs
-        user)</option></term>
+        <term id="dialogs.preferences.glossary.ignore.hits.with.very.different.case.title"><link linkend="dialogs.preferences.glossary.ignore.hits.with.very.different.case"> </link><option>Ignore matches with very different case (e.g., USER vs user)</option></term>
 
         <listitem>
           <para>Matches with very different case are not displayed.</para>
@@ -253,7 +249,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.glossary.layout">
-        <term id="dialogs.preferences.glossary.glossary.layout.title"><option>Layout</option></term>
+        <term id="dialogs.preferences.glossary.glossary.layout.title"><link linkend="dialogs.preferences.glossary.glossary.layout"> </link><option>Layout</option></term>
 
         <listitem>
           <para>Select a layout for the glossaries pane contents. Additional
@@ -262,7 +258,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term">
-        <term id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title"><option>Merge alternate definition of the same term</option></term>
+        <term id="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term.title"><link linkend="dialogs.preferences.glossary.merge.alternate.definitions.for.the.same.term"> </link><option>Merge alternate definition of the same term</option></term>
 
         <listitem>
           <para>If a glossary item has multiple definitions, they will be
@@ -271,7 +267,7 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.glossary.sort.by.source.term.length">
-        <term id="dialogs.preferences.glossary.sort.by.source.term.length.title"><option>Sort by source text term length</option></term>
+        <term id="dialogs.preferences.glossary.sort.by.source.term.length.title"><link linkend="dialogs.preferences.glossary.sort.by.source.term.length"> </link><option>Sort by source text term length</option></term>
 		<listitem>
 		  <para>If some glossary items are similar in a source term text,
 		  and one contains another term text, sort by a length of source text.</para>
@@ -279,7 +275,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.glossary.sort.by.target.term.length">
-        <term id="dialogs.preferences.glossary.sort.by.target.term.length.title"><option>Sort by source text term length</option></term>
+        <term id="dialogs.preferences.glossary.sort.by.target.term.length.title"><link linkend="dialogs.preferences.glossary.sort.by.target.term.length"> </link><option>Sort by source text term length</option></term>
 		<listitem>
 		  <para>If a glossary item has multiple definitions, sort by a length of definition text.</para>
 		</listitem>
@@ -288,7 +284,7 @@
   </section>
 
   <section id="dialogs.preferences.dictionary">
-	<title id="dialogs.preferences.dictionary.title"><guilabel>Dictionaries</guilabel></title>
+	<title id="dialogs.preferences.dictionary.title"><link linkend="dialogs.preferences.dictionary"> </link><guilabel>Dictionaries</guilabel></title>
 
 	<para>Preferences here define how the contents of the <link
 	linkend="project.folder.dictionary"
@@ -298,7 +294,7 @@
 	
     <variablelist>
       <varlistentry id="dialogs.preferences.dictionary.automatically.search.segment">
-        <term id="dialogs.preferences.dictionary.automatically.search.segment.title"><option>Search automatically</option></term>
+        <term id="dialogs.preferences.dictionary.automatically.search.segment.title"><link linkend="dialogs.preferences.dictionary.automatically.search.segment"> </link><option>Search automatically</option></term>
 
         <listitem>
           <para>While the option is disabled, use <link linkend="menus.edit"
@@ -313,7 +309,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries">
-        <term id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"><option>Use fuzzy matching</option></term>
+        <term id="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries.title"><link linkend="dialogs.preferences.dictionary.use.fuzzy.matching.for.dictionary.entries"> </link><option>Use fuzzy matching</option></term>
 
         <listitem>
           <para>OmegaT will use the associated tokenizer to find matches.</para>
@@ -321,7 +317,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.dictionary.use.condensed.view">
-        <term id="dialogs.preferences.dictionary.use.condensed.view.title"><option>Use condensed view</option></term>
+        <term id="dialogs.preferences.dictionary.use.condensed.view.title"><link linkend="dialogs.preferences.dictionary.use.condensed.view"> </link><option>Use condensed view</option></term>
 
         <listitem>
           <para>Some dictionary drivers provided as plugins do not support this
@@ -332,11 +328,11 @@
   </section>
 
   <section id="dialogs.preferences.appearance">
-	<title id="dialogs.preferences.appearance.title"><guilabel>Appearance</guilabel></title>
+	<title id="dialogs.preferences.appearance.title"><link linkend="dialogs.preferences.appearance"> </link><guilabel>Appearance</guilabel></title>
 
     <variablelist>
       <varlistentry id="dialogs.preferences.appearance.theme">
-        <term id="dialogs.preferences.appearance.theme.title"><option>Theme</option></term>
+        <term id="dialogs.preferences.appearance.theme.title"><link linkend="dialogs.preferences.appearance.theme"> </link><option>Theme</option></term>
 
         <listitem>
           <para>Select a theme for the OmegaT user interface.</para>
@@ -350,7 +346,7 @@
       </varlistentry>
 
       <varlistentry id="dialogs.preferences.appearance.restore.main.window">
-        <term id="dialogs.preferences.appearance.restore.main.window.title"><option>Restore Main Window</option></term>
+        <term id="dialogs.preferences.appearance.restore.main.window.title"><link linkend="dialogs.preferences.appearance.restore.main.window"> </link><option>Restore Main Window</option></term>
 
         <listitem>
           <para>Restores the OmegaT window panes to their default
@@ -365,7 +361,7 @@
     </variablelist>
 	
 	<section id="dialogs.preferences.fonts">
-	  <title id="dialogs.preferences.fonts.title"><guilabel>Font</guilabel></title>
+	  <title id="dialogs.preferences.fonts.title"><link linkend="dialogs.preferences.fonts"> </link><guilabel>Font</guilabel></title>
 
       <para>Select the font and font size used to display the text in the main
       window panes.</para>
@@ -380,9 +376,7 @@
 
 	  <variablelist>
 		<varlistentry id="dialogs.preferences.fonts.apply.font.to.tabular.data">
-          <term id="dialogs.preferences.fonts.apply.font.to.tabular.data.title">
-			<option>Apply this font to tabular data (project files, statistics,
-          etc.)</option></term>
+          <term id="dialogs.preferences.fonts.apply.font.to.tabular.data.title"><link linkend="dialogs.preferences.fonts.apply.font.to.tabular.data"> </link><option>Apply this font to tabular data (project files, statistics, etc.)</option></term>
 		  <listitem>
 			<para>Tabular data is by default displayed in a monospaced font that
 			keeps columns properly aligned. Using a proportional font will break
@@ -391,9 +385,7 @@
 		</varlistentry>
 
 		<varlistentry id="dialogs.preferences.fonts.apply.different.font.to.dictionaries">
-          <term id="dialogs.preferences.fonts.apply.different.font.to.dictionaries.title">
-			<option>Apply a different font size to the dictionaries
-          pane</option></term>
+          <term id="dialogs.preferences.fonts.apply.different.font.to.dictionaries.title"><link linkend="dialogs.preferences.fonts.apply.different.font.to.dictionaries"> </link><option>Apply a different font size to the dictionaries pane</option></term>
 		  <listitem>
 			<para>By default, the dictionaries pane uses the same font size as
 			the main window panes.</para>
@@ -403,7 +395,7 @@
 	</section>
 
 	<section id="dialogs.preferences.colours">
-	  <title id="dialogs.preferences.colours.title"><guilabel>Colours</guilabel></title>
+	  <title id="dialogs.preferences.colours.title"><link linkend="dialogs.preferences.colours"> </link><guilabel>Colours</guilabel></title>
 
       <para>You can assign different colours for the various parts of the user
       interface.</para>
@@ -425,9 +417,7 @@
   </section>
 
   <section id="dialogs.preferences.file.filters">
-	<title id="dialogs.preferences.file.filters.title">
-      <guilabel>Global File
-	Filters</guilabel></title>
+	<title id="dialogs.preferences.file.filters.title"><link linkend="dialogs.preferences.file.filters"> </link><guilabel>Global File Filters</guilabel></title>
 
 	<para>This dialog lists the file filters available to projects that do not
 	use local file filters.</para>
@@ -445,9 +435,7 @@
 
 
   <section id="dialogs.preferences.segmentation.setup">
-	<title id="dialogs.preferences.segmentation.setup.title">
-      <guilabel>Global
-	Segmentation Rules</guilabel></title>
+	<title id="dialogs.preferences.segmentation.setup.title"><link linkend="dialogs.preferences.segmentation.setup"> </link><guilabel>Global Segmentation Rules</guilabel></title>
 
 	<para>See the <link linkend="app.segmentation"
 	endterm="app.segmentation.title"/> appendix for a general explanation of
@@ -461,9 +449,7 @@
 	</warning>
 	
 	<section id="dialogs.preferences.segmentation.setup.scope">
-	  <title id="dialogs.preferences.segmentation.setup.scope.title">
-		Language
-	  sets</title>
+	  <title id="dialogs.preferences.segmentation.setup.scope.title"><link linkend="dialogs.preferences.segmentation.setup.scope"> </link>Language sets</title>
 
 	  <para>Only the rules associated to language patterns that correspond to
 	  the source language of your project are applied. See the <link
@@ -525,7 +511,7 @@
 	</section>
 
 	<section id="segmentation.rules">
-	  <title id="segmentation.rules.title"><guilabel>Set contents</guilabel></title>
+	  <title id="segmentation.rules.title"><link linkend="segmentation.rules"> </link><guilabel>Set contents</guilabel></title>
 	  <warning>
 		<para>Exception rules should be listed <emphasis>above</emphasis> break
 		rules.</para>
@@ -537,7 +523,7 @@
 	  
 	  <variablelist>
 		<varlistentry id="segmentation.rules.exceptionrule">
-          <term id="segmentation.rules.exceptionrule.title"><option>Exceptions</option></term>
+          <term id="segmentation.rules.exceptionrule.title"><link linkend="segmentation.rules.exceptionrule"> </link><option>Exceptions</option></term>
 
 		  <listitem>
 			<para>To define an exception rule, leave the <guilabel>Break/Exception
@@ -552,7 +538,7 @@
 		</varlistentry>
 
 		<varlistentry id="segmentation.rules.breakrule">
-          <term id="segmentation.rules.breakrule.title"><option>Breaks</option></term>
+          <term id="segmentation.rules.breakrule.title"><link linkend="segmentation.rules.breakrule"> </link><option>Breaks</option></term>
 
 		  <listitem>
 			<para>To define a break rule, check the
@@ -565,7 +551,7 @@
 		</varlistentry>
 
 		<varlistentry id="creating.new.rule">
-          <term id="creating.new.rule.title"><guibutton>Add</guibutton></term>
+          <term id="creating.new.rule.title"><link linkend="creating.new.rule"> </link><guibutton>Add</guibutton></term>
 		  <listitem>
 			<para>The <emphasis role="bold">Before</emphasis> pattern identifies
 			the parts that are before the break or exception point.</para>
@@ -586,9 +572,7 @@
   </section>
 
   <section id="dialog.preferences.auto.completion">
-	<title
-	    id="dialog.preferences.auto.completion.title">
-    <guilabel>Auto-Completion</guilabel></title>
+	<title id="dialog.preferences.auto.completion.title"><link linkend="dialog.preferences.auto.completion"> </link><guilabel>Auto-Completion</guilabel></title>
 
 	<para>The auto-completion menu is available in the <link
 	linkend="panes.editor" endterm="panes.editor.title"/> pane. See the <link
@@ -622,9 +606,7 @@
   </section>
 
   <section id="dialog.preferences.spellchecker">
-	<title
-	    id="dialog.preferences.spellchecker.title">
-    <guilabel>Spellchecker</guilabel></title>
+	<title id="dialog.preferences.spellchecker.title"><link linkend="dialog.preferences.spellchecker"> </link><guilabel>Spellchecker</guilabel></title>
 
 	<para>OmegaT has a built-in spellchecker but requires you to install
 	spellchecking dictionaries based on your target languages.</para>
@@ -641,7 +623,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.spellchecker.automatic.check">
-        <term id="dialog.preferences.spellchecker.automatic.check.title"><option>Spellcheck the translation</option></term>
+        <term id="dialog.preferences.spellchecker.automatic.check.title"><link linkend="dialog.preferences.spellchecker.automatic.check"> </link><option>Spellcheck the translation</option></term>
 		<listitem>
 		  <para>Enable after installing a spellchecking dictionary. OmegaT will
 		  underline spelling mistakes with red wavy-lines.</para>
@@ -655,7 +637,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.dictionary.folder">
-        <term id="dialog.preferences.spellchecker.dictionary.folder.title"><option>Spellchecking dictionaries location</option></term>
+        <term id="dialog.preferences.spellchecker.dictionary.folder.title"><link linkend="dialog.preferences.spellchecker.dictionary.folder"> </link><option>Spellchecking dictionaries location</option></term>
 		<listitem>
 		  <para>The folder where OmegaT will install and search for spelling
 		  dictionaries. It is generally in the <link
@@ -671,7 +653,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.already.installed">
-        <term id="dialog.preferences.spellchecker.already.installed.title"><option>Available languages</option></term>
+        <term id="dialog.preferences.spellchecker.already.installed.title"><link linkend="dialog.preferences.spellchecker.already.installed"> </link><option>Available languages</option></term>
 		<listitem>
 		  <para>The list of dictionaries that are present in the above
 		  folder.</para>
@@ -684,7 +666,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.spellchecker.url">
-        <term id="dialog.preferences.spellchecker.url.title"><option>URL of downloadable spellchecking dictionaries</option></term>
+        <term id="dialog.preferences.spellchecker.url.title"><link linkend="dialog.preferences.spellchecker.url"> </link><option>URL of downloadable spellchecking dictionaries</option></term>
 		<listitem>
 		  <para>The default URL where OmegaT will look for dictionaries to
 		  install.</para>
@@ -694,7 +676,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.spellchecker.install.new">
-        <term id="dialog.preferences.spellchecker.install.new.title"><guibutton>Install new language...</guibutton></term>
+        <term id="dialog.preferences.spellchecker.install.new.title"><link linkend="dialog.preferences.spellchecker.install.new"> </link><guibutton>Install new language...</guibutton></term>
 		<listitem>
 		  <para>Displays the list of available dictionaries from the above
 		  URL.</para>
@@ -712,11 +694,11 @@
   </section>
   
   <section id="dialog.preferences.languagetool.plugin">
-    <title id="dialog.preferences.languagetool.plugin.title"><guilabel>LanguageTool</guilabel></title>
+    <title id="dialog.preferences.languagetool.plugin.title"><link linkend="dialog.preferences.languagetool.plugin"> </link><guilabel>LanguageTool</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.languagetool.plugin.servicetype">
-        <term id="dialog.preferences.languagetool.plugin.servicetype.title"><option>Service type</option></term>
+        <term id="dialog.preferences.languagetool.plugin.servicetype.title"><link linkend="dialog.preferences.languagetool.plugin.servicetype"> </link><option>Service type</option></term>
 
 		<listitem>
 		  <para>Select the location of the language checker.</para>
@@ -728,7 +710,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.languagetool.plugin.rules">
-        <term id="dialog.preferences.languagetool.plugin.rules.title"><option>Rules</option></term>
+        <term id="dialog.preferences.languagetool.plugin.rules.title"><link linkend="dialog.preferences.languagetool.plugin.rules"> </link><option>Rules</option></term>
 
 		<listitem>
 		  <para>Select the rules depending on whether they are relevant to the
@@ -739,9 +721,7 @@
   </section>
 
   <section id="dialogs.preferences.external.searches">
-	<title id="dialogs.preferences.external.searches.title">
-      <guilabel>Global External
-	Searches</guilabel></title>
+	<title id="dialogs.preferences.external.searches.title"><link linkend="dialogs.preferences.external.searches"> </link><guilabel>Global External Searches</guilabel></title>
 	<para>External searches are either web searches or local commands that take
 	the string selected in the Editor as a parameter. The web searches are
 	opened in the default browser and the commands are equivalent to items
@@ -749,7 +729,7 @@
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.external.search.enable.project.specific.commands">
-        <term id="dialogs.preferences.external.search.enable.project.specific.commands.title"><option>Allow local external search commands</option></term>
+        <term id="dialogs.preferences.external.search.enable.project.specific.commands.title"><link linkend="dialogs.preferences.external.search.enable.project.specific.commands"> </link><option>Allow local external search commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -766,7 +746,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.external.search.context.menu.priority">
-        <term id="dialogs.preferences.external.search.context.menu.priority.title"><option>Context Menu Priority</option></term>
+        <term id="dialogs.preferences.external.search.context.menu.priority.title"><link linkend="dialogs.preferences.external.search.context.menu.priority"> </link><option>Context Menu Priority</option></term>
 
 		<listitem>
 		  <para>This option enables you to change the order of the commands in
@@ -781,7 +761,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.external.search.items">
-        <term id="dialogs.preferences.external.search.items.title"><option>Sets</option></term>
+        <term id="dialogs.preferences.external.search.items.title"><link linkend="dialogs.preferences.external.search.items"> </link><option>Sets</option></term>
 		<listitem>
 		  <para>Each set represents a group of web searches or local commands
 		  that are launched simultaneously.</para>
@@ -804,9 +784,7 @@
 		  tab.</para>
 
 		  <example id="dialogs.preferences.external.search.items.url.search.example">
-			<title id="dialogs.preferences.external.search.items.url.search.example.title">
-              URL
-			search example</title>
+			<title id="dialogs.preferences.external.search.items.url.search.example.title"><link linkend="dialogs.preferences.external.search.items.url.search.example"> </link>URL search example</title>
 			<programlisting>https://duckduckgo.com/?q=%22{target}%22+site%3A.fr+-linguee</programlisting>
 
 			<para>This opens a search for the {target} term on DuckDuckGo with a
@@ -817,9 +795,7 @@
 		  parameters. The default delimiter is <code>|</code>.</para>
 
 		  <example id="dialogs.preferences.external.search.items.command.example">
-			<title id="dialogs.preferences.external.search.items.command.example.title">
-              Command
-			example</title>
+			<title id="dialogs.preferences.external.search.items.command.example.title"><link linkend="dialogs.preferences.external.search.items.command.example"> </link>Command example</title>
 			<programlisting>/usr/bin/open|dict://{target}</programlisting>
 
 			<para>This opens the dictionary application that implements the
@@ -831,12 +807,12 @@
   </section>
 
   <section id="dialogs.preferences.editor">
-	<title id="dialogs.preferences.editor.title"><guilabel>Editor</guilabel></title>
+	<title id="dialogs.preferences.editor.title"><link linkend="dialogs.preferences.editor"> </link><guilabel>Editor</guilabel></title>
 
 	<para>When entering an empty segment:</para>
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.insert.the.source.text">
-        <term id="dialogs.preferences.editor.insert.the.source.text.title"><option>Insert the source text</option></term>
+        <term id="dialogs.preferences.editor.insert.the.source.text.title"><link linkend="dialogs.preferences.editor.insert.the.source.text"> </link><option>Insert the source text</option></term>
 
 		<listitem>
 		  <para>Use this option temporarily for parts of the translation that do
@@ -845,7 +821,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.leave.the.segment.empty">
-        <term id="dialogs.preferences.editor.leave.the.segment.empty.title"><option>Leave the segment empty</option></term>
+        <term id="dialogs.preferences.editor.leave.the.segment.empty.title"><link linkend="dialogs.preferences.editor.leave.the.segment.empty"> </link><option>Leave the segment empty</option></term>
 
 		<listitem>
 		  <para>You can enter your translation right away.</para>
@@ -853,7 +829,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.insert.the.best.fuzzy.match">
-        <term id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"><option>Insert the best fuzzy match</option></term>
+        <term id="dialogs.preferences.editor.insert.the.best.fuzzy.match.title"><link linkend="dialogs.preferences.editor.insert.the.best.fuzzy.match"> </link><option>Insert the best fuzzy match</option></term>
 
 		<listitem>
 		  <para>OmegaT inserts the translation with the highest match percentage
@@ -871,7 +847,7 @@
 	
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match">
-        <term id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title"><option>Attempt to replace fuzzy match numbers</option></term>
+        <term id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.title"><link linkend="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match"> </link><option>Attempt to replace fuzzy match numbers</option></term>
 
 		<listitem>
 		  <para>When a fuzzy match is inserted, OmegaT tries to replace the numbers
@@ -883,7 +859,7 @@
 		  </note>
 
 		  <example id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers">
-			<title id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers.title">Fuzzy match number conversion</title>
+			<title id="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers.title"><link linkend="dialogs.preferences.editor.attempt.to.replace.numbers.when.inserting.a.fuzzy.match.convert.match.numbers"> </link>Fuzzy match number conversion</title>
 			<para><token>2001</token> in the source:</para>
 			<para>
 			<programlisting>[[<token>2001</token>年]]、ドイツの永住権を取得。</programlisting></para>
@@ -901,7 +877,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source">
-        <term id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"><option>Allow translation to be equal to source</option></term>
+        <term id="dialogs.preferences.editor.allow.translation.to.be.equal.to.source.title"><link linkend="dialogs.preferences.editor.allow.translation.to.be.equal.to.source"> </link><option>Allow translation to be equal to source</option></term>
 
 		<listitem>
 		  <para>A translation that is identical to the source text is not
@@ -914,7 +890,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.export.the.segment.to.text.files">
-        <term id="dialogs.preferences.editor.export.the.segment.to.text.files.title"><option>Export the segment to a text file</option></term>
+        <term id="dialogs.preferences.editor.export.the.segment.to.text.files.title"><link linkend="dialogs.preferences.editor.export.the.segment.to.text.files"> </link><option>Export the segment to a text file</option></term>
 
 		<listitem>
 		  <para>When OmegaT enters a segment,</para>
@@ -956,9 +932,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation">
-        <term id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title">
-          <option>Stop at untranslated and alternatives
-        translations</option></term>
+        <term id="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation.title"><link linkend="dialogs.preferences.editor.go.to.next.untranslated.segment.stops.where.there.is.at.least.one.alternative.translation"> </link><option>Stop at untranslated and alternatives translations</option></term>
 
 		<listitem>
 		  <para><link linkend="menus.goto" endterm="menus.goto.title"/><link
@@ -969,7 +943,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.allow.tag.editing">
-        <term id="dialogs.preferences.editor.allow.tag.editing.title"><option>Allow tag editing</option></term>
+        <term id="dialogs.preferences.editor.allow.tag.editing.title"><link linkend="dialogs.preferences.editor.allow.tag.editing"> </link><option>Allow tag editing</option></term>
 
 		<listitem>
 		  <para>Tags should generally not be modified, but that is possible when
@@ -978,7 +952,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment">
-        <term id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"><option>Check issues when leaving a segment</option></term>
+        <term id="dialogs.preferences.editor.validate.tags.when.leaving.a.segment.title"><link linkend="dialogs.preferences.editor.validate.tags.when.leaving.a.segment"> </link><option>Check issues when leaving a segment</option></term>
 
 		<listitem>
 		  <para>OmegaT runs an issues check on the segment as you leave it. The
@@ -989,7 +963,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.save.auto-populated.status">
-        <term id="dialogs.preferences.editor.save.auto-populated.status.title"><option>Save auto-populated status</option></term>
+        <term id="dialogs.preferences.editor.save.auto-populated.status.title"><link linkend="dialogs.preferences.editor.save.auto-populated.status"> </link><option>Save auto-populated status</option></term>
 
 		<listitem>
 		  <para>Translation memories located in <link
@@ -1009,7 +983,7 @@
 	  </varlistentry>
 
       <varlistentry id="dialogs.preferences.editor.save.orgin.of.translation">
-        <term id="dialogs.preferences.editor.save.orgin.of.translation.title"><option>Save origin of translation</option></term>
+        <term id="dialogs.preferences.editor.save.orgin.of.translation.title"><link linkend="dialogs.preferences.editor.save.orgin.of.translation"> </link><option>Save origin of translation</option></term>
 
 		<listitem>
           <para>When machine translation is enabled, OmegaT registers the name
@@ -1018,7 +992,7 @@
       </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.initially.load.this.many.segments">
-        <term id="dialogs.preferences.editor.initially.load.this.many.segments.title"><option>Initial number of loaded segments</option></term>
+        <term id="dialogs.preferences.editor.initially.load.this.many.segments.title"><link linkend="dialogs.preferences.editor.initially.load.this.many.segments"> </link><option>Initial number of loaded segments</option></term>
 
 		<listitem>
 		  <para>The editor initially loads and displays 2,000 segments, and
@@ -1028,7 +1002,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.editor.paragraph.delimitation.format">
-        <term id="dialogs.preferences.editor.paragraph.delimitation.format.title"><option>Paragraph delimitation format</option></term>
+        <term id="dialogs.preferences.editor.paragraph.delimitation.format.title"><link linkend="dialogs.preferences.editor.paragraph.delimitation.format"> </link><option>Paragraph delimitation format</option></term>
 
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
@@ -1041,11 +1015,11 @@
   </section>
 
   <section id="dialogs.preferences.tag.processing">
-	<title id="dialogs.preferences.tag.processing.title"><guilabel>Tag Processing</guilabel></title>
+	<title id="dialogs.preferences.tag.processing.title"><link linkend="dialogs.preferences.tag.processing"> </link><guilabel>Tag Processing</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialogs.preferences.tag.processing.programming.variables">
-        <term id="dialogs.preferences.tag.processing.programming.variables.title"><option>Check printf function variables</option></term>
+        <term id="dialogs.preferences.tag.processing.programming.variables.title"><link linkend="dialogs.preferences.tag.processing.programming.variables"> </link><option>Check printf function variables</option></term>
 		<listitem>
 		  <para>Check printf variables in file formats other than the PO
 		  format. The PO filter already handles variables marked with
@@ -1055,21 +1029,21 @@
 		  
 		  <variablelist>
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.none">
-              <term id="dialogs.preferences.tag.processing.programming.variables.none.title"><option>None</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.none.title"><link linkend="dialogs.preferences.tag.processing.programming.variables.none"> </link><option>None</option></term>
 			  <listitem>
 				<para>None of the variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 			
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.simple">
-              <term id="dialogs.preferences.tag.processing.programming.variables.simple.title"><option>Simple variables (e.g., %s, %d)</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.simple.title"><link linkend="dialogs.preferences.tag.processing.programming.variables.simple"> </link><option>Simple variables (e.g., %s, %d)</option></term>
 			  <listitem>
 				<para>Only the simple variable patterns are checked.</para>
 			  </listitem>
 			</varlistentry>
 
 			<varlistentry id="dialogs.preferences.tag.processing.programming.variables.all">
-              <term id="dialogs.preferences.tag.processing.programming.variables.all.title"><option>All variables (e.g., %s, %-s)</option></term>
+              <term id="dialogs.preferences.tag.processing.programming.variables.all.title"><link linkend="dialogs.preferences.tag.processing.programming.variables.all"> </link><option>All variables (e.g., %s, %-s)</option></term>
 			  <listitem>
 				<para>This can result in false positives in some files.</para>
 			  </listitem>
@@ -1079,7 +1053,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.simple.java.messageformat">
-        <term id="dialogs.preferences.tag.processing.simple.java.messageformat.title"><option>Check simple Java MessageFormat placeholders</option></term>
+        <term id="dialogs.preferences.tag.processing.simple.java.messageformat.title"><link linkend="dialogs.preferences.tag.processing.simple.java.messageformat"> </link><option>Check simple Java MessageFormat placeholders</option></term>
 		<listitem>
 		  <para>Check Java MessageFormat placeholders in file formats other than
 		  the Java Bundles format. The Java Bundles filter already handles
@@ -1089,7 +1063,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order">
-        <term id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title"><option>Allow translated tags to be in a different order</option></term>
+        <term id="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order.title"><link linkend="dialogs.preferences.tag.processing.allow.translated.tags.to.be.in.a.different.order"> </link><option>Allow translated tags to be in a different order</option></term>
 		<listitem>
 		  <para>Tags in a different order than the source will not appear in the
 		  list of tag issues. See the <link linkend="menus.tools"
@@ -1099,9 +1073,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues">
-        <term id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title">
-          <option>Block the creation of translated files with tag
-        issues</option></term>
+        <term id="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues.title"><link linkend="dialogs.preferences.tag.processing.do.not.allow.creating.translated.documents.with.tag.issues"> </link><option>Block the creation of translated files with tag issues</option></term>
 		<listitem>
 		  <para>If you try to create the translated files, OmegaT will display
 		  the issues dialog until no issues are found. See the <link
@@ -1112,7 +1084,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics">
-        <term id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"><option>Count flagged text and custom tags in statistics</option></term>
+        <term id="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics.title"><link linkend="dialogs.preferences.tag.processing.count.protected.text.and.custom.tags.in.statistics"> </link><option>Count flagged text and custom tags in statistics</option></term>
 		<listitem>
 		  <para>Unlike OmegaT tags, flagged text and custom tags are by default
 		  counted in the statistics. See the <link
@@ -1124,7 +1096,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags">
-        <term id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"><option>Custom tags</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags.title"><link linkend="dialogs.preferences.tag.processing.regular.expressions.for.custom.tags"> </link><option>Custom tags</option></term>
 		<listitem>
 		  <para>Use regular expressions to define custom tags. To define a list
 		  of tags, group each tag between parentheses and separate the groups
@@ -1148,7 +1120,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation">
-        <term id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"><option>Flagged text</option></term>
+        <term id="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title"><link linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"> </link><option>Flagged text</option></term>
 		<listitem>
 		  <para>Text in the target segment matching this expression is marked in
 		  red and identified as an extraneous tag for issue checking
@@ -1162,14 +1134,14 @@
   </section>
 
   <section id="dialog.preferences.team">
-	<title id="dialog.preferences.team.title"><guilabel>Team</guilabel></title>
+	<title id="dialog.preferences.team.title"><link linkend="dialog.preferences.team"> </link><guilabel>Team</guilabel></title>
 
 	<para>The name you enter here will be attached to all the segments you
 	translate.</para>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.team.title.repository.credentials">
-        <term id="dialog.preferences.team.title.repository.credentials.title"><option>Repository Credentials</option></term>
+        <term id="dialog.preferences.team.title.repository.credentials.title"><link linkend="dialog.preferences.team.title.repository.credentials"> </link><option>Repository Credentials</option></term>
 		<listitem>
 		  <para>List of projects for which login details have been stored in
 		  OmegaT. Remove a project from this list if you want OmegaT to ask you
@@ -1180,11 +1152,11 @@
   </section>
 
   <section id="dialog.preferences.tm.matches">
-	<title id="dialog.preferences.tm.matches.title"><option>TM Matches</option></title>
+	<title id="dialog.preferences.tm.matches.title"><link linkend="dialog.preferences.tm.matches"> </link><option>TM Matches</option></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.tm.matches.sort.fuzzy.matches.by">
-        <term id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title"><option>Sort fuzzy matches by:</option></term>
+        <term id="dialog.preferences.tm.matches.sort.fuzzy.matches.by.title"><link linkend="dialog.preferences.tm.matches.sort.fuzzy.matches.by"> </link><option>Sort fuzzy matches by:</option></term>
 
 		<listitem>
 		  <para>By default, stemming is used to determine the closest matches
@@ -1197,7 +1169,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.minimum.threshold">
-        <term id="dialog.preferences.tm.matches.minimum.threshold.title"><option>Minimal threshold to show a fuzzy match</option></term>
+        <term id="dialog.preferences.tm.matches.minimum.threshold.title"><link linkend="dialog.preferences.tm.matches.minimum.threshold"> </link><option>Minimal threshold to show a fuzzy match</option></term>
 		<listitem>
 		  <para>OmegaT displays the five best fuzzy matches above 30% by
 		  default. You can change that threshold here.</para>
@@ -1212,9 +1184,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs">
-        <term id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title">
-          <option>Select how tags of non-OmegaT TMXs should be
-        displayed</option></term>
+        <term id="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs.title"><link linkend="dialog.preferences.tm.matches.displaying.tags.in.non-omegat.tmxs"> </link><option>Select how tags of non-OmegaT TMXs should be displayed</option></term>
 
 		<listitem>
 		  <para>Determine how to handle tags in TMX files generated by other
@@ -1226,7 +1196,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.tm.matches.other.languages">
-        <term id="dialog.preferences.tm.matches.other.languages.title"><option>Include matches from other languages</option></term>
+        <term id="dialog.preferences.tm.matches.other.languages.title"><link linkend="dialog.preferences.tm.matches.other.languages"> </link><option>Include matches from other languages</option></term>
 		<listitem>
 		  <para>Segments that have matches in different target languages can
 		  also be displayed in the <link linkend="panes.fuzzy.matches"
@@ -1237,7 +1207,7 @@
 
 	  
 	  <varlistentry id="dialog.preferences.tm.matches.match.display.template">
-        <term id="dialog.preferences.tm.matches.match.display.template.title"><option>Match display template</option></term>
+        <term id="dialog.preferences.tm.matches.match.display.template.title"><link linkend="dialog.preferences.tm.matches.match.display.template"> </link><option>Match display template</option></term>
 
 		<listitem>
 		  <para>Change how fuzzy matches are displayed, through the use of
@@ -1263,7 +1233,7 @@ ${filePath}></programlisting></para>
 		  and can be inserted with a button.</para>
 
 		  <table id="table.match.pane.setup" colsep="0" rowsep="0">
-			<title id="table.match.pane.setup.title">Match template variables</title>
+			<title id="table.match.pane.setup.title"><link linkend="table.match.pane.setup"> </link>Match template variables</title>
 
 			<tgroup cols="2" colsep="1" rowsep="1">
 			  <colspec align="left"/>
@@ -1410,11 +1380,11 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialog.preferences.view">
-	<title id="dialog.preferences.view.title"><guilabel>View</guilabel></title>
+	<title id="dialog.preferences.view.title"><link linkend="dialog.preferences.view"> </link><guilabel>View</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.view.display.all.source.segments.in.bold">
-        <term id="dialog.preferences.view.display.all.source.segments.in.bold.title"><option>Display all source segments in bold</option></term>
+        <term id="dialog.preferences.view.display.all.source.segments.in.bold.title"><link linkend="dialog.preferences.view.display.all.source.segments.in.bold"> </link><option>Display all source segments in bold</option></term>
 		<listitem>
 		  <para>By default, only the current segment is displayed in bold
 		  face.</para>
@@ -1422,7 +1392,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.display.active.source.segment.in.bold">
-        <term id="dialog.preferences.view.display.active.source.segment.in.bold.title"><option>Display active source segment in bold</option></term>
+        <term id="dialog.preferences.view.display.active.source.segment.in.bold.title"><link linkend="dialog.preferences.view.display.active.source.segment.in.bold"> </link><option>Display active source segment in bold</option></term>
 		<listitem>
 		  <para>If source segments are displayed in normal face, you can use
 		  this option to display only the current source segment in bold.</para>
@@ -1430,7 +1400,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments">
-        <term id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title"><option>Mark all repeated segments</option></term>
+        <term id="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments.title"><link linkend="dialog.preferences.view.include.the.first.non-unique.segment.when.marking.non.unique.segments"> </link><option>Mark all repeated segments</option></term>
 		<listitem>
 		  <para>Use <link linkend="menus.view" endterm="menus.view.title"/><link
 		  linkend="menus.view.mark.non.unique.segments"
@@ -1441,7 +1411,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.simplify.tooltip.on.protected.parts">
-        <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title"><option>Simplify tag tooltips</option></term>
+        <term id="dialog.preferences.view.simplify.tooltip.on.protected.parts.title"><link linkend="dialog.preferences.view.simplify.tooltip.on.protected.parts"> </link><option>Simplify tag tooltips</option></term>
 		<listitem>
 		  <para>OmegaT tags are protected text that represents format-specific
 		  tags in the source document. When hovering on an OmegaT tag, OmegaT
@@ -1452,7 +1422,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.use.custom.templates.for.modification.info">
-        <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title"><option>Customize segment modification information</option></term>
+        <term id="dialog.preferences.view.use.custom.templates.for.modification.info.title"><link linkend="dialog.preferences.view.use.custom.templates.for.modification.info"> </link><option>Customize segment modification information</option></term>
 		<listitem>
 		  <para>Segment modification information is displayed over the
 		  segment. the default setting shows who last modified the translation
@@ -1480,7 +1450,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 	  
 	  <varlistentry id="dialog.preferences.view.modification.info.template">
-        <term id="dialog.preferences.view.modification.info.template.title"><option>Standard template</option></term>
+        <term id="dialog.preferences.view.modification.info.template.title"><link linkend="dialog.preferences.view.modification.info.template"> </link><option>Standard template</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1488,7 +1458,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialog.preferences.view.modification.info.template.for.segments.without.date">
-        <term id="dialog.preferences.view.modification.info.template.for.segments.without.date.title"><option>Template for segments without date</option></term>
+        <term id="dialog.preferences.view.modification.info.template.for.segments.without.date.title"><link linkend="dialog.preferences.view.modification.info.template.for.segments.without.date"> </link><option>Template for segments without date</option></term>
 		<listitem>
 		  <para>Use the template variables to adapt this template to your
 		  needs.</para>
@@ -1498,13 +1468,11 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.saving.and.output">
-	<title id="dialogs.preferences.saving.and.output.title">
-      <guilabel>Saving and
-	Output</guilabel></title>
+	<title id="dialogs.preferences.saving.and.output.title"><link linkend="dialogs.preferences.saving.and.output"> </link><guilabel>Saving and Output</guilabel></title>
 
 	<variablelist>
 	  <varlistentry id="dialog.preferences.saving.and.output.interval">
-        <term id="dialog.preferences.saving.and.output.interval.title"><option>Project data saving interval</option></term>
+        <term id="dialog.preferences.saving.and.output.interval.title"><link linkend="dialog.preferences.saving.and.output.interval"> </link><option>Project data saving interval</option></term>
 		<listitem>
 		  <para>Allows the user to select the interval between automatic project
 		  data saves.  See the <link
@@ -1530,7 +1498,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.external.post-processing.command">
-        <term id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><option>Global post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.external.post-processing.command.title"><link linkend="dialogs.preferences.saving.and.output.external.post-processing.command"> </link><option>Global post-processing commands</option></term>
 
 		<listitem>
 		  <para>OmegaT can automatically run commands after you use <link
@@ -1558,7 +1526,7 @@ ${filePath}></programlisting></para>
 	  </varlistentry>
 
 	  <varlistentry id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands">
-        <term id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><option>Allow local post-processing commands</option></term>
+        <term id="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands.title"><link linkend="dialogs.preferences.saving.and.output.also.allow.per.project.external.commands"> </link><option>Allow local post-processing commands</option></term>
 
 		<listitem>
 		  <warning>
@@ -1588,14 +1556,14 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.proxy.login">
-	<title id="dialogs.preferences.proxy.login.title"><guilabel>Proxy Login</guilabel></title>
+	<title id="dialogs.preferences.proxy.login.title"><link linkend="dialogs.preferences.proxy.login"> </link><guilabel>Proxy Login</guilabel></title>
 
 	<para>If you use an authenticated proxy server to access the Internet, enter
 	your credentials here.</para>
   </section>
 
   <section id="dialogs.preferences.secure.store">
-	<title id="dialogs.preferences.secure.store.title"><guilabel>Secure store</guilabel></title>
+	<title id="dialogs.preferences.secure.store.title"><link linkend="dialogs.preferences.secure.store"> </link><guilabel>Secure store</guilabel></title>
 
 	<para>Define or reset the master password used to protect login credentials
 	as well as access keys for machine translation services.</para>
@@ -1606,7 +1574,7 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.plugins">
-	<title id="dialogs.preferences.plugins.title"><guilabel>Plugins</guilabel></title>
+	<title id="dialogs.preferences.plugins.title"><link linkend="dialogs.preferences.plugins"> </link><guilabel>Plugins</guilabel></title>
 
 	<para>Displays the list of all the installed plugins.</para>
 
@@ -1632,7 +1600,7 @@ ${filePath}></programlisting></para>
   </section>
 
   <section id="dialogs.preferences.updates">
-	<title id="dialogs.preferences.updates.title"><guilabel>Updates</guilabel></title>
+	<title id="dialogs.preferences.updates.title"><link linkend="dialogs.preferences.updates"> </link><guilabel>Updates</guilabel></title>
 
 	<para>Use this option to choose whether to be automatically notified of
 	updates to OmegaT.</para>

--- a/doc_src/en/OmegaT_ProjectFolder.xml
+++ b/doc_src/en/OmegaT_ProjectFolder.xml
@@ -98,16 +98,16 @@
 		  <filename>omegat.project</filename> file contains remote repository
 		  information, the project will be recognized as a team project by
 		  OmegaT:</para>
-		  
+
 		  <programlisting>...
-    &lt;external_command&gt;&lt;/external_command&gt;
-    &lt;repositories&gt;
-        &lt;repository type="git" url="https://URL/OF/THE/REMOTE/PROJECT/REPOSITORY"&gt;
-            &lt;mapping local="/" repository="/"/&gt;
-        &lt;/repository&gt;
-    &lt;/repositories&gt;
+&lt;external_command&gt;&lt;/external_command&gt;
+&lt;repositories&gt;
+    &lt;repository type="git" url="https://URL/OF/THE/REMOTE/PROJECT/REPOSITORY"&gt;
+        &lt;mapping local="/" repository="/"/&gt;
+    &lt;/repository&gt;
+&lt;/repositories&gt;
 &lt;/project&gt;
-		  </programlisting>
+</programlisting>
 
 		  <para>See the <link linkend="how.to.setup.team.project"
 		  endterm="how.to.setup.team.project.title"/> how-to for details.</para>
@@ -123,7 +123,8 @@
 	
 	<variablelist>
 	  <varlistentry id="project.folder.omegat">
-		<term id="project.folder.omegat.title">omegat</term>
+        <term id="project.folder.omegat.title">
+		omegat</term>
 		<listitem>
 		  <para>This is the project folder that always contains <link
 		  linkend="project.folder.project.save.tmx"
@@ -140,7 +141,8 @@
 	  </varlistentry>
 
 	  <varlistentry id="project.folder.omegat.project.file">
-		<term id="project.folder.omegat.project.file.title">omegat.project</term>
+        <term id="project.folder.omegat.project.file.title">
+		omegat.project</term>
 		<listitem>
 		  <para>This file contains the project parameters defined in the <link
 		  linkend="dialogs.project.properties">project properties</link>, such as
@@ -159,7 +161,8 @@
   </section>
   
   <section id="project.folder.source">
-    <title id="project.folder.source.title">source</title>
+	<title id="project.folder.source.title">
+    source</title>
     <para>The source folder contains the files to translate.</para>
 
 	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
@@ -184,7 +187,8 @@
   </section>
 
   <section id="project.folder.target">
-    <title id="project.folder.target.title">target</title>
+	<title id="project.folder.target.title">
+    target</title>
     <para>This folder is initially empty.</para>
 
 	<para>It will be populated with the translated files every time you use
@@ -204,7 +208,8 @@
   </section>
 
   <section id="project.folder.tm">
-    <title id="project.folder.tm.title">tm</title>
+	<title id="project.folder.tm.title">
+    tm</title>
     <para>This folder can contain any number of bilingual reference documents
     (TMX files, but also any file in a bilingual format supported by OmegaT,
     including PO files, etc.) and the TMX files can also be compressed in the
@@ -236,7 +241,8 @@
 
 	<variablelist>
       <varlistentry id="project.folder.tm.auto">
-		<term id="project.folder.tm.auto.title">tm/auto</term>
+        <term id="project.folder.tm.auto.title">
+		tm/auto</term>
 		<listitem>
 		  <para>This folder is intended for reliable references files that can
 		  automatically fill exactly matching and not yet translated
@@ -257,7 +263,7 @@
 			this folder.</para>
 		  </note>
 
-		<orderedlist>
+		  <orderedlist>
 			<listitem>
 			  <para>Put the applicable memories in the <filename
 			  class="directory">tm/auto</filename> folder.</para>
@@ -284,7 +290,7 @@
 		  linkend="menus.goto.auto.populated.segments"
 		  endterm="menus.goto.auto.populated.segments.title"/> to navigate to the
 		  inserted segments.</para>
-				
+		  
 		  <warning>
 			<para>If you remove a TMX file from <filename
 			class="directory">tm/auto</filename> before Step 3, its content will
@@ -294,7 +300,8 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.enforce">
-		<term id="project.folder.tm.enforce.title">tm/enforce</term>
+        <term id="project.folder.tm.enforce.title">
+		tm/enforce</term>
 		<listitem>
 		  <para>This folder is made for reliable references files that are also
 		  meant to automatically overwrite previously translated contents.</para>
@@ -374,7 +381,8 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.mt">
-		<term id="project.folder.tm.mt.title">tm/mt</term>
+        <term id="project.folder.tm.mt.title">
+		tm/mt</term>
 		<listitem>
 		  <para>When a match is inserted from a TMX contained in this folder, the
 		  background colour of the active segment changes to red.</para>
@@ -385,7 +393,8 @@
 	  </varlistentry>
 	  
       <varlistentry id="project.folder.tm.penalty">
-		<term id="project.folder.tm.penalty.title">tm/penalty-xxx</term>
+        <term id="project.folder.tm.penalty.title">
+		tm/penalty-xxx</term>
 		<listitem>
 		  <para><literal>xxx</literal> is a number from 0 to 100 that will act as
 		  a penalty subtracted from the match percentage of segments coming from
@@ -399,7 +408,8 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.tmx2source">
-		<term id="project.folder.tm.tmx2source.title">tm/tmx2source</term>
+        <term id="project.folder.tm.tmx2source.title">
+		tm/tmx2source</term>
 		<listitem>
 		  <para>You can display a third language <emphasis>right
 		  under</emphasis> the source segment to use as a third language
@@ -420,7 +430,8 @@
   </section>
 
   <section id="project.folder.exported.tm">
-	<title id="project.folder.exported.tm.title">exported tms folder</title>
+	<title id="project.folder.exported.tm.title">
+    exported tms folder</title>
 	<para>By default, that folder is the project folder itself but you can
 	change its location to make it more practical to share exported TM
 	files. See the <link linkend="how.to.tm.share.translation.memories"
@@ -429,7 +440,8 @@
   </section>
 
   <section id="project.folder.dictionary">
-    <title id="project.folder.dictionary.title">dictionary</title>
+	<title id="project.folder.dictionary.title">
+    dictionary</title>
     <para>This folder is initially empty, and is used to store any dictionaries
     you add to the project.</para>
 
@@ -466,7 +478,8 @@
   </section>
 
   <section id="project.folder.glossary">
-    <title id="project.folder.glossary.title">glossary</title>
+	<title id="project.folder.glossary.title">
+    glossary</title>
     <para>This folder is initially empty. It is used to store the default
     writable glossary and any other glossaries you use in the project.</para>
 
@@ -477,7 +490,8 @@
 
 	<variablelist>
       <varlistentry id="project.folder.glossary.txt">
-        <term id="project.folder.glossary.txt.title">glossary.txt</term>
+        <term id="project.folder.glossary.txt.title">
+		glossary.txt</term>
         <listitem>
           <para>This is the project writable glossary. It is created the first
           time you use <link linkend="menus.edit.create.glossary.entry"
@@ -494,7 +508,8 @@
   </section>
 
   <section id="project.folder.omegat.folder">
-    <title id="project.folder.omegat.folder.title">omegat</title>
+	<title id="project.folder.omegat.folder.title">
+    omegat</title>
     <para>The <filename class="directory">omegat</filename> folder contains, at
     a minimum, the <link linkend="project.folder.project.save.tmx"
     endterm="project.folder.project.save.tmx.title"/> and <link
@@ -504,7 +519,8 @@
 
     <variablelist>
       <varlistentry id="project.folder.project.save.tmx">
-        <term id="project.folder.project.save.tmx.title">project_save.tmx</term>
+        <term id="project.folder.project.save.tmx.title">
+		project_save.tmx</term>
         <listitem>
           <para>This is the most important file in the project. When you create
           a new project, the file is empty and is gradually filled with the
@@ -522,7 +538,8 @@
       </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.bak">
-		<term id="project.folder.project.save.tmx.bak.title">project_save.tmx.bak</term>
+        <term id="project.folder.project.save.tmx.bak.title">
+		project_save.tmx.bak</term>
 		<listitem>
 		  <para>This file is a backup of <filename>project_save.tmx</filename>
 		  and is automatically recreated every time
@@ -538,7 +555,8 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.timestamp.bak">
-		<term id="project.folder.project.save.tmx.timestamp.bak.title">project_save.tmx.timestamp.bak</term>
+        <term id="project.folder.project.save.tmx.timestamp.bak.title">
+		project_save.tmx.timestamp.bak</term>
 		<listitem>
 		  <para>Every time a project is loaded, OmegaT creates a backup of
 		  <filename>project_save.tmx</filename> with the name
@@ -548,7 +566,8 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.project.stats">
-        <term id="project.folder.project.stats.title">project_stats.txt</term>
+        <term id="project.folder.project.stats.title">
+		project_stats.txt</term>
         <listitem>
           <para>This is the statistics file for the whole project. It is updated
           each time the project is reloaded.</para>
@@ -560,7 +579,8 @@
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.project.stats.match">
-        <term id="project.folder.omegat.project.stats.match.title">project_stats_match.txt</term>
+        <term id="project.folder.omegat.project.stats.match.title">
+		project_stats_match.txt</term>
         <listitem>
           <para>This file contains the latest project match statistics. Use
           <link linkend="menus.tools" endterm="menus.tools.title"/><link
@@ -571,7 +591,8 @@
 
       <varlistentry id="project.folder.omegat.project.stats.match.per.file">
         <term
-        id="project.folder.omegat.project.stats.match.per.file.title">project_stats_match_per_file.txt</term>
+			id="project.folder.omegat.project.stats.match.per.file.title">
+		project_stats_match_per_file.txt</term>
         <listitem>
           <para>This file contains the latest project match statistics by file.
           Use <link linkend="menus.tools" endterm="menus.tools.title"/><link
@@ -581,10 +602,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry id="
-						project.folder.omegat.spellcheck">
-        <term
-        id="project.folder.omegat.ignored.words.title">ignored_words.txt</term>
+      <varlistentry id="project.folder.omegat.ignored.words">
+        <term id="project.folder.omegat.ignored.words.title">
+		ignored_words.txt</term>
         <term id="project.folder.omegat.learned.words">learned_words.txt</term>
         <listitem>
           <para>These files are created and used by the spellchecker. You can
@@ -609,7 +629,8 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.segmentation">
-        <term id="project.folder.omegat.segmentation.title">segmentation.conf</term>
+        <term id="project.folder.omegat.segmentation.title">
+		segmentation.conf</term>
         <listitem>
           <para>This file contains the project-specific segmentation
           rules.</para>
@@ -617,28 +638,32 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.filters">
-        <term id="project.folder.omegat.filters.title">filters.xml</term>
+        <term id="project.folder.omegat.filters.title">
+		filters.xml</term>
         <listitem>
           <para>This file contains the project-specific file filters.</para>
         </listitem>
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.uiLayout">
-        <term id="project.folder.omegat.uiLayout.title">uiLayout.xml</term>
+        <term id="project.folder.omegat.uiLayout.title">
+		uiLayout.xml</term>
         <listitem>
           <para>This file contains the project-specific GUI settings.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.finder">
-        <term id="project.folder.omegat.finder.title">finder.xml</term>
+        <term id="project.folder.omegat.finder.title">
+		finder.xml</term>
         <listitem>
           <para>This file contains the project-specific external searches.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.file.order">
-        <term id="project.folder.omegat.file.order.title">files_order.txt</term>
+        <term id="project.folder.omegat.file.order.title">
+		files_order.txt</term>
         <listitem>
           <para>This file is created if you manually change the order of the
           files in the <link linkend="windows.source.files.list"
@@ -647,7 +672,8 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.last.entry">
-        <term id="project.folder.omegat.last.entry.title">last_entry.properties</term>
+        <term id="project.folder.omegat.last.entry.title">
+		last_entry.properties</term>
         <listitem>
           <para>This file keeps a record of the last segment you visited,
           including its number, its source contents, the file name and the date,
@@ -659,7 +685,8 @@
   </section>
 
   <section id="project.folder.repositories">
-    <title id="project.folder.repositories.title">.repositories</title>
+	<title id="project.folder.repositories.title">
+    .repositories</title>
     <para>In a team project, this folder contains a versioned copy of the
     project tree structure linked directly to the remote server.</para>
 

--- a/doc_src/en/OmegaT_ProjectFolder.xml
+++ b/doc_src/en/OmegaT_ProjectFolder.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.project.folder">
-  <title id="chapter.project.folder.title">Project Folder</title>
+  <title id="chapter.project.folder.title"><link linkend="chapter.project.folder"> </link>Project Folder</title>
 
-  <section>
-	<title>Default structure</title>
+  <section id="chapter.project.folder.default.structure">
+	<title id="chapter.project.folder.default.structure.title"><link linkend="chapter.project.folder.default.structure"> </link>Default structure</title>
 	<para>An OmegaT project consists of a set of folders and files that contain
 	the resources used for translating.</para>
 
@@ -116,14 +116,14 @@
 	</note>
   </section>
 
-  <section>
-	<title>Minimal contents</title>
+  <section id="chapter.project.folder.minimal.contents">
+	<title id="chapter.project.folder.minimal.contents.title"><link linkend="chapter.project.folder.minimal.contents"> </link>Minimal contents</title>
 
 	<para>A project is a folder containing, at a minimum, the following:</para>
 	
 	<variablelist>
 	  <varlistentry id="project.folder.omegat">
-        <term id="project.folder.omegat.title">omegat</term>
+        <term id="project.folder.omegat.title"><link linkend="project.folder.omegat"> </link>omegat</term>
 		<listitem>
 		  <para>This is the project folder that always contains <link
 		  linkend="project.folder.project.save.tmx"
@@ -140,7 +140,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="project.folder.omegat.project.file">
-        <term id="project.folder.omegat.project.file.title">omegat.project</term>
+        <term id="project.folder.omegat.project.file.title"><link linkend="project.folder.omegat.project.file"> </link>omegat.project</term>
 		<listitem>
 		  <para>This file contains the project parameters defined in the <link
 		  linkend="dialogs.project.properties">project properties</link>, such as
@@ -159,7 +159,7 @@
   </section>
   
   <section id="project.folder.source">
-	<title id="project.folder.source.title">source</title>
+	<title id="project.folder.source.title"><link linkend="project.folder.source"> </link>source</title>
     <para>The source folder contains the files to translate.</para>
 
 	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
@@ -184,7 +184,7 @@
   </section>
 
   <section id="project.folder.target">
-	<title id="project.folder.target.title">target</title>
+	<title id="project.folder.target.title"><link linkend="project.folder.target"> </link>target</title>
     <para>This folder is initially empty.</para>
 
 	<para>It will be populated with the translated files every time you use
@@ -204,7 +204,7 @@
   </section>
 
   <section id="project.folder.tm">
-	<title id="project.folder.tm.title">tm</title>
+	<title id="project.folder.tm.title"><link linkend="project.folder.tm"> </link>tm</title>
     <para>This folder can contain any number of bilingual reference documents
     (TMX files, but also any file in a bilingual format supported by OmegaT,
     including PO files, etc.) and the TMX files can also be compressed in the
@@ -236,7 +236,7 @@
 
 	<variablelist>
       <varlistentry id="project.folder.tm.auto">
-        <term id="project.folder.tm.auto.title">tm/auto</term>
+        <term id="project.folder.tm.auto.title"><link linkend="project.folder.tm.auto"> </link>tm/auto</term>
 		<listitem>
 		  <para>This folder is intended for reliable references files that can
 		  automatically fill exactly matching and not yet translated
@@ -294,7 +294,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.enforce">
-        <term id="project.folder.tm.enforce.title">tm/enforce</term>
+        <term id="project.folder.tm.enforce.title"><link linkend="project.folder.tm.enforce"> </link>tm/enforce</term>
 		<listitem>
 		  <para>This folder is made for reliable references files that are also
 		  meant to automatically overwrite previously translated contents.</para>
@@ -374,7 +374,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.mt">
-        <term id="project.folder.tm.mt.title">tm/mt</term>
+        <term id="project.folder.tm.mt.title"><link linkend="project.folder.tm.mt"> </link>tm/mt</term>
 		<listitem>
 		  <para>When a match is inserted from a TMX contained in this folder, the
 		  background colour of the active segment changes to red.</para>
@@ -385,7 +385,7 @@
 	  </varlistentry>
 	  
       <varlistentry id="project.folder.tm.penalty">
-        <term id="project.folder.tm.penalty.title">tm/penalty-xxx</term>
+        <term id="project.folder.tm.penalty.title"><link linkend="project.folder.tm.penalty"> </link>tm/penalty-xxx</term>
 		<listitem>
 		  <para><literal>xxx</literal> is a number from 0 to 100 that will act as
 		  a penalty subtracted from the match percentage of segments coming from
@@ -399,7 +399,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.tmx2source">
-        <term id="project.folder.tm.tmx2source.title">tm/tmx2source</term>
+        <term id="project.folder.tm.tmx2source.title"><link linkend="project.folder.tm.tmx2source"> </link>tm/tmx2source</term>
 		<listitem>
 		  <para>You can display a third language <emphasis>right
 		  under</emphasis> the source segment to use as a third language
@@ -420,7 +420,7 @@
   </section>
 
   <section id="project.folder.exported.tm">
-	<title id="project.folder.exported.tm.title">exported tms folder</title>
+	<title id="project.folder.exported.tm.title"><link linkend="project.folder.exported.tm"> </link>exported tms folder</title>
 	<para>By default, that folder is the project folder itself but you can
 	change its location to make it more practical to share exported TM
 	files. See the <link linkend="how.to.tm.share.translation.memories"
@@ -429,7 +429,7 @@
   </section>
 
   <section id="project.folder.dictionary">
-	<title id="project.folder.dictionary.title">dictionary</title>
+	<title id="project.folder.dictionary.title"><link linkend="project.folder.dictionary"> </link>dictionary</title>
     <para>This folder is initially empty, and is used to store any dictionaries
     you add to the project.</para>
 
@@ -466,7 +466,7 @@
   </section>
 
   <section id="project.folder.glossary">
-	<title id="project.folder.glossary.title">glossary</title>
+	<title id="project.folder.glossary.title"><link linkend="project.folder.glossary"> </link>glossary</title>
     <para>This folder is initially empty. It is used to store the default
     writable glossary and any other glossaries you use in the project.</para>
 
@@ -477,7 +477,7 @@
 
 	<variablelist>
       <varlistentry id="project.folder.glossary.txt">
-        <term id="project.folder.glossary.txt.title">glossary.txt</term>
+        <term id="project.folder.glossary.txt.title"><link linkend="project.folder.glossary.txt"> </link>glossary.txt</term>
         <listitem>
           <para>This is the project writable glossary. It is created the first
           time you use <link linkend="menus.edit.create.glossary.entry"
@@ -494,7 +494,7 @@
   </section>
 
   <section id="project.folder.omegat.folder">
-	<title id="project.folder.omegat.folder.title">omegat</title>
+	<title id="project.folder.omegat.folder.title"><link linkend="project.folder.omegat.folder"> </link>omegat</title>
     <para>The <filename class="directory">omegat</filename> folder contains, at
     a minimum, the <link linkend="project.folder.project.save.tmx"
     endterm="project.folder.project.save.tmx.title"/> and <link
@@ -504,7 +504,7 @@
 
     <variablelist>
       <varlistentry id="project.folder.project.save.tmx">
-        <term id="project.folder.project.save.tmx.title">project_save.tmx</term>
+        <term id="project.folder.project.save.tmx.title"><link linkend="project.folder.project.save.tmx"> </link>project_save.tmx</term>
         <listitem>
           <para>This is the most important file in the project. When you create
           a new project, the file is empty and is gradually filled with the
@@ -522,7 +522,7 @@
       </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.bak">
-        <term id="project.folder.project.save.tmx.bak.title">project_save.tmx.bak</term>
+        <term id="project.folder.project.save.tmx.bak.title"><link linkend="project.folder.project.save.tmx.bak"> </link>project_save.tmx.bak</term>
 		<listitem>
 		  <para>This file is a backup of <filename>project_save.tmx</filename>
 		  and is automatically recreated every time
@@ -538,7 +538,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.timestamp.bak">
-        <term id="project.folder.project.save.tmx.timestamp.bak.title">project_save.tmx.timestamp.bak</term>
+        <term id="project.folder.project.save.tmx.timestamp.bak.title"><link linkend="project.folder.project.save.tmx.timestamp.bak"> </link>project_save.tmx.timestamp.bak</term>
 		<listitem>
 		  <para>Every time a project is loaded, OmegaT creates a backup of
 		  <filename>project_save.tmx</filename> with the name
@@ -548,7 +548,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.project.stats">
-        <term id="project.folder.project.stats.title">project_stats.txt</term>
+        <term id="project.folder.project.stats.title"><link linkend="project.folder.project.stats"> </link>project_stats.txt</term>
         <listitem>
           <para>This is the statistics file for the whole project. It is updated
           each time the project is reloaded.</para>
@@ -560,7 +560,7 @@
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.project.stats.match">
-        <term id="project.folder.omegat.project.stats.match.title">project_stats_match.txt</term>
+        <term id="project.folder.omegat.project.stats.match.title"><link linkend="project.folder.omegat.project.stats.match"> </link>project_stats_match.txt</term>
         <listitem>
           <para>This file contains the latest project match statistics. Use
           <link linkend="menus.tools" endterm="menus.tools.title"/><link
@@ -570,9 +570,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.project.stats.match.per.file">
-        <term
-			id="project.folder.omegat.project.stats.match.per.file.title">
-		project_stats_match_per_file.txt</term>
+        <term id="project.folder.omegat.project.stats.match.per.file.title"><link linkend="project.folder.omegat.project.stats.match.per.file"> </link>project_stats_match_per_file.txt</term>
         <listitem>
           <para>This file contains the latest project match statistics by file.
           Use <link linkend="menus.tools" endterm="menus.tools.title"/><link
@@ -583,7 +581,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.ignored.words">
-        <term id="project.folder.omegat.ignored.words.title">ignored_words.txt</term>
+        <term id="project.folder.omegat.ignored.words.title"><link linkend="project.folder.omegat.ignored.words"> </link>ignored_words.txt</term>
         <term id="project.folder.omegat.learned.words">learned_words.txt</term>
         <listitem>
           <para>These files are created and used by the spellchecker. You can
@@ -608,7 +606,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.segmentation">
-        <term id="project.folder.omegat.segmentation.title">segmentation.conf</term>
+        <term id="project.folder.omegat.segmentation.title"><link linkend="project.folder.omegat.segmentation"> </link>segmentation.conf</term>
         <listitem>
           <para>This file contains the project-specific segmentation
           rules.</para>
@@ -616,28 +614,28 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.filters">
-        <term id="project.folder.omegat.filters.title">filters.xml</term>
+        <term id="project.folder.omegat.filters.title"><link linkend="project.folder.omegat.filters"> </link>filters.xml</term>
         <listitem>
           <para>This file contains the project-specific file filters.</para>
         </listitem>
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.uiLayout">
-        <term id="project.folder.omegat.uiLayout.title">uiLayout.xml</term>
+        <term id="project.folder.omegat.uiLayout.title"><link linkend="project.folder.omegat.uiLayout"> </link>uiLayout.xml</term>
         <listitem>
           <para>This file contains the project-specific GUI settings.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.finder">
-        <term id="project.folder.omegat.finder.title">finder.xml</term>
+        <term id="project.folder.omegat.finder.title"><link linkend="project.folder.omegat.finder"> </link>finder.xml</term>
         <listitem>
           <para>This file contains the project-specific external searches.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.file.order">
-        <term id="project.folder.omegat.file.order.title">files_order.txt</term>
+        <term id="project.folder.omegat.file.order.title"><link linkend="project.folder.omegat.file.order"> </link>files_order.txt</term>
         <listitem>
           <para>This file is created if you manually change the order of the
           files in the <link linkend="windows.source.files.list"
@@ -646,7 +644,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.last.entry">
-        <term id="project.folder.omegat.last.entry.title">last_entry.properties</term>
+        <term id="project.folder.omegat.last.entry.title"><link linkend="project.folder.omegat.last.entry"> </link>last_entry.properties</term>
         <listitem>
           <para>This file keeps a record of the last segment you visited,
           including its number, its source contents, the file name and the date,
@@ -658,7 +656,7 @@
   </section>
 
   <section id="project.folder.repositories">
-	<title id="project.folder.repositories.title">.repositories</title>
+	<title id="project.folder.repositories.title"><link linkend="project.folder.repositories"> </link>.repositories</title>
     <para>In a team project, this folder contains a versioned copy of the
     project tree structure linked directly to the remote server.</para>
 

--- a/doc_src/en/OmegaT_ProjectFolder.xml
+++ b/doc_src/en/OmegaT_ProjectFolder.xml
@@ -123,8 +123,7 @@
 	
 	<variablelist>
 	  <varlistentry id="project.folder.omegat">
-        <term id="project.folder.omegat.title">
-		omegat</term>
+        <term id="project.folder.omegat.title">omegat</term>
 		<listitem>
 		  <para>This is the project folder that always contains <link
 		  linkend="project.folder.project.save.tmx"
@@ -141,8 +140,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="project.folder.omegat.project.file">
-        <term id="project.folder.omegat.project.file.title">
-		omegat.project</term>
+        <term id="project.folder.omegat.project.file.title">omegat.project</term>
 		<listitem>
 		  <para>This file contains the project parameters defined in the <link
 		  linkend="dialogs.project.properties">project properties</link>, such as
@@ -161,8 +159,7 @@
   </section>
   
   <section id="project.folder.source">
-	<title id="project.folder.source.title">
-    source</title>
+	<title id="project.folder.source.title">source</title>
     <para>The source folder contains the files to translate.</para>
 
 	<para>Use <link linkend="menus.project" endterm="menus.project.title"/><link
@@ -187,8 +184,7 @@
   </section>
 
   <section id="project.folder.target">
-	<title id="project.folder.target.title">
-    target</title>
+	<title id="project.folder.target.title">target</title>
     <para>This folder is initially empty.</para>
 
 	<para>It will be populated with the translated files every time you use
@@ -208,8 +204,7 @@
   </section>
 
   <section id="project.folder.tm">
-	<title id="project.folder.tm.title">
-    tm</title>
+	<title id="project.folder.tm.title">tm</title>
     <para>This folder can contain any number of bilingual reference documents
     (TMX files, but also any file in a bilingual format supported by OmegaT,
     including PO files, etc.) and the TMX files can also be compressed in the
@@ -241,8 +236,7 @@
 
 	<variablelist>
       <varlistentry id="project.folder.tm.auto">
-        <term id="project.folder.tm.auto.title">
-		tm/auto</term>
+        <term id="project.folder.tm.auto.title">tm/auto</term>
 		<listitem>
 		  <para>This folder is intended for reliable references files that can
 		  automatically fill exactly matching and not yet translated
@@ -300,8 +294,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.enforce">
-        <term id="project.folder.tm.enforce.title">
-		tm/enforce</term>
+        <term id="project.folder.tm.enforce.title">tm/enforce</term>
 		<listitem>
 		  <para>This folder is made for reliable references files that are also
 		  meant to automatically overwrite previously translated contents.</para>
@@ -381,8 +374,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.mt">
-        <term id="project.folder.tm.mt.title">
-		tm/mt</term>
+        <term id="project.folder.tm.mt.title">tm/mt</term>
 		<listitem>
 		  <para>When a match is inserted from a TMX contained in this folder, the
 		  background colour of the active segment changes to red.</para>
@@ -393,8 +385,7 @@
 	  </varlistentry>
 	  
       <varlistentry id="project.folder.tm.penalty">
-        <term id="project.folder.tm.penalty.title">
-		tm/penalty-xxx</term>
+        <term id="project.folder.tm.penalty.title">tm/penalty-xxx</term>
 		<listitem>
 		  <para><literal>xxx</literal> is a number from 0 to 100 that will act as
 		  a penalty subtracted from the match percentage of segments coming from
@@ -408,8 +399,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.tm.tmx2source">
-        <term id="project.folder.tm.tmx2source.title">
-		tm/tmx2source</term>
+        <term id="project.folder.tm.tmx2source.title">tm/tmx2source</term>
 		<listitem>
 		  <para>You can display a third language <emphasis>right
 		  under</emphasis> the source segment to use as a third language
@@ -430,8 +420,7 @@
   </section>
 
   <section id="project.folder.exported.tm">
-	<title id="project.folder.exported.tm.title">
-    exported tms folder</title>
+	<title id="project.folder.exported.tm.title">exported tms folder</title>
 	<para>By default, that folder is the project folder itself but you can
 	change its location to make it more practical to share exported TM
 	files. See the <link linkend="how.to.tm.share.translation.memories"
@@ -440,8 +429,7 @@
   </section>
 
   <section id="project.folder.dictionary">
-	<title id="project.folder.dictionary.title">
-    dictionary</title>
+	<title id="project.folder.dictionary.title">dictionary</title>
     <para>This folder is initially empty, and is used to store any dictionaries
     you add to the project.</para>
 
@@ -478,8 +466,7 @@
   </section>
 
   <section id="project.folder.glossary">
-	<title id="project.folder.glossary.title">
-    glossary</title>
+	<title id="project.folder.glossary.title">glossary</title>
     <para>This folder is initially empty. It is used to store the default
     writable glossary and any other glossaries you use in the project.</para>
 
@@ -490,8 +477,7 @@
 
 	<variablelist>
       <varlistentry id="project.folder.glossary.txt">
-        <term id="project.folder.glossary.txt.title">
-		glossary.txt</term>
+        <term id="project.folder.glossary.txt.title">glossary.txt</term>
         <listitem>
           <para>This is the project writable glossary. It is created the first
           time you use <link linkend="menus.edit.create.glossary.entry"
@@ -508,8 +494,7 @@
   </section>
 
   <section id="project.folder.omegat.folder">
-	<title id="project.folder.omegat.folder.title">
-    omegat</title>
+	<title id="project.folder.omegat.folder.title">omegat</title>
     <para>The <filename class="directory">omegat</filename> folder contains, at
     a minimum, the <link linkend="project.folder.project.save.tmx"
     endterm="project.folder.project.save.tmx.title"/> and <link
@@ -519,8 +504,7 @@
 
     <variablelist>
       <varlistentry id="project.folder.project.save.tmx">
-        <term id="project.folder.project.save.tmx.title">
-		project_save.tmx</term>
+        <term id="project.folder.project.save.tmx.title">project_save.tmx</term>
         <listitem>
           <para>This is the most important file in the project. When you create
           a new project, the file is empty and is gradually filled with the
@@ -538,8 +522,7 @@
       </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.bak">
-        <term id="project.folder.project.save.tmx.bak.title">
-		project_save.tmx.bak</term>
+        <term id="project.folder.project.save.tmx.bak.title">project_save.tmx.bak</term>
 		<listitem>
 		  <para>This file is a backup of <filename>project_save.tmx</filename>
 		  and is automatically recreated every time
@@ -555,8 +538,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="project.folder.project.save.tmx.timestamp.bak">
-        <term id="project.folder.project.save.tmx.timestamp.bak.title">
-		project_save.tmx.timestamp.bak</term>
+        <term id="project.folder.project.save.tmx.timestamp.bak.title">project_save.tmx.timestamp.bak</term>
 		<listitem>
 		  <para>Every time a project is loaded, OmegaT creates a backup of
 		  <filename>project_save.tmx</filename> with the name
@@ -566,8 +548,7 @@
 	  </varlistentry>
 
       <varlistentry id="project.folder.project.stats">
-        <term id="project.folder.project.stats.title">
-		project_stats.txt</term>
+        <term id="project.folder.project.stats.title">project_stats.txt</term>
         <listitem>
           <para>This is the statistics file for the whole project. It is updated
           each time the project is reloaded.</para>
@@ -579,8 +560,7 @@
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.project.stats.match">
-        <term id="project.folder.omegat.project.stats.match.title">
-		project_stats_match.txt</term>
+        <term id="project.folder.omegat.project.stats.match.title">project_stats_match.txt</term>
         <listitem>
           <para>This file contains the latest project match statistics. Use
           <link linkend="menus.tools" endterm="menus.tools.title"/><link
@@ -603,8 +583,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.ignored.words">
-        <term id="project.folder.omegat.ignored.words.title">
-		ignored_words.txt</term>
+        <term id="project.folder.omegat.ignored.words.title">ignored_words.txt</term>
         <term id="project.folder.omegat.learned.words">learned_words.txt</term>
         <listitem>
           <para>These files are created and used by the spellchecker. You can
@@ -629,8 +608,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.segmentation">
-        <term id="project.folder.omegat.segmentation.title">
-		segmentation.conf</term>
+        <term id="project.folder.omegat.segmentation.title">segmentation.conf</term>
         <listitem>
           <para>This file contains the project-specific segmentation
           rules.</para>
@@ -638,32 +616,28 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.filters">
-        <term id="project.folder.omegat.filters.title">
-		filters.xml</term>
+        <term id="project.folder.omegat.filters.title">filters.xml</term>
         <listitem>
           <para>This file contains the project-specific file filters.</para>
         </listitem>
       </varlistentry>
 	  
       <varlistentry id="project.folder.omegat.uiLayout">
-        <term id="project.folder.omegat.uiLayout.title">
-		uiLayout.xml</term>
+        <term id="project.folder.omegat.uiLayout.title">uiLayout.xml</term>
         <listitem>
           <para>This file contains the project-specific GUI settings.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.finder">
-        <term id="project.folder.omegat.finder.title">
-		finder.xml</term>
+        <term id="project.folder.omegat.finder.title">finder.xml</term>
         <listitem>
           <para>This file contains the project-specific external searches.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.file.order">
-        <term id="project.folder.omegat.file.order.title">
-		files_order.txt</term>
+        <term id="project.folder.omegat.file.order.title">files_order.txt</term>
         <listitem>
           <para>This file is created if you manually change the order of the
           files in the <link linkend="windows.source.files.list"
@@ -672,8 +646,7 @@
       </varlistentry>
 
       <varlistentry id="project.folder.omegat.last.entry">
-        <term id="project.folder.omegat.last.entry.title">
-		last_entry.properties</term>
+        <term id="project.folder.omegat.last.entry.title">last_entry.properties</term>
         <listitem>
           <para>This file keeps a record of the last segment you visited,
           including its number, its source contents, the file name and the date,
@@ -685,8 +658,7 @@
   </section>
 
   <section id="project.folder.repositories">
-	<title id="project.folder.repositories.title">
-    .repositories</title>
+	<title id="project.folder.repositories.title">.repositories</title>
     <para>In a team project, this folder contains a versioned copy of the
     project tree structure linked directly to the remote server.</para>
 

--- a/doc_src/en/OmegaT_WindowsAndDialogs.xml
+++ b/doc_src/en/OmegaT_WindowsAndDialogs.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <chapter id="chapter.windows.and.dialogs">
-  <title id="chapter.windows.and.dialogs.title">Windows and Dialogs</title>
+  <title id="chapter.windows.and.dialogs.title"><link linkend="chapter.windows.and.dialogs"> </link>Windows and Dialogs</title>
   
   <para>A <emphasis>window</emphasis> can be kept open next to the editor and
   lets you interact with both.</para>

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.aligner">
-  <title id="windows.aligner.title">
-  <guilabel>Align Files</guilabel></title>
+  <title id="windows.aligner.title"><guilabel>Align Files</guilabel></title>
 
   <para>Use <link endterm="menus.tools.title"
   linkend="menus.tools"/><link endterm="menus.tools.align.files.title"
@@ -82,8 +81,7 @@
   </itemizedlist>
 
   <section id="windows.aligner.adjust">
-	<title id="windows.aligner.adjust.title">
-    Settings</title>
+	<title id="windows.aligner.adjust.title">Settings</title>
 
     <para>In this step, the bottom part of the window presents various
     parameters and options you can change if the initial alignment looks like it
@@ -98,8 +96,7 @@
     <variablelist>
 	  <title>Parameters</title>
 	  <varlistentry id="windows.aligner.adjust.comparison">
-        <term id="windows.aligner.adjust.comparison.title">
-		Comparison mode</term>
+        <term id="windows.aligner.adjust.comparison.title">Comparison mode</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -125,8 +122,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.algorithm">
-        <term id="windows.aligner.adjust.algorithm.title">
-		Algorithm:</term>
+        <term id="windows.aligner.adjust.algorithm.title">Algorithm:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -147,8 +143,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.calculator">
-        <term id="windows.aligner.adjust.calculator.title">
-		Calculator:</term>
+        <term id="windows.aligner.adjust.calculator.title">Calculator:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -169,8 +164,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.counter">
-        <term id="windows.aligner.adjust.counter.title">
-		Counter:</term>
+        <term id="windows.aligner.adjust.counter.title">Counter:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -200,8 +194,7 @@
     <variablelist>
 	  <title>Options</title>
       <varlistentry id="windows.aligner.adjust.segment">
-        <term id="windows.aligner.adjust.segment.title">
-		Segment</term>
+        <term id="windows.aligner.adjust.segment.title">Segment</term>
         <listitem>
           <para>The aligner uses sentence segmentation by default. Uncheck the
           check box to use paragraph segmentation. See the <link
@@ -211,8 +204,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.remove.tags">
-        <term id="windows.aligner.adjust.remove.tags.title">
-		Remove Tags</term>
+        <term id="windows.aligner.adjust.remove.tags.title">Remove Tags</term>
         <listitem>
           <para>The aligner includes tags in the segments by default. Uncheck
           the check box to remove all tags from the alignment and the resulting
@@ -221,8 +213,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.highlight">
-        <term id="windows.aligner.adjust.highlight.title">
-		Highlight</term>
+        <term id="windows.aligner.adjust.highlight.title">Highlight</term>
         <listitem>
 		  <para>Uncheck the check box to turn off highlighting.</para>
 
@@ -235,8 +226,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.rules">
-        <term id="windows.aligner.adjust.rules.title">
-		Rules...</term>
+        <term id="windows.aligner.adjust.rules.title">Rules...</term>
         <listitem>
           <para>Clicking this button lets you edit the segmentation rules that
           apply to this project. See the <link linkend="app.segmentation"
@@ -252,8 +242,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.filters">
-        <term id="windows.aligner.adjust.filters.title">
-		Filters...</term>
+        <term id="windows.aligner.adjust.filters.title">Filters...</term>
         <listitem>
           <para>Clicking this button lets you edit the file filters that apply
           to this project. See the <link
@@ -271,8 +260,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.pattern">
-        <term id="windows.aligner.adjust.pattern.title">
-		Pattern...</term>
+        <term id="windows.aligner.adjust.pattern.title">Pattern...</term>
         <listitem>
           <para>This option lets you enter a regular expression to define the
           pattern used to highlight text in the source and target
@@ -328,8 +316,7 @@
   </section>
 
   <section id="windows.aligner.manual.corrections">
-	<title id="windows.aligner.manual.corrections.title">
-    Corrections</title>
+	<title id="windows.aligner.manual.corrections.title">Corrections</title>
 
     <para>Manual adjustments are generally required after the initial automatic
     alignment process. This generally involves moving segments up or down to
@@ -360,8 +347,7 @@
 
     <variablelist>
       <varlistentry id="windows.aligner.manual.corrections.up">
-        <term id="windows.aligner.manual.corrections.up.title">
-		Move Up (<keycap>U</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.up.title">Move Up (<keycap>U</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments, up
           one row.</para>
@@ -371,8 +357,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.down">
-        <term id="windows.aligner.manual.corrections.down.title">
-		Move Down (<keycap>D</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.down.title">Move Down (<keycap>D</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments,
           down one row.</para>
@@ -383,8 +368,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.split">
-        <term id="windows.aligner.manual.corrections.split.title">
-		Split (<keycap>S</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.split.title">Split (<keycap>S</keycap>)</term>
         <listitem>
           <para>If a single segment is selected, this command opens the
           <guilabel>Split Text</guilabel> dialog. Use the mouse or arrow keys to
@@ -403,8 +387,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.merge">
-        <term id="windows.aligner.manual.corrections.merge.title">
-		Merge (<keycap>M</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.merge.title">Merge (<keycap>M</keycap>)</term>
         <listitem>
           <para>If only one segment is selected, the aligner will merge it with
           the following segment. If two or more segments are selected, they will
@@ -418,8 +401,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.edit">
-        <term id="windows.aligner.manual.corrections.edit.title">
-		Edit (<keycap>E</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.edit.title">Edit (<keycap>E</keycap>)</term>
         <listitem>
           <para>This command can only be performed on a single segment. Calling
           this command opens the <guilabel>Edit Text</guilabel> dialog, which
@@ -438,8 +420,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.accepted">
-        <term id="windows.aligner.manual.corrections.accepted.title">
-		Mark Accepted (<keycap>A</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.accepted.title">Mark Accepted (<keycap>A</keycap>)</term>
         <listitem>
           <para>Use this command to confirm that the alignment of the segments
           in the selected row or block of rows is correct. This highlights the
@@ -448,8 +429,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.needs.review">
-        <term id="windows.aligner.manual.corrections.needs.review.title">
-		Mark Needs Review (<keycap>R</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.needs.review.title">Mark Needs Review (<keycap>R</keycap>)</term>
         <listitem>
           <para>Use this command to identify a row or block of rows for which
           the alignment of the segments is in doubt. This highlights the
@@ -458,8 +438,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.clear">
-        <term id="windows.aligner.manual.corrections.clear.title">
-		Clear Mark (<keycap>C</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.clear.title">Clear Mark (<keycap>C</keycap>)</term>
         <listitem>
           <para>Use this command to remove one or more marks set by the
           <guilabel>Mark Accepted</guilabel> or <guilabel>Mark Needs
@@ -478,8 +457,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.keep.all">
-        <term id="windows.aligner.manual.corrections.keep.all.title">
-		Keep All</term>
+        <term id="windows.aligner.manual.corrections.keep.all.title">Keep All</term>
         <listitem>
           <para>Use this command to check the <guilabel>Keep</guilabel> box for
           all rows.</para>
@@ -487,8 +465,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.keep.none">
-        <term id="windows.aligner.manual.corrections.keep.none.title">
-		Keep None</term>
+        <term id="windows.aligner.manual.corrections.keep.none.title">Keep None</term>
         <listitem>
           <para>Use this command to uncheck the <guilabel>Keep</guilabel> check
           box for all rows.</para>
@@ -496,8 +473,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.toggle.selected">
-        <term id="windows.aligner.manual.corrections.toggle.selected.title">
-		Toggle Selected (<keycap>K</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.toggle.selected.title">Toggle Selected (<keycap>K</keycap>)</term>
         <listitem>
           <para>Use this command to switch the <guilabel>Keep</guilabel> check
           box of the selected row or block of rows from checked to unchecked, or
@@ -506,8 +482,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.start.pinpoint">
-        <term id="windows.aligner.manual.corrections.start.pinpoint.title">
-		Start Pinpoint Align (<keycap>Space</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.start.pinpoint.title">Start Pinpoint Align (<keycap>Space</keycap>)</term>
         <listitem>
           <para>If the corresponding segments are several rows apart and you
           want to quickly align them, use this command to select the first 

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.aligner">
-  <title id="windows.aligner.title"><guilabel>Align Files</guilabel></title>
+  <title id="windows.aligner.title">
+  <guilabel>Align Files</guilabel></title>
 
   <para>Use <link endterm="menus.tools.title"
   linkend="menus.tools"/><link endterm="menus.tools.align.files.title"
@@ -81,7 +82,8 @@
   </itemizedlist>
 
   <section id="windows.aligner.adjust">
-    <title id="windows.aligner.adjust.title">Settings</title>
+	<title id="windows.aligner.adjust.title">
+    Settings</title>
 
     <para>In this step, the bottom part of the window presents various
     parameters and options you can change if the initial alignment looks like it
@@ -95,8 +97,9 @@
 
     <variablelist>
 	  <title>Parameters</title>
-	  <varlistentry>
-        <term>Comparison mode</term>
+	  <varlistentry id="windows.aligner.adjust.comparison">
+        <term id="windows.aligner.adjust.comparison.title">
+		Comparison mode</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -121,8 +124,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Algorithm:</term>
+      <varlistentry id="windows.aligner.adjust.algorithm">
+        <term id="windows.aligner.adjust.algorithm.title">
+		Algorithm:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -142,8 +146,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Calculator:</term>
+      <varlistentry id="windows.aligner.adjust.calculator">
+        <term id="windows.aligner.adjust.calculator.title">
+		Calculator:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -163,8 +168,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Counter:</term>
+      <varlistentry id="windows.aligner.adjust.counter">
+        <term id="windows.aligner.adjust.counter.title">
+		Counter:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -193,8 +199,9 @@
 
     <variablelist>
 	  <title>Options</title>
-      <varlistentry>
-        <term>Segment</term>
+      <varlistentry id="windows.aligner.adjust.segment">
+        <term id="windows.aligner.adjust.segment.title">
+		Segment</term>
         <listitem>
           <para>The aligner uses sentence segmentation by default. Uncheck the
           check box to use paragraph segmentation. See the <link
@@ -203,17 +210,19 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Remove Tags</term>
+      <varlistentry id="windows.aligner.adjust.remove.tags">
+        <term id="windows.aligner.adjust.remove.tags.title">
+		Remove Tags</term>
         <listitem>
           <para>The aligner includes tags in the segments by default. Uncheck
           the check box to remove all tags from the alignment and the resulting
-	  TMX.</para>
+		  TMX.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.highlight">
-        <term id="windows.aligner.adjust.highlight.title">Highlight</term>
+        <term id="windows.aligner.adjust.highlight.title">
+		Highlight</term>
         <listitem>
 		  <para>Uncheck the check box to turn off highlighting.</para>
 
@@ -225,8 +234,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Rules...</term>
+      <varlistentry id="windows.aligner.adjust.rules">
+        <term id="windows.aligner.adjust.rules.title">
+		Rules...</term>
         <listitem>
           <para>Clicking this button lets you edit the segmentation rules that
           apply to this project. See the <link linkend="app.segmentation"
@@ -241,8 +251,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Filters...</term>
+      <varlistentry id="windows.aligner.adjust.filters">
+        <term id="windows.aligner.adjust.filters.title">
+		Filters...</term>
         <listitem>
           <para>Clicking this button lets you edit the file filters that apply
           to this project. See the <link
@@ -259,8 +270,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Pattern...</term>
+      <varlistentry id="windows.aligner.adjust.pattern">
+        <term id="windows.aligner.adjust.pattern.title">
+		Pattern...</term>
         <listitem>
           <para>This option lets you enter a regular expression to define the
           pattern used to highlight text in the source and target
@@ -316,7 +328,8 @@
   </section>
 
   <section id="windows.aligner.manual.corrections">
-    <title id="windows.aligner.manual.corrections.title">Corrections</title>
+	<title id="windows.aligner.manual.corrections.title">
+    Corrections</title>
 
     <para>Manual adjustments are generally required after the initial automatic
     alignment process. This generally involves moving segments up or down to
@@ -346,8 +359,9 @@
 	are presented below.</para>
 
     <variablelist>
-      <varlistentry>
-        <term>Move Up (<keycap>U</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.up">
+        <term id="windows.aligner.manual.corrections.up.title">
+		Move Up (<keycap>U</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments, up
           one row.</para>
@@ -356,8 +370,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Move Down (<keycap>D</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.down">
+        <term id="windows.aligner.manual.corrections.down.title">
+		Move Down (<keycap>D</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments,
           down one row.</para>
@@ -367,8 +382,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Split (<keycap>S</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.split">
+        <term id="windows.aligner.manual.corrections.split.title">
+		Split (<keycap>S</keycap>)</term>
         <listitem>
           <para>If a single segment is selected, this command opens the
           <guilabel>Split Text</guilabel> dialog. Use the mouse or arrow keys to
@@ -386,8 +402,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Merge (<keycap>M</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.merge">
+        <term id="windows.aligner.manual.corrections.merge.title">
+		Merge (<keycap>M</keycap>)</term>
         <listitem>
           <para>If only one segment is selected, the aligner will merge it with
           the following segment. If two or more segments are selected, they will
@@ -400,8 +417,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Edit (<keycap>E</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.edit">
+        <term id="windows.aligner.manual.corrections.edit.title">
+		Edit (<keycap>E</keycap>)</term>
         <listitem>
           <para>This command can only be performed on a single segment. Calling
           this command opens the <guilabel>Edit Text</guilabel> dialog, which
@@ -419,8 +437,9 @@
         </listitem>
       </varlistentry>
 
-	  <varlistentry>
-        <term>Mark Accepted (<keycap>A</keycap>)</term>
+	  <varlistentry id="windows.aligner.manual.corrections.accepted">
+        <term id="windows.aligner.manual.corrections.accepted.title">
+		Mark Accepted (<keycap>A</keycap>)</term>
         <listitem>
           <para>Use this command to confirm that the alignment of the segments
           in the selected row or block of rows is correct. This highlights the
@@ -428,8 +447,9 @@
         </listitem>
       </varlistentry>
 
-	  <varlistentry>
-        <term>Mark Needs Review (<keycap>R</keycap>)</term>
+	  <varlistentry id="windows.aligner.manual.corrections.needs.review">
+        <term id="windows.aligner.manual.corrections.needs.review.title">
+		Mark Needs Review (<keycap>R</keycap>)</term>
         <listitem>
           <para>Use this command to identify a row or block of rows for which
           the alignment of the segments is in doubt. This highlights the
@@ -437,8 +457,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Clear Mark (<keycap>C</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.clear">
+        <term id="windows.aligner.manual.corrections.clear.title">
+		Clear Mark (<keycap>C</keycap>)</term>
         <listitem>
           <para>Use this command to remove one or more marks set by the
           <guilabel>Mark Accepted</guilabel> or <guilabel>Mark Needs
@@ -446,8 +467,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Realign Pending
+      <varlistentry id="windows.aligner.manual.corrections.realign.pending">
+        <term id="windows.aligner.manual.corrections.realign.pending.title">
+		  Realign Pending
         (<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>)</term>
         <listitem>
           <para>If any rows have been marked as accepted, use this command to
@@ -455,24 +477,27 @@
         </listitem>
       </varlistentry>
 
-	  <varlistentry>
-        <term>Keep All</term>
+	  <varlistentry id="windows.aligner.manual.corrections.keep.all">
+        <term id="windows.aligner.manual.corrections.keep.all.title">
+		Keep All</term>
         <listitem>
           <para>Use this command to check the <guilabel>Keep</guilabel> box for
           all rows.</para>
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Keep None</term>
+      <varlistentry id="windows.aligner.manual.corrections.keep.none">
+        <term id="windows.aligner.manual.corrections.keep.none.title">
+		Keep None</term>
         <listitem>
           <para>Use this command to uncheck the <guilabel>Keep</guilabel> check
           box for all rows.</para>
         </listitem>
       </varlistentry>
 
-	  <varlistentry>
-        <term>Toggle Selected (<keycap>K</keycap>)</term>
+	  <varlistentry id="windows.aligner.manual.corrections.toggle.selected">
+        <term id="windows.aligner.manual.corrections.toggle.selected.title">
+		Toggle Selected (<keycap>K</keycap>)</term>
         <listitem>
           <para>Use this command to switch the <guilabel>Keep</guilabel> check
           box of the selected row or block of rows from checked to unchecked, or
@@ -480,8 +505,9 @@
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term>Start Pinpoint Align (<keycap>Space</keycap>)</term>
+      <varlistentry id="windows.aligner.manual.corrections.start.pinpoint">
+        <term id="windows.aligner.manual.corrections.start.pinpoint.title">
+		Start Pinpoint Align (<keycap>Space</keycap>)</term>
         <listitem>
           <para>If the corresponding segments are several rows apart and you
           want to quickly align them, use this command to select the first 

--- a/doc_src/en/Windows_Aligner.xml
+++ b/doc_src/en/Windows_Aligner.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.aligner">
-  <title id="windows.aligner.title"><guilabel>Align Files</guilabel></title>
+  <title id="windows.aligner.title"><link linkend="windows.aligner"> </link><guilabel>Align Files</guilabel></title>
 
   <para>Use <link endterm="menus.tools.title"
   linkend="menus.tools"/><link endterm="menus.tools.align.files.title"
@@ -81,7 +81,7 @@
   </itemizedlist>
 
   <section id="windows.aligner.adjust">
-	<title id="windows.aligner.adjust.title">Settings</title>
+	<title id="windows.aligner.adjust.title"><link linkend="windows.aligner.adjust"> </link>Settings</title>
 
     <para>In this step, the bottom part of the window presents various
     parameters and options you can change if the initial alignment looks like it
@@ -96,7 +96,7 @@
     <variablelist>
 	  <title>Parameters</title>
 	  <varlistentry id="windows.aligner.adjust.comparison">
-        <term id="windows.aligner.adjust.comparison.title">Comparison mode</term>
+        <term id="windows.aligner.adjust.comparison.title"><link linkend="windows.aligner.adjust.comparison"> </link>Comparison mode</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -122,7 +122,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.algorithm">
-        <term id="windows.aligner.adjust.algorithm.title">Algorithm:</term>
+        <term id="windows.aligner.adjust.algorithm.title"><link linkend="windows.aligner.adjust.algorithm"> </link>Algorithm:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -143,7 +143,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.calculator">
-        <term id="windows.aligner.adjust.calculator.title">Calculator:</term>
+        <term id="windows.aligner.adjust.calculator.title"><link linkend="windows.aligner.adjust.calculator"> </link>Calculator:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -164,7 +164,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.counter">
-        <term id="windows.aligner.adjust.counter.title">Counter:</term>
+        <term id="windows.aligner.adjust.counter.title"><link linkend="windows.aligner.adjust.counter"> </link>Counter:</term>
         <listitem>
           <itemizedlist>
             <listitem>
@@ -194,7 +194,7 @@
     <variablelist>
 	  <title>Options</title>
       <varlistentry id="windows.aligner.adjust.segment">
-        <term id="windows.aligner.adjust.segment.title">Segment</term>
+        <term id="windows.aligner.adjust.segment.title"><link linkend="windows.aligner.adjust.segment"> </link>Segment</term>
         <listitem>
           <para>The aligner uses sentence segmentation by default. Uncheck the
           check box to use paragraph segmentation. See the <link
@@ -204,7 +204,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.remove.tags">
-        <term id="windows.aligner.adjust.remove.tags.title">Remove Tags</term>
+        <term id="windows.aligner.adjust.remove.tags.title"><link linkend="windows.aligner.adjust.remove.tags"> </link>Remove Tags</term>
         <listitem>
           <para>The aligner includes tags in the segments by default. Uncheck
           the check box to remove all tags from the alignment and the resulting
@@ -213,7 +213,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.highlight">
-        <term id="windows.aligner.adjust.highlight.title">Highlight</term>
+        <term id="windows.aligner.adjust.highlight.title"><link linkend="windows.aligner.adjust.highlight"> </link>Highlight</term>
         <listitem>
 		  <para>Uncheck the check box to turn off highlighting.</para>
 
@@ -226,7 +226,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.rules">
-        <term id="windows.aligner.adjust.rules.title">Rules...</term>
+        <term id="windows.aligner.adjust.rules.title"><link linkend="windows.aligner.adjust.rules"> </link>Rules...</term>
         <listitem>
           <para>Clicking this button lets you edit the segmentation rules that
           apply to this project. See the <link linkend="app.segmentation"
@@ -242,7 +242,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.filters">
-        <term id="windows.aligner.adjust.filters.title">Filters...</term>
+        <term id="windows.aligner.adjust.filters.title"><link linkend="windows.aligner.adjust.filters"> </link>Filters...</term>
         <listitem>
           <para>Clicking this button lets you edit the file filters that apply
           to this project. See the <link
@@ -260,7 +260,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.adjust.pattern">
-        <term id="windows.aligner.adjust.pattern.title">Pattern...</term>
+        <term id="windows.aligner.adjust.pattern.title"><link linkend="windows.aligner.adjust.pattern"> </link>Pattern...</term>
         <listitem>
           <para>This option lets you enter a regular expression to define the
           pattern used to highlight text in the source and target
@@ -316,7 +316,7 @@
   </section>
 
   <section id="windows.aligner.manual.corrections">
-	<title id="windows.aligner.manual.corrections.title">Corrections</title>
+	<title id="windows.aligner.manual.corrections.title"><link linkend="windows.aligner.manual.corrections"> </link>Corrections</title>
 
     <para>Manual adjustments are generally required after the initial automatic
     alignment process. This generally involves moving segments up or down to
@@ -347,7 +347,7 @@
 
     <variablelist>
       <varlistentry id="windows.aligner.manual.corrections.up">
-        <term id="windows.aligner.manual.corrections.up.title">Move Up (<keycap>U</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.up.title"><link linkend="windows.aligner.manual.corrections.up"> </link>Move Up (<keycap>U</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments, up
           one row.</para>
@@ -357,7 +357,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.down">
-        <term id="windows.aligner.manual.corrections.down.title">Move Down (<keycap>D</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.down.title"><link linkend="windows.aligner.manual.corrections.down"> </link>Move Down (<keycap>D</keycap>)</term>
         <listitem>
           <para>Moves the selected segment, or block of consecutive segments,
           down one row.</para>
@@ -368,7 +368,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.split">
-        <term id="windows.aligner.manual.corrections.split.title">Split (<keycap>S</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.split.title"><link linkend="windows.aligner.manual.corrections.split"> </link>Split (<keycap>S</keycap>)</term>
         <listitem>
           <para>If a single segment is selected, this command opens the
           <guilabel>Split Text</guilabel> dialog. Use the mouse or arrow keys to
@@ -387,7 +387,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.merge">
-        <term id="windows.aligner.manual.corrections.merge.title">Merge (<keycap>M</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.merge.title"><link linkend="windows.aligner.manual.corrections.merge"> </link>Merge (<keycap>M</keycap>)</term>
         <listitem>
           <para>If only one segment is selected, the aligner will merge it with
           the following segment. If two or more segments are selected, they will
@@ -401,7 +401,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.edit">
-        <term id="windows.aligner.manual.corrections.edit.title">Edit (<keycap>E</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.edit.title"><link linkend="windows.aligner.manual.corrections.edit"> </link>Edit (<keycap>E</keycap>)</term>
         <listitem>
           <para>This command can only be performed on a single segment. Calling
           this command opens the <guilabel>Edit Text</guilabel> dialog, which
@@ -420,7 +420,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.accepted">
-        <term id="windows.aligner.manual.corrections.accepted.title">Mark Accepted (<keycap>A</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.accepted.title"><link linkend="windows.aligner.manual.corrections.accepted"> </link>Mark Accepted (<keycap>A</keycap>)</term>
         <listitem>
           <para>Use this command to confirm that the alignment of the segments
           in the selected row or block of rows is correct. This highlights the
@@ -429,7 +429,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.needs.review">
-        <term id="windows.aligner.manual.corrections.needs.review.title">Mark Needs Review (<keycap>R</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.needs.review.title"><link linkend="windows.aligner.manual.corrections.needs.review"> </link>Mark Needs Review (<keycap>R</keycap>)</term>
         <listitem>
           <para>Use this command to identify a row or block of rows for which
           the alignment of the segments is in doubt. This highlights the
@@ -438,7 +438,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.clear">
-        <term id="windows.aligner.manual.corrections.clear.title">Clear Mark (<keycap>C</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.clear.title"><link linkend="windows.aligner.manual.corrections.clear"> </link>Clear Mark (<keycap>C</keycap>)</term>
         <listitem>
           <para>Use this command to remove one or more marks set by the
           <guilabel>Mark Accepted</guilabel> or <guilabel>Mark Needs
@@ -447,9 +447,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.realign.pending">
-        <term id="windows.aligner.manual.corrections.realign.pending.title">
-		  Realign Pending
-        (<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>)</term>
+        <term id="windows.aligner.manual.corrections.realign.pending.title"><link linkend="windows.aligner.manual.corrections.realign.pending"> </link>Realign Pending (<keycombo><keycap>C</keycap><keycap>R</keycap></keycombo>)</term>
         <listitem>
           <para>If any rows have been marked as accepted, use this command to
           update the alignment for the remaining rows.</para>
@@ -457,7 +455,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.keep.all">
-        <term id="windows.aligner.manual.corrections.keep.all.title">Keep All</term>
+        <term id="windows.aligner.manual.corrections.keep.all.title"><link linkend="windows.aligner.manual.corrections.keep.all"> </link>Keep All</term>
         <listitem>
           <para>Use this command to check the <guilabel>Keep</guilabel> box for
           all rows.</para>
@@ -465,7 +463,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.keep.none">
-        <term id="windows.aligner.manual.corrections.keep.none.title">Keep None</term>
+        <term id="windows.aligner.manual.corrections.keep.none.title"><link linkend="windows.aligner.manual.corrections.keep.none"> </link>Keep None</term>
         <listitem>
           <para>Use this command to uncheck the <guilabel>Keep</guilabel> check
           box for all rows.</para>
@@ -473,7 +471,7 @@
       </varlistentry>
 
 	  <varlistentry id="windows.aligner.manual.corrections.toggle.selected">
-        <term id="windows.aligner.manual.corrections.toggle.selected.title">Toggle Selected (<keycap>K</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.toggle.selected.title"><link linkend="windows.aligner.manual.corrections.toggle.selected"> </link>Toggle Selected (<keycap>K</keycap>)</term>
         <listitem>
           <para>Use this command to switch the <guilabel>Keep</guilabel> check
           box of the selected row or block of rows from checked to unchecked, or
@@ -482,7 +480,7 @@
       </varlistentry>
 
       <varlistentry id="windows.aligner.manual.corrections.start.pinpoint">
-        <term id="windows.aligner.manual.corrections.start.pinpoint.title">Start Pinpoint Align (<keycap>Space</keycap>)</term>
+        <term id="windows.aligner.manual.corrections.start.pinpoint.title"><link linkend="windows.aligner.manual.corrections.start.pinpoint"> </link>Start Pinpoint Align (<keycap>Space</keycap>)</term>
         <listitem>
           <para>If the corresponding segments are several rows apart and you
           want to quickly align them, use this command to select the first 

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.scripts">
-  <title id="windows.scripts.title">
-  <guilabel>Scripting</guilabel></title>
+  <title id="windows.scripts.title"><guilabel>Scripting</guilabel></title>
 
   <para>Scripts are short programs (similar to macros in office applications)
   that can be used to automate tasks as well as to extend or customize OmegaT
@@ -19,8 +18,7 @@
   access the window.</para>
 
   <section id="windows.scripts.folder">
-	<title id="windows.scripts.folder.title">
-    The script folder</title>
+	<title id="windows.scripts.folder.title">The script folder</title>
 
 	<para>By default, scripts are stored in the <link
 	linkend="application.folder.scripts"
@@ -49,33 +47,27 @@
 
 	<variablelist>
 	  <varlistentry id="application.folder.scripts.application.shutdown">
-		<term id="application.folder.scripts.application.shutdown.title">
-		application_shutdown</term>
+		<term id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
 		<listitem><para>Scripts in this folder are launched before OmegaT shuts down.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.application.startup">
-		<term id="application.folder.scripts.application.startup.title">
-		application_startup</term>
+		<term id="application.folder.scripts.application.startup.title">application_startup</term>
 		<listitem><para>Scripts in this folder are launched as soon as the scripting engine is available, shortly after OmegaT starts.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.entry.activated">
-		<term id="application.folder.scripts.entry.activated.title">
-		entry_activated</term>
+		<term id="application.folder.scripts.entry.activated.title">entry_activated</term>
 		<listitem><para>Scripts in this folder are launched when editing a new segment. The segment is in the <code>newEntry></code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.new.file">
-		<term id="application.folder.scripts.new.file.title">
-		new_file</term>
+		<term id="application.folder.scripts.new.file.title">new_file</term>
 		<listitem><para>Scripts in this folder are launched when the editor switches to the next file in the project. The new filename is in the <code>activeFileName</code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.new.word">
-		<term id="application.folder.scripts.new.word.title">
-		new_word</term>
+		<term id="application.folder.scripts.new.word.title">new_word</term>
 		<listitem><para>Scripts in this folder are launched when a new word is edited in the Editor window. The new word is available from the <code>newWord</code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.project.changed">
-		<term id="application.folder.scripts.project.changed.title">
-		project_changed</term>
+		<term id="application.folder.scripts.project.changed.title">project_changed</term>
 		<listitem><para>Scripts in this folder are launched when the state of the project changes. An <code>eventType</code> object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, or SAVE.</para></listitem>
 	  </varlistentry>
 	</variablelist>
@@ -93,8 +85,7 @@
   </section>
   
   <section id="windows.scripts.usage">
-	<title id="windows.scripts.usage.title">
-    Usage</title>
+	<title id="windows.scripts.usage.title">Usage</title>
 
 	<itemizedlist>
       <listitem>
@@ -148,8 +139,7 @@
   </section>
 
   <section id="windows.scripts.distribution">
-    <title id="windows.scripts.distribution.title">
-    Distributed scripts</title>
+    <title id="windows.scripts.distribution.title">Distributed scripts</title>
 
     <para>OmegaT comes with a number of scripts developed by OmegaT
     contributors. Use the script editor to open, run, or modify scripts
@@ -164,8 +154,7 @@
 
     <variablelist>
       <varlistentry id="windows.scripts.distribution.adapt.standard.tags">
-        <term id="windows.scripts.distribution.adapt.standard.tags.title">
-		Adapt standard tags</term>
+        <term id="windows.scripts.distribution.adapt.standard.tags.title">Adapt standard tags</term>
 
         <listitem>
           <para>Adapt standard tags when the Replace with Match command
@@ -174,8 +163,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.auto.open.last.project">
-        <term id="windows.scripts.distribution.auto.open.last.project.title">
-		Auto Open Last Project</term>
+        <term id="windows.scripts.distribution.auto.open.last.project.title">Auto Open Last Project</term>
 
         <listitem>
           <para>Automatically open the last used OmegaT project.</para>
@@ -183,8 +171,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.check.same.segment">
-        <term id="windows.scripts.distribution.check.same.segment.title">
-		Check Same Segment</term>
+        <term id="windows.scripts.distribution.check.same.segment.title">Check Same Segment</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -192,8 +179,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.currency.translator">
-        <term id="windows.scripts.distribution.currency.translator.title">
-		Currency Translator</term>
+        <term id="windows.scripts.distribution.currency.translator.title">Currency Translator</term>
 
         <listitem>
           <para>Translate currencies representation according to the source and
@@ -205,8 +191,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.gui.scripting">
-        <term id="windows.scripts.distribution.example.gui.scripting.title">
-		Example - GUI Scripting</term>
+        <term id="windows.scripts.distribution.example.gui.scripting.title">Example - GUI Scripting</term>
 
         <listitem>
           <para>Example of GUI scripting.</para>
@@ -214,8 +199,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.key.binding">
-        <term id="windows.scripts.distribution.example.key.binding.title">
-		Example - Key Binding</term>
+        <term id="windows.scripts.distribution.example.key.binding.title">Example - Key Binding</term>
 
         <listitem>
           <para>Example of using a keybinding event.</para>
@@ -223,8 +207,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.modify.segment">
-        <term id="windows.scripts.distribution.example.modify.segment.title">
-		Example - Modify Segment</term>
+        <term id="windows.scripts.distribution.example.modify.segment.title">Example - Modify Segment</term>
 
         <listitem>
           <para>Example that shows how to modify a segment.</para>
@@ -232,8 +215,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.search.and.replace">
-        <term id="windows.scripts.distribution.example.search.and.replace.title">
-		Example - Search and Replace</term>
+        <term id="windows.scripts.distribution.example.search.and.replace.title">Example - Search and Replace</term>
 
         <listitem>
           <para>A simple search and replace script.</para>
@@ -241,8 +223,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.external.spellcheck">
-        <term id="windows.scripts.distribution.external.spellcheck.title">
-		External spellcheck</term>
+        <term id="windows.scripts.distribution.external.spellcheck.title">External spellcheck</term>
 
         <listitem>
           <para>Writes all segments to a file named
@@ -254,8 +235,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.extract.text.content">
-        <term id="windows.scripts.distribution.extract.text.content.title">
-		Extract Text Content</term>
+        <term id="windows.scripts.distribution.extract.text.content.title">Extract Text Content</term>
 
         <listitem>
           <para>Extracts the content of the project to a single text file (one
@@ -266,8 +246,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.non.breaking.space">
-        <term id="windows.scripts.distribution.non.breaking.space.title">
-		Non-breaking space</term>
+        <term id="windows.scripts.distribution.non.breaking.space.title">Non-breaking space</term>
 
         <listitem>
           <para>Replace spaces with non-breakable spaces where appropriate in
@@ -276,8 +255,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.current.file">
-        <term id="windows.scripts.distribution.open.current.file.title">
-		Open Current File</term>
+        <term id="windows.scripts.distribution.open.current.file.title">Open Current File</term>
 
         <listitem>
           <para>Open the current source file.</para>
@@ -285,8 +263,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.glossary">
-        <term id="windows.scripts.distribution.open.glossary.title">
-		Open Glossary</term>
+        <term id="windows.scripts.distribution.open.glossary.title">Open Glossary</term>
 
         <listitem>
           <para>Open the writable glossary in an editor.</para>
@@ -294,8 +271,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.folder">
-        <term id="windows.scripts.distribution.open.project.folder.title">
-		Open Project Folder</term>
+        <term id="windows.scripts.distribution.open.project.folder.title">Open Project Folder</term>
 
         <listitem>
           <para>Open the project folder in the default file manager.</para>
@@ -303,8 +279,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.tm.folder">
-        <term id="windows.scripts.distribution.open.tm.folder.title">
-		Open TM Folder</term>
+        <term id="windows.scripts.distribution.open.tm.folder.title">Open TM Folder</term>
 
         <listitem>
           <para>Open the <filename class="directory">/tm</filename> folder.</para>
@@ -312,8 +287,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.save.tmx">
-        <term id="windows.scripts.distribution.open.project.save.tmx.title">
-		Open project_save.tmx.</term>
+        <term id="windows.scripts.distribution.open.project.save.tmx.title">Open project_save.tmx.</term>
 
         <listitem>
           <para>Open project_save.tmx in a text editor.</para>
@@ -321,8 +295,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.check.rules">
-        <term id="windows.scripts.distribution.qa.check.rules.title">
-		QA - Check Rules</term>
+        <term id="windows.scripts.distribution.qa.check.rules.title">QA - Check Rules</term>
 
         <listitem>
           <para>QA script.</para>
@@ -330,8 +303,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.identical.segments">
-        <term id="windows.scripts.distribution.qa.identical.segments.title">
-		QA - Identical Segments</term>
+        <term id="windows.scripts.distribution.qa.identical.segments.title">QA - Identical Segments</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -339,8 +311,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.svn.cleanup.recursive">
-        <term id="windows.scripts.distribution.svn.cleanup.recursive.title">
-		SVN - Cleanup (recursive)</term>
+        <term id="windows.scripts.distribution.svn.cleanup.recursive.title">SVN - Cleanup (recursive)</term>
 
         <listitem>
           <para>Perform SVN cleanup on current project or any folder (recursively).</para>
@@ -348,8 +319,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.show.same.segments">
-        <term id="windows.scripts.distribution.show.same.segments.title">
-		Show Same Segments</term>
+        <term id="windows.scripts.distribution.show.same.segments.title">Show Same Segments</term>
 
         <listitem>
           <para>Display a list of segments where the source and target have
@@ -358,8 +328,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.spellcheck">
-        <term id="windows.scripts.distribution.spellcheck.title">
-		Spellcheck</term>
+        <term id="windows.scripts.distribution.spellcheck.title">Spellcheck</term>
 
         <listitem>
           <para>Global spell checking.</para>
@@ -367,8 +336,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.bidi.marks">
-        <term id="windows.scripts.distribution.strip.bidi.marks.title">
-		Strip Bidi Marks</term>
+        <term id="windows.scripts.distribution.strip.bidi.marks.title">Strip Bidi Marks</term>
 
         <listitem>
           <para>Remove bidi mark in the current target or in selection.</para>
@@ -376,8 +344,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.tags">
-        <term id="windows.scripts.distribution.strip.tags.title">
-		Strip tags</term>
+        <term id="windows.scripts.distribution.strip.tags.title">Strip tags</term>
 
         <listitem>
           <para>Remove tags in the current target or selection.</para>
@@ -385,8 +352,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.switch.colour.theme">
-        <term id="windows.scripts.distribution.switch.colour.theme.title">
-		Switch Colour Theme</term>
+        <term id="windows.scripts.distribution.switch.colour.theme.title">Switch Colour Theme</term>
 
         <listitem>
           <para>Switch the colour theme used in the editor.</para>
@@ -394,8 +360,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tag.free.match">
-        <term id="windows.scripts.distribution.tag.free.match.title">
-		Tag-Free Match</term>
+        <term id="windows.scripts.distribution.tag.free.match.title">Tag-Free Match</term>
 
         <listitem>
           <para>Replace current target with a tag-free match.</para>
@@ -403,8 +368,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tagwipe">
-        <term id="windows.scripts.distribution.tagwipe.title">
-		Tagwipe</term>
+        <term id="windows.scripts.distribution.tagwipe.title">Tagwipe</term>
 
         <listitem>
           <para>Remove extraneous tags from docx documents.</para>
@@ -412,8 +376,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.issue.provider.sample.groovy">
-        <term id="windows.scripts.distribution.issue.provider.sample.groovy.title">
-		issue_provider_sample.groovy</term>
+        <term id="windows.scripts.distribution.issue.provider.sample.groovy.title">issue_provider_sample.groovy</term>
 
         <listitem>
           <para>(no description)</para>
@@ -421,8 +384,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.toolbar.groovy">
-        <term id="windows.scripts.distribution.toolbar.groovy.title">
-		toolbar.groovy</term>
+        <term id="windows.scripts.distribution.toolbar.groovy.title">toolbar.groovy</term>
         <listitem>
           <para>(no description)</para>
         </listitem>
@@ -431,8 +393,7 @@
   </section>
 
   <section id="windows.scripts.references">
-    <title id="windows.scripts.references.title">
-    References</title>
+    <title id="windows.scripts.references.title">References</title>
 
     <variablelist>
       <varlistentry>

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.scripts">
-  <title id="windows.scripts.title"><guilabel>Scripting</guilabel></title>
+  <title id="windows.scripts.title"><link linkend="windows.scripts"> </link><guilabel>Scripting</guilabel></title>
 
   <para>Scripts are short programs (similar to macros in office applications)
   that can be used to automate tasks as well as to extend or customize OmegaT
@@ -18,7 +18,7 @@
   access the window.</para>
 
   <section id="windows.scripts.folder">
-	<title id="windows.scripts.folder.title">The script folder</title>
+	<title id="windows.scripts.folder.title"><link linkend="windows.scripts.folder"> </link>The script folder</title>
 
 	<para>By default, scripts are stored in the <link
 	linkend="application.folder.scripts"
@@ -47,27 +47,27 @@
 
 	<variablelist>
 	  <varlistentry id="application.folder.scripts.application.shutdown">
-		<term id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
+		<term id="application.folder.scripts.application.shutdown.title"><link linkend="application.folder.scripts.application.shutdown"> </link>application_shutdown</term>
 		<listitem><para>Scripts in this folder are launched before OmegaT shuts down.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.application.startup">
-		<term id="application.folder.scripts.application.startup.title">application_startup</term>
+		<term id="application.folder.scripts.application.startup.title"><link linkend="application.folder.scripts.application.startup"> </link>application_startup</term>
 		<listitem><para>Scripts in this folder are launched as soon as the scripting engine is available, shortly after OmegaT starts.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.entry.activated">
-		<term id="application.folder.scripts.entry.activated.title">entry_activated</term>
+		<term id="application.folder.scripts.entry.activated.title"><link linkend="application.folder.scripts.entry.activated"> </link>entry_activated</term>
 		<listitem><para>Scripts in this folder are launched when editing a new segment. The segment is in the <code>newEntry></code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.new.file">
-		<term id="application.folder.scripts.new.file.title">new_file</term>
+		<term id="application.folder.scripts.new.file.title"><link linkend="application.folder.scripts.new.file"> </link>new_file</term>
 		<listitem><para>Scripts in this folder are launched when the editor switches to the next file in the project. The new filename is in the <code>activeFileName</code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.new.word">
-		<term id="application.folder.scripts.new.word.title">new_word</term>
+		<term id="application.folder.scripts.new.word.title"><link linkend="application.folder.scripts.new.word"> </link>new_word</term>
 		<listitem><para>Scripts in this folder are launched when a new word is edited in the Editor window. The new word is available from the <code>newWord</code> binding.</para></listitem>
 	  </varlistentry>
 	  <varlistentry id="application.folder.scripts.project.changed">
-		<term id="application.folder.scripts.project.changed.title">project_changed</term>
+		<term id="application.folder.scripts.project.changed.title"><link linkend="application.folder.scripts.project.changed"> </link>project_changed</term>
 		<listitem><para>Scripts in this folder are launched when the state of the project changes. An <code>eventType</code> object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, or SAVE.</para></listitem>
 	  </varlistentry>
 	</variablelist>
@@ -85,7 +85,7 @@
   </section>
   
   <section id="windows.scripts.usage">
-	<title id="windows.scripts.usage.title">Usage</title>
+	<title id="windows.scripts.usage.title"><link linkend="windows.scripts.usage"> </link>Usage</title>
 
 	<itemizedlist>
       <listitem>
@@ -139,7 +139,7 @@
   </section>
 
   <section id="windows.scripts.distribution">
-    <title id="windows.scripts.distribution.title">Distributed scripts</title>
+    <title id="windows.scripts.distribution.title"><link linkend="windows.scripts.distribution"> </link>Distributed scripts</title>
 
     <para>OmegaT comes with a number of scripts developed by OmegaT
     contributors. Use the script editor to open, run, or modify scripts
@@ -154,7 +154,7 @@
 
     <variablelist>
       <varlistentry id="windows.scripts.distribution.adapt.standard.tags">
-        <term id="windows.scripts.distribution.adapt.standard.tags.title">Adapt standard tags</term>
+        <term id="windows.scripts.distribution.adapt.standard.tags.title"><link linkend="windows.scripts.distribution.adapt.standard.tags"> </link>Adapt standard tags</term>
 
         <listitem>
           <para>Adapt standard tags when the Replace with Match command
@@ -163,7 +163,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.auto.open.last.project">
-        <term id="windows.scripts.distribution.auto.open.last.project.title">Auto Open Last Project</term>
+        <term id="windows.scripts.distribution.auto.open.last.project.title"><link linkend="windows.scripts.distribution.auto.open.last.project"> </link>Auto Open Last Project</term>
 
         <listitem>
           <para>Automatically open the last used OmegaT project.</para>
@@ -171,7 +171,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.check.same.segment">
-        <term id="windows.scripts.distribution.check.same.segment.title">Check Same Segment</term>
+        <term id="windows.scripts.distribution.check.same.segment.title"><link linkend="windows.scripts.distribution.check.same.segment"> </link>Check Same Segment</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -179,7 +179,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.currency.translator">
-        <term id="windows.scripts.distribution.currency.translator.title">Currency Translator</term>
+        <term id="windows.scripts.distribution.currency.translator.title"><link linkend="windows.scripts.distribution.currency.translator"> </link>Currency Translator</term>
 
         <listitem>
           <para>Translate currencies representation according to the source and
@@ -191,7 +191,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.gui.scripting">
-        <term id="windows.scripts.distribution.example.gui.scripting.title">Example - GUI Scripting</term>
+        <term id="windows.scripts.distribution.example.gui.scripting.title"><link linkend="windows.scripts.distribution.example.gui.scripting"> </link>Example - GUI Scripting</term>
 
         <listitem>
           <para>Example of GUI scripting.</para>
@@ -199,7 +199,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.key.binding">
-        <term id="windows.scripts.distribution.example.key.binding.title">Example - Key Binding</term>
+        <term id="windows.scripts.distribution.example.key.binding.title"><link linkend="windows.scripts.distribution.example.key.binding"> </link>Example - Key Binding</term>
 
         <listitem>
           <para>Example of using a keybinding event.</para>
@@ -207,7 +207,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.modify.segment">
-        <term id="windows.scripts.distribution.example.modify.segment.title">Example - Modify Segment</term>
+        <term id="windows.scripts.distribution.example.modify.segment.title"><link linkend="windows.scripts.distribution.example.modify.segment"> </link>Example - Modify Segment</term>
 
         <listitem>
           <para>Example that shows how to modify a segment.</para>
@@ -215,7 +215,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.search.and.replace">
-        <term id="windows.scripts.distribution.example.search.and.replace.title">Example - Search and Replace</term>
+        <term id="windows.scripts.distribution.example.search.and.replace.title"><link linkend="windows.scripts.distribution.example.search.and.replace"> </link>Example - Search and Replace</term>
 
         <listitem>
           <para>A simple search and replace script.</para>
@@ -223,7 +223,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.external.spellcheck">
-        <term id="windows.scripts.distribution.external.spellcheck.title">External spellcheck</term>
+        <term id="windows.scripts.distribution.external.spellcheck.title"><link linkend="windows.scripts.distribution.external.spellcheck"> </link>External spellcheck</term>
 
         <listitem>
           <para>Writes all segments to a file named
@@ -235,7 +235,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.extract.text.content">
-        <term id="windows.scripts.distribution.extract.text.content.title">Extract Text Content</term>
+        <term id="windows.scripts.distribution.extract.text.content.title"><link linkend="windows.scripts.distribution.extract.text.content"> </link>Extract Text Content</term>
 
         <listitem>
           <para>Extracts the content of the project to a single text file (one
@@ -246,7 +246,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.non.breaking.space">
-        <term id="windows.scripts.distribution.non.breaking.space.title">Non-breaking space</term>
+        <term id="windows.scripts.distribution.non.breaking.space.title"><link linkend="windows.scripts.distribution.non.breaking.space"> </link>Non-breaking space</term>
 
         <listitem>
           <para>Replace spaces with non-breakable spaces where appropriate in
@@ -255,7 +255,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.current.file">
-        <term id="windows.scripts.distribution.open.current.file.title">Open Current File</term>
+        <term id="windows.scripts.distribution.open.current.file.title"><link linkend="windows.scripts.distribution.open.current.file"> </link>Open Current File</term>
 
         <listitem>
           <para>Open the current source file.</para>
@@ -263,7 +263,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.glossary">
-        <term id="windows.scripts.distribution.open.glossary.title">Open Glossary</term>
+        <term id="windows.scripts.distribution.open.glossary.title"><link linkend="windows.scripts.distribution.open.glossary"> </link>Open Glossary</term>
 
         <listitem>
           <para>Open the writable glossary in an editor.</para>
@@ -271,7 +271,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.folder">
-        <term id="windows.scripts.distribution.open.project.folder.title">Open Project Folder</term>
+        <term id="windows.scripts.distribution.open.project.folder.title"><link linkend="windows.scripts.distribution.open.project.folder"> </link>Open Project Folder</term>
 
         <listitem>
           <para>Open the project folder in the default file manager.</para>
@@ -279,7 +279,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.tm.folder">
-        <term id="windows.scripts.distribution.open.tm.folder.title">Open TM Folder</term>
+        <term id="windows.scripts.distribution.open.tm.folder.title"><link linkend="windows.scripts.distribution.open.tm.folder"> </link>Open TM Folder</term>
 
         <listitem>
           <para>Open the <filename class="directory">/tm</filename> folder.</para>
@@ -287,7 +287,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.save.tmx">
-        <term id="windows.scripts.distribution.open.project.save.tmx.title">Open project_save.tmx.</term>
+        <term id="windows.scripts.distribution.open.project.save.tmx.title"><link linkend="windows.scripts.distribution.open.project.save.tmx"> </link>Open project_save.tmx.</term>
 
         <listitem>
           <para>Open project_save.tmx in a text editor.</para>
@@ -295,7 +295,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.check.rules">
-        <term id="windows.scripts.distribution.qa.check.rules.title">QA - Check Rules</term>
+        <term id="windows.scripts.distribution.qa.check.rules.title"><link linkend="windows.scripts.distribution.qa.check.rules"> </link>QA - Check Rules</term>
 
         <listitem>
           <para>QA script.</para>
@@ -303,7 +303,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.identical.segments">
-        <term id="windows.scripts.distribution.qa.identical.segments.title">QA - Identical Segments</term>
+        <term id="windows.scripts.distribution.qa.identical.segments.title"><link linkend="windows.scripts.distribution.qa.identical.segments"> </link>QA - Identical Segments</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -311,7 +311,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.svn.cleanup.recursive">
-        <term id="windows.scripts.distribution.svn.cleanup.recursive.title">SVN - Cleanup (recursive)</term>
+        <term id="windows.scripts.distribution.svn.cleanup.recursive.title"><link linkend="windows.scripts.distribution.svn.cleanup.recursive"> </link>SVN - Cleanup (recursive)</term>
 
         <listitem>
           <para>Perform SVN cleanup on current project or any folder (recursively).</para>
@@ -319,7 +319,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.show.same.segments">
-        <term id="windows.scripts.distribution.show.same.segments.title">Show Same Segments</term>
+        <term id="windows.scripts.distribution.show.same.segments.title"><link linkend="windows.scripts.distribution.show.same.segments"> </link>Show Same Segments</term>
 
         <listitem>
           <para>Display a list of segments where the source and target have
@@ -328,7 +328,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.spellcheck">
-        <term id="windows.scripts.distribution.spellcheck.title">Spellcheck</term>
+        <term id="windows.scripts.distribution.spellcheck.title"><link linkend="windows.scripts.distribution.spellcheck"> </link>Spellcheck</term>
 
         <listitem>
           <para>Global spell checking.</para>
@@ -336,7 +336,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.bidi.marks">
-        <term id="windows.scripts.distribution.strip.bidi.marks.title">Strip Bidi Marks</term>
+        <term id="windows.scripts.distribution.strip.bidi.marks.title"><link linkend="windows.scripts.distribution.strip.bidi.marks"> </link>Strip Bidi Marks</term>
 
         <listitem>
           <para>Remove bidi mark in the current target or in selection.</para>
@@ -344,7 +344,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.tags">
-        <term id="windows.scripts.distribution.strip.tags.title">Strip tags</term>
+        <term id="windows.scripts.distribution.strip.tags.title"><link linkend="windows.scripts.distribution.strip.tags"> </link>Strip tags</term>
 
         <listitem>
           <para>Remove tags in the current target or selection.</para>
@@ -352,7 +352,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.switch.colour.theme">
-        <term id="windows.scripts.distribution.switch.colour.theme.title">Switch Colour Theme</term>
+        <term id="windows.scripts.distribution.switch.colour.theme.title"><link linkend="windows.scripts.distribution.switch.colour.theme"> </link>Switch Colour Theme</term>
 
         <listitem>
           <para>Switch the colour theme used in the editor.</para>
@@ -360,7 +360,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tag.free.match">
-        <term id="windows.scripts.distribution.tag.free.match.title">Tag-Free Match</term>
+        <term id="windows.scripts.distribution.tag.free.match.title"><link linkend="windows.scripts.distribution.tag.free.match"> </link>Tag-Free Match</term>
 
         <listitem>
           <para>Replace current target with a tag-free match.</para>
@@ -368,7 +368,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tagwipe">
-        <term id="windows.scripts.distribution.tagwipe.title">Tagwipe</term>
+        <term id="windows.scripts.distribution.tagwipe.title"><link linkend="windows.scripts.distribution.tagwipe"> </link>Tagwipe</term>
 
         <listitem>
           <para>Remove extraneous tags from docx documents.</para>
@@ -376,7 +376,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.issue.provider.sample.groovy">
-        <term id="windows.scripts.distribution.issue.provider.sample.groovy.title">issue_provider_sample.groovy</term>
+        <term id="windows.scripts.distribution.issue.provider.sample.groovy.title"><link linkend="windows.scripts.distribution.issue.provider.sample.groovy"> </link>issue_provider_sample.groovy</term>
 
         <listitem>
           <para>(no description)</para>
@@ -384,7 +384,7 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.toolbar.groovy">
-        <term id="windows.scripts.distribution.toolbar.groovy.title">toolbar.groovy</term>
+        <term id="windows.scripts.distribution.toolbar.groovy.title"><link linkend="windows.scripts.distribution.toolbar.groovy"> </link>toolbar.groovy</term>
         <listitem>
           <para>(no description)</para>
         </listitem>
@@ -393,7 +393,7 @@
   </section>
 
   <section id="windows.scripts.references">
-    <title id="windows.scripts.references.title">References</title>
+    <title id="windows.scripts.references.title"><link linkend="windows.scripts.references"> </link>References</title>
 
     <variablelist>
       <varlistentry>

--- a/doc_src/en/Windows_Scripts.xml
+++ b/doc_src/en/Windows_Scripts.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.scripts">
-  <title id="windows.scripts.title"><guilabel>Scripting</guilabel></title>
+  <title id="windows.scripts.title">
+  <guilabel>Scripting</guilabel></title>
 
   <para>Scripts are short programs (similar to macros in office applications)
   that can be used to automate tasks as well as to extend or customize OmegaT
@@ -18,77 +19,85 @@
   access the window.</para>
 
   <section id="windows.scripts.folder">
-  <title id="windows.scripts.folder.title">The script folder</title>
+	<title id="windows.scripts.folder.title">
+    The script folder</title>
 
-  <para>By default, scripts are stored in the <link
-  linkend="application.folder.scripts"
-  endterm="application.folder.scripts.title"/> folder of the OmegaT
-  application folder.</para>
+	<para>By default, scripts are stored in the <link
+	linkend="application.folder.scripts"
+	endterm="application.folder.scripts.title"/> folder of the OmegaT
+	application folder.</para>
 
-  <para>New scripts added there will appear in the list of available scripts
-  in the left-hand panel of the window.</para>
+	<para>New scripts added there will appear in the list of available scripts
+	in the left-hand panel of the window.</para>
 
-  <warning>
-    <para>If no list of scripts is displayed on the left side of 
-    the script editor window, use the Scripting window <guimenu>File</guimenu> >
-    <guimenuitem>Set Scripts Folder...</guimenuitem> menu to set 
-    the location of the scripts.</para>
-  </warning>
+	<warning>
+      <para>If no list of scripts is displayed on the left side of 
+      the script editor window, use the Scripting window <guimenu>File</guimenu> >
+      <guimenuitem>Set Scripts Folder...</guimenuitem> menu to set 
+      the location of the scripts.</para>
+	</warning>
 
-  <para>Additional scripts can be found here: <ulink
-  url="https://sourceforge.net/projects/omegatscripts/">OmegaT
-  Scripts</ulink>. Just copy the file to the <link
-  linkend="application.folder.scripts"
-  endterm="application.folder.scripts.title"/> folder.</para>
+	<para>Additional scripts can be found here: <ulink
+	url="https://sourceforge.net/projects/omegatscripts/">OmegaT
+	Scripts</ulink>. Just copy the file to the <link
+	linkend="application.folder.scripts"
+	endterm="application.folder.scripts.title"/> folder.</para>
 
-  <para>Some scripts are <emphasis>event</emphasis>-based. The folder containing
-  the scripts includes subfolders corresponding to the available events. You can
-  trigger scripts automatically by placing them in the appropriate subfolder:</para>
+	<para>Some scripts are <emphasis>event</emphasis>-based. The folder containing
+	the scripts includes subfolders corresponding to the available events. You can
+	trigger scripts automatically by placing them in the appropriate subfolder:</para>
 
-  <variablelist>
-	<varlistentry id="application.folder.scripts.application.shutdown">
-	  <term id="application.folder.scripts.application.shutdown.title">application_shutdown</term>
-	  <listitem><para>Scripts in this folder are launched before OmegaT shuts down.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.application.startup">
-	  <term id="application.folder.scripts.application.startup.title">application_startup</term>
-	  <listitem><para>Scripts in this folder are launched as soon as the scripting engine is available, shortly after OmegaT starts.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.entry.activated">
-	  <term id="application.folder.scripts.entry.activated.title">entry_activated</term>
-	  <listitem><para>Scripts in this folder are launched when editing a new segment. The segment is in the <code>newEntry></code> binding.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.new.file">
-	  <term id="application.folder.scripts.new.file.title">new_file</term>
-	  <listitem><para>Scripts in this folder are launched when the editor switches to the next file in the project. The new filename is in the <code>activeFileName</code> binding.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.new.word">
-	  <term id="application.folder.scripts.new.word.title">new_word</term>
-	  <listitem><para>Scripts in this folder are launched when a new word is edited in the Editor window. The new word is available from the <code>newWord</code> binding.</para></listitem>
-	</varlistentry>
-	<varlistentry id="application.folder.scripts.project.changed">
-	  <term id="application.folder.scripts.project.changed.title">project_changed</term>
-	  <listitem><para>Scripts in this folder are launched when the state of the project changes. An <code>eventType</code> object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, or SAVE.</para></listitem>
-	</varlistentry>
-  </variablelist>
+	<variablelist>
+	  <varlistentry id="application.folder.scripts.application.shutdown">
+		<term id="application.folder.scripts.application.shutdown.title">
+		application_shutdown</term>
+		<listitem><para>Scripts in this folder are launched before OmegaT shuts down.</para></listitem>
+	  </varlistentry>
+	  <varlistentry id="application.folder.scripts.application.startup">
+		<term id="application.folder.scripts.application.startup.title">
+		application_startup</term>
+		<listitem><para>Scripts in this folder are launched as soon as the scripting engine is available, shortly after OmegaT starts.</para></listitem>
+	  </varlistentry>
+	  <varlistentry id="application.folder.scripts.entry.activated">
+		<term id="application.folder.scripts.entry.activated.title">
+		entry_activated</term>
+		<listitem><para>Scripts in this folder are launched when editing a new segment. The segment is in the <code>newEntry></code> binding.</para></listitem>
+	  </varlistentry>
+	  <varlistentry id="application.folder.scripts.new.file">
+		<term id="application.folder.scripts.new.file.title">
+		new_file</term>
+		<listitem><para>Scripts in this folder are launched when the editor switches to the next file in the project. The new filename is in the <code>activeFileName</code> binding.</para></listitem>
+	  </varlistentry>
+	  <varlistentry id="application.folder.scripts.new.word">
+		<term id="application.folder.scripts.new.word.title">
+		new_word</term>
+		<listitem><para>Scripts in this folder are launched when a new word is edited in the Editor window. The new word is available from the <code>newWord</code> binding.</para></listitem>
+	  </varlistentry>
+	  <varlistentry id="application.folder.scripts.project.changed">
+		<term id="application.folder.scripts.project.changed.title">
+		project_changed</term>
+		<listitem><para>Scripts in this folder are launched when the state of the project changes. An <code>eventType</code> object is bound and can take the following values: CLOSE, COMPILE, CREATE, LOAD, or SAVE.</para></listitem>
+	  </varlistentry>
+	</variablelist>
 
-  <para>These subfolders are already created in the script folder that comes with the
-  distribution.</para>
-  
-  <warning>
-	<para>Scripts are also launched when you are executing other scripts. 
-	Consequently, in a large project, an <code>entry_activated</code> script is
-  called frequently when a search/replace type of script that
-  loops through all segments is used, rendering the application
-  unresponsive.</para>
-  </warning>
+	<para>These subfolders are already created in the script folder that comes with the
+	distribution.</para>
+	
+	<warning>
+	  <para>Scripts are also launched when you are executing other scripts. 
+	  Consequently, in a large project, an <code>entry_activated</code> script is
+	  called frequently when a search/replace type of script that
+	  loops through all segments is used, rendering the application
+	  unresponsive.</para>
+	</warning>
   </section>
   
   <section id="windows.scripts.usage">
-	<title id="windows.scripts.usage.title">Usage</title>
+	<title id="windows.scripts.usage.title">
+    Usage</title>
 
 	<itemizedlist>
-    <listitem>
+      <listitem>
 		<para>Click the name of a script in the list in the left-hand panel. The
 		script is loaded in the editor.</para>
       </listitem>
@@ -139,7 +148,8 @@
   </section>
 
   <section id="windows.scripts.distribution">
-    <title id="windows.scripts.distribution.title">Distributed scripts</title>
+    <title id="windows.scripts.distribution.title">
+    Distributed scripts</title>
 
     <para>OmegaT comes with a number of scripts developed by OmegaT
     contributors. Use the script editor to open, run, or modify scripts
@@ -154,8 +164,8 @@
 
     <variablelist>
       <varlistentry id="windows.scripts.distribution.adapt.standard.tags">
-        <term id="windows.scripts.distribution.adapt.standard.tags.title">Adapt
-        standard tags</term>
+        <term id="windows.scripts.distribution.adapt.standard.tags.title">
+		Adapt standard tags</term>
 
         <listitem>
           <para>Adapt standard tags when the Replace with Match command
@@ -164,9 +174,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.auto.open.last.project">
-        <term
-        id="windows.scripts.distribution.auto.open.last.project.title">Auto Open
-        Last Project</term>
+        <term id="windows.scripts.distribution.auto.open.last.project.title">
+		Auto Open Last Project</term>
 
         <listitem>
           <para>Automatically open the last used OmegaT project.</para>
@@ -174,8 +183,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.check.same.segment">
-        <term id="windows.scripts.distribution.check.same.segment.title">Check
-        Same Segment</term>
+        <term id="windows.scripts.distribution.check.same.segment.title">
+		Check Same Segment</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -183,9 +192,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.currency.translator">
-        <term
-        id="windows.scripts.distribution.currency.translator.title">Currency
-        Translator</term>
+        <term id="windows.scripts.distribution.currency.translator.title">
+		Currency Translator</term>
 
         <listitem>
           <para>Translate currencies representation according to the source and
@@ -197,9 +205,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.gui.scripting">
-        <term
-        id="windows.scripts.distribution.example.gui.scripting.title">Example -
-        GUI Scripting</term>
+        <term id="windows.scripts.distribution.example.gui.scripting.title">
+		Example - GUI Scripting</term>
 
         <listitem>
           <para>Example of GUI scripting.</para>
@@ -207,9 +214,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.key.binding">
-        <term
-        id="windows.scripts.distribution.example.key.binding.title">Example -
-        Key Binding</term>
+        <term id="windows.scripts.distribution.example.key.binding.title">
+		Example - Key Binding</term>
 
         <listitem>
           <para>Example of using a keybinding event.</para>
@@ -217,9 +223,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.modify.segment">
-        <term
-        id="windows.scripts.distribution.example.modify.segment.title">Example -
-        Modify Segment</term>
+        <term id="windows.scripts.distribution.example.modify.segment.title">
+		Example - Modify Segment</term>
 
         <listitem>
           <para>Example that shows how to modify a segment.</para>
@@ -227,9 +232,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.example.search.and.replace">
-        <term
-        id="windows.scripts.distribution.example.search.and.replace.title">Example
-        - Search and Replace</term>
+        <term id="windows.scripts.distribution.example.search.and.replace.title">
+		Example - Search and Replace</term>
 
         <listitem>
           <para>A simple search and replace script.</para>
@@ -237,9 +241,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.external.spellcheck">
-        <term
-        id="windows.scripts.distribution.external.spellcheck.title">External
-        spellcheck</term>
+        <term id="windows.scripts.distribution.external.spellcheck.title">
+		External spellcheck</term>
 
         <listitem>
           <para>Writes all segments to a file named
@@ -251,9 +254,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.extract.text.content">
-        <term
-        id="windows.scripts.distribution.extract.text.content.title">Extract
-        Text Content</term>
+        <term id="windows.scripts.distribution.extract.text.content.title">
+		Extract Text Content</term>
 
         <listitem>
           <para>Extracts the content of the project to a single text file (one
@@ -264,9 +266,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.non.breaking.space">
-        <term
-        id="windows.scripts.distribution.non.breaking.space.title">Non-breaking
-        space</term>
+        <term id="windows.scripts.distribution.non.breaking.space.title">
+		Non-breaking space</term>
 
         <listitem>
           <para>Replace spaces with non-breakable spaces where appropriate in
@@ -275,8 +276,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.current.file">
-        <term id="windows.scripts.distribution.open.current.file.title">Open
-        Current File</term>
+        <term id="windows.scripts.distribution.open.current.file.title">
+		Open Current File</term>
 
         <listitem>
           <para>Open the current source file.</para>
@@ -284,8 +285,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.glossary">
-        <term id="windows.scripts.distribution.open.glossary.title">Open
-        Glossary</term>
+        <term id="windows.scripts.distribution.open.glossary.title">
+		Open Glossary</term>
 
         <listitem>
           <para>Open the writable glossary in an editor.</para>
@@ -293,8 +294,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.folder">
-        <term id="windows.scripts.distribution.open.project.folder.title">Open
-        Project Folder</term>
+        <term id="windows.scripts.distribution.open.project.folder.title">
+		Open Project Folder</term>
 
         <listitem>
           <para>Open the project folder in the default file manager.</para>
@@ -302,8 +303,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.tm.folder">
-        <term id="windows.scripts.distribution.open.tm.folder.title">Open TM
-        Folder</term>
+        <term id="windows.scripts.distribution.open.tm.folder.title">
+		Open TM Folder</term>
 
         <listitem>
           <para>Open the <filename class="directory">/tm</filename> folder.</para>
@@ -311,8 +312,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.open.project.save.tmx">
-        <term id="windows.scripts.distribution.open.project.save.tmx.title">Open
-        project_save.tmx.</term>
+        <term id="windows.scripts.distribution.open.project.save.tmx.title">
+		Open project_save.tmx.</term>
 
         <listitem>
           <para>Open project_save.tmx in a text editor.</para>
@@ -320,8 +321,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.check.rules">
-        <term id="windows.scripts.distribution.qa.check.rules.title">QA - Check
-        Rules</term>
+        <term id="windows.scripts.distribution.qa.check.rules.title">
+		QA - Check Rules</term>
 
         <listitem>
           <para>QA script.</para>
@@ -329,8 +330,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.qa.identical.segments">
-        <term id="windows.scripts.distribution.qa.identical.segments.title">QA -
-        Identical Segments</term>
+        <term id="windows.scripts.distribution.qa.identical.segments.title">
+		QA - Identical Segments</term>
 
         <listitem>
           <para>Check for identical segments (case sensitive).</para>
@@ -338,8 +339,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.svn.cleanup.recursive">
-        <term id="windows.scripts.distribution.svn.cleanup.recursive.title">SVN
-        - Cleanup (recursive)</term>
+        <term id="windows.scripts.distribution.svn.cleanup.recursive.title">
+		SVN - Cleanup (recursive)</term>
 
         <listitem>
           <para>Perform SVN cleanup on current project or any folder (recursively).</para>
@@ -347,8 +348,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.show.same.segments">
-        <term id="windows.scripts.distribution.show.same.segments.title">Show
-        Same Segments</term>
+        <term id="windows.scripts.distribution.show.same.segments.title">
+		Show Same Segments</term>
 
         <listitem>
           <para>Display a list of segments where the source and target have
@@ -357,8 +358,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.spellcheck">
-        <term
-        id="windows.scripts.distribution.spellcheck.title">Spellcheck</term>
+        <term id="windows.scripts.distribution.spellcheck.title">
+		Spellcheck</term>
 
         <listitem>
           <para>Global spell checking.</para>
@@ -366,8 +367,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.bidi.marks">
-        <term id="windows.scripts.distribution.strip.bidi.marks.title">Strip
-        Bidi Marks</term>
+        <term id="windows.scripts.distribution.strip.bidi.marks.title">
+		Strip Bidi Marks</term>
 
         <listitem>
           <para>Remove bidi mark in the current target or in selection.</para>
@@ -375,8 +376,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.strip.tags">
-        <term id="windows.scripts.distribution.strip.tags.title">Strip
-        tags</term>
+        <term id="windows.scripts.distribution.strip.tags.title">
+		Strip tags</term>
 
         <listitem>
           <para>Remove tags in the current target or selection.</para>
@@ -384,8 +385,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.switch.colour.theme">
-        <term id="windows.scripts.distribution.switch.colour.theme.title">Switch
-        Colour Theme</term>
+        <term id="windows.scripts.distribution.switch.colour.theme.title">
+		Switch Colour Theme</term>
 
         <listitem>
           <para>Switch the colour theme used in the editor.</para>
@@ -393,8 +394,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tag.free.match">
-        <term id="windows.scripts.distribution.tag.free.match.title">Tag-Free
-        Match</term>
+        <term id="windows.scripts.distribution.tag.free.match.title">
+		Tag-Free Match</term>
 
         <listitem>
           <para>Replace current target with a tag-free match.</para>
@@ -402,7 +403,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.tagwipe">
-        <term id="windows.scripts.distribution.tagwipe.title">Tagwipe</term>
+        <term id="windows.scripts.distribution.tagwipe.title">
+		Tagwipe</term>
 
         <listitem>
           <para>Remove extraneous tags from docx documents.</para>
@@ -410,8 +412,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.issue.provider.sample.groovy">
-        <term
-        id="windows.scripts.distribution.issue.provider.sample.groovy.title">issue_provider_sample.groovy</term>
+        <term id="windows.scripts.distribution.issue.provider.sample.groovy.title">
+		issue_provider_sample.groovy</term>
 
         <listitem>
           <para>(no description)</para>
@@ -419,8 +421,8 @@
       </varlistentry>
 
       <varlistentry id="windows.scripts.distribution.toolbar.groovy">
-        <term
-        id="windows.scripts.distribution.toolbar.groovy.title">toolbar.groovy</term>
+        <term id="windows.scripts.distribution.toolbar.groovy.title">
+		toolbar.groovy</term>
         <listitem>
           <para>(no description)</para>
         </listitem>
@@ -429,7 +431,8 @@
   </section>
 
   <section id="windows.scripts.references">
-    <title id="windows.scripts.references.title">References</title>
+    <title id="windows.scripts.references.title">
+    References</title>
 
     <variablelist>
       <varlistentry>
@@ -478,17 +481,17 @@
 
     <programlisting>files = project.projectFiles;
 for (i in 0 ..&lt; files.size())
-{
-	for (j in 0 ..&lt; files[i].entries.size())
 	{
-		currSegment = files[i].entries[j];
-		if (project.getTranslationInfo(currSegment))
-		{
-			source = currSegment.getSrcText();
-			target = project.getTranslationInfo(currSegment).translation;
-			console.println(source + " >>>> " + target);
-		}     
-	}
-}</programlisting>
+		for (j in 0 ..&lt; files[i].entries.size())
+			{
+				currSegment = files[i].entries[j];
+				if (project.getTranslationInfo(currSegment))
+					{
+						source = currSegment.getSrcText();
+						target = project.getTranslationInfo(currSegment).translation;
+						console.println(source + " >>>> " + target);
+				}     
+			}
+	}</programlisting>
   </section>
 </section>

--- a/doc_src/en/Windows_SourceFilesList.xml
+++ b/doc_src/en/Windows_SourceFilesList.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.source.files.list">
-  <title id="windows.source.files.list.title">
-    <guilabel>Source
-  Files</guilabel></title>
+  <title id="windows.source.files.list.title"><link linkend="windows.source.files.list"> </link><guilabel>Source Files</guilabel></title>
 
   <para>This window is displayed automatically when OmegaT loads a project, and
   can be called at any time using <link linkend="menus.project"
@@ -77,9 +75,7 @@
   
   <variablelist>
 	<varlistentry id="windows.source.files.list.copy.files">
-      <term id="windows.source.files.list.copy.files.title">
-		<guibutton>Add
-	  Files...</guibutton></term>
+      <term id="windows.source.files.list.copy.files.title"><link linkend="windows.source.files.list.copy.files"> </link><guibutton>Add Files...</guibutton></term>
 	  <listitem>
 		<para>Copies the selected files to the <link
 		linkend="project.folder.source" endterm="project.folder.source.title"/>
@@ -88,9 +84,7 @@
 	</varlistentry>
 	
 	<varlistentry id="windows.source.files.list.download.page">
-      <term id="windows.source.files.list.download.page.title">
-		<guibutton>Add
-	  MediaWiki Page...</guibutton></term>
+      <term id="windows.source.files.list.download.page.title"><link linkend="windows.source.files.list.download.page"> </link><guibutton>Add MediaWiki Page...</guibutton></term>
 	  <listitem>
 		<para>Asks for the URL of the page and downloads it into the <link
 		linkend="project.folder.source" endterm="project.folder.source.title"/>

--- a/doc_src/en/Windows_SourceFilesList.xml
+++ b/doc_src/en/Windows_SourceFilesList.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.source.files.list">
-  <title id="windows.source.files.list.title"><guilabel>Source
+  <title id="windows.source.files.list.title">
+    <guilabel>Source
   Files</guilabel></title>
 
   <para>This window is displayed automatically when OmegaT loads a project, and
@@ -51,7 +52,7 @@
 	<para>Filenames (the first column) can be sorted alphabetically by
 	clicking the header. You can change the position of a file by selecting it
 	and clicking one of the <guibutton>Move...</guibutton> buttons
-  on the right.</para>
+	on the right.</para>
   </note>
 
   <para>Right-clicking a filename brings up a popup menu that lets you open the
@@ -76,17 +77,19 @@
   
   <variablelist>
 	<varlistentry id="windows.source.files.list.copy.files">
-	  <term id="windows.source.files.list.copy.files.title"><guibutton>Add
+      <term id="windows.source.files.list.copy.files.title">
+		<guibutton>Add
 	  Files...</guibutton></term>
-	<listitem>
-	  <para>Copies the selected files to the <link
-	  linkend="project.folder.source" endterm="project.folder.source.title"/>
-	  folder and reloads the project to take the new files into account.</para>
-	</listitem>
+	  <listitem>
+		<para>Copies the selected files to the <link
+		linkend="project.folder.source" endterm="project.folder.source.title"/>
+		folder and reloads the project to take the new files into account.</para>
+	  </listitem>
 	</varlistentry>
 	
 	<varlistentry id="windows.source.files.list.download.page">
-	  <term id="windows.source.files.list.download.page.title"><guibutton>Add
+      <term id="windows.source.files.list.download.page.title">
+		<guibutton>Add
 	  MediaWiki Page...</guibutton></term>
 	  <listitem>
 		<para>Asks for the URL of the page and downloads it into the <link
@@ -109,6 +112,6 @@
 	linkend="configuration.folder.default.contents.omegat.prefs"
 	endterm="configuration.folder.default.contents.omegat.prefs.title"/>
 	configuration file to prevent the Source Files list window from opening
-  automatically when a project is loaded.</para>
+	automatically when a project is loaded.</para>
   </note>
 </section>

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.replace">
-  <title id="windows.text.replace.title"><guilabel>Text
+  <title id="windows.text.replace.title">
+      <guilabel>Text
   Replace</guilabel></title>
 
   <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
@@ -35,7 +36,8 @@
 
 
   <example id="replace.with.allemand">
-	<title id="replace.with.allemand.title">Replace a term</title>
+    <title id="replace.with.allemand.title">
+      Replace a term</title>
 	<para>
 	  <programlisting>多和田葉子.UTF8
 -- 148> | language = [[日本語]]・[[ドイツ語]]
@@ -122,7 +124,8 @@
   </itemizedlist>
 
   <section id="windows.text.replace.methods">
-    <title id="windows.text.replace.methods.title">Search type</title>
+    <title id="windows.text.replace.methods.title">
+      Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -130,7 +133,8 @@
 
     <variablelist>
       <varlistentry id="windows.text.replace.methods.exact">
-        <term id="windows.text.replace.methods.exact.title">Exact search</term>
+        <term id="windows.text.replace.methods.exact.title">
+      Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -163,7 +167,8 @@
       </varlistentry>
 
       <varlistentry id="windows.text.replace.methods.regex">
-        <term id="windows.text.replace.methods.regex.title">Regular expressions</term>
+        <term id="windows.text.replace.methods.regex.title">
+      Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 
@@ -184,42 +189,48 @@
   </section>
 
   <section id="windows.text.replace.options">
-	<title id="windows.text.replace.options.title">Options</title>
+    <title id="windows.text.replace.options.title">
+      Options</title>
 	
 	<variablelist>
-	  <varlistentry>
-		<term>Case sensitive</term>
+	  <varlistentry id="windows.text.replace.options.case.sensitive">
+        <term id="windows.text.replace.options.case.sensitive.title">
+      Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
 		</listitem>
 	  </varlistentry>
 	
-	  <varlistentry>
-		<term>Space matches nbsp</term>
+	  <varlistentry id="windows.text.replace.options.space.matches.nbsp">
+        <term id="windows.text.replace.options.space.matches.nbsp.title">
+      Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A) character.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Untranslated</term>
+	  <varlistentry id="windows.text.replace.options.untranslated">
+        <term id="windows.text.replace.options.untranslated.title">
+      Untranslated</term>
 		<listitem>
 		  <para>Also search in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
  
-	  <varlistentry>
-		<term><guibutton>Show Advanced Options</guibutton></term>
+	  <varlistentry id="windows.text.replace.options.advanced.options">
+        <term id="windows.text.replace.options.advanced.options.title">
+      <guibutton>Show Advanced Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
 		  (modification), or whether to exclude orphan segments.</para>
 
 		  <variablelist>
-			<varlistentry>
-			  <term>Full/Half-width char insensitive</term>
+			<varlistentry id="windows.text.replace.options.full.half.width">
+              <term id="windows.text.replace.options.full.half.width.title">
+      Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -235,7 +246,8 @@
   </section>
 
   <section id="windows.text.replace.result.display">
-    <title id="windows.text.replace.result.display.title">Results display</title>
+    <title id="windows.text.replace.result.display.title">
+      Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -273,8 +285,9 @@
 	<para>The selected segment is highlighted in green.</para>
 	
 	<variablelist>
-	  <varlistentry>
-		<term>Auto-sync with editor</term>
+	  <varlistentry id="windows.text.replace.result.display.auto.sync">
+        <term id="windows.text.replace.result.display.auto.sync.title">
+      Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
@@ -282,8 +295,9 @@
 		</listitem>
 	  </varlistentry>
 	  
-	  <varlistentry>
-		<term>Back to the initial segment on close</term>
+	  <varlistentry id="windows.text.replace.result.display.back.to.initial.segment">
+        <term id="windows.text.replace.result.display.back.to.initial.segment.title">
+      Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -36,8 +36,7 @@
 
 
   <example id="replace.with.allemand">
-    <title id="replace.with.allemand.title">
-      Replace a term</title>
+    <title id="replace.with.allemand.title">Replace a term</title>
 	<para>
 	  <programlisting>多和田葉子.UTF8
 -- 148> | language = [[日本語]]・[[ドイツ語]]
@@ -124,8 +123,7 @@
   </itemizedlist>
 
   <section id="windows.text.replace.methods">
-    <title id="windows.text.replace.methods.title">
-      Search type</title>
+    <title id="windows.text.replace.methods.title">Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -133,8 +131,7 @@
 
     <variablelist>
       <varlistentry id="windows.text.replace.methods.exact">
-        <term id="windows.text.replace.methods.exact.title">
-      Exact search</term>
+        <term id="windows.text.replace.methods.exact.title">Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -167,8 +164,7 @@
       </varlistentry>
 
       <varlistentry id="windows.text.replace.methods.regex">
-        <term id="windows.text.replace.methods.regex.title">
-      Regular expressions</term>
+        <term id="windows.text.replace.methods.regex.title">Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 
@@ -189,13 +185,11 @@
   </section>
 
   <section id="windows.text.replace.options">
-    <title id="windows.text.replace.options.title">
-      Options</title>
+    <title id="windows.text.replace.options.title">Options</title>
 	
 	<variablelist>
 	  <varlistentry id="windows.text.replace.options.case.sensitive">
-        <term id="windows.text.replace.options.case.sensitive.title">
-      Case sensitive</term>
+        <term id="windows.text.replace.options.case.sensitive.title">Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
@@ -203,8 +197,7 @@
 	  </varlistentry>
 	
 	  <varlistentry id="windows.text.replace.options.space.matches.nbsp">
-        <term id="windows.text.replace.options.space.matches.nbsp.title">
-      Space matches nbsp</term>
+        <term id="windows.text.replace.options.space.matches.nbsp.title">Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A) character.</para>
@@ -212,16 +205,14 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.replace.options.untranslated">
-        <term id="windows.text.replace.options.untranslated.title">
-      Untranslated</term>
+        <term id="windows.text.replace.options.untranslated.title">Untranslated</term>
 		<listitem>
 		  <para>Also search in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
  
 	  <varlistentry id="windows.text.replace.options.advanced.options">
-        <term id="windows.text.replace.options.advanced.options.title">
-      <guibutton>Show Advanced Options</guibutton></term>
+        <term id="windows.text.replace.options.advanced.options.title"><guibutton>Show Advanced Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
@@ -229,8 +220,7 @@
 
 		  <variablelist>
 			<varlistentry id="windows.text.replace.options.full.half.width">
-              <term id="windows.text.replace.options.full.half.width.title">
-      Full/Half-width char insensitive</term>
+              <term id="windows.text.replace.options.full.half.width.title">Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -246,8 +236,7 @@
   </section>
 
   <section id="windows.text.replace.result.display">
-    <title id="windows.text.replace.result.display.title">
-      Results display</title>
+    <title id="windows.text.replace.result.display.title">Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -286,8 +275,7 @@
 	
 	<variablelist>
 	  <varlistentry id="windows.text.replace.result.display.auto.sync">
-        <term id="windows.text.replace.result.display.auto.sync.title">
-      Auto-sync with editor</term>
+        <term id="windows.text.replace.result.display.auto.sync.title">Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
@@ -296,8 +284,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.replace.result.display.back.to.initial.segment">
-        <term id="windows.text.replace.result.display.back.to.initial.segment.title">
-      Back to the initial segment on close</term>
+        <term id="windows.text.replace.result.display.back.to.initial.segment.title">Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane

--- a/doc_src/en/Windows_TextReplace.xml
+++ b/doc_src/en/Windows_TextReplace.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.replace">
-  <title id="windows.text.replace.title">
-      <guilabel>Text
-  Replace</guilabel></title>
+  <title id="windows.text.replace.title"><link linkend="windows.text.replace"> </link><guilabel>Text Replace</guilabel></title>
 
   <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
   linkend="menus.edit.search.and.replace"
@@ -36,7 +34,7 @@
 
 
   <example id="replace.with.allemand">
-    <title id="replace.with.allemand.title">Replace a term</title>
+    <title id="replace.with.allemand.title"><link linkend="replace.with.allemand"> </link>Replace a term</title>
 	<para>
 	  <programlisting>多和田葉子.UTF8
 -- 148> | language = [[日本語]]・[[ドイツ語]]
@@ -123,7 +121,7 @@
   </itemizedlist>
 
   <section id="windows.text.replace.methods">
-    <title id="windows.text.replace.methods.title">Search type</title>
+    <title id="windows.text.replace.methods.title"><link linkend="windows.text.replace.methods"> </link>Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -131,7 +129,7 @@
 
     <variablelist>
       <varlistentry id="windows.text.replace.methods.exact">
-        <term id="windows.text.replace.methods.exact.title">Exact search</term>
+        <term id="windows.text.replace.methods.exact.title"><link linkend="windows.text.replace.methods.exact"> </link>Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -164,7 +162,7 @@
       </varlistentry>
 
       <varlistentry id="windows.text.replace.methods.regex">
-        <term id="windows.text.replace.methods.regex.title">Regular expressions</term>
+        <term id="windows.text.replace.methods.regex.title"><link linkend="windows.text.replace.methods.regex"> </link>Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 
@@ -185,11 +183,11 @@
   </section>
 
   <section id="windows.text.replace.options">
-    <title id="windows.text.replace.options.title">Options</title>
+    <title id="windows.text.replace.options.title"><link linkend="windows.text.replace.options"> </link>Options</title>
 	
 	<variablelist>
 	  <varlistentry id="windows.text.replace.options.case.sensitive">
-        <term id="windows.text.replace.options.case.sensitive.title">Case sensitive</term>
+        <term id="windows.text.replace.options.case.sensitive.title"><link linkend="windows.text.replace.options.case.sensitive"> </link>Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
@@ -197,7 +195,7 @@
 	  </varlistentry>
 	
 	  <varlistentry id="windows.text.replace.options.space.matches.nbsp">
-        <term id="windows.text.replace.options.space.matches.nbsp.title">Space matches nbsp</term>
+        <term id="windows.text.replace.options.space.matches.nbsp.title"><link linkend="windows.text.replace.options.space.matches.nbsp"> </link>Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A) character.</para>
@@ -205,14 +203,14 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.replace.options.untranslated">
-        <term id="windows.text.replace.options.untranslated.title">Untranslated</term>
+        <term id="windows.text.replace.options.untranslated.title"><link linkend="windows.text.replace.options.untranslated"> </link>Untranslated</term>
 		<listitem>
 		  <para>Also search in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
  
 	  <varlistentry id="windows.text.replace.options.advanced.options">
-        <term id="windows.text.replace.options.advanced.options.title"><guibutton>Show Advanced Options</guibutton></term>
+        <term id="windows.text.replace.options.advanced.options.title"><link linkend="windows.text.replace.options.advanced.options"> </link><guibutton>Show Advanced Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
@@ -220,7 +218,7 @@
 
 		  <variablelist>
 			<varlistentry id="windows.text.replace.options.full.half.width">
-              <term id="windows.text.replace.options.full.half.width.title">Full/Half-width char insensitive</term>
+              <term id="windows.text.replace.options.full.half.width.title"><link linkend="windows.text.replace.options.full.half.width"> </link>Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -236,7 +234,7 @@
   </section>
 
   <section id="windows.text.replace.result.display">
-    <title id="windows.text.replace.result.display.title">Results display</title>
+    <title id="windows.text.replace.result.display.title"><link linkend="windows.text.replace.result.display"> </link>Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -275,7 +273,7 @@
 	
 	<variablelist>
 	  <varlistentry id="windows.text.replace.result.display.auto.sync">
-        <term id="windows.text.replace.result.display.auto.sync.title">Auto-sync with editor</term>
+        <term id="windows.text.replace.result.display.auto.sync.title"><link linkend="windows.text.replace.result.display.auto.sync"> </link>Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
@@ -284,7 +282,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.replace.result.display.back.to.initial.segment">
-        <term id="windows.text.replace.result.display.back.to.initial.segment.title">Back to the initial segment on close</term>
+        <term id="windows.text.replace.result.display.back.to.initial.segment.title"><link linkend="windows.text.replace.result.display.back.to.initial.segment"> </link>Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.search">
-  <title id="windows.text.search.title">
-  <guilabel>Text Search</guilabel></title>
+  <title id="windows.text.search.title"><guilabel>Text Search</guilabel></title>
 
   <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
   linkend="menus.edit.search.project"
@@ -33,8 +32,7 @@
   <para>Matches will be displayed in bold blue characters.</para>
 
   <example id="search.for.doitsu">
-	<title id="search.for.doitsu.title">
-    Search for ドイツ</title>
+	<title id="search.for.doitsu.title">Search for ドイツ</title>
 	<para>
 	  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -91,8 +89,7 @@
   </itemizedlist>
 
   <section id="windows.text.search.methods">
-    <title id="windows.text.search.methods.title">
-    Search type</title>
+    <title id="windows.text.search.methods.title">Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -100,8 +97,7 @@
 
     <variablelist>
       <varlistentry id="windows.text.search.methods.exact">
-        <term id="windows.text.search.methods.exact.title">
-        Exact search</term>
+        <term id="windows.text.search.methods.exact.title">Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -111,8 +107,7 @@
       </varlistentry>
 
       <varlistentry id="windows.text.search.methods.keyword">
-        <term id="windows.text.search.methods.keyword.title">
-        Keyword search</term>
+        <term id="windows.text.search.methods.keyword.title">Keyword search</term>
         <listitem>
           <para>Search for segments containing each of the search terms
           separated by a space.</para>
@@ -151,8 +146,7 @@
 
 	<variablelist>
       <varlistentry id="windows.text.search.methods.regex">
-        <term id="windows.text.search.methods.regex.title">
-        Regular expressions</term>
+        <term id="windows.text.search.methods.regex.title">Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 		  <para>Regular expressions are a very powerful way to search for
@@ -171,13 +165,11 @@
   </section>
 
   <section id="windows.text.search.options">
-    <title id="windows.text.search.options.title">
-    Options</title>
+    <title id="windows.text.search.options.title">Options</title>
 	
 	<variablelist>
 	  <varlistentry id="windows.text.search.options.case.sensitive">
-        <term id="windows.text.search.options.case.sensitive.title">
-        Case sensitive</term>
+        <term id="windows.text.search.options.case.sensitive.title">Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
@@ -185,8 +177,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.search.options.space.matches.nbsp">
-        <term id="windows.text.search.options.space.matches.nbsp.title">
-        Space matches nbsp</term>
+        <term id="windows.text.search.options.space.matches.nbsp.title">Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A)
@@ -195,64 +186,56 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.source">
-        <term id="windows.text.search.options.in.source.title">
-        In source</term>
+        <term id="windows.text.search.options.in.source.title">In source</term>
 		<listitem>
 		  <para>Search in the source segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.translation">
-        <term id="windows.text.search.options.in.translation.title">
-        In translation</term>
+        <term id="windows.text.search.options.in.translation.title">In translation</term>
 		<listitem>
 		  <para>Search in the target segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.notes">
-        <term id="windows.text.search.options.in.notes.title">
-        In notes</term>
+        <term id="windows.text.search.options.in.notes.title">In notes</term>
 		<listitem>
 		  <para>Search in notes attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.comments">
-        <term id="windows.text.search.options.in.comments.title">
-        In comments</term>
+        <term id="windows.text.search.options.in.comments.title">In comments</term>
 		<listitem>
 		  <para>Search in comments attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.translated.or.untranslated">
-        <term id="windows.text.search.options.translated.or.untranslated.title">
-        Translated or untranslated</term>
+        <term id="windows.text.search.options.translated.or.untranslated.title">Translated or untranslated</term>
 		<listitem>
 		  <para>Search in both translated and untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.translated">
-        <term id="windows.text.search.options.translated.title">
-        Translated</term>
+        <term id="windows.text.search.options.translated.title">Translated</term>
 		<listitem>
 		  <para>Search only in translated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.untranslated">
-        <term id="windows.text.search.options.untranslated.title">
-        Untranslated</term>
+        <term id="windows.text.search.options.untranslated.title">Untranslated</term>
 		<listitem>
 		  <para>Search only in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.display.all">
-        <term id="windows.text.search.options.display.all.title">
-        Display: all matching segments</term>
+        <term id="windows.text.search.options.display.all.title">Display: all matching segments</term>
 		<listitem>
 		  <para>Every segment is displayed individually, even if it is a
 		  repetition found in either the same document or a different document in
@@ -261,8 +244,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.display.file.names">
-        <term id="windows.text.search.options.display.file.names.title">
-        Display: file names</term>
+        <term id="windows.text.search.options.display.file.names.title">Display: file names</term>
 		<listitem>
 		  <para>The name of the file where the segment is found is
 		  displayed above each result.</para>
@@ -270,8 +252,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.search.in.project">
-        <term id="windows.text.search.options.search.in.project.title">
-        Search in: Project</term>
+        <term id="windows.text.search.options.search.in.project.title">Search in: Project</term>
 		<listitem>
 		  <para>Search in the various bilingual resources of the project.</para>
 
@@ -279,8 +260,7 @@
 		  
 		  <variablelist>
 			<varlistentry id="windows.text.search.options.main.memory">
-              <term id="windows.text.search.options.main.memory.title">
-              Main Memory</term>
+              <term id="windows.text.search.options.main.memory.title">Main Memory</term>
 			  <listitem>
 				<para>Include the project memory (<link
 				linkend="project.folder.project.save.tmx"
@@ -289,8 +269,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.reference.tm">
-              <term id="windows.text.search.options.reference.tm.title">
-              Reference TMs</term>
+              <term id="windows.text.search.options.reference.tm.title">Reference TMs</term>
 			  <listitem>
 				<para>Include the translation memories located in the <link
 				linkend="project.folder.tm" endterm="project.folder.tm.title"/>
@@ -299,8 +278,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.glossaries">
-              <term id="windows.text.search.options.glossaries.title">
-              Glossaries</term>
+              <term id="windows.text.search.options.glossaries.title">Glossaries</term>
 			  <listitem>
 				<para>Include the glossaries located in the <link
 				linkend="project.folder.glossary"
@@ -312,8 +290,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.search.options.search.in.files">
-        <term id="windows.text.search.options.search.in.files.title">
-        Search in: Files</term>
+        <term id="windows.text.search.options.search.in.files.title">Search in: Files</term>
 		<listitem>
 		  <para>Search in reference files not included in the project
 		  resources.</para>
@@ -329,8 +306,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.tm.search.options">
-        <term id="windows.text.search.options.tm.search.options.title">
-        <guibutton>TM Search Options</guibutton></term>
+        <term id="windows.text.search.options.tm.search.options.title"><guibutton>TM Search Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
@@ -343,8 +319,7 @@
 
 		  <variablelist>
 			<varlistentry id="windows.text.search.options.full.half.width">
-              <term id="windows.text.search.options.full.half.width.title">
-              Full/Half-width char insensitive</term>
+              <term id="windows.text.search.options.full.half.width.title">Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -353,8 +328,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.number.of.matching.segments">
-              <term id="windows.text.search.options.number.of.matching.segments.title">
-              Number of matching segments</term>
+              <term id="windows.text.search.options.number.of.matching.segments.title">Number of matching segments</term>
 			  <listitem>
 				<para>Sets the maximum number of matches displayed in the search
 				result area.</para>
@@ -370,8 +344,7 @@
   </section>
 
   <section id="windows.text.search.result.display">
-    <title id="windows.text.search.result.display.title">
-    Results display</title>
+    <title id="windows.text.search.result.display.title">Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -407,8 +380,7 @@
 	<para>The selected segment is highlighted in green:</para>
 
   	<example id="select.second.match">
-	  <title id="select.second.match.title">
-      Select the second match</title>
+	  <title id="select.second.match.title">Select the second match</title>
 	  <para>
 		<programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -419,8 +391,7 @@
 
 	<variablelist>
 	  <varlistentry id="windows.text.search.result.display.auto.sync">
-        <term id="windows.text.search.result.display.auto.sync.title">
-        Auto-sync with editor</term>
+        <term id="windows.text.search.result.display.auto.sync.title">Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
@@ -428,8 +399,7 @@
 		</listitem>
 	  </varlistentry>
 	  <varlistentry id="windows.text.search.result.display.back.to.initial.segment">
-        <term id="windows.text.search.result.display.back.to.initial.segment.title">
-        Back to the initial segment on close</term>
+        <term id="windows.text.search.result.display.back.to.initial.segment.title">Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane
@@ -441,8 +411,7 @@
   </section>
   
   <section id="windows.text.search.filter">
-    <title id="windows.text.search.filter.title">
-    Filter</title>
+    <title id="windows.text.search.filter.title">Filter</title>
 
 	<para>Click on the <guibutton>Filter</guibutton> button to show only the 
 	matching search result segments in the <link linkend="panes.editor"

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.search">
-  <title id="windows.text.search.title"><guilabel>Text Search</guilabel></title>
+  <title id="windows.text.search.title"><link linkend="windows.text.search"> </link><guilabel>Text Search</guilabel></title>
 
   <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
   linkend="menus.edit.search.project"
@@ -32,7 +32,7 @@
   <para>Matches will be displayed in bold blue characters.</para>
 
   <example id="search.for.doitsu">
-	<title id="search.for.doitsu.title">Search for ドイツ</title>
+	<title id="search.for.doitsu.title"><link linkend="search.for.doitsu"> </link>Search for ドイツ</title>
 	<para>
 	  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -89,7 +89,7 @@
   </itemizedlist>
 
   <section id="windows.text.search.methods">
-    <title id="windows.text.search.methods.title">Search type</title>
+    <title id="windows.text.search.methods.title"><link linkend="windows.text.search.methods"> </link>Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -97,7 +97,7 @@
 
     <variablelist>
       <varlistentry id="windows.text.search.methods.exact">
-        <term id="windows.text.search.methods.exact.title">Exact search</term>
+        <term id="windows.text.search.methods.exact.title"><link linkend="windows.text.search.methods.exact"> </link>Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -107,7 +107,7 @@
       </varlistentry>
 
       <varlistentry id="windows.text.search.methods.keyword">
-        <term id="windows.text.search.methods.keyword.title">Keyword search</term>
+        <term id="windows.text.search.methods.keyword.title"><link linkend="windows.text.search.methods.keyword"> </link>Keyword search</term>
         <listitem>
           <para>Search for segments containing each of the search terms
           separated by a space.</para>
@@ -146,7 +146,7 @@
 
 	<variablelist>
       <varlistentry id="windows.text.search.methods.regex">
-        <term id="windows.text.search.methods.regex.title">Regular expressions</term>
+        <term id="windows.text.search.methods.regex.title"><link linkend="windows.text.search.methods.regex"> </link>Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 		  <para>Regular expressions are a very powerful way to search for
@@ -165,11 +165,11 @@
   </section>
 
   <section id="windows.text.search.options">
-    <title id="windows.text.search.options.title">Options</title>
+    <title id="windows.text.search.options.title"><link linkend="windows.text.search.options"> </link>Options</title>
 	
 	<variablelist>
 	  <varlistentry id="windows.text.search.options.case.sensitive">
-        <term id="windows.text.search.options.case.sensitive.title">Case sensitive</term>
+        <term id="windows.text.search.options.case.sensitive.title"><link linkend="windows.text.search.options.case.sensitive"> </link>Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
@@ -177,7 +177,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.search.options.space.matches.nbsp">
-        <term id="windows.text.search.options.space.matches.nbsp.title">Space matches nbsp</term>
+        <term id="windows.text.search.options.space.matches.nbsp.title"><link linkend="windows.text.search.options.space.matches.nbsp"> </link>Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A)
@@ -186,56 +186,56 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.source">
-        <term id="windows.text.search.options.in.source.title">In source</term>
+        <term id="windows.text.search.options.in.source.title"><link linkend="windows.text.search.options.in.source"> </link>In source</term>
 		<listitem>
 		  <para>Search in the source segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.translation">
-        <term id="windows.text.search.options.in.translation.title">In translation</term>
+        <term id="windows.text.search.options.in.translation.title"><link linkend="windows.text.search.options.in.translation"> </link>In translation</term>
 		<listitem>
 		  <para>Search in the target segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.notes">
-        <term id="windows.text.search.options.in.notes.title">In notes</term>
+        <term id="windows.text.search.options.in.notes.title"><link linkend="windows.text.search.options.in.notes"> </link>In notes</term>
 		<listitem>
 		  <para>Search in notes attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.in.comments">
-        <term id="windows.text.search.options.in.comments.title">In comments</term>
+        <term id="windows.text.search.options.in.comments.title"><link linkend="windows.text.search.options.in.comments"> </link>In comments</term>
 		<listitem>
 		  <para>Search in comments attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.translated.or.untranslated">
-        <term id="windows.text.search.options.translated.or.untranslated.title">Translated or untranslated</term>
+        <term id="windows.text.search.options.translated.or.untranslated.title"><link linkend="windows.text.search.options.translated.or.untranslated"> </link>Translated or untranslated</term>
 		<listitem>
 		  <para>Search in both translated and untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.translated">
-        <term id="windows.text.search.options.translated.title">Translated</term>
+        <term id="windows.text.search.options.translated.title"><link linkend="windows.text.search.options.translated"> </link>Translated</term>
 		<listitem>
 		  <para>Search only in translated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.untranslated">
-        <term id="windows.text.search.options.untranslated.title">Untranslated</term>
+        <term id="windows.text.search.options.untranslated.title"><link linkend="windows.text.search.options.untranslated"> </link>Untranslated</term>
 		<listitem>
 		  <para>Search only in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.display.all">
-        <term id="windows.text.search.options.display.all.title">Display: all matching segments</term>
+        <term id="windows.text.search.options.display.all.title"><link linkend="windows.text.search.options.display.all"> </link>Display: all matching segments</term>
 		<listitem>
 		  <para>Every segment is displayed individually, even if it is a
 		  repetition found in either the same document or a different document in
@@ -244,7 +244,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.display.file.names">
-        <term id="windows.text.search.options.display.file.names.title">Display: file names</term>
+        <term id="windows.text.search.options.display.file.names.title"><link linkend="windows.text.search.options.display.file.names"> </link>Display: file names</term>
 		<listitem>
 		  <para>The name of the file where the segment is found is
 		  displayed above each result.</para>
@@ -252,7 +252,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.search.in.project">
-        <term id="windows.text.search.options.search.in.project.title">Search in: Project</term>
+        <term id="windows.text.search.options.search.in.project.title"><link linkend="windows.text.search.options.search.in.project"> </link>Search in: Project</term>
 		<listitem>
 		  <para>Search in the various bilingual resources of the project.</para>
 
@@ -260,7 +260,7 @@
 		  
 		  <variablelist>
 			<varlistentry id="windows.text.search.options.main.memory">
-              <term id="windows.text.search.options.main.memory.title">Main Memory</term>
+              <term id="windows.text.search.options.main.memory.title"><link linkend="windows.text.search.options.main.memory"> </link>Main Memory</term>
 			  <listitem>
 				<para>Include the project memory (<link
 				linkend="project.folder.project.save.tmx"
@@ -269,7 +269,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.reference.tm">
-              <term id="windows.text.search.options.reference.tm.title">Reference TMs</term>
+              <term id="windows.text.search.options.reference.tm.title"><link linkend="windows.text.search.options.reference.tm"> </link>Reference TMs</term>
 			  <listitem>
 				<para>Include the translation memories located in the <link
 				linkend="project.folder.tm" endterm="project.folder.tm.title"/>
@@ -278,7 +278,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.glossaries">
-              <term id="windows.text.search.options.glossaries.title">Glossaries</term>
+              <term id="windows.text.search.options.glossaries.title"><link linkend="windows.text.search.options.glossaries"> </link>Glossaries</term>
 			  <listitem>
 				<para>Include the glossaries located in the <link
 				linkend="project.folder.glossary"
@@ -290,7 +290,7 @@
 	  </varlistentry>
 	  
 	  <varlistentry id="windows.text.search.options.search.in.files">
-        <term id="windows.text.search.options.search.in.files.title">Search in: Files</term>
+        <term id="windows.text.search.options.search.in.files.title"><link linkend="windows.text.search.options.search.in.files"> </link>Search in: Files</term>
 		<listitem>
 		  <para>Search in reference files not included in the project
 		  resources.</para>
@@ -306,7 +306,7 @@
 	  </varlistentry>
 
 	  <varlistentry id="windows.text.search.options.tm.search.options">
-        <term id="windows.text.search.options.tm.search.options.title"><guibutton>TM Search Options</guibutton></term>
+        <term id="windows.text.search.options.tm.search.options.title"><link linkend="windows.text.search.options.tm.search.options"> </link><guibutton>TM Search Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
@@ -319,7 +319,7 @@
 
 		  <variablelist>
 			<varlistentry id="windows.text.search.options.full.half.width">
-              <term id="windows.text.search.options.full.half.width.title">Full/Half-width char insensitive</term>
+              <term id="windows.text.search.options.full.half.width.title"><link linkend="windows.text.search.options.full.half.width"> </link>Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -328,7 +328,7 @@
 			</varlistentry>
 
 			<varlistentry id="windows.text.search.options.number.of.matching.segments">
-              <term id="windows.text.search.options.number.of.matching.segments.title">Number of matching segments</term>
+              <term id="windows.text.search.options.number.of.matching.segments.title"><link linkend="windows.text.search.options.number.of.matching.segments"> </link>Number of matching segments</term>
 			  <listitem>
 				<para>Sets the maximum number of matches displayed in the search
 				result area.</para>
@@ -344,7 +344,7 @@
   </section>
 
   <section id="windows.text.search.result.display">
-    <title id="windows.text.search.result.display.title">Results display</title>
+    <title id="windows.text.search.result.display.title"><link linkend="windows.text.search.result.display"> </link>Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -380,7 +380,7 @@
 	<para>The selected segment is highlighted in green:</para>
 
   	<example id="select.second.match">
-	  <title id="select.second.match.title">Select the second match</title>
+	  <title id="select.second.match.title"><link linkend="select.second.match"> </link>Select the second match</title>
 	  <para>
 		<programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -391,7 +391,7 @@
 
 	<variablelist>
 	  <varlistentry id="windows.text.search.result.display.auto.sync">
-        <term id="windows.text.search.result.display.auto.sync.title">Auto-sync with editor</term>
+        <term id="windows.text.search.result.display.auto.sync.title"><link linkend="windows.text.search.result.display.auto.sync"> </link>Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
@@ -399,7 +399,7 @@
 		</listitem>
 	  </varlistentry>
 	  <varlistentry id="windows.text.search.result.display.back.to.initial.segment">
-        <term id="windows.text.search.result.display.back.to.initial.segment.title">Back to the initial segment on close</term>
+        <term id="windows.text.search.result.display.back.to.initial.segment.title"><link linkend="windows.text.search.result.display.back.to.initial.segment"> </link>Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane
@@ -411,7 +411,7 @@
   </section>
   
   <section id="windows.text.search.filter">
-    <title id="windows.text.search.filter.title">Filter</title>
+    <title id="windows.text.search.filter.title"><link linkend="windows.text.search.filter"> </link>Filter</title>
 
 	<para>Click on the <guibutton>Filter</guibutton> button to show only the 
 	matching search result segments in the <link linkend="panes.editor"

--- a/doc_src/en/Windows_TextSearch.xml
+++ b/doc_src/en/Windows_TextSearch.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "../../../docbook-xml-4.5/docbookx.dtd">
 <section id="windows.text.search">
-  <title id="windows.text.search.title"><guilabel>Text Search</guilabel></title>
+  <title id="windows.text.search.title">
+  <guilabel>Text Search</guilabel></title>
 
   <para>Use <link linkend="menus.edit" endterm="menus.edit.title"/><link
   linkend="menus.edit.search.project"
@@ -32,7 +33,8 @@
   <para>Matches will be displayed in bold blue characters.</para>
 
   <example id="search.for.doitsu">
-	<title id="search.for.doitsu.title">Search for ドイツ</title>
+	<title id="search.for.doitsu.title">
+    Search for ドイツ</title>
 	<para>
 	  <programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -89,7 +91,8 @@
   </itemizedlist>
 
   <section id="windows.text.search.methods">
-    <title id="windows.text.search.methods.title">Search type</title>
+    <title id="windows.text.search.methods.title">
+    Search type</title>
 
     <para>Use the radio buttons to select the type of search.</para>
 
@@ -97,7 +100,8 @@
 
     <variablelist>
       <varlistentry id="windows.text.search.methods.exact">
-        <term id="windows.text.search.methods.exact.title">Exact search</term>
+        <term id="windows.text.search.methods.exact.title">
+        Exact search</term>
         <listitem>
           <para>Search for the string exactly as entered in the search
           field.</para>
@@ -107,8 +111,8 @@
       </varlistentry>
 
       <varlistentry id="windows.text.search.methods.keyword">
-        <term id="windows.text.search.methods.keyword.title">Keyword
-        search</term>
+        <term id="windows.text.search.methods.keyword.title">
+        Keyword search</term>
         <listitem>
           <para>Search for segments containing each of the search terms
           separated by a space.</para>
@@ -147,8 +151,8 @@
 
 	<variablelist>
       <varlistentry id="windows.text.search.methods.regex">
-        <term id="windows.text.search.methods.regex.title">Regular
-        expressions</term>
+        <term id="windows.text.search.methods.regex.title">
+        Regular expressions</term>
         <listitem>
           <para>Treat the search string as a regular expression.</para>
 		  <para>Regular expressions are a very powerful way to search for
@@ -167,19 +171,22 @@
   </section>
 
   <section id="windows.text.search.options">
-	<title id="windows.text.search.options.title">Options</title>
+    <title id="windows.text.search.options.title">
+    Options</title>
 	
 	<variablelist>
-	  <varlistentry>
-		<term>Case sensitive</term>
+	  <varlistentry id="windows.text.search.options.case.sensitive">
+        <term id="windows.text.search.options.case.sensitive.title">
+        Case sensitive</term>
 		<listitem>
 		  <para>Only returns results with the same letter case as the search
 		  terms.</para>
 		</listitem>
 	  </varlistentry>
 	  
-	  <varlistentry>
-		<term>Space matches nbsp</term>
+	  <varlistentry id="windows.text.search.options.space.matches.nbsp">
+        <term id="windows.text.search.options.space.matches.nbsp.title">
+        Space matches nbsp</term>
 		<listitem>
 		  <para>Space characters in search terms will match both a normal space
 		  and a non-breaking space (\u00A)
@@ -187,57 +194,65 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>In source</term>
+	  <varlistentry id="windows.text.search.options.in.source">
+        <term id="windows.text.search.options.in.source.title">
+        In source</term>
 		<listitem>
 		  <para>Search in the source segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>In translation</term>
+	  <varlistentry id="windows.text.search.options.in.translation">
+        <term id="windows.text.search.options.in.translation.title">
+        In translation</term>
 		<listitem>
 		  <para>Search in the target segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>In notes</term>
+	  <varlistentry id="windows.text.search.options.in.notes">
+        <term id="windows.text.search.options.in.notes.title">
+        In notes</term>
 		<listitem>
 		  <para>Search in notes attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>In comments</term>
+	  <varlistentry id="windows.text.search.options.in.comments">
+        <term id="windows.text.search.options.in.comments.title">
+        In comments</term>
 		<listitem>
 		  <para>Search in comments attached to segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Translated or untranslated</term>
+	  <varlistentry id="windows.text.search.options.translated.or.untranslated">
+        <term id="windows.text.search.options.translated.or.untranslated.title">
+        Translated or untranslated</term>
 		<listitem>
 		  <para>Search in both translated and untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Translated</term>
+	  <varlistentry id="windows.text.search.options.translated">
+        <term id="windows.text.search.options.translated.title">
+        Translated</term>
 		<listitem>
 		  <para>Search only in translated segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Untranslated</term>
+	  <varlistentry id="windows.text.search.options.untranslated">
+        <term id="windows.text.search.options.untranslated.title">
+        Untranslated</term>
 		<listitem>
 		  <para>Search only in untranslated segments.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Display: all matching segments</term>
+	  <varlistentry id="windows.text.search.options.display.all">
+        <term id="windows.text.search.options.display.all.title">
+        Display: all matching segments</term>
 		<listitem>
 		  <para>Every segment is displayed individually, even if it is a
 		  repetition found in either the same document or a different document in
@@ -245,24 +260,27 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Display: file names</term>
+	  <varlistentry id="windows.text.search.options.display.file.names">
+        <term id="windows.text.search.options.display.file.names.title">
+        Display: file names</term>
 		<listitem>
 		  <para>The name of the file where the segment is found is
 		  displayed above each result.</para>
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term>Search in: Project</term>
+	  <varlistentry id="windows.text.search.options.search.in.project">
+        <term id="windows.text.search.options.search.in.project.title">
+        Search in: Project</term>
 		<listitem>
 		  <para>Search in the various bilingual resources of the project.</para>
 
 		  <para>Select the scope of the search:</para>
 		  
 		  <variablelist>
-			<varlistentry>
-			  <term>Main Memory</term>
+			<varlistentry id="windows.text.search.options.main.memory">
+              <term id="windows.text.search.options.main.memory.title">
+              Main Memory</term>
 			  <listitem>
 				<para>Include the project memory (<link
 				linkend="project.folder.project.save.tmx"
@@ -270,8 +288,9 @@
 			  </listitem>
 			</varlistentry>
 
-			<varlistentry>
-			  <term>Reference TMs</term>
+			<varlistentry id="windows.text.search.options.reference.tm">
+              <term id="windows.text.search.options.reference.tm.title">
+              Reference TMs</term>
 			  <listitem>
 				<para>Include the translation memories located in the <link
 				linkend="project.folder.tm" endterm="project.folder.tm.title"/>
@@ -279,8 +298,9 @@
 			  </listitem>
 			</varlistentry>
 
-			<varlistentry>
-			  <term>Glossaries</term>
+			<varlistentry id="windows.text.search.options.glossaries">
+              <term id="windows.text.search.options.glossaries.title">
+              Glossaries</term>
 			  <listitem>
 				<para>Include the glossaries located in the <link
 				linkend="project.folder.glossary"
@@ -291,8 +311,9 @@
 		</listitem>
 	  </varlistentry>
 	  
-	  <varlistentry>
-		<term>Search in: Files</term>
+	  <varlistentry id="windows.text.search.options.search.in.files">
+        <term id="windows.text.search.options.search.in.files.title">
+        Search in: Files</term>
 		<listitem>
 		  <para>Search in reference files not included in the project
 		  resources.</para>
@@ -307,8 +328,9 @@
 		</listitem>
 	  </varlistentry>
 
-	  <varlistentry>
-		<term><guibutton>TM Search Options</guibutton></term>
+	  <varlistentry id="windows.text.search.options.tm.search.options">
+        <term id="windows.text.search.options.tm.search.options.title">
+        <guibutton>TM Search Options</guibutton></term>
 		<listitem>
 		  <para>Select additional criteria such as the person who authored or
 		  changed the translation, the date and time of translation
@@ -320,8 +342,9 @@
 		  </warning>
 
 		  <variablelist>
-			<varlistentry>
-			  <term>Full/Half-width char insensitive</term>
+			<varlistentry id="windows.text.search.options.full.half.width">
+              <term id="windows.text.search.options.full.half.width.title">
+              Full/Half-width char insensitive</term>
 			  <listitem>
 				<para>Returns results that match both the full- and half-width
 				forms (CJK characters) of the characters in the search
@@ -329,8 +352,9 @@
 			  </listitem>
 			</varlistentry>
 
-			<varlistentry>
-			  <term>Number of matching segments</term>
+			<varlistentry id="windows.text.search.options.number.of.matching.segments">
+              <term id="windows.text.search.options.number.of.matching.segments.title">
+              Number of matching segments</term>
 			  <listitem>
 				<para>Sets the maximum number of matches displayed in the search
 				result area.</para>
@@ -339,14 +363,15 @@
 		  </variablelist>
 
 		  <para>Use the <guibutton>Hide Advanced Options</guibutton> button to stop showing
-			the advanced options.</para>
+		  the advanced options.</para>
 		</listitem>
 	  </varlistentry>
 	</variablelist>
   </section>
 
   <section id="windows.text.search.result.display">
-    <title id="windows.text.search.result.display.title">Results display</title>
+    <title id="windows.text.search.result.display.title">
+    Results display</title>
 
     <para>Matches are displayed in their order of appearance in the project. For
     translated segments, the original text is displayed above the translated
@@ -382,7 +407,8 @@
 	<para>The selected segment is highlighted in green:</para>
 
   	<example id="select.second.match">
-	  <title id="select.second.match.title">Select the second match</title>
+	  <title id="select.second.match.title">
+      Select the second match</title>
 	  <para>
 		<programlisting>-- 148> | language = [[日本語]]・[[<token>ドイツ</token>語]]
 ---------
@@ -392,16 +418,18 @@
 	</example>
 
 	<variablelist>
-	  <varlistentry>
-		<term>Auto-sync with editor</term>
+	  <varlistentry id="windows.text.search.result.display.auto.sync">
+        <term id="windows.text.search.result.display.auto.sync.title">
+        Auto-sync with editor</term>
 		<listitem>
 		  <para>The <link linkend="panes.editor" endterm="panes.editor.title"/>
 		  pane synchronizes its display with the selection in the search
 		  results</para>
 		</listitem>
 	  </varlistentry>
-	  <varlistentry>
-		<term>Back to the initial segment on close</term>
+	  <varlistentry id="windows.text.search.result.display.back.to.initial.segment">
+        <term id="windows.text.search.result.display.back.to.initial.segment.title">
+        Back to the initial segment on close</term>
 		<listitem>
 		  <para>When you close the search windows, the <link
 		  linkend="panes.editor" endterm="panes.editor.title"/> pane
@@ -413,7 +441,8 @@
   </section>
   
   <section id="windows.text.search.filter">
-    <title id="windows.text.search.filter.title">Filter</title>
+    <title id="windows.text.search.filter.title">
+    Filter</title>
 
 	<para>Click on the <guibutton>Filter</guibutton> button to show only the 
 	matching search result segments in the <link linkend="panes.editor"


### PR DESCRIPTION
This feature adds a small space in front of relevant headers to provide access to direct links to the related subjects.

## Which ticket is resolved?
https://sourceforge.net/p/omegat/documentation/410/
