### PR TITLE
[6.0] chore: check for the existence of the menu invocation action method

### DIFF
--- a/test/src/org/omegat/gui/main/MainWindowMenuTest.java
+++ b/test/src/org/omegat/gui/main/MainWindowMenuTest.java
@@ -28,16 +28,29 @@ package org.omegat.gui.main;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import org.junit.Test;
+
 import org.omegat.core.TestCore;
 
 /**
@@ -53,7 +66,7 @@ public class MainWindowMenuTest extends TestCore {
     public void testMenuActions() throws Exception {
         int count = 0;
 
-        Map<String, Method> existsMethods = new HashMap<String, Method>();
+        Map<String, Method> existsMethods = new HashMap<>();
 
         for (Method m : MainWindowMenuHandler.class.getDeclaredMethods()) {
             if (Modifier.isPublic(m.getModifiers()) && !Modifier.isStatic(m.getModifiers())) {
@@ -84,7 +97,63 @@ public class MainWindowMenuTest extends TestCore {
             }
         }
         assertTrue("menu items not found", count > 30);
-        assertTrue("There is action handlers in MainWindow which doesn't used in menu: " + existsMethods.keySet(),
-                existsMethods.isEmpty());
+        assertTrue("There is action handlers in MainWindow which doesn't used in menu: "
+                + existsMethods.keySet(), existsMethods.isEmpty());
+    }
+
+    @Test
+    public void testMenuActions_invokeActions() throws Exception {
+        Pattern pattern = Pattern.compile("getMainMenu\\(\\).invokeAction\\(\\s*\"([^\"]+)\"\\s*,");
+        final String[] target = {"src"};
+        processSourceContent(target, (path, chars) -> {
+            Matcher matcher = pattern.matcher(chars);
+            while (matcher.find()) {
+                String actionMethodName = matcher.group(1) + "ActionPerformed";
+                Method method = null;
+                try {
+                    method = MainWindowMenuHandler.class.getMethod(actionMethodName);
+                } catch (NoSuchMethodException ignore) {
+                    // See if the method accepts a modifier key argument.
+                    try {
+                        method = MainWindowMenuHandler.class.getMethod(actionMethodName, Integer.TYPE);
+                    } catch (NoSuchMethodException ex) {
+                        assertNotNull("Action method \"" + actionMethodName + "\" not defined for invoked from " + path,
+                                method);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Process the text content of all .java files under /src. Also check
+     * DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE for security reasons.
+     * And check invisible space character.
+     *
+     * @param consumer
+     *            A function that accepts the file path and content
+     * @throws IOException
+     *             from Files.find()
+     */
+    public void processSourceContent(String[] targets, BiConsumer<Path, CharSequence> consumer)
+            throws IOException {
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        decoder.onMalformedInput(CodingErrorAction.REPORT);
+        decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        for (String root : targets) {
+            Path rootPath = Paths.get(".", root);
+            assertTrue(rootPath.toFile().isDirectory());
+            try (Stream<Path> files = Files.find(rootPath, 100,
+                    (path, attrs) -> attrs.isRegularFile() && path.toString().endsWith(".java"))) {
+                files.forEach(p -> {
+                    try {
+                        byte[] bytes = Files.readAllBytes(p);
+                        consumer.accept(p, decoder.decode(ByteBuffer.wrap(bytes)));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+        }
     }
 }

--- a/test/src/org/omegat/gui/main/MainWindowMenuTest.java
+++ b/test/src/org/omegat/gui/main/MainWindowMenuTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2008 Alex Buloichik
+               2025 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -58,9 +59,24 @@ import org.omegat.core.TestCore;
  */
 public class MainWindowMenuTest extends TestCore {
     /**
-     * Check MainWindow for all menu items action handlers exist.
+     * Tests the actions defined in the main menu of the application to ensure
+     * that each menu item has a corresponding action handler method implemented
+     * in the `MainWindowMenuHandler` class.
+     * <p>
+     * It checks for the following:
+     * - Each menu item has an associated action method in the handler class
+     *   with the naming convention `<menuItemName>ActionPerformed`.
+     * - The action methods can optionally accept a single integer argument
+     *   representing a modifier key.
+     * - All public, non-static methods in the handler class are used by the
+     *   menu items, ensuring no unused action handlers exist.
+     * Verifies:
+     * - There are more than 30 menu items in the main menu.
+     * - All defined menu items have corresponding action handler methods.
+     * - There are no unused public action handler methods in the handler class.
      *
-     * @throws Exception
+     * @throws Exception if any menu item lacks a corresponding action handler
+     *                   method or any unexpected error occurs during the test.
      */
     @Test
     public void testMenuActions() throws Exception {
@@ -101,6 +117,24 @@ public class MainWindowMenuTest extends TestCore {
                 + existsMethods.keySet(), existsMethods.isEmpty());
     }
 
+    /**
+     * Tests that all menu actions referenced in the application's main menu have
+     * corresponding action handler methods implemented in the `MainWindowMenuHandler`
+     * class.
+     * <p>
+     * This test scans the source code for all invocations of menu actions and verifies:
+     * - Each menu action has a corresponding handler method with the naming convention
+     *   `<menuItemName>ActionPerformed`.
+     * - The handler methods may optionally accept a single integer argument, representing
+     *   a modifier key.
+     * - If no matching handler method is found, the test fails with an assertion error.
+     *
+     * The method uses a source code processing utility to locate method calls in all
+     * `.java` files under the `src` directory for validation.
+     *
+     * @throws Exception if the source code processing fails or any menu action lacks
+     *                   a corresponding handler method.
+     */
     @Test
     public void testMenuActions_invokeActions() throws Exception {
         Pattern pattern = Pattern.compile("getMainMenu\\(\\).invokeAction\\(\\s*\"([^\"]+)\"\\s*,");
@@ -126,9 +160,7 @@ public class MainWindowMenuTest extends TestCore {
     }
 
     /**
-     * Process the text content of all .java files under /src. Also check
-     * DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE for security reasons.
-     * And check invisible space character.
+     * Process the text content of all .java files under /src with the given consumer.
      *
      * @param consumer
      *            A function that accepts the file path and content


### PR DESCRIPTION
- Backport the check for BUGS#1290
- OmegaT 6.0.x does not have the same issue.
- The bug is not detected in master branch because there is missing the test, so backport the test case.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Added testMenuActions_invokeActions test method to validate that all menu actions in the source match defined methods in MainWindowMenuHandler.
- Introduced processSourceContent utility method for processing .java files in the /src directory.
- Improved code readability by:
    -  Replacing generic type declarations with the diamond operator (<>).
    - Reformatting assertions for better clarity.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
