### PR TITLE
fix: EditrorArea3:  avoid NPE when detecting a carret position

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2546,7 +2546,7 @@ PREFS_TITLE_COLORS=Colours
 
 # EditorTextArea3
 ETA_WARNING_TAB_ADVANCE=<html><i>Preferences</i> &gt; <i>General</i> &gt; <i>Use TAB to advance</i> is checked</html>
-ETA_ERROR_BAD_LOCATION=Unexpected caret location is detected
+ETA_ERROR_BAD_LOCATION=Unexpected caret location detected
 # 0: Key shortcut text ("Ctrl+Shift+O")
 ETA_INFO_TOGGLE_LTR_RTL={0} toggles orientation between LTR, RTL, and language-dependent
 

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2546,6 +2546,7 @@ PREFS_TITLE_COLORS=Colours
 
 # EditorTextArea3
 ETA_WARNING_TAB_ADVANCE=<html><i>Preferences</i> &gt; <i>General</i> &gt; <i>Use TAB to advance</i> is checked</html>
+ETA_ERROR_BAD_LOCATION=Unexpected caret location is detected
 # 0: Key shortcut text ("Ctrl+Shift+O")
 ETA_INFO_TOGGLE_LTR_RTL={0} toggles orientation between LTR, RTL, and language-dependent
 

--- a/src/org/omegat/gui/editor/Document3.java
+++ b/src/org/omegat/gui/editor/Document3.java
@@ -40,6 +40,7 @@ import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
 
