### PR TITLE
the 'latest' suffix is not used anymore

### DIFF
--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -74,7 +74,7 @@ public final class Help {
      */
     public static final String ONLINE_HELP_URL = OStrings.IS_BETA
             //? "https://omegat.sourceforge.io/manual-latest/"
-            ? "https://omegat.sourceforge.io/manual-standard/"
+            ? "https://omegat.sourceforge.io/manual-snapshot/"
             : "https://omegat.sourceforge.io/manual-standard/";
 
     public static final String ONLINE_JAVADOC_URL = OStrings.IS_BETA

--- a/src/org/omegat/help/Help.java
+++ b/src/org/omegat/help/Help.java
@@ -69,13 +69,17 @@ public final class Help {
 
     /**
      * URL for the online manual.
+     * TODO implement a "manual-dev" and "javadoc-dev"
+     * since the "latest" suffix is not used anymore
      */
     public static final String ONLINE_HELP_URL = OStrings.IS_BETA
-            ? "https://omegat.sourceforge.io/manual-latest/"
+            //? "https://omegat.sourceforge.io/manual-latest/"
+            ? "https://omegat.sourceforge.io/manual-standard/"
             : "https://omegat.sourceforge.io/manual-standard/";
 
     public static final String ONLINE_JAVADOC_URL = OStrings.IS_BETA
-            ? "https://omegat.sourceforge.io/javadoc-latest/"
+            //? "https://omegat.sourceforge.io/javadoc-latest/"
+            ? "https://omegat.sourceforge.io/javadoc-standard/"
             : "https://omegat.sourceforge.io/javadoc-standard/";
 
     public static void showJavadoc() throws IOException {


### PR DESCRIPTION
When using the online help, the master build points at "omegat-latest" on sourceforge.

The "latest" suffix is not used anymore and instead of pointing at a recent "weekly" build, it points at obsolete data.

This is a temporary fix until we implement a "weekly" or "dev" suffix for the online documentation system.