### PR TITLE
refactor: adjust spotbugs warnings on RepositoriesMappingDialog GUI parts visibility

### DIFF
--- a/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.form
+++ b/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.form
@@ -38,6 +38,9 @@
           </Border>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+      </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
           <BorderConstraints direction="Center"/>
@@ -56,6 +59,9 @@
               </Border>
             </Property>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+          </AuxValues>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
           <SubComponents>
@@ -65,6 +71,9 @@
                   <ResourceString bundle="org/omegat/Bundle.properties" key="RMD_TABLE_REPOSITORIES" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                 </Property>
               </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+              </AuxValues>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                   <BorderConstraints direction="North"/>
@@ -73,6 +82,7 @@
             </Component>
             <Container class="javax.swing.JScrollPane" name="jScrollPane1">
               <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
                 <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
               </AuxValues>
               <Constraints>
@@ -91,10 +101,16 @@
                       <JTableSelectionModel selectionMode="0"/>
                     </Property>
                   </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                  </AuxValues>
                 </Component>
               </SubComponents>
             </Container>
             <Container class="javax.swing.JPanel" name="jPanel5">
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+              </AuxValues>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                   <BorderConstraints direction="East"/>
@@ -104,6 +120,9 @@
               <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
               <SubComponents>
                 <Container class="javax.swing.JPanel" name="jPanel6">
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+                  </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                       <BorderConstraints direction="Center"/>
@@ -118,6 +137,9 @@
                           <ResourceString bundle="org/omegat/Bundle.properties" key="RMD_BTN_ADD" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                         </Property>
                       </Properties>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                      </AuxValues>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                           <GridBagConstraints gridX="2" gridY="1" gridWidth="-1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
@@ -131,6 +153,12 @@
                         </Property>
                         <Property name="enabled" type="boolean" value="false"/>
                       </Properties>
+                      <Events>
+                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRepoRemoveActionPerformed"/>
+                      </Events>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                      </AuxValues>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                           <GridBagConstraints gridX="2" gridY="2" gridWidth="-1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
@@ -144,6 +172,9 @@
           </SubComponents>
         </Container>
         <Container class="javax.swing.JPanel" name="jPanel4">
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+          </AuxValues>
 
           <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
           <SubComponents>
@@ -153,6 +184,9 @@
                   <ResourceString bundle="org/omegat/Bundle.properties" key="RMD_TABLE_MAPPING" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                 </Property>
               </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+              </AuxValues>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                   <BorderConstraints direction="North"/>
@@ -161,6 +195,7 @@
             </Component>
             <Container class="javax.swing.JScrollPane" name="jScrollPane2">
               <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
                 <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
               </AuxValues>
               <Constraints>
@@ -179,10 +214,16 @@
                       <JTableSelectionModel selectionMode="0"/>
                     </Property>
                   </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                  </AuxValues>
                 </Component>
               </SubComponents>
             </Container>
             <Container class="javax.swing.JPanel" name="jPanel7">
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+              </AuxValues>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                   <BorderConstraints direction="East"/>
@@ -192,6 +233,9 @@
               <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
               <SubComponents>
                 <Container class="javax.swing.JPanel" name="jPanel8">
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+                  </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                       <BorderConstraints direction="Center"/>
@@ -207,6 +251,9 @@
                         </Property>
                         <Property name="enabled" type="boolean" value="false"/>
                       </Properties>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                      </AuxValues>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                           <GridBagConstraints gridX="2" gridY="7" gridWidth="-1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
@@ -220,6 +267,9 @@
                         </Property>
                         <Property name="enabled" type="boolean" value="false"/>
                       </Properties>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                      </AuxValues>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                           <GridBagConstraints gridX="2" gridY="6" gridWidth="-1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
@@ -242,6 +292,9 @@
           </Border>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+      </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
           <BorderConstraints direction="South"/>
@@ -251,6 +304,9 @@
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
       <SubComponents>
         <Container class="javax.swing.JPanel" name="jPanel1">
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="2"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
               <BorderConstraints direction="East"/>
