### PR TITLE
fix: Set default and persist preferences for paragraph match from segmented tmx toggle

### DIFF
--- a/src/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
@@ -138,6 +138,6 @@ public class TMMatchesPreferencesController extends BasePreferencesController {
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, panel.keepForeignMatches.isSelected());
         Preferences.setPreference(Preferences.PENALTY_FOR_FOREIGN_MATCHES, panel.foreignPenaltySpinner.getValue());
         Preferences.setPreference(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD, panel.fuzzyMatchThreshold.getValue());
-        Preferences.setPreference(Preferences.PARAGRAPH_MATCH_FROM_SEGMENT_TMX, panel.paragraphMatchesFromSegmentedTmxCB);
+        Preferences.setPreference(Preferences.PARAGRAPH_MATCH_FROM_SEGMENT_TMX, panel.paragraphMatchesFromSegmentedTmxCB.isSelected());
     }
 }

--- a/src/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
@@ -122,11 +122,12 @@ public class TMMatchesPreferencesController extends BasePreferencesController {
         panel.matchesTemplate.setText(MatchesVarExpansion.DEFAULT_TEMPLATE);
         panel.matchesTemplate.setCaretPosition(0);
         panel.fuzzyMatchThreshold.setValue(OConsts.FUZZY_MATCH_THRESHOLD);
+        panel.paragraphMatchesFromSegmentedTmxCB.setSelected(true);
     }
 
     @Override
     public void persist() {
-        Preferences.setPreference(Preferences.EXT_TMX_SORT_KEY, (SORT_KEY) panel.sortMatchesList.getSelectedItem());
+        Preferences.setPreference(Preferences.EXT_TMX_SORT_KEY, panel.sortMatchesList.getSelectedItem());
         Preferences.setPreference(Preferences.EXT_TMX_SHOW_LEVEL2, panel.displayLevel2Tags.isSelected());
         Preferences.setPreference(Preferences.EXT_TMX_USE_SLASH, panel.useSlash.isSelected());
         Preferences.setPreference(Preferences.EXT_TMX_MATCH_TEMPLATE, panel.matchesTemplate.getText());
@@ -137,5 +138,6 @@ public class TMMatchesPreferencesController extends BasePreferencesController {
         Preferences.setPreference(Preferences.EXT_TMX_KEEP_FOREIGN_MATCH, panel.keepForeignMatches.isSelected());
         Preferences.setPreference(Preferences.PENALTY_FOR_FOREIGN_MATCHES, panel.foreignPenaltySpinner.getValue());
         Preferences.setPreference(Preferences.EXT_TMX_FUZZY_MATCH_THRESHOLD, panel.fuzzyMatchThreshold.getValue());
+        Preferences.setPreference(Preferences.PARAGRAPH_MATCH_FROM_SEGMENT_TMX, panel.paragraphMatchesFromSegmentedTmxCB);
     }
 }


### PR DESCRIPTION

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Reviewer comment in PR#963 about PR#1217
https://github.com/omegat-org/omegat/pull/963#issuecomment-2833433548

## What does this PR change?

- - Fix the issue feedback given by the reviewer after merging approved PR#1217.
- Added reset and persistence logic for the paragraph match toggle related to segmented TMX.
- Ensures consistent behavior by setting a default value during initialization and saving the user preference when changes are made.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
