### PR TITLE
Update First_Steps translations and restore some languages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ omtWebsite=https://omegat.org
 # Don't include extra stuff like version number in JAR name
 omegatJarFilename=OmegaT.jar
 manualLangs=ca,de,en,fr,it,ja,nl
-firstStepLangs=ca,de,en,fr,it,ja,nl
+firstStepLangs=ca,co,de,en,fr,ia,it,ja,nl,pt_BR,zh_CN

--- a/src_docs/greeting/ca/First_Steps.xml
+++ b/src_docs/greeting/ca/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="ca" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/co/First_Steps.xml
+++ b/src_docs/greeting/co/First_Steps.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<article lang="co" id="first.steps">
+  <title>OmegaT</title>
+  <section>
+	<title id="first-steps">Primi passi</title>
+	<para>Appughjate nant’à u tastu <keycap>F1</keycap> o accidite à u listinu d’<guimenu>Aiutu</guimenu> per apre u manuale di l’utilizatore. Stu manuale cuntene una intruduzzione sana à OmegaT. Per impiegà OmegaT cù parametri simplificati, fate cusì :<orderedlist id="first-step-list">
+	  <listitem>
+		<para>In u listinu <guimenu>Prughjettu</guimenu>, selezziunate <guimenuitem>Novu…</guimenuitem> per creà un prughjettu novu.</para>
+	  </listitem>
+	  <listitem>
+		<para>Cambiate i codici di lingua per indicà a lingua d’origine è quella di destinazione. Fate un cliccu nant’à <guibutton>Vai</guibutton>.</para>
+
+		<para>→ OmegaT hà da creà un cartulare chì cuntenerà i vostri schedarii. Una memoria di traduzzione serà creata viota dinù chì serà riempiuta, in tacca di sfondulu, un segmentu dopu à l’altru, durante a vostra traduzzione E currispundenze per sta memoria seranu affissate in fine di contu nant’à u pannellu <guilabel>Currispundenze simile</guilabel>.</para>
+	  </listitem>
+	  <listitem>
+		<para>Fate un cliccu nant’à <guibutton>Aghjunghje schedarii…</guibutton> è aghjunghjite i schedarii chì sò à traduce. Chjudite a finestra.</para>
+
+		<para>→ OmegaT hà da cupià i schedarii selezziunati in u prughjettu creatu durante a tappa precedente. Sti schedarii sò affissati, un segmentu dopu à l’altru, per esse tradutti da voi.</para>
+	  </listitem>
+	  <listitem>
+		<para>Stampittate a traduzzione di u primu segmentu. Appughjate nant’à <keycap>Entre</keycap>.</para>
+
+		<para>→ OmegaT hà da arregistrà stu segmentu in a memoria di traduzzione di u prughjettu è hà da dispiazzà u cursore versu u segmentu prossimu.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>In u listinu <guimenu>Prughjettu</guimenu>, selezziunate <guimenuitem>Creà i schedarii tradutti</guimenuitem> per creà i ducumenti tradutti quand’ella vi pare.</para>
+
+		<para>→ OmegaT hà da piazzà i schedarii tradutti in u cartulare <guilabel>target</guilabel> di u prughjettu chì hè statu creatu durante a prima tappa. In u listinu <guimenu>Prughjettu</guimenu>, selezziunate <guisubmenu>Accessu à u cuntenutu di u prughjettu</guisubmenu> per accede à i schedarii.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Per sapene di più, fighjate u manuale di l’utilizatore.</para>
+	  </listitem>
+	</orderedlist>
+	</para>
+  </section>
+
+  <section>
+	<title id="freedoms">Libertà d’usu è di mudificazione</title>
+	<para>OmegaT hè una suluzione libera di traduzzione assistita da l’urdinatore (TAO in
+francese è CAT in inglese) per i traduttori prufessiunali. Stu prugramma hè distribuitu sottu à i termini di a <emphasis>Licenza Publica Generale GNU, versione 3.0</emphasis>. Fighjate <guimenu>Aiutu</guimenu> eppò <guimenu>Apprupositu</guimenu>. A licenza vi cuncede quelle libertà :<itemizedlist id="freedoms.list">
+	  <listitem>
+		<para>A libertà di lancià OmegaT cum’ella vi pare, per tutti i vostri bisogni.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A libertà di studià cumu funziuneghja OmegaT è di mudificallu cum’ella vi pare.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A libertà di ridistribuisce copie per aiutà d’altre persone.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A libertà di distribuisce e copie di e vostre versioni mudificate à d’altre persone.</para>
+	  </listitem>
+	</itemizedlist>
+	</para>
+  </section>
+</article>

