### PR TITLE
fix: acceptance-test: 'MatchesTextAreaTest' to prepare temporary project directory

### DIFF
--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -25,9 +25,12 @@
 
 package org.omegat.gui.matches;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,5 +60,14 @@ public class MatchesTextAreaTest extends TestCoreGUI {
                         "MATCHES_VAR_EXPANSION_MATCH_COMES_FROM_MEMORY") + "\\s*>");
         window.textBox("matches_pane").requireText(pattern);
         closeProject();
+    }
+
+    @Override
+    protected void onSetUp() throws Exception {
+        super.onSetUp();
+        tmpDir = Files.createTempDirectory("omegat-sample-project-").toFile();
+        File projSrc = new File(PROJECT_PATH);
+        FileUtils.copyDirectory(projSrc, tmpDir);
+        FileUtils.forceDeleteOnExit(tmpDir);
     }
 }


### PR DESCRIPTION

## Pull request type
- Other (describe below)
 refactor

## Which ticket is resolved?

There is no issue to point.

## What does this PR change?

- When running acceptance test, it does not open the sample project directory, but copy project files into temporary directory and open.
- The test changes the files to be opened. It cause second test become failure.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
