### PR TITLE
refactor: adjust custom exception class not to expose internal object

### DIFF
--- a/src/org/omegat/core/KnownException.java
+++ b/src/org/omegat/core/KnownException.java
@@ -24,8 +24,11 @@
  **************************************************************************/
 package org.omegat.core;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
+
+import java.util.Arrays;
 
 /**
  * Know exception for some problems.
@@ -47,7 +50,7 @@ public class KnownException extends RuntimeException {
     }
 
     public Object[] getParams() {
-        return params;
+        return Arrays.copyOf(params, params.length, Object[].class);
     }
 
     @Override

--- a/src/org/omegat/core/KnownException.java
+++ b/src/org/omegat/core/KnownException.java
@@ -24,7 +24,6 @@
  **************************************************************************/
 package org.omegat.core;
 
-import org.jspecify.annotations.Nullable;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 

--- a/src/org/omegat/core/KnownException.java
+++ b/src/org/omegat/core/KnownException.java
@@ -27,7 +27,8 @@ package org.omegat.core;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Know exception for some problems.
@@ -36,24 +37,28 @@ import java.util.Arrays;
  */
 @SuppressWarnings("serial")
 public class KnownException extends RuntimeException {
-    protected final Object[] params;
+    protected final List<Object> parameters = new ArrayList<>(0);
 
     public KnownException(String errorCode, Object... params) {
         super(errorCode);
-        this.params = params;
+        if (params != null) {
+            this.parameters.addAll(List.of(params));
+        }
     }
 
     public KnownException(Throwable ex, String errorCode, Object... params) {
         super(errorCode, ex);
-        this.params = params;
+        if (params != null) {
+            this.parameters.addAll(List.of(params));
+        }
     }
 
     public Object[] getParams() {
-        return Arrays.copyOf(params, params.length, Object[].class);
+        return parameters.toArray();
     }
 
     @Override
     public String getLocalizedMessage() {
-        return StringUtil.format(OStrings.getString(getMessage()), params);
+        return StringUtil.format(OStrings.getString(getMessage()), parameters);
     }
 }

--- a/test/src/org/omegat/core/KnownExceptionTest.java
+++ b/test/src/org/omegat/core/KnownExceptionTest.java
@@ -1,0 +1,60 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.omegat.util.LocaleRule;
+import org.omegat.util.OStrings;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class KnownExceptionTest {
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+
+    @Test
+    public void testExceptions() {
+        // Call constructor with error code and parameters
+        KnownException ex1 = new KnownException("TF_ERROR", "param1", "param2");
+        assertEquals(2, ex1.getParams().length);
+        assertEquals("param1", ex1.getParams()[0]);
+        assertEquals("param2", ex1.getParams()[1]);
+        // Usage of <code>OStrings.getString(ex1.getMessage(), ex1.getParams())</code>
+        assertEquals("TF_ERROR", ex1.getMessage());
+        assertEquals(OStrings.getString("TF_ERROR"), ex1.getLocalizedMessage());
+
+        // Call constructor with throwable, error code, and parameters
+        KnownException ex2 = new KnownException(new RuntimeException("Cause"), "TF_ERROR", "param1", "param2");
+        assertEquals(2, ex2.getParams().length);
+        assertEquals("param1", ex2.getParams()[0]);
+        assertEquals("param2", ex2.getParams()[1]);
+        assertEquals(OStrings.getString("TF_ERROR"), ex2.getLocalizedMessage());
+        assertEquals("Cause", ex2.getCause().getMessage());
+    }
+
+}


### PR DESCRIPTION
This change make getparams method of KnownException class returns copy of a array of object. It reduces the risk of exposing internal fields.


## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?


## What does this PR change?

- Added a @Nullable annotation for better null-safety awareness.
- Modified the getParams() method to return a copy of the params array for immutability and preventing potential side effects.
- Introduced additional imports to support the changes (e.g., Arrays and Nullable).

## Other information

#1296