--- a/src_docs/greeting/de/First_Steps.xml
+++ b/src_docs/greeting/de/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="de" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/en/First_Steps.xml
+++ b/src_docs/greeting/en/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="en" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/fr/First_Steps.xml
+++ b/src_docs/greeting/fr/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="fr" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/ia/First_Steps.xml
+++ b/src_docs/greeting/ia/First_Steps.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<article lang="ia" id="first.steps">
+  <title>OmegaT</title>
+  <section>
+	<title id="first-steps">Prime passos</title>
+	<para>Pulsa <keycap>F1</keycap> o accede al menu <guimenu>&gt; Adjuta (Help)</guimenu> pro aperir le manual del usator. Il forni un introduction minutiose a OmegaT. Pro comenciar a usar OmegaT con configurationes minime:<orderedlist id="first-step-list">
+	  <listitem>
+		<para>Usa <guimenu> &gt; Projecto</guimenu> <guimenuitem>&gt; Nove...</guimenuitem> pro crear un nove projecto.</para>
+	  </listitem>
+	  <listitem>
+		<para>Cambia le codice de lingua pro reflecter tu lingua fonte e de destination. Pulsa <guibutton>OK</guibutton>.</para>
+
+		<para>→ OmegaT creara un insimul de plicas que contine tu files. Illo alsi creara un memoria de traduction vacue que illo compilara in secunde plano, un segmento a cata vice dum tu scribe tu traduction. concordantias pro ille memoria finalmente apparera in le pannello de <guilabel>Concordantias partial</guilabel> pannello.</para>
+	  </listitem>
+	  <listitem>
+		<para>Clicca sur <guibutton>Adder Files...</guibutton> e adde le files que tu vole traducer. Claude le fenestra.</para>
+
+		<para>→ OmegaT copiara le files eligite in le projecto que tu ha create in le passo precedente. Illo ora te los monstra segmento per segmento pro traducer los.</para>
+	  </listitem>
+	  <listitem>
+		<para>Typa le traduction del prime segmento. Pulsa <keycap>Entrar</keycap>.</para>
+
+		<para>→ OmegaT registrara ille segmento in le memoria de traduction del projecto e movera le cursor al segmento successive.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Usa <guimenu>&gt; Projecto</guimenu><guimenuitem>&gt; Crear Files traducite</guimenuitem> pro quandocunque crear le documento traducite.</para>
+
+		<para>→ OmegaT immagazinara le files traducite in le plica <guilabel>target</guilabel> del projecto, que era create in le prime passo. Usa <guimenu>&gt; Projecto</guimenu> <guisubmenu>&gt; Acceder contentos del projecto</guisubmenu> pro acceder al files.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Si tu desidera saper plus, lege le manual del usator.</para>
+	  </listitem>
+	</orderedlist>
+	</para>
+  </section>
+
+  <section>
+	<title id="freedoms">Libertates de uso e modification</title>
+	<para>OmegaT es un application gratuite de traduction assistite per le computator (CAT), pro traductores professional. Il es distribuite sub le terminos del <emphasis>GNU General Public License, version 3.0</emphasis>. Vider <guimenu>&gt; Adjutar</guimenu> <guimenu>&gt; Re</guimenu>. Le licentia te concede le libertates sequente:<itemizedlist id="freedoms.list">
+	  <listitem>
+		<para>Le libertate de exequer OmegaT como tu desidera, pro qualcunque scopo.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Le libertate de studiar como OmegaT functiona, e cambiar lo assi que illo computa como tu desidera.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Le libertate de redistribuer copia assi que tu pote adjutar alteres.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Le libertate de distribuer copia de tu versiones modificate a alteres.</para>
+	  </listitem>
+	</itemizedlist>
+	</para>
+  </section>
+</article>

