### PR TITLE
security: change SRX handling by removing legacy configuration format

### DIFF
--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -212,7 +212,7 @@ public final class ProjectUICommands {
                 remoteRepositoryProvider.switchAllToLatest();
                 for (String file : new String[] { OConsts.FILE_PROJECT,
                         OConsts.DEFAULT_INTERNAL + '/' + FilterMaster.FILE_FILTERS,
-                        OConsts.DEFAULT_INTERNAL + '/' + SRX.CONF_SENTSEG }) {
+                        OConsts.DEFAULT_INTERNAL + '/' + SRX.SRX_SENTSEG }) {
                     remoteRepositoryProvider.copyFilesFromReposToProject(file);
                 }
 


### PR DESCRIPTION
work around for CVE-2024-51366

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

## What does this PR change?

- Replaced support for legacy "segmentation.conf" format with updated "segmentation.srx" handling.
- Drop vulnerable logic by removing migration logic.

## Other information
