### PR TITLE
[SECURITY][6.0]Fix: XML parsing vulnerability with segmentation.conf loader in SRX class

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1686,8 +1686,8 @@ XHTML_Filter_Options=XHTML Filter Options
 
 # 0 - exceptions
 CORE_SRX_EXC_LOADING_SEG_RULES=Exceptions occurred while loading segmentation rules:
-
 CORE_SRX_ERROR_SAVING_SEGMENTATION_CONFIG=Error saving segmentation rules configuration:
+CORE_SRX_ERROR_DELETING_FILE=Error during deleting old segmentation rules configuration:
 
 CORE_SRX_TABLE_HEADER_Language_Name=Language name
 

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -129,13 +129,16 @@ public class SRX implements Serializable {
      */
     public static void saveTo(SRX srx, File outFile) throws IOException {
         if (srx == null) {
-            try {
-                Files.delete(outFile.toPath());
-            } catch (IOException e) {
-                Log.logErrorRB(e, "CORE_SRX_ERROR_DELETING_FILE");
+            if (outFile.exists()) {
+                try {
+                    Files.delete(outFile.toPath());
+                } catch (IOException e) {
+                    Log.logErrorRB(e, "CORE_SRX_ERROR_DELETING_FILE");
+                }
             }
             return;
         }
+
         try {
             srx.setVersion(CURRENT_VERSION);
             XMLEncoder xmlenc = new XMLEncoder(new FileOutputStream(outFile));

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -76,14 +76,8 @@ public class SRXTest {
                 "</java>";
         Files.writeString(segmentConf, xmlContent);
         SRX srx = null;
-        try {
-            srx = SRX.loadSRX(segmentConf.toFile());
-        } catch (RuntimeException e) {
-            fail();
-        }
-        if (srx == null) {
-            fail();
-        }
+        srx = SRX.loadSRX(segmentConf.toFile());
+        assertNotNull(srx);
         assertEquals("\\s", srx.getMappingRules().get(0).getRules().get(0).getAfterbreak());
     }
 }

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -75,8 +75,7 @@ public class SRXTest {
                 "    </object>\n" +
                 "</java>";
         Files.writeString(segmentConf, xmlContent);
-        SRX srx = null;
-        srx = SRX.loadSRX(segmentConf.toFile());
+        SRX srx = SRX.loadSRX(segmentConf.toFile());
         assertNotNull(srx);
         assertEquals("\\s", srx.getMappingRules().get(0).getRules().get(0).getAfterbreak());
     }

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -28,8 +28,8 @@ package org.omegat.core.segmentation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Fix vulnerbility of OmegaT 6.0.1 reported as CVE-2024-51366.


## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- CVE-2024-51366
- https://cvefeed.io/vuln/detail/CVE-2024-51366

## What does this PR change?

- - Replaced XMLDecoder with a secure JAXB-based implementation by using SAX parsing to prevent attacks.
- Added tests to verify secure loading of SRX files.

## Other information

- The exploit code has already been disclosed in Nov 2024
- https://github.com/Gelcon/PoCofOmegaTV6_0_1