--- a/src_docs/greeting/it/First_Steps.xml
+++ b/src_docs/greeting/it/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="it" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/ja/First_Steps.xml
+++ b/src_docs/greeting/ja/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="ja" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/nl/First_Steps.xml
+++ b/src_docs/greeting/nl/First_Steps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <article lang="nl" id="first.steps">
   <title>OmegaT</title>
   <section>

--- a/src_docs/greeting/pt_BR/First_Steps.xml
+++ b/src_docs/greeting/pt_BR/First_Steps.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<article lang="en" id="first.steps">
+  <title>OmegaT</title>
+  <section>
+	<title id="first-steps">Primeiros passos</title>
+	<para>Pressione <keycap>F1</keycap> ou acesse o menu <guimenu>Ajuda do &gt;</guimenu> para abrir o manual do usuário. Ele vem com uma introdução completa ao OmegaT. Para começar a usar o OmegaT com configurações mínimas, faça o seguinte:<orderedlist id="first-step-list">
+	  <listitem>
+		<para>Use <guimenu>&gt; Projeto</guimenu> <guimenuitem>&gt; Novo...</guimenuitem> para criar um novo projeto.</para>
+	  </listitem>
+	  <listitem>
+		<para>Altere os códigos de idioma para refletir seus idiomas de origem e destino. Clique em <guibutton>OK.</guibutton></para>
+
+		<para>→ o OmegaT criará um conjunto de pastas que contém seus arquivos. Ele também criará uma memória de tradução vazia que preencherá o plano de fundo, um segmento por vez que você digitar sua tradução. As correspondências para essa memória eventualmente aparecerão no painel <guilabel>Correspondências Difusas</guilabel>.</para>
+	  </listitem>
+	  <listitem>
+		<para>Clique em <guibutton>Adicionar arquivos...</guibutton> e adicione os arquivos que deseja traduzir. Dispense a janela.</para>
+
+		<para>→ OmegaT copiará os arquivos selecionados para o projeto que você criou na etapa anterior. Agora ele os exibe segmento por segmento para você traduzi-los.</para>
+	  </listitem>
+	  <listitem>
+		<para>Digite a translação do primeiro segmento. Pressione <keycap>Enter</keycap>.</para>
+
+		<para>→ OmegaT registrará esse segmento na memória de tradução do projeto e moverá o cursor para o próximo segmento.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Use <guimenu>&gt; Projeto</guimenu><guimenuitem>&gt; Criar arquivos traduzidos</guimenuitem> para criar o documento traduzido a qualquer momento.</para>
+
+		<para>→ OmegaT armazenará os arquivos traduzidos na pasta de <guilabel>destino</guilabel> do projeto que foi criado na primeira etapa. Use <guimenu>&gt; projeto</guimenu> <guisubmenu>&gt; acessar o conteúdo do projeto</guisubmenu> para acessar os arquivos.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>Se quiser saber mais, leia o manual do usuário.</para>
+	  </listitem>
+	</orderedlist>
+	</para>
+  </section>
+
+  <section>
+	<title id="freedoms">Freedoms</title>
+	<para>O OmegaT é uma solução gratuita de tradução assistida por computador (CAT) para tradutores profissionais. sob as condições da <emphasis>Licença Pública Geral (GNU)  3.0 </emphasis> como publicado pela Consulte <guimenu>&gt; ajuda</guimenu> <guimenu>&gt; sobre</guimenu>. A licença concede a você as seguintes liberdades:<itemizedlist id="freedoms.list">
+	  <listitem>
+		<para>A liberdade de executar o OmegaT como desejar, para qualquer finalidade.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A liberdade de estudar como o OmegaT funciona e alterá-lo para que ele faça sua computação como você deseja.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A liberdade de redistribuir cópias para que você possa ajudar os outros.</para>
+	  </listitem>
+
+	  <listitem>
+		<para>A liberdade de distribuir cópias de suas versões modificadas para outras pessoas.</para>
+	  </listitem>
+	</itemizedlist>
+	</para>
+  </section>
+</article>

