### PR TITLE
refactor: adjust spotbugs warnings on RepositoriesCredentialsPanel GUI parts visibility

### DIFF
--- a/src/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.form
+++ b/src/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.form
@@ -28,6 +28,7 @@
   <SubComponents>
     <Container class="javax.swing.JScrollPane" name="jScrollPane2">
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
 
@@ -43,10 +44,16 @@
               <Connection code="null" type="code"/>
             </Property>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="jPanel2">
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+      </AuxValues>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
         <Property name="axis" type="int" value="3"/>
@@ -59,6 +66,9 @@
             </Property>
             <Property name="enabled" type="boolean" value="false"/>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.Box$Filler" name="filler1">
           <Properties>
@@ -67,6 +77,7 @@
             </Property>
           </Properties>
           <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
             <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.VerticalGlue"/>
           </AuxValues>
         </Component>

--- a/src/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.java
+++ b/src/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.java
@@ -77,10 +77,10 @@ public class RepositoriesCredentialsPanel extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    public javax.swing.JButton btnRemove;
-    public javax.swing.Box.Filler filler1;
-    public javax.swing.JPanel jPanel2;
-    public javax.swing.JScrollPane jScrollPane2;
-    public javax.swing.JTable list;
+    javax.swing.JButton btnRemove;
+    private javax.swing.Box.Filler filler1;
+    private javax.swing.JPanel jPanel2;
+    javax.swing.JScrollPane jScrollPane2;
+    javax.swing.JTable list;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

-
```
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field 
org.omegat.core.team2.gui.RepositoriesCredentialsPanel.btnRemove is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesCredentialsPanel.java:[line 55]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.core.team2.gui.RepositoriesCredentialsPanel.filler1 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesCredentialsPanel.java:[line 56]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.core.team2.gui.RepositoriesCredentialsPanel.jPanel2 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesCredentialsPanel.java:[line 54]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.core.team2.gui.RepositoriesCredentialsPanel.jScrollPane2 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesCredentialsPanel.java:[line 52]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.core.team2.gui.RepositoriesCredentialsPanel.list is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesCredentialsPanel.java:[line 53]
```


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
