### PR TITLE
Fix: BUGS#1291: Sometimes called SegmentProperties.onEntryActivated after closed a project

### DIFF
--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -286,6 +286,23 @@ public class SegmentPropertiesArea implements IPaneMenu {
         }
     }
 
+    private String getBooleanValueVerb(String key, boolean value) {
+        try {
+            if (value) {
+                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + key.toUpperCase());
+            } else {
+                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_NVERB + key.toUpperCase());
+            }
+        } catch (MissingResourceException ex) {
+            // fallback to default expression
+            if (value) {
+                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + "YES");
+            } else {
+                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + "NO");
+            }
+        }
+    }
+
     private void setProperties(SourceTextEntry ste) {
         properties.clear();
         if (ste == null) {
@@ -352,24 +369,6 @@ public class SegmentPropertiesArea implements IPaneMenu {
             setProperty(KEY_ORIGIN, entry.getPropValue(PROP_ORIGIN));
         } else {
             setProperty(KEY_ORIGIN, OStrings.getString("SEGPROP_ORIGIN_UNKNOWN"));
-        }
-    }
-
-
-    private String getBooleanValueVerb(String key, boolean value) {
-        try {
-            if (value) {
-                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + key.toUpperCase());
-            } else {
-                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_NVERB + key.toUpperCase());
-            }
-        } catch (MissingResourceException ex) {
-            // fallback to default expression
-            if (value) {
-                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + "YES");
-            } else {
-                return OStrings.getString(ISegmentPropertiesView.PROPERTY_TRANSLATION_VERB + "NO");
-            }
         }
     }
 

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -40,8 +40,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import javax.swing.ButtonGroup;
@@ -137,8 +135,8 @@ public class SegmentPropertiesArea implements IPaneMenu {
         try {
             Constructor<?> constructor = viewClass.getConstructor();
             newImpl = (ISegmentPropertiesView) constructor.newInstance();
-        } catch (Throwable e) {
-            Logger.getLogger(getClass().getName()).log(Level.FINE, e.getMessage());
+        } catch (Exception e) {
+            Log.log(e);
             return;
         }
         viewImpl = newImpl;
@@ -179,7 +177,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
         try {
             menu.show(scrollPane, p.x, p.y);
         } catch (IllegalComponentStateException e) {
-            e.printStackTrace();
+            Log.log(e);
         }
     }
 

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -376,7 +376,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
 
         private final SegmentPropertiesArea segmentPropertiesArea;
 
-        public SegmentPropertiesEntryEventListener(SegmentPropertiesArea segmentPropertiesArea) {
+        SegmentPropertiesEntryEventListener(SegmentPropertiesArea segmentPropertiesArea) {
             this.segmentPropertiesArea = segmentPropertiesArea;
         }
 


### PR DESCRIPTION

## Pull request type


Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?
- Sometimes called `SegmentProperties.onEntryActivated` after closed a project
- https://sourceforge.net/p/omegat/bugs/1291/

## What does this PR change?

- Check project is loaded in the event handler
- Refactoring the event handler as internal class
- Reduce complexity of the setProperties method

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
