### PR TITLE
Fix: null check in saveWordLists method of SpellChecker

### DIFF
--- a/src/org/omegat/core/spellchecker/AbstractSpellChecker.java
+++ b/src/org/omegat/core/spellchecker/AbstractSpellChecker.java
@@ -225,6 +225,9 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
      * Save the word lists to disk
      */
     public void saveWordLists() {
+        if (ignoreFilePath == null || learnedFilePath == null) {
+            return;
+        }
         // Write the ignored and learned words to the disk
         try {
             Files.write(ignoreFilePath, ignoreList);


### PR DESCRIPTION
Add a safeguard to prevent potential NullPointerException in the saveWordLists method by ensuring file paths are not null before proceeding. This ensures stability when saving ignored and learned words.


## Pull request type


Please mark the GitHub LABEL of the change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Spellchecker raised NPE when writing word list file
- https://sourceforge.net/p/omegat/bugs/1288/

## What does this PR change?

- Null check for the ignore words file and the learned file path on the saveWordLists method


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