@@ -265,6 +321,9 @@
                   <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_OK" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                 </Property>
               </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
             </Component>
             <Component class="javax.swing.JButton" name="cancelButton">
               <Properties>
@@ -272,6 +331,9 @@
                   <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_CANCEL" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
                 </Property>
               </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
             </Component>
           </SubComponents>
         </Container>

--- a/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
+++ b/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
@@ -109,6 +109,11 @@ public class RepositoriesMappingDialog extends javax.swing.JDialog {
 
         org.openide.awt.Mnemonics.setLocalizedText(btnRepoRemove, OStrings.getString("RMD_BTN_REMOVE")); // NOI18N
         btnRepoRemove.setEnabled(false);
+        btnRepoRemove.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnRepoRemoveActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 2;
@@ -185,27 +190,31 @@ public class RepositoriesMappingDialog extends javax.swing.JDialog {
         pack();
     }// </editor-fold>//GEN-END:initComponents
 
+    private void btnRepoRemoveActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRepoRemoveActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_btnRepoRemoveActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    public javax.swing.JButton btnMappingAdd;
-    public javax.swing.JButton btnMappingRemove;
-    public javax.swing.JButton btnRepoAdd;
-    public javax.swing.JButton btnRepoRemove;
-    public javax.swing.JButton cancelButton;
-    public javax.swing.JLabel jLabel1;
-    public javax.swing.JLabel jLabel2;
-    public javax.swing.JPanel jPanel1;
-    public javax.swing.JPanel jPanel2;
-    public javax.swing.JPanel jPanel3;
-    public javax.swing.JPanel jPanel4;
-    public javax.swing.JPanel jPanel5;
-    public javax.swing.JPanel jPanel6;
-    public javax.swing.JPanel jPanel7;
-    public javax.swing.JPanel jPanel8;
-    public javax.swing.JPanel jPanel9;
-    public javax.swing.JScrollPane jScrollPane1;
-    public javax.swing.JScrollPane jScrollPane2;
-    public javax.swing.JButton okButton;
-    public javax.swing.JTable tableMapping;
-    public javax.swing.JTable tableRepositories;
+    javax.swing.JButton btnMappingAdd;
+    javax.swing.JButton btnMappingRemove;
+    javax.swing.JButton btnRepoAdd;
+    javax.swing.JButton btnRepoRemove;
+    javax.swing.JButton cancelButton;
+    private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
+    private javax.swing.JPanel jPanel1;
+    private javax.swing.JPanel jPanel2;
+    private javax.swing.JPanel jPanel3;
+    private javax.swing.JPanel jPanel4;
+    private javax.swing.JPanel jPanel5;
+    private javax.swing.JPanel jPanel6;
+    private javax.swing.JPanel jPanel7;
+    private javax.swing.JPanel jPanel8;
+    private javax.swing.JPanel jPanel9;
+    javax.swing.JScrollPane jScrollPane1;
+    javax.swing.JScrollPane jScrollPane2;
+    javax.swing.JButton okButton;
+    javax.swing.JTable tableMapping;
+    javax.swing.JTable tableRepositories;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

-
- fix the following SpotBugs Errors.
```
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.btnMappingAdd is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 71]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.btnMappingRemove is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 70]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.btnRepoAdd is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 62]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.btnRepoRemove is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 63]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.cancelButton is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 75]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jLabel1 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 57]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jLabel2 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 65]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel1 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 73]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel2 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 55]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel3 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 56]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel4 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 64]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel5 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 60]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel6 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 61]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel7 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 68]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel8 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 69]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jPanel9 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 72]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jScrollPane1 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 58]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.jScrollPane2 is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 66]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.okButton is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingDialog.java:[line 74]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.tableMapping is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingController.java:[line 332]	
M B PA_PUBLIC_PRIMITIVE_ATTRIBUTE PA: Primitive field org.omegat.gui.dialogs.RepositoriesMappingDialog.tableRepositories is public and set from inside the class, which makes it too exposed. Consider making it private to limit external accessibility. At RepositoriesMappingController.java:[line 326]	

```

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
#1296