### PR TITLE
Refactor Google Translate response handling to use JsonNode.

### DIFF
--- a/machinetranslators/google/src/main/java/org/omegat/machinetranslators/google/Google2Translate.java
+++ b/machinetranslators/google/src/main/java/org/omegat/machinetranslators/google/Google2Translate.java
@@ -30,13 +30,13 @@
 package org.omegat.machinetranslators.google;
 
 import java.awt.Window;
-import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TreeMap;
 
 import javax.swing.JCheckBox;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import tokyo.northside.logging.ILogger;
 import tokyo.northside.logging.LoggerFactory;
@@ -81,7 +81,6 @@ public class Google2Translate extends BaseCachedTranslate {
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle(BUNDLE_BASENAME);
     private static final ILogger LOGGER = LoggerFactory.getLogger(Google2Translate.class, BUNDLE);
 
-
     /**
      * Register plugins into OmegaT.
      */
@@ -98,8 +97,11 @@ public class Google2Translate extends BaseCachedTranslate {
 
     /**
      * Constructor for test.
-     * @param baseUrl custom url.
-     * @param key temprary key.
+     * 
+     * @param baseUrl
+     *            custom url.
+     * @param key
+     *            temprary key.
      */
     public Google2Translate(String baseUrl, String key) {
         googleTranslateUrl = baseUrl + GT_PATH;
@@ -204,10 +206,12 @@ public class Google2Translate extends BaseCachedTranslate {
     protected String getJsonResults(String json) throws MachineTranslateError {
         ObjectMapper mapper = new ObjectMapper();
         try {
-            Response response = mapper.readValue(json, Response.class);
-            List<Translation> translations = response.getData().getTranslations();
-            if (translations.size() > 0) {
-                return translations.get(0).getTranslatedText();
+            JsonNode root = mapper.readTree(json);
+            if (root != null && root.get("error") == null) {
+                var translations = root.get("data").get("translations");
+                if (translations != null && !translations.isEmpty()) {
+                    return translations.get(0).get("translatedText").asText();
+                }
             }
         } catch (Exception e) {
             LOGGER.atError().setCause(e).setMessageRB("MT_JSON_ERROR").log();
@@ -274,86 +278,5 @@ public class Google2Translate extends BaseCachedTranslate {
         dialog.panel.itemsPanel.add(premiumCheckBox);
 
         dialog.show();
-    }
-
-    /**
-     * Data schema class for Google2 translate API response.
-     */
-    public static final class Response {
-        private Data data;
-
-        public Data getData() {
-            return data;
-        }
-
-        public void setData(Data data) {
-            this.data = data;
-        }
-
-        @Override
-        public String toString() {
-            return "Response{" + "data=" + data + '}';
-        }
-    }
-
-    /**
-     * Data schema class.
-     */
-    public static final class Data {
-        private List<Translation> translations;
-
-        public List<Translation> getTranslations() {
-            return translations;
-        }
-
-        public void setTranslations(List<Translation> translations) {
-            this.translations = translations;
-        }
-
-        @Override
-        public String toString() {
-            return "Data{" + "translations=" + translations + '}';
-        }
-    }
-
-    /**
-     * Data schema class.
-     */
-    public static final class Translation {
-        private String translatedText;
-        private String detectedSourceLanguage;
-        private String model;
-
-        public String getTranslatedText() {
-            return translatedText;
-        }
-
-        public void setTranslatedText(String translatedText) {
-            this.translatedText = translatedText;
-        }
-
-        public String getDetectedSourceLanguage() {
-            return detectedSourceLanguage;
-        }
-
-        public void setDetectedSourceLanguage(String detectedSourceLanguage) {
-            this.detectedSourceLanguage = detectedSourceLanguage;
-        }
-
-        public String getModel() {
-            return model;
-        }
-
-        public void setModel(final String model) {
-            this.model = model;
-        }
-
-        @Override
-        public String toString() {
-            return "Translation{"
-                    + "translatedText='" + translatedText + '\''
-                    + ", detectedSourceLanguage='" + detectedSourceLanguage + '\''
-                    + ", model='" + model + '\'' + '}';
-        }
     }
 }


### PR DESCRIPTION
Removed nested static classes and replaced the response parsing logic with JsonNode for improved flexibility and reduced complexity. Updated translation extraction to handle null checks more effectively and ensure robust error handling.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

- Fix the following SpotBugs errors
```
M V EI_EXPOSE_REP EI: org.omegat.machinetranslators.google.Google2Translate$Data.getTranslations() may expose internal representation by returning Google2Translate$Data.translations At Google2Translate.java:[line 306]	
M V EI_EXPOSE_REP2 EI2: org.omegat.machinetranslators.google.Google2Translate$Data.setTranslations(List) may expose internal representation by storing an externally mutable object into Google2Translate$Data.translations At Google2Translate.java:[line 310]	
M V EI_EXPOSE_REP EI: org.omegat.machinetranslators.google.Google2Translate$Response.getData() may expose internal representation by returning Google2Translate$Response.data At Google2Translate.java:[line 286]	
M V EI_EXPOSE_REP2 EI2: org.omegat.machinetranslators.google.Google2Translate$Response.setData(Google2Translate$Data) may expose internal representation by storing an externally mutable object into Google2Translate$Response.data At Google2Translate.java:[line 290]
```


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
