### PR TITLE
fix: GlossaryTextArea listener invoking menu handler and test menu action mapping for invokeAction call

### DIFF
--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -37,8 +37,6 @@ import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -109,7 +107,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
      * Currently processed entry. Used to detect if user moved into new entry.
      * In this case, new find should be started.
      */
-    protected StringEntry processedEntry;
+    protected transient StringEntry processedEntry;
 
     /**
      * Holds the current GlossaryEntries for the TransTips
@@ -134,7 +132,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         setMinimumSize(new Dimension(100, 50));
         setName(TEXTPANE_NAME);
 
-        addMouseListener(mouseListener);
+        addMouseListener(myMouseListener);
 
         Core.getEditor().registerPopupMenuConstructors(300, new TransTipsPopup());
 
@@ -270,7 +268,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     /**
      * MouseListener for the GlossaryTextArea.
      */
-    protected final transient MouseListener mouseListener = new MouseAdapter() {
+    protected final transient MouseListener myMouseListener = new MouseAdapter() {
         @Override
         public void mousePressed(MouseEvent e) {
             if (e.isPopupTrigger()) {
@@ -298,12 +296,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         final String selection = getSelectedText();
         JMenuItem item = popup.add(OStrings.getString("GUI_GLOSSARYWINDOW_insertselection"));
         item.setEnabled(projectLoaded && !StringUtil.isEmpty(selection));
-        item.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                Core.getEditor().insertText(selection);
-            }
-        });
+        item.addActionListener(e -> Core.getEditor().insertText(selection));
         item = popup.add(OStrings.getString("GUI_GLOSSARYWINDOW_addentry"));
         item.setEnabled(projectLoaded);
         item.addActionListener(
@@ -344,6 +337,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         dialog.addWindowFocusListener(new WindowFocusListener() {
             @Override
             public void windowLostFocus(WindowEvent e) {
+                // nothing to do
             }
 
             @Override
@@ -411,13 +405,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         populateContextMenu(menu);
         menu.addSeparator();
         final JMenuItem openFile = new JMenuItem(OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_OPEN_FILE"));
-        openFile.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                Core.getMainWindow().getMainMenu().invokeAction("projectAccessWritableGlossaryMenuItem",
-                        e.getModifiers());
-            }
-        });
+        openFile.addActionListener(e -> Core.getMainWindow().getMainMenu().invokeAction("projectAccessWriteableGlossaryMenuItem",
+                e.getModifiers()));
         openFile.setEnabled(false);
         if (Core.getProject().isProjectLoaded()) {
             String glossaryPath = Core.getProject().getProjectProperties().getWriteableGlossary();
@@ -428,12 +417,7 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         final JMenuItem notify = new JCheckBoxMenuItem(
                 OStrings.getString("GUI_GLOSSARYWINDOW_SETTINGS_NOTIFICATIONS"));
         notify.setSelected(Preferences.isPreference(Preferences.NOTIFY_GLOSSARY_HITS));
-        notify.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                Preferences.setPreference(Preferences.NOTIFY_GLOSSARY_HITS, notify.isSelected());
-            }
-        });
+        notify.addActionListener(e -> Preferences.setPreference(Preferences.NOTIFY_GLOSSARY_HITS, notify.isSelected()));
         menu.add(notify);
         menu.addSeparator();
         final JMenuItem sortOrderSrcLength = new JCheckBoxMenuItem(

--- a/test/src/org/omegat/gui/main/MainWindowMenuTest.java
+++ b/test/src/org/omegat/gui/main/MainWindowMenuTest.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION

Fix the bug reported.

## Pull request type

- Bug fix -> [bug]
- Refactoring
- 
## Which ticket is resolved?

- Mismatch in method name causes exception when selecting "Open Writable Glossary File"
- https://sourceforge.net/p/omegat/bugs/1290/


## What does this PR change?

- Refactored action listeners: Converted anonymous inner classes for event listeners into lambda expressions for better readability.
- Renamed variables: Updated variable names (mouseListener to myMouseListener, etc.) to align with naming conventions.
- Replaced non-transient with transient fields: Made certain fields transient, ensuring compatibility with serialization.
- Enhanced test cases: Added a new test to verify menu action methods and their existence, improving test coverage.
- Code modernization: Applied modern Java syntax, such as diamond operators (<>) and utility classes.



## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
