### PR TITLE
Fix incorrect file existence check for restart logic

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -269,7 +269,7 @@ public final class Main {
                 return;
             } else {
                 javaBin = Paths.get(installDir).getParent().resolve("bin/OmegaT");
-                if (javaBin.toFile().exists()) {
+                if (!javaBin.toFile().exists()) {
                     // abort restart
                     Core.getMainWindow().displayWarningRB("LOG_RESTART_FAILED_NOT_FOUND");
                     return;


### PR DESCRIPTION
The logic for checking if the restart binary exists was inverted, causing the application to proceed incorrectly. This update corrects the condition to ensure proper handling when the binary is missing, preventing erroneous behavior during restart. This logic failure introduced in PR#1308 refactoring

## Pull request type

- Bug fix -> [bug]


## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
