### PR TITLE
security: Vulnerabilities in the LanguageTool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,13 @@ dependencies {
             exclude module: 'language-detector'
             exclude group: 'com.google.android'
             exclude module: 'hunspell'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         runtimeOnly(libs.language.detector)
         runtimeOnly(libs.dumont.hunspell)
+        runtimeOnly(libs.json)
+        runtimeOnly(libs.protobuf)
         implementation(libs.icu4j)
 
         // Lucene for tokenizers
@@ -216,7 +220,11 @@ dependencies {
     testImplementation(libs.languagetool.server) {
         exclude module: "logback-classic"
         exclude module: "hunspell"
+        exclude module: "json"
+        exclude module: "protobuf"
     }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testRuntimeOnly(libs.bundles.groovy)
     testRuntimeOnly(libs.nashorn.core)
     testRuntimeOnly(libs.slf4j.jdk14)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,8 @@ assertj_swing_junit = "4.0.0-beta-2"
 morfologik = "2.1.9"
 jaxb = "2.3.0"
 swing_extra_locales = "0.3.3"
+json_java = "20250107"
+protobuf_java = "3.25.5"
 
 [libraries]
 slf4j-api = {group = "org.slf4j", name = "slf4j-api",  version.ref = "slf4j"}
@@ -168,9 +170,11 @@ jfa = {group = "de.jangassen", name = "jfa", version.ref = "jfa"}
 flatlaf = {group = "com.formdev", name = "flatlaf", version.ref = "flatlaf"}
 language-detector = {group = "org.omegat", name = "language-detector", version.ref = "languagedetector"}
 assertj_swing_junit = {group = "tokyo.northside", name = "assertj-swing-junit", version.ref = "assertj_swing_junit"}
-morfologik-stemming = { group = "org.carrot2", name = "morfologik-stemming", version.ref = "morfologik" }
-morfologik-speller = { group = "org.carrot2", name = "morfologik-speller", version.ref = "morfologik" }
-swing-extra-locales = { group = "org.omegat", name = "swing-extra-locales", version.ref = "swing_extra_locales"}
+morfologik-stemming = {group = "org.carrot2", name = "morfologik-stemming", version.ref = "morfologik" }
+morfologik-speller = {group = "org.carrot2", name = "morfologik-speller", version.ref = "morfologik" }
+swing-extra-locales = {group = "org.omegat", name = "swing-extra-locales", version.ref = "swing_extra_locales"}
+json = {group = "org.json", name = "json", version.ref = "json_java"}
+protobuf = {group = "com.google.protobuf", name = "protobuf-java", version.ref = "protobuf_java"}
 
 [bundles]
 groovy = ["groovy-jsr223", "groovy-dateutil", "groovy-json", "groovy-xml", "groovy-swing", "groovy-templates", "ivy"]

--- a/language-modules/ar/build.gradle
+++ b/language-modules/ar/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ar) {
             exclude module: 'languagetool-core'
@@ -29,7 +31,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation(project(":spellchecker:hunspell"))
     testRuntimeOnly(libs.commons.io)
 }

--- a/language-modules/ast/build.gradle
+++ b/language-modules/ast/build.gradle
@@ -19,6 +19,7 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
         }
         implementation(libs.languagetool.ast) {
             exclude module: 'languagetool-core'

--- a/language-modules/be/build.gradle
+++ b/language-modules/be/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.be) {
             exclude module: 'languagetool-core'
@@ -29,7 +31,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation(libs.commons.io)
 }

--- a/language-modules/br/build.gradle
+++ b/language-modules/br/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.br) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,13 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
+    testImplementation(project(":spellchecker:hunspell"))
     testImplementation project(":spellchecker:morfologik")
     testImplementation(libs.commons.io)
 }

--- a/language-modules/ca/build.gradle
+++ b/language-modules/ca/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ca) {
             exclude module: 'languagetool-core'
@@ -31,6 +33,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(project(":spellchecker:hunspell"))
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testRuntimeOnly(libs.commons.io)
 }
 

--- a/language-modules/da/build.gradle
+++ b/language-modules/da/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.da) {
             exclude module: 'languagetool-core'
@@ -29,7 +31,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation(project(":spellchecker:hunspell"))
     testRuntimeOnly(libs.commons.io)
 }

--- a/language-modules/de/build.gradle
+++ b/language-modules/de/build.gradle
@@ -22,6 +22,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.de) {
             exclude module: 'languagetool-core'
@@ -33,7 +35,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
 }

--- a/language-modules/el/build.gradle
+++ b/language-modules/el/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.el) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
 }

