### PR TITLE
Correct small typos in the gradle tasks

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -25,7 +25,7 @@ tasks.register('genDocIndex', Copy) {
          'name'  : Locale.forLanguageTag(props.parentFile.name.replace('_', '-')).getDisplayName(),
          'status': docVersion == version ? 'up-to-date' : 'out-of-date']
     }
-    description = 'Generate the docs index file'
+    description = 'Generates the HTML docs index file.'
     inputs.files docPropsFiles, inputTemplate
     from inputTemplate
     into layout.buildDirectory.dir("tmp/manual/")
@@ -40,12 +40,12 @@ tasks.register('genDocIndex', Copy) {
 }
 
 tasks.register('manualZips') {
-    description = 'Build ZIP manuals to bundle into application.'
+    description = 'Builds the zipped manuals to bundle into the application.'
     group = 'other'
 }
 
 tasks.register('manualHtmls') {
-    description = 'Build HTML manuals and zip for all languages.'
+    description = 'Builds and zips the HTML manuals for all languages.'
     finalizedBy(genDocIndex)
     group = 'documentation'
 }
@@ -58,20 +58,20 @@ ext.makeDocumentationTasks = { lang ->
     }
 
     def copyCss = tasks.register("copyCss${lang.capitalize()}", Copy) {
-        description = 'Copy Images and CSS file to target'
+        description = 'Copies images and CSS files to target.'
         into layout.buildDirectory.dir("docs/manual/${lang}")
         from new File(documentRootDir, 'style/omegat.css')
     }
 
     def copyImages = tasks.register("copyImages${lang.capitalize()}", Copy) {
-        description 'Copy Images and CSS file to target'
+        description 'Copies images and CSS files to target.'
         into layout.buildDirectory.dir("docs/manual/${lang}/images/")
         from fileTree(dir: layout.projectDirectory.dir("src_docs/manual/${lang}/images/"), include: "*.png")
         from layout.projectDirectory.file("images/OmegaT.svg")
     }
 
     def docbookHtml = tasks.register("docbookHtml${lang.capitalize()}", DocbookHtmlTask) {
-        description = 'Generate chunked HTML documentation'
+        description = 'Generates a chunked HTML documentation.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/xhtml.xsl"))
         inputFile.set(layout.projectDirectory.file("${documentRootDir}/manual/${lang}/OmegaTUsersManual_xinclude_full.xml"))
         outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
@@ -79,7 +79,7 @@ ext.makeDocumentationTasks = { lang ->
     }
 
     def whcToc = tasks.register("whcToc${lang.capitalize()}", TransformationTask) {
-        description = 'Generate whc header and index'
+        description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-toc.xsl"))
         inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
         outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/toc.xml"))
@@ -87,7 +87,7 @@ ext.makeDocumentationTasks = { lang ->
     }
 
     def whcIndex = tasks.register("whcIndex${lang.capitalize()}", TransformationTask) {
-        description = 'Generate whc header and index'
+        description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-index.xsl"))
         inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
         outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/index.html"))
@@ -95,14 +95,14 @@ ext.makeDocumentationTasks = { lang ->
     }
 
     def whcHeader = tasks.register("whcHeader${lang.capitalize()}", TransformationTask) {
-        description = 'Generate whc header and index'
+        description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-header.xsl"))
         inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.xml"))
         outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_header.xhtml"))
         dependsOn(copyCss, docbookInclude)
     }
     def buildDocumentTask = tasks.register("manual${lang.capitalize()}", WhcTask) {
-        description = 'Build whc contents'
+        description = 'Builds the whc contents.'
         tocFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/toc.xml"))
         inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/index.html"))
         headerFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_header.xhtml"))
@@ -177,7 +177,7 @@ ext.makeDocumentationTasks = { lang ->
 }
 
 tasks.register('firstSteps') {
-    description = 'Build first pages for all languages at src/docs/greetings/.'
+    description = 'Builds the introductory page for all languages at src/docs/greetings/.'
     group = 'documentation'
 }
 assemble.dependsOn(firstSteps)
@@ -188,7 +188,7 @@ ext.makeFirstStepTask = { lang ->
         into layout.buildDirectory.dir("docs/greetings/${lang}/")
     }
     def firstStepsHtml = tasks.register("firstSteps${lang.capitalize()}", DocbookHtmlTask) {
-        description = 'Generate chunked HTML documentation'
+        description = 'Generates a chunked HTML documentation.'
         inputFile.set(layout.projectDirectory.file("${documentRootDir}/greeting/${lang}/First_Steps.xml"))
         outputFile.set(layout.buildDirectory.file("docs/greetings/${lang}/first_steps.html"))
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/html.xsl"))

--- a/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 tasks.register('genJAXB') {
-    description = 'Generate classes for loading and manipulating XML formats'
+    description = 'Generates classes for loading and manipulating XML formats.'
     group = 'jaxb'
 }
 

--- a/build-logic/src/main/groovy/org.omegat.linux-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.linux-conventions.gradle
@@ -5,7 +5,7 @@ ext.makeLinuxTask = { args ->
     def parentTask = tasks.getByName(args.parentTaskName)
     tasks.register(distTaskName, Sync) {
         group = 'distribution'
-        description = "Create a linux installDist for ${args.name}. "
+        description = "Creates a linux installDist for ${args.name}."
         with distributions.main.contents
         destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${args.suffix}"))
         onlyIf {
@@ -24,7 +24,7 @@ ext.makeLinuxTask = { args ->
         }
     }
     tasks.register(tarTaskName, Tar) {
-        description = "Create a Linux distribution for ${args.name}. "
+        description = "Creates a Linux distribution for ${args.name}."
         with distributions.main.contents
         onlyIf {
             condition(!args.jrePath.empty, 'JRE not found')

--- a/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
@@ -16,7 +16,7 @@ tasks.register('genMac') {
     def outDir = layout.buildDirectory.file("appbundler").get().toString()
     def appName = appName
     def appClass = mainClassName
-    description = 'Generate the Mac .app skeleton. Depends AppBundler (https://github.com/TheInfiniteKind/appbundler)'
+    description = 'Generates the macOS .app skeleton. Depends on AppBundler (https://github.com/TheInfiniteKind/appbundler).'
     outputs.dir layout.buildDirectory.file("appbundler")
     doLast {
         ant.taskdef(name: 'appbundler',
@@ -90,7 +90,7 @@ ext.makeMacTask = { args ->
     def parentTask = tasks.getByName(args.parentTaskName)
 
     def distZipTask = tasks.register(distZipTaskName, Zip) {
-        description = "Create Mac distribution for ${args.name}"
+        description = "Creates a macOS distribution for ${args.name}."
         // mac specific contents
         from(genMac.outputs) {
             exclude '**/MacOS/OmegaT', '**/Info.plist', '**/java.entitlements'
@@ -140,7 +140,7 @@ ext.makeMacTask = { args ->
     parentTask.dependsOn distZipTask
 
     def installTask = tasks.register(installTaskName, Sync) {
-        description = 'Build a Mac distribution.'
+        description = 'Builds the macOS distribution.'
         onlyIf {
             condition(!args.jrePath || !args.jrePath.empty, 'JRE not found')
         }
@@ -190,7 +190,7 @@ ext.makeMacTask = { args ->
     }
 
     def signedInstallTask = tasks.register(signedInstallTaskName, Sync) {
-        description = 'Build a signed Mac distribution. Requires an Apple Developer Account.'
+        description = 'Builds the signed macOS distribution. Requires an Apple Developer Account.'
         onlyIf {
             // Set this in e.g. local.properties
             conditions([project.hasProperty('macCodesignIdentity'), 'Code signing property not set'],

--- a/build-logic/src/main/groovy/org.omegat.main-utilities.gradle
+++ b/build-logic/src/main/groovy/org.omegat.main-utilities.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 tasks.register('changedOnBranch') {
-    description = 'List files that have been modified on this git branch.'
+    description = 'Lists files that have been modified on this git branch.'
     doLast {
         def branch = providers.exec {commandLine("git", "name-rev", "--name-only", "HEAD")}
                 .standardOutput.asText.get().trim()
@@ -35,7 +35,7 @@ tasks.register('changedOnBranch') {
 }
 
 tasks.register('spotlessChangedApply') {
-    description = 'Apply code formatting to files that have been changed on the current branch.'
+    description = 'Applies code formatting to files that have been changed on the current branch.'
     group = 'omegat workflow'
     finalizedBy 'spotlessApply'
     dependsOn changedOnBranch
@@ -48,7 +48,7 @@ tasks.register('spotlessChangedApply') {
 
 tasks.register('checksums') {
     def algos = ['SHA-512']
-    description = "Generate ${algos.join(', ')} checksums for distribution files"
+    description = "Generates ${algos.join(', ')} checksums for distribution files."
     inputs.files fileTree(dir: base.distsDirectory, exclude: 'checksums')
     outputs.dir base.distsDirectory.dir('checksums')
     onlyIf {

--- a/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
@@ -9,7 +9,7 @@ ext.htdocs = '/home/project-web/omegat/htdocs'
 
 ext.publishAtomically = { args ->
     tasks.register("publish${args.name.capitalize()}", Exec) {
-        description = "Copy ${args.name} to SourceForge web."
+        description = "Copies ${args.name} to SourceForge web."
         dependsOn args.sourceTask
         group = 'omegat release'
         doLast {
@@ -88,7 +88,7 @@ signing {
 }
 
 tasks.register('publishVersion') {
-    description = 'Update the version considered current by the version check.'
+    description = 'Updates the version considered current by the version check.'
     group = 'omegat release'
     doLast {
         ssh.run {

--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -77,7 +77,7 @@ tasks.named("run") {
 }
 
 tasks.register('runDebugger', JavaExec) {
-    description = 'Launch app for debugging.' // Special debug task for NetBeans
+    description = 'Runs application for debugging.' // Special debug task for NetBeans
     group = 'application'
     mainClass = application.mainClass
     classpath = sourceSets.main.runtimeClasspath
@@ -86,7 +86,7 @@ tasks.register('runDebugger', JavaExec) {
 }
 
 tasks.register('runOnJava17', JavaExec) {
-    description = 'Launch app on Java 17'
+    description = 'Runs application on Java 17.'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -98,7 +98,7 @@ tasks.register('runOnJava17', JavaExec) {
 }
 
 tasks.register('runOnJava21', JavaExec) {
-    description = 'Launch app on Java 21'
+    description = 'Runs application on Java 21.'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(21)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -110,7 +110,7 @@ tasks.register('runOnJava21', JavaExec) {
 }
 
 tasks.register('testIntegration', JavaExec) {
-    description = 'Run integration tests. Pass repo URL as -Domegat.test.repo=<repo>'
+    description = 'Runs integration tests. Pass repo URL as -Domegat.test.repo=<repo>.'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -125,7 +125,7 @@ tasks.register('testIntegration', JavaExec) {
 }
 
 tasks.register('testOnJava17', Test) {
-    description = 'Run test cases on Java 17'
+    description = 'Runs test cases on Java 17.'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -138,7 +138,7 @@ tasks.register('testOnJava17', Test) {
 }
 
 tasks.register('testOnJava21', Test) {
-    description = 'Run test cases on Java 21'
+    description = 'Runs test cases on Java 21.'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(21)
         vendor = JvmVendorSpec.ADOPTIUM
@@ -188,7 +188,7 @@ tasks.register('testAcceptance', Test) {
     }
     finalizedBy testAcceptanceFinally
 
-    description = 'Run Acceptance GUI test'
+    description = 'Runs acceptance GUI test.'
     group = 'verification'
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = JavaLanguageVersion.of(17)

--- a/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
@@ -167,7 +167,7 @@ ext.makeWinTask = { args ->
     }
 
     tasks.register(distsTaskName, Copy) {
-        description = "Create a Windows installer for ${args.name} distro. " +
+        description = "Creates a Windows installer for ${args.name} distro. " +
                 'Requires Inno Setup (http://www.jrsoftware.org/isinfo.php).'
         onlyIf { execWinTasks }
         from layout.buildDirectory.file("innosetup/${args.name}/${installerBasename}.exe")

--- a/build.gradle
+++ b/build.gradle
@@ -403,7 +403,7 @@ distributions {
 }
 
 tasks.register('mac') {
-    description = 'Build the Mac distributions.'
+    description = 'Builds the Mac distributions.'
     group = 'omegat distribution'
 }
 makeHunspellSignTask()
@@ -411,7 +411,7 @@ makeMacTask(name: 'macX64', suffix: 'Mac_x64', jrePath: macJRE, parentTaskName: 
 makeMacTask(name: 'macArm', suffix: 'Mac_arm', jrePath: armMacJRE, parentTaskName: 'mac')
 
 tasks.register('linux') {
-    description = 'Build the Linux distributions.'
+    description = 'Builds the Linux distributions.'
     group = 'omegat distribution'
     dependsOn linuxDebDist
     dependsOn linuxRpmDist
@@ -425,7 +425,7 @@ startScripts.enabled = false
 application.executableDir = ""
 
 tasks.register('win') {
-    description = 'Build the Windows distributions.'
+    description = 'Builds the Windows distributions.'
     group = 'omegat distribution'
 }
 makeWinTask(name: 'winNoJRE', suffix: 'Windows_without_JRE', parentTask: 'win')


### PR DESCRIPTION
The task descriptions should use a verb conjugated at the 3rd person/singular (i.e. ending with "s") a end with a period.
Some wordings were corrected.

There are some tasks for which I could not find the descriptions.

For ex.

- linuxDebDist
- linuxRpmDist
- Launch4j tasks
- generateMetadataFileForManualCaPublication and the other similar tasks (should be "for publication *of* 'manualCa'."
- spotbugsMain tasks (should all be "Runs ...")