### PR TITLE
Do not eat exception in loadConfFile

### DIFF
--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -204,7 +204,11 @@ public class SRX implements Serializable {
         // If file was not present or not readable
         inFile = new File(configDir, CONF_SENTSEG);
         if (inFile.exists()) {
-            return loadConfFile(inFile, configDir);
+            try {
+                return loadConfFile(inFile, configDir);
+            } catch (Exception ex) {
+                return SRX.getDefault();
+            }
         }
 
         // If none of the files (conf and srx) are present,
@@ -220,7 +224,7 @@ public class SRX implements Serializable {
      * is older than that of the current OmegaT, and tries to merge the two sets
      * of rules.
      */
-    static SRX loadConfFile(File configFile, File configDir) {
+    static SRX loadConfFile(File configFile, File configDir) throws Exception {
         SRX res;
         try {
             SRX.MyExceptionListener myel = new SRX.MyExceptionListener();
@@ -251,12 +255,15 @@ public class SRX implements Serializable {
                 Log.logInfoRB("SRX_RULE_FROM", configFile);
             }
         } catch (Exception e) {
+            res = null;
             // silently ignoring FNF
             if (!(e instanceof FileNotFoundException)) {
                 Log.log(e);
+            } else {
+                throw e;
             }
-            res = SRX.getDefault();
         }
+        // save only if we could read the file correctly...
         try {
             saveToSrx(res, configDir);
         } catch (Exception o3) {

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -114,7 +114,7 @@ public final class SRXTest {
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
 
         @Test
-        public void testSrxMigration() throws IOException {
+        public void testSrxMigration() throws Exception {
             File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_en", "segmentation.conf").toFile();
             File configDir = folder.newFolder();
             SRXTest.testSrxMigration(segmentConf, configDir);
@@ -130,7 +130,7 @@ public final class SRXTest {
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
 
         @Test
-        public void testSrxMigration() throws IOException {
+        public void testSrxMigration() throws Exception {
             File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_ja", "segmentation.conf").toFile();
             File configDir = folder.newFolder();
             SRXTest.testSrxMigration(segmentConf, configDir);
@@ -146,7 +146,7 @@ public final class SRXTest {
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
 
         @Test
-        public void testSrxMigration() throws IOException {
+        public void testSrxMigration() throws Exception {
             File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_de_54", "segmentation.conf").toFile();
             File configDir = folder.newFolder();
             SRXTest.testSrxMigration(segmentConf, configDir);
@@ -163,7 +163,7 @@ public final class SRXTest {
      * a segmentation.conf file that is produced by OmegaT in English
      * environment and Japanese environment.
      */
-    public static void testSrxMigration(File segmentConf, File configDir) throws IOException {
+    public static void testSrxMigration(File segmentConf, File configDir) throws Exception {
         File segmentSrx = new File(configDir, "segmentation.srx");
         // load from conf file
         SRX srxOrig = SRX.loadConfFile(segmentConf, configDir);

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;


### PR DESCRIPTION
SRX.loadConfigFile: If we fail to read the file, throw the exception instead of silently ignore it In unit tests, that can show whenever we break compatiblityhat is normal. 

## Pull request type

- Bug fix -> [bug]
- 
## Which ticket is resolved?

None, it is done to make resolution of CVE-2024-51366 better