--- a/language-modules/en/build.gradle
+++ b/language-modules/en/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.en) {
             exclude module: 'languagetool-core'
@@ -29,7 +31,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/eo/build.gradle
+++ b/language-modules/eo/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.eo) {
             exclude module: 'languagetool-core'
@@ -29,7 +31,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/es/build.gradle
+++ b/language-modules/es/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.es) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
 }

--- a/language-modules/fa/build.gradle
+++ b/language-modules/fa/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.fa) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/fr/build.gradle
+++ b/language-modules/fr/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.fr) {
             exclude module: 'languagetool-core'
@@ -31,7 +33,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/ga/build.gradle
+++ b/language-modules/ga/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ga) {
             exclude module: 'languagetool-core'
@@ -31,7 +33,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/gl/build.gradle
+++ b/language-modules/gl/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.gl) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/it/build.gradle
+++ b/language-modules/it/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.it) {
             exclude module: 'languagetool-core'
@@ -31,7 +33,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -20,13 +20,22 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ja) {
             // Temporary exclusion; see https://sourceforge.net/p/omegat/bugs/814/
+            exclude module: 'languagetool-core'
             exclude module: 'lucene-gosen'
             exclude module: 'languagetool-core'
             exclude module: 'icu4j'
         }
+        testImplementation(libs.languagetool.core) {
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
+        }
+        testRuntimeOnly(libs.json)
+        testRuntimeOnly(libs.protobuf)
         implementation(dependencies.variantOf(libs.lucene.gosen) { classifier("ipadic") })
         compileOnly(libs.icu4j)
     }

--- a/language-modules/km/build.gradle
+++ b/language-modules/km/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.km) {
             exclude module: 'languagetool-core'

--- a/language-modules/nl/build.gradle
+++ b/language-modules/nl/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         compileOnly(libs.morfologik.stemming)
         implementation(libs.languagetool.nl) {

--- a/language-modules/pl/build.gradle
+++ b/language-modules/pl/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.pl) {
             exclude module: 'languagetool-core'

--- a/language-modules/pt/build.gradle
+++ b/language-modules/pt/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.pt) {
             exclude module: 'languagetool-core'

--- a/language-modules/ro/build.gradle
+++ b/language-modules/ro/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ro) {
             exclude module: 'languagetool-core'

--- a/language-modules/ru/build.gradle
+++ b/language-modules/ru/build.gradle
@@ -21,6 +21,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.ru) {
             exclude module: 'languagetool-core'
@@ -31,7 +33,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/sk/build.gradle
+++ b/language-modules/sk/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.sk) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/sl/build.gradle
+++ b/language-modules/sl/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.sl) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/sv/build.gradle
+++ b/language-modules/sv/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
         }
         implementation(libs.languagetool.sv) {
             exclude module: 'languagetool-core'
@@ -30,7 +31,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/ta/build.gradle
+++ b/language-modules/ta/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
         }
         implementation(libs.languagetool.ta) {
             exclude module: 'languagetool-core'
@@ -30,7 +31,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/tl/build.gradle
+++ b/language-modules/tl/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.tl) {
             exclude module: 'languagetool-core'
@@ -30,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
 }
 

--- a/language-modules/uk/build.gradle
+++ b/language-modules/uk/build.gradle
@@ -21,6 +21,7 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
         }
         implementation(libs.languagetool.uk) {
             exclude module: 'languagetool-core'
@@ -31,7 +32,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
-    testImplementation(libs.languagetool.core)
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
 }
 

--- a/language-modules/zh/build.gradle
+++ b/language-modules/zh/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             exclude module: 'commons-lang3'
             exclude module: 'commons-text'
             exclude module: 'commons-logging'
+            exclude module: 'json'
+            exclude module: 'protobuf-java'
         }
         implementation(libs.languagetool.zh) {
             exclude module: 'languagetool-core'
@@ -28,6 +30,12 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
+    testImplementation(libs.languagetool.core) {
+        exclude module: 'json'
+        exclude module: 'protobuf-java'
+    }
+    testRuntimeOnly(libs.json)
+    testRuntimeOnly(libs.protobuf)
     testImplementation(libs.commons.io)
 }
 makeModuleTask(loadProperties(file('plugin.properties')))


### PR DESCRIPTION
There are multiple transitive vulnerbility in languagetool 6.1. To avoid vulnerbility, we excluded `json` and `protobuf-java` from multiple modules to avoid conflicts and added them as runtime-only dependencies. Updated `libs.versions.toml` to define their versions for consistent management across the project.
- Avoid CVE-2023-5072
- Avoid CVE-2024-7254

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- Transient dependencies of dependent library LanguageTool are vulnerable
- https://sourceforge.net/p/omegat/bugs/1292

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
