### PR TITLE
[6.0][java17] Add nashorn javascript engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,9 @@ dependencies {
         runtimeOnly 'org.codehaus.groovy:groovy-dateutil:3.0.9'
         runtimeOnly 'org.apache.ivy:ivy:2.5.1'
 
+        // Javascript used for scripts
+        implementation 'org.openjdk.nashorn:nashorn-core:15.4'
+
         // Script editor
         implementation 'com.fifesoft:rsyntaxtextarea:3.2.0'
         implementation 'com.fifesoft:rstaui:3.2.0'

--- a/lib/licenses/Licenses.txt
+++ b/lib/licenses/Licenses.txt
@@ -76,3 +76,6 @@ mALIGNa is distributed under the MIT License (required for Aligner
 tool).
 
 DeNormalize.java is licensed under the DeNormalize license.
+
+Nashorn javascript engine is distributed under the GNU General Public
+License version 2.0 only with classpath link exception.


### PR DESCRIPTION
Backport PR #290

## Pull request type


- Build and release changes -> [build/release]


## Which ticket is resolved?
- Java 17 compatibility
-    https://sourceforge.net/p/omegat/feature-requests/1525/

## What does this PR change?

- Added org.openjdk.nashorn:nashorn-core:15.4 as a new JavaScript engine dependency in build.gradle.
- Updated Licenses.txt to include the licensing information for the newly added Nashorn JavaScript engine.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
