### PR TITLE
refactor(Core): Make editor, saveThread, and glossary package-private

### DIFF
--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -100,6 +100,7 @@ public final class Core {
 
     private static IProject currentProject;
     private static IMainWindow mainWindow;
+    // package-private for test fixture TestCoreInitializer
     static IEditor editor;
     private static ITagValidation tagValidation;
     private static IIssues issuesWindow;
@@ -107,9 +108,11 @@ public final class Core {
     private static FilterMaster filterMaster;
     private static IProjectFilesList projWin;
 
+    // package-private for test fixture TestCoreInitializer
     static IAutoSave saveThread;
     private static final ReentrantLock EXCLUSIVE_RUN_LOCK = new ReentrantLock();
 
+    // package-private for test fixture TestCoreInitializer
     static IGlossaries glossary;
     private static GlossaryManager glossaryManager;
     private static MachineTranslateTextArea machineTranslatePane;

--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -100,17 +100,17 @@ public final class Core {
 
     private static IProject currentProject;
     private static IMainWindow mainWindow;
-    protected static IEditor editor;
+    static IEditor editor;
     private static ITagValidation tagValidation;
     private static IIssues issuesWindow;
     private static IMatcher matcher;
     private static FilterMaster filterMaster;
     private static IProjectFilesList projWin;
 
-    protected static IAutoSave saveThread;
+    static IAutoSave saveThread;
     private static final ReentrantLock EXCLUSIVE_RUN_LOCK = new ReentrantLock();
 
-    protected static IGlossaries glossary;
+    static IGlossaries glossary;
     private static GlossaryManager glossaryManager;
     private static MachineTranslateTextArea machineTranslatePane;
     private static DictionariesTextArea dictionaries;


### PR DESCRIPTION
Refactor access modifiers for `editor`, `saveThread`, and `glossary` from `protected` to package-private. This simplifies access control and aligns with typical encapsulation practices within the package. No functional changes were introduced.

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Other (describe below)
refactor - adjust for spotbugss warnings

## Which ticket is resolved?

## What does this PR change?

-This Pull Request modifies the access modifiers of several class fields in the Core.java file, changing them from protected to default (package-private) scope.
    - Access modifiers for editor, saveThread, and glossary were updated from protected to default (package-private).
    - No additional changes like new logic or features were introduced in the code. It is purely a refactoring of access levels.
- There is only one user class, `TestCoreInitializer` that does not inherit but access in same package.


## Other information

#1296
