### PR TITLE
feat: expand manual in the application data directory to allow users to keep bookmark on the browser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1525,6 +1525,7 @@ tasks.jacocoTestCoverageVerification {
 
 tasks.getByName("run") {
     jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
+    dependsOn manualZips
 }
 
 tasks.register('debug', JavaExec) {
@@ -1545,6 +1546,7 @@ tasks.register('runOnJava17', JavaExec) {
     mainClass.set application.mainClass
     classpath = sourceSets.main.runtimeClasspath
     jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
+    dependsOn manualZips
     group = 'application'
 }
 
@@ -1557,6 +1559,7 @@ tasks.register('runOnJava21', JavaExec) {
     mainClass.set application.mainClass
     classpath = sourceSets.main.runtimeClasspath
     jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
+    dependsOn manualZips
     group = 'application'
 }
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1962,7 +1962,7 @@ SU_CONFIG_DIR_CREATE_ERROR=Your operating system refused to let OmegaT\n\
 SU_SCRIPT_DIR_CREATE_ERROR=It was not possible to create the script folder\n\
     inside the configuration folder. The configuration folder will be used\n\
     instead.
-SU_DATA_DIR_CREATE_ERROR=Your operationg system refused to let OmegaT create the application data folder.
+SU_DATA_DIR_CREATE_ERROR=Your operating system refused to let OmegaT create the application data folder.
 
 # HttpConnectionUtils
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1962,6 +1962,7 @@ SU_CONFIG_DIR_CREATE_ERROR=Your operating system refused to let OmegaT\n\
 SU_SCRIPT_DIR_CREATE_ERROR=It was not possible to create the script folder\n\
     inside the configuration folder. The configuration folder will be used\n\
     instead.
+SU_DATA_DIR_CREATE_ERROR=Your operationg system refused to let OmegaT create the application data folder.
 
 # HttpConnectionUtils
 

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -8,7 +8,7 @@
                2007 Didier Briel
                2009 Alex Buloichik
                2015 Aaron Madlon-Kay
-               2023 Hiroshi Miura
+               2023-2025 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -89,7 +89,8 @@ public final class Help {
     /**
      * Shows help in the system browser.
      *
-     * @throws IOException when URI creation failed.
+     * @throws IOException
+     *             when URI creation failed.
      */
     public static void showHelp() throws IOException {
         String lang = detectHelpLanguage();

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -48,6 +48,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.omegat.util.Language;
+import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;
@@ -88,7 +89,7 @@ public final class Help {
     /**
      * Shows help in the system browser.
      *
-     * @throws IOException
+     * @throws IOException when URI creation failed.
      */
     public static void showHelp() throws IOException {
         String lang = detectHelpLanguage();
@@ -125,7 +126,11 @@ public final class Help {
             return null;
         }
         try {
-            Path destinationDir = Files.createTempDirectory("omegat-" + OStrings.VERSION + "-help-" + lang);
+            Path destinationDir = Paths.get(StaticUtils.getConfigDir(), "manual", OStrings.VERSION, lang);
+            if (destinationDir.resolve("index.html").toFile().exists()) {
+                // already have manual
+                return destinationDir.toUri();
+            }
             return extractZip(zipFile, destinationDir).toURI();
         } catch (IOException ignored) {
         }
@@ -148,7 +153,7 @@ public final class Help {
             try {
                 cleanUp(destinationDir);
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.log(e);
             }
         }));
         return destinationDir.resolve(OConsts.HELP_HOME).toFile();
@@ -223,7 +228,7 @@ public final class Help {
 
     /**
      * Detects the documentation language to use.
-     *
+     * <p>
      * If the latest manual is not available in the system locale language, it
      * returns null, i.e. show a language selection screen.
      */

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -40,15 +40,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Comparator;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.omegat.util.Language;
-import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -151,27 +151,7 @@ public final class Help {
                 zipInputStream.closeEntry();
             }
         }
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                cleanUp(destinationDir);
-            } catch (IOException e) {
-                Log.log(e);
-            }
-        }));
         return destinationDir.resolve(OConsts.HELP_HOME).toFile();
