### PR TITLE
refactor: define enum value by getString and avoid dynamic key for bundle lookup

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -226,8 +226,7 @@ OUT_OF_MEMORY=OmegaT ran out of memory and will close when you click OK.\n\
     line or in the OmegaT start script;\n\
     The current setting is {0}MB;\n\
     \n\
-    See "How To... Run OmegaT" in the user manual.\n\
-
+    See "How To... Run OmegaT" in the user manual.
 # 0: JVM version number e.g. 1.6.0_65
 # 1: JVM bitness (32 or 64)
 JAVA_VERSION=Running on Java {0} ({1}-bit)
@@ -2894,7 +2893,7 @@ PREFS_PLUGINS_CONFIRM_UPGRADE=Upgrade the {0} plugin?\n\
    Current version: {1}\n\
    New version: {2}
 PREFS_PLUGINS_CONFIRM_OVERWRITE=Version {1} is already installed.\n\
-   Reinstall the {0} plugin?\n
+   Reinstall the {0} plugin?
 PREFS_PLUGINS_CONFIRM_INSTALL=Install the {0} {1} plugin?
 PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
 PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Restart OmegaT to activate it.
@@ -2949,7 +2948,7 @@ SOURCE_TOKENIZER=Source tokenizer: {0}
 TARGET_TOKENIZER=Target tokenizer: {0}
 EXECUTING_COMMAND=Executing command: {0}
 DICTIONARY_LOAD_FILE=Loaded dictionary from '{0}': {1} ms
-DICTIONARY_LOAD_ERROR=Error load dictionary from '{0}': {1} 
+DICTIONARY_LOAD_ERROR=Error load dictionary from '{0}': {1}
 DICTIONARY_MANAGER_ERROR_SAVE_IGNORE=Error saving ignore words"
 EDITOR_CONTROLLER_EXCEPTION=bad location exception when changing case
 

--- a/src/org/omegat/externalfinder/item/ExternalFinderItem.java
+++ b/src/org/omegat/externalfinder/item/ExternalFinderItem.java
@@ -49,24 +49,61 @@ public final class ExternalFinderItem {
 
     public enum TARGET {
 
-        // default BOTH for URL and command
-        ASCII_ONLY, NON_ASCII_ONLY, BOTH;
+        /**
+         * search ascii only.
+         */
+        ASCII_ONLY(OStrings.getString("EXTERNALFINDER_TARGET_ASCII_ONLY")),
+        /**
+         * Search non ascii only.
+         */
+        NON_ASCII_ONLY(OStrings.getString("EXTERNALFINDER_TARGET_NON_ASCII_ONLY")),
+        /**
+         * Search BOTH.
+         * <p>
+         * It is default for URL and command lookups.
+         */
+        BOTH(OStrings.getString("EXTERNALFINDER_TARGET_BOTH"));
+
+        TARGET(String value) {
+            this.value = value;
+        }
+
+        private final String value;
 
         @Override
         public String toString() {
-            return OStrings.getString("EXTERNALFINDER_TARGET_" + name());
+            return value;
         }
     }
 
     public enum ENCODING {
 
-        // default DEFAULT for URL
-        // default NONE for command
-        DEFAULT, ESCAPE, NONE;
+        /**
+         * Default encoding.
+         * <p>
+         * It is a default for URL.
+         */
+        DEFAULT(OStrings.getString("EXTERNALFINDER_ENCODING_DEFAULT")),
+        /**
+         * Escape encoding.
+         */
+        ESCAPE(OStrings.getString("EXTERNALFINDER_ENCODING_ESCAPE")),
+        /**
+         * No encoding.
+         * <p>
+         * It is a default for command.
+         */
+        NONE(OStrings.getString("EXTERNALFINDER_ENCODING_NONE"));
+
+        ENCODING(String value) {
+            this.value = value;
+        }
+
+        private final String value;
 
         @Override
         public String toString() {
-            return OStrings.getString("EXTERNALFINDER_ENCODING_" + name());
+            return value;
         }
     }
 


### PR DESCRIPTION
- ExternalFinder construct bundle key from enum name. This is to avoid a dynamic key and use enum ctor to define value.
- Add javadoc for enum entries

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

## What does this PR change?

-
-
-

## Other information

