### PR TITLE
update macOS signed/notarized builds information

### DIFF
--- a/src_docs/developer/90.ReleaseProcedure.md
+++ b/src_docs/developer/90.ReleaseProcedure.md
@@ -203,7 +203,7 @@ which can be checked in the system tool certmg.msc
 
 A file is updated with signature. You should keep an original file for backup.
 
-## 9. Build a notarized Mac distribution file locally, and publish
+## 9. Build a notarized macOS distribution file locally, and publish
 
 First, make sure the local JRE is up-to-date.
 

--- a/src_docs/developer/92.CodeSigning.md
+++ b/src_docs/developer/92.CodeSigning.md
@@ -1,4 +1,4 @@
-# Code signing how-to
+# Code signing How-To
 
 ## What is code signing and why is it required?
 
@@ -15,10 +15,20 @@ When code sign is provided, Windows reduces the number of warnings when running.
 
 ### macOS
 
-Code signing your app assures users that it's from a known source 
-and hasn’t been modified since it was last signed. Signing uses a certificate issued by Apple.
+[App code signing process in macOS](https://support.apple.com/guide/security/app-code-signing-process-sec3ad8e6e53/web)
 
-## How to obtain Certificate?
+“On devices with macOS 10.15, all apps distributed outside the App
+Store must be signed by the developer using an Apple-issued Developer
+ID certificate (combined with a private key) and notarized by Apple to
+run under the default Gatekeeper settings. Apps developed in-house
+should also be signed with an Apple-issued Developer ID so that users
+can validate their integrity.”
+
+Starting with OmegaT 6.0.2, OmegaT is distributed as a notarized
+application for both the old Intel CPU machines and the new Apple CPU
+machines (starting with M1).
+
+## How to obtain a certificate?
 
 A certificate can be obtained from certification authority companies.
 Both Microsoft and Apple specify which companies are compatible with
@@ -27,7 +37,7 @@ their respective platforms.
 ### Windows
 
 Many certification authority companies provide a certification for code
-signing for windows.
+signing for Windows.
 
 #### Certum Open Source developer certificate program
 
@@ -43,10 +53,18 @@ Comodo provides a certification with affordable prices for individuals.
 
 ### macOS
 
+Apple is the only authority that provides a certification for code
+signing and notarization. The certification comes with an Apple
+Developper account.
+
 #### Certificate issued by Apple
+
+A developper account comes with an Apple verified developper ID.
 
 #### Application notarized by Apple
 
+Apple provides the notarization service based on the Apple verified
+developper ID.
 
 ## Tools
 
@@ -89,3 +107,8 @@ The list of supported hardware is at
 
 
 ### macOS
+
+The tools and processes are described here:
+
+[Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package)
+

--- a/src_docs/developer/93.BuildingInstallerPackage.md
+++ b/src_docs/developer/93.BuildingInstallerPackage.md
@@ -100,14 +100,26 @@ released for java applications on macOS.
 We also use a `gradle-appbundler-plugin` configured to produce both an Intel-compatible launcher and
 an M1/M2 compatible launcher. The `genMac` task is used to configure the launcher generation.
 
+**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
+
+See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
+
 ### build distribution
 
 There are several tasks defined to assemble distributions for macOS.
 
 #### basic distribution without signing
 
-The `armMacDiztZip` and `macDistCip` tasks are used to build the standard distribution packages.
-If you launch the `mac` task, you will get these 2 package files. 
+The `armMacDistZip` and `macDistZip` tasks are used to build the standard distribution packages.
+If you launch the `mac` task, you will get these 2 package files.
+
+**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
+
+See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
+
+**Warning** The `mac` tasks does not fail even though the task `armMacDisZip` fails with
+`Task 'armMacDistZip' not found in root project 'OmegaT' and its subprojects.`
+
 
 #### signed package
 
@@ -118,13 +130,23 @@ The OmegaT project prepares tasks to sign packages for macOS.
 - macStapledNotarizedDistZip
 - armMacStapledNotarizedDistZip
 
+**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
+
+See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
+
 #### Debug mac packages
 
 Use one of the following tasks to prepare the package directory
 structure in a `build/install/` folder:
 
 - installArmMacDist
-- installMacDist
+- InstallMacDist
+
+**Warning** The `installArmMacDist` task errors with this message:
+`Task 'installArmMacDist' not found in root project 'OmegaT' and its subprojects.`
+
+**Warning** The `InstallMacDist` task errors with this message:
+`Task 'installMacDist' is ambiguous in root project 'OmegaT' and its subprojects. Candidates are: 'installMacArmDist', 'installMacArmSignedDist'.`
 
 ## Building the distribution with a Linux Java runtime
 

--- a/src_docs/developer/93.BuildingInstallerPackage.md
+++ b/src_docs/developer/93.BuildingInstallerPackage.md
@@ -139,7 +139,7 @@ See the [Notes regarding the notarization of the macOS package](https://github.c
 Use one of the following tasks to prepare the package directory
 structure in a `build/install/` folder:
 
-- installArmMacDist
+- installMacArmDist
 - InstallMacX64Dist
 
 **Warning** The `installArmMacDist` task errors with this message:

--- a/src_docs/developer/93.BuildingInstallerPackage.md
+++ b/src_docs/developer/93.BuildingInstallerPackage.md
@@ -140,7 +140,7 @@ Use one of the following tasks to prepare the package directory
 structure in a `build/install/` folder:
 
 - installArmMacDist
-- InstallMacDist
+- InstallMacX64Dist
 
 **Warning** The `installArmMacDist` task errors with this message:
 `Task 'installArmMacDist' not found in root project 'OmegaT' and its subprojects.`


### PR DESCRIPTION
## Which ticket is resolved?

This is a development guide update regarding macOS notarization, which is compulsory now to run on the latest version of macOS (15 at the date of this PR).

https://sourceforge.net/p/omegat/feature-requests/1704/

## What does this PR change?

It updates the macOS notarization documentation but also includes warning that refer to seemingly non working tasks to be investigated.