-    }
-
-    private static void cleanUp(Path destinationDir) throws IOException {
-        if (Files.exists(destinationDir)) {
-            try (Stream<Path> walk = Files.walk(destinationDir)) {
-                walk.sorted(Comparator.reverseOrder()).forEachOrdered(file -> {
-                    try {
-                        Files.delete(file);
-                    } catch (IOException ignored) {
-                    }
-                });
-            }
-        }
     }
 
     public static URI getHelpFileURI(String filename) {

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -127,10 +127,11 @@ public final class Help {
             return null;
         }
         try {
-            Path destinationDir = Paths.get(StaticUtils.getConfigDir(), "manual", OStrings.VERSION, lang);
-            if (destinationDir.resolve("index.html").toFile().exists()) {
+            Path destinationDir = Paths.get(StaticUtils.getApplicationDataDir(), "manual", OStrings.VERSION, lang);
+            Path indexPath = destinationDir.resolve("index.html");
+            if (indexPath.toFile().exists()) {
                 // already have manual
-                return destinationDir.toUri();
+                return indexPath.toUri();
             }
             return extractZip(zipFile, destinationDir).toURI();
         } catch (IOException ignored) {

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -360,7 +360,7 @@ public final class StaticUtils {
 
         if (Platform.isWindows) {
             String appData = null;
-            File appDataFile = new File(home, "AppData\\Roaming");
+            File appDataFile = new File(home, "AppData\\Local");
             if (appDataFile.exists()) {
                 appData = appDataFile.getAbsolutePath();
             }

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -351,7 +351,7 @@ public final class StaticUtils {
      * @return directory path to store application data.
      */
     public static String getApplicationDataDir() {
-        String dataDir;
+        String dataDir = null;
         String home = getHomeDir();
         // if os or user home is null or empty, we cannot reliably determine
         // the data dir, so we use the current working dir (= empty string)
@@ -363,9 +363,8 @@ public final class StaticUtils {
         if (Platform.isWindows) {
             File appDataFile = new File(home, WINDOWS_LOCAL_DATA_DIR);
             if (appDataFile.exists()) {
-                appData = appDataFile.getAbsolutePath();
+                dataDir = appDataFile.getAbsolutePath() + WINDOWS_DATA_DIR;
             }
-            dataDir = appData + WINDOWS_DATA_DIR;
         } else if (Platform.isUnixLike()) {
             dataDir = home + UNIX_DATA_DIR;
         } else if (Platform.isMacOSX()) {
@@ -375,23 +374,24 @@ public final class StaticUtils {
             // use the user's home directory by default
             dataDir = home + File.separator;
         }
-        if (!dataDir.isEmpty()) {
-            try {
-                // check if the dir exists
-                File dir = new File(dataDir);
-                if (!dir.exists()) {
-                    // create the dir
-                    boolean created = dir.mkdirs();
-                    if (!created) {
-                        Log.logErrorRB("SU_DATA_DIR_CREATE_ERROR");
-                        dataDir = new File(".").getAbsolutePath() + File.separator;
-                    }
+        if (dataDir == null || dataDir.isEmpty()) {
+            return new File(".").getAbsolutePath() + File.separator;
+        }
+        try {
+            // check if the dir exists
+            File dir = new File(dataDir);
+            if (!dir.exists()) {
+                // create the dir
+                boolean created = dir.mkdirs();
+                if (!created) {
+                    Log.logErrorRB("SU_DATA_DIR_CREATE_ERROR");
+                    dataDir = new File(".").getAbsolutePath() + File.separator;
                 }
-            } catch (SecurityException e) {
-                // the system doesn't want us to write where we want to write
-                dataDir = new File(".").getAbsolutePath() + File.separator;
-                Log.log(e.toString());
             }
+        } catch (SecurityException e) {
+            // the system doesn't want us to write where we want to write
+            dataDir = new File(".").getAbsolutePath() + File.separator;
+            Log.log(e.toString());
         }
         return dataDir;
     }

--- a/src/org/omegat/util/StaticUtils.java
+++ b/src/org/omegat/util/StaticUtils.java
@@ -74,6 +74,7 @@ public final class StaticUtils {
     /**
      * Configuration directory on Windows platforms.
      */
+    private static final String WINDOWS_ROAMING_DATA_DIR = "AppData\\Roaming";
     private static final String WINDOWS_CONFIG_DIR = "\\OmegaT\\";
 
     /**
@@ -89,6 +90,7 @@ public final class StaticUtils {
     /**
      * Application data directory on Windows platforms.
      */
+    private static final String WINDOWS_LOCAL_DATA_DIR = "AppData\\Local";
     private static final String WINDOWS_DATA_DIR = "\\OmegaT\\";
 
     /**
@@ -273,7 +275,7 @@ public final class StaticUtils {
             // Trying first Vista/7, because "Application Data" exists also as
             // virtual folder,
             // so we would not be able to differentiate with 2000/XP otherwise
-            File appDataFile = new File(home, "AppData\\Roaming");
+            File appDataFile = new File(home, WINDOWS_ROAMING_DATA_DIR);
             if (appDataFile.exists()) {
                 appData = appDataFile.getAbsolutePath();
             } else {
@@ -359,8 +361,7 @@ public final class StaticUtils {
         }
 
         if (Platform.isWindows) {
-            String appData = null;
-            File appDataFile = new File(home, "AppData\\Local");
+            File appDataFile = new File(home, WINDOWS_LOCAL_DATA_DIR);
             if (appDataFile.exists()) {
                 appData = appDataFile.getAbsolutePath();
             }


### PR DESCRIPTION
- allow users to make bookmark in the browser

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- https://sourceforge.net/p/omegat/feature-requests/1778/
- expand manual in the application data directory to allow users to keep bookmark on the browser

- related https://sourceforge.net/p/omegat/mailman/message/59152285/

## What does this PR change?

- Expand HTML manual under `~/Library/Application Support/OmegaT/manual/<version>/<lang>/` instead of temporary folder on macos. `%USERPROFILE%\\AppData\\Local\OmegaT` on Windows and `~/.local/share/OmegaT/` on Linux. 


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