+import org.jetbrains.annotations.Nullable;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -55,8 +56,8 @@ public class Document3 extends DefaultStyledDocument {
     protected final EditorController controller;
 
     /** Position of active translation in text. */
-    Position activeTranslationBeginM1;
-    Position activeTranslationEndP1;
+    @Nullable Position activeTranslationBeginM1;
+    @Nullable Position activeTranslationEndP1;
 
     /**
      * Flag for check internal changes of content, which should be always
@@ -123,6 +124,9 @@ public class Document3 extends DefaultStyledDocument {
      * Calculate the position of the start of the current translation
      */
     public int getTranslationStart() {
+        if (activeTranslationBeginM1 == null) {
+            return 0;
+        }
         return activeTranslationBeginM1.getOffset() + 1;
     }
 
@@ -130,6 +134,9 @@ public class Document3 extends DefaultStyledDocument {
      * Calculate the position of the end of the current translation
      */
     protected int getTranslationEnd() {
+        if (activeTranslationEndP1 == null) {
+            return 0;
+        }
         return activeTranslationEndP1.getOffset() - 1;
     }
 
@@ -154,7 +161,7 @@ public class Document3 extends DefaultStyledDocument {
      *
      * @return active translation text
      */
-    String extractTranslation() {
+    @Nullable String extractTranslation() {
         if (!isEditMode()) {
             return null;
         }

--- a/src/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/org/omegat/gui/editor/EditorTextArea3.java
@@ -61,6 +61,7 @@ import javax.swing.text.Utilities;
 import javax.swing.text.View;
 import javax.swing.text.ViewFactory;
 
+import org.jetbrains.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.ProtectedPart;
@@ -225,7 +226,7 @@ public class EditorTextArea3 extends JEditorPane {
      * initialized with OmDocument, it will contain another Document
      * implementation. In this case, we don't need it.
      */
-    public Document3 getOmDocument() {
+    public @Nullable Document3 getOmDocument() {
         try {
             return (Document3) getDocument();
         } catch (ClassCastException ex) {
@@ -243,6 +244,9 @@ public class EditorTextArea3 extends JEditorPane {
     public boolean isInActiveTranslation(int position) {
         Document3 doc = getOmDocument();
         if (doc == null) {
+            return false;
+        }
+        if (!doc.isEditMode()) {
             return false;
         }
         return (position >= doc.getTranslationStart() && position <= doc.getTranslationEnd());

--- a/src/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/org/omegat/gui/editor/EditorTextArea3.java
@@ -237,8 +237,12 @@ public class EditorTextArea3 extends JEditorPane {
      * @return
      */
     public boolean isInActiveTranslation(int position) {
-        return (position >= getOmDocument().getTranslationStart()
-                && position <= getOmDocument().getTranslationEnd());
+        Document3  doc = getOmDocument();
+        if (doc == null) {
+            return false;
+        }
+        return (position >= doc.getTranslationStart()
+                && position <= doc.getTranslationEnd());
     }
 
     protected final transient MouseListener mouseListener = new MouseAdapter() {

--- a/src/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/org/omegat/gui/editor/EditorTextArea3.java
@@ -67,6 +67,7 @@ import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.autocompleter.AutoCompleter;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
+import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.Styles;
@@ -138,7 +139,8 @@ public class EditorTextArea3 extends JEditorPane {
     protected boolean lockCursorToInputArea = true;
 
     /**
-     * Flag indicating if the editor is in Insert (false) or Overwrite (true) mode.
+     * Flag indicating if the editor is in Insert (false) or Overwrite (true)
+     * mode.
      */
     protected boolean overtypeMode = false;
 
@@ -189,7 +191,7 @@ public class EditorTextArea3 extends JEditorPane {
                     CoreEvents.fireEditorNewWord(newWord);
                 }
             } catch (BadLocationException ex) {
-                ex.printStackTrace();
+                Log.logErrorRB(ex, "ETA_ERROR_BAD_LOCATION");
             }
         });
         setToolTipText("");
@@ -219,9 +221,9 @@ public class EditorTextArea3 extends JEditorPane {
     }
 
     /**
-     * Return OmDocument instead just a Document. If editor was not initialized
-     * with OmDocument, it will contains other Document implementation. In this
-     * case we don't need it.
+     * Return OmDocument instead just a Document. If the editor was not
+     * initialized with OmDocument, it will contain another Document
+     * implementation. In this case, we don't need it.
      */
     public Document3 getOmDocument() {
         try {
@@ -232,17 +234,18 @@ public class EditorTextArea3 extends JEditorPane {
     }
 
     /**
-     * Return true if the specified position is within the active translation
+     * Check the specified position is within the active translation.
+     * 
      * @param position
-     * @return
+     *            caret position
+     * @return true, when caret is in active translation, otherwise return false
      */
     public boolean isInActiveTranslation(int position) {
-        Document3  doc = getOmDocument();
+        Document3 doc = getOmDocument();
         if (doc == null) {
             return false;
         }
-        return (position >= doc.getTranslationStart()
-                && position <= doc.getTranslationEnd());
+        return (position >= doc.getTranslationStart() && position <= doc.getTranslationEnd());
     }
 
     protected final transient MouseListener mouseListener = new MouseAdapter() {
@@ -290,8 +293,7 @@ public class EditorTextArea3 extends JEditorPane {
         PopupMenuConstructorInfo[] cons;
         synchronized (popupConstructors) {
             /**
-             * Copy constructors - for disable blocking in the procesing
-             * time.
+             * Copy constructors - for disable blocking in the procesing time.
              */
             cons = popupConstructors.toArray(new PopupMenuConstructorInfo[popupConstructors.size()]);
         }
@@ -339,7 +341,7 @@ public class EditorTextArea3 extends JEditorPane {
             super.processKeyEvent(e);
             return;
         } else if (keyEvent == KeyEvent.KEY_TYPED) {
-            //key typed
+            // key typed
             super.processKeyEvent(e);
             return;
         }
@@ -355,11 +357,11 @@ public class EditorTextArea3 extends JEditorPane {
             // The AutoCompleter needs special treatment.
             processed = true;
         } else if (s.equals(KEYSTROKE_CONTEXT_MENU)) {
-            // Context Menu key for contextual (right-click) menu (Shift+Esc on Mac)
+            // Context Menu key for contextual (right-click) menu (Shift+Esc on
+            // Mac)
             JPopupMenu popup = makePopupMenu(getCaretPosition());
             if (popup.getComponentCount() > 0) {
-                popup.show(EditorTextArea3.this,
-                        (int) getCaret().getMagicCaretPosition().getX(),
+                popup.show(EditorTextArea3.this, (int) getCaret().getMagicCaretPosition().getX(),
                         (int) getCaret().getMagicCaretPosition().getY());
                 processed = true;
             }
@@ -480,14 +482,16 @@ public class EditorTextArea3 extends JEditorPane {
                 }
             }
             super.processKeyEvent(e);
-            // note that the translation start/end position are not updated yet. This has been updated when
-            // then keyreleased event occurs.
+            // Note that the translation start/end position are not updated yet.
+            // This has been updated when key-released event occurs.
         }
 
         // some after-processing catches
         if (!processed && e.getKeyChar() != 0 && isNavigationKey(e.getKeyCode())) {
-            // if caret is moved over existing chars, check and fix caret position
-            // works only in after-processing if translation length (start and end position) has not changed,
+            // if caret is moved over existing chars, check and fix caret
+            // position
+            // works only in after-processing if translation length (start and
+            // end position) has not changed,
             // because start and end position are not updated yet.
             checkAndFixCaret(false);
             autoCompleter.updatePopup(true);
@@ -498,7 +502,8 @@ public class EditorTextArea3 extends JEditorPane {
         String lock = OStrings.getString("MW_STATUS_CURSOR_LOCK_" + (lockCursorToInputArea ? "ON" : "OFF"));
         String ins = OStrings.getString("MW_STATUS_CURSOR_OVERTYPE_" + (overtypeMode ? "ON" : "OFF"));
 
-        String lockTip = OStrings.getString("MW_STATUS_TIP_CURSOR_LOCK_" + (lockCursorToInputArea ? "ON" : "OFF"));
+        String lockTip = OStrings
+                .getString("MW_STATUS_TIP_CURSOR_LOCK_" + (lockCursorToInputArea ? "ON" : "OFF"));
         String insTip = OStrings.getString("MW_STATUS_TIP_CURSOR_OVERTYPE_" + (overtypeMode ? "ON" : "OFF"));
         Core.getMainWindow().showLockInsertMessage(lock + " | " + ins, lockTip + " | " + insTip);
     }
@@ -512,8 +517,8 @@ public class EditorTextArea3 extends JEditorPane {
             setCaretColor(Styles.EditorColor.COLOR_BACKGROUND.getColor());
             putClientProperty("caretWidth", getCaretWidth());
 
-            // We need to force the caret damage to have the rectangle to correctly show up,
-            // otherwise half of the caret is shown.
+            // We need to force the caret damage to have the rectangle to
+            // correctly show up, otherwise half of the caret is shown.
             try {
                 OvertypeCaret caret = (OvertypeCaret) getCaret();
                 Rectangle r = modelToView2D(caret.getDot()).getBounds();
@@ -567,7 +572,8 @@ public class EditorTextArea3 extends JEditorPane {
             return false;
         }
         if ((caret == start && !checkTagStart) || (caret == end && checkTagStart)) {
-            // We are at the edge of the translation but moving toward the outside.
+            // We are at the edge of the translation but moving toward the
+            // outside.
             // Don't try to jump over tags.
             return false;
         }


### PR DESCRIPTION
NPE is reported when using OmegaT 6.1 weekly when RTL languages.


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- 
## Which ticket is resolved?

- Uncaught exception in weekly build (2025-01-18) 
- https://sourceforge.net/p/omegat/bugs/1280/

- Dev-ML thread

https://sourceforge.net/p/omegat/mailman/omegat-development/thread/bc__wDAb_8HhKI8874uzACXxlNkr1AsqREJeuM1f7MRE6sbjXIHjLerxgavXTTEOUFbSSBf3mn7Dxybdx9uqCx4Q-LWCvrd1xSvAlyN-M0c%3D%40northside.tokyo/#msg59161278

## What does this PR change?

- Check nullity of the return value of EditorArea3#getOmDocument
- Improve javadoc 
- Improve error log

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