--- a/src_docs/greeting/zh_CN/First_Steps.xml
+++ b/src_docs/greeting/zh_CN/First_Steps.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<article lang="zh_CN" id="first.steps">
+  <title>OmegaT</title>
+  <section>
+	<title id="first-steps">第一步</title>
+	<para>按 <keycap>F1</keycap> 或访问 <guimenu>&gt; 帮助</guimenu>菜单来打开用户手册。它附带了对 OmegaT 的详细介绍。想用最少设置步骤就开始使用 OmegaT，如此进行：<orderedlist id="first-step-list">
+	  <listitem>
+		<para>用 <guimenu>&gt; 项目</guimenu> <guimenuitem>&gt; 新建...</guimenuitem> 来创建一个新项目。</para>
+	  </listitem>
+	  <listitem>
+		<para>更改语言代码以反映您的原文语言与译文语言。单击<guibutton>确定</guibutton>。</para>
+
+		<para>→ OmegaT 会创建一组文件夹，其中包含您的文件。它还会创建一个空的翻译记忆库，当你输入译文时，会在背景填充此文件，每次一个片段。该记忆项的匹配项最终会出现在<guilabel>模糊匹配</guilabel>窗格中。</para>
+	  </listitem>
+	  <listitem>
+		<para>单击<guibutton>添加文件...</guibutton>并添加要翻译的文件。关闭窗口。</para>
+
+		<para>→ OmegaT 会将选定的文件复制到上一步创建的项目中。现在它将逐段显示它们以供翻译。</para>
+	  </listitem>
+	  <listitem>
+		<para>输入第一个片段的翻译。按下<keycap>回车</keycap>。</para>
+
+		<para>→ OmegaT 会将此片段注册到项目的翻译记忆库中，并将光标移动到下一个片段。</para>
+	  </listitem>
+
+	  <listitem>
+		<para>随时都可以用 <guimenu>&gt; 项目</guimenu><guimenuitem>&gt; 创建译文文件</guimenuitem>来创建译文文档。</para>
+
+		<para>→ OmegaT 会将译文文件存储到第一步中创建的项目内的 <guilabel>target</guilabel> 文件夹中。使用 <guimenu>&gt; 项目</guimenu> <guisubmenu>&gt; 访问项目内容</guisubmenu>来访问这些文件。</para>
+	  </listitem>
+
+	  <listitem>
+		<para>如果想了解更多信息，请阅读用户手册。</para>
+	  </listitem>
+	</orderedlist>
+	</para>
+  </section>
+
+  <section>
+	<title id="freedoms">自由</title>
+	<para>OmegaT 是针对专业译者的自由计算机辅助翻译（CAT）解决方案。它是根据 <emphasis>GNU 通用公共许可证 3.0 版</emphasis>的条款分发的。参见 <guimenu>&gt; 帮助</guimenu> <guimenu>&gt; 关于</guimenu>。此许可证给予你以下自由：<itemizedlist id="freedoms.list">
+	  <listitem>
+		<para>出于任何目的，随心所欲地运行 OmegaT 的自由。</para>
+	  </listitem>
+
+	  <listitem>
+		<para>研究 OmegaT 如何工作、以及对其进行更改使其按照您的意愿进行计算的自由。</para>
+	  </listitem>
+
+	  <listitem>
+		<para>重新分发副本的自由，这样您就可以帮助其他人。</para>
+	  </listitem>
+
+	  <listitem>
+		<para>将修改后的版本的副本分发给其他人的自由。</para>
+	  </listitem>
+	</itemizedlist>
+	</para>
+  </section>
+</article>


### PR DESCRIPTION
Changed Doctype from 'book' to 'article' for all existing First_Steps translation files. Added new translations for Corsican, Interlingua, Portuguese (Brazil), and Chinese (Simplified). Updated gradle.properties to reflect the new languages.

## Pull request type

- Documentation -> [documentation]
- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

- Adding First Steps sources from L10N projects


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
