### PR TITLE
[6.0][BUGS#1279]fix: glossary sorting and issue handling logic

### DIFF
--- a/test/src/org/omegat/gui/glossary/FindGlossaryThreadTest.java
+++ b/test/src/org/omegat/gui/glossary/FindGlossaryThreadTest.java
@@ -48,7 +48,8 @@ public class FindGlossaryThreadTest extends TestCore {
         entries.add(new GlossaryEntry("\u4E0A", "up", "", false, null));
         Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH, true);
         Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, false);
-        GlossarySearcher.sortGlossaryEntries(entries);
+        //
+        entries = GlossarySearcher.sortGlossaryEntries(entries);
         assertEquals("zzz", entries.get(0).getSrcText());
         assertEquals("cat", entries.get(1).getSrcText());
         assertEquals("mikeneko", entries.get(1).getLocText());
@@ -57,7 +58,8 @@ public class FindGlossaryThreadTest extends TestCore {
         assertEquals("dog", entries.get(3).getSrcText());
         assertEquals("horse", entries.get(4).getSrcText());
         Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_LENGTH, false);
-        GlossarySearcher.sortGlossaryEntries(entries);
+        //
+        entries = GlossarySearcher.sortGlossaryEntries(entries);
         assertEquals("zzz", entries.get(0).getSrcText());
         assertEquals("cat", entries.get(1).getSrcText());
         assertEquals("catty", entries.get(1).getLocText());
@@ -69,7 +71,8 @@ public class FindGlossaryThreadTest extends TestCore {
         assertEquals("direct", entries.get(6).getLocText());
         assertEquals("enhance", entries.get(7).getLocText());
         Preferences.setPreference(Preferences.GLOSSARY_SORT_BY_SRC_LENGTH, true);
-        GlossarySearcher.sortGlossaryEntries(entries);
+        //
+        entries = GlossarySearcher.sortGlossaryEntries(entries);
         assertEquals("zzz", entries.get(0).getSrcText());
         assertEquals("cat", entries.get(1).getSrcText());
         assertEquals("catty", entries.get(1).getLocText());


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Checking for problems throws error: "Comparison method violates its general contract"
- https://sourceforge.net/p/omegat/bugs/1279/


## What does this PR change?

-- Refactored `sortGlossaryEntries` to return a list and ensure null safety.
- Extracted issue provider logic in IssuesPanelController into a separate method for better readability and maintainability.
- Updated tests and adjusted method usage to align with these changes.
- Fix the IllegalArgument Error on sort with filter(Objects::nonNull) enforcement
- Trying to fix BUGS#1279


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
