### PR TITLE
[6.0] feature: refactor SRX handling and add configuration migration tools

### DIFF
--- a/src/org/omegat/convert/segmentation/SegmentationConfMigrator.java
+++ b/src/org/omegat/convert/segmentation/SegmentationConfMigrator.java
@@ -1,0 +1,136 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.convert.segmentation;
+
+import org.omegat.core.segmentation.SRX;
+import org.omegat.util.ValidationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.ExceptionListener;
+import java.beans.XMLDecoder;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Hiroshi Miura
+ */
+public class SegmentationConfMigrator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SegmentationConfMigrator.class);
+
+    public static void main(String[] args) {
+        String targetDir = ".";
+        Path confFilePath = Paths.get(targetDir).resolve(SRX.CONF_SENTSEG);
+        Path srxFilePath = Paths.get(targetDir).resolve(SRX.SRX_SENTSEG);
+        ValidationResult validationResult = checkConfigFile(confFilePath);
+        if (!validationResult.isValid()) {
+            LOGGER.error(validationResult.getErrorMessage());
+            System.exit(2);
+        }
+        SRX srx = convertToSrx(confFilePath, srxFilePath);
+        if (srx == null) {
+            System.exit(1);
+        }
+    }
+
+    static ValidationResult checkConfigFile(Path configPath) {
+        if (!configPath.toFile().exists()) {
+            return ValidationResult.failure("File " + SRX.CONF_SENTSEG + " is not found!");
+        }
+        return ValidationResult.success();
+    }
+
+    static SRX convertToSrx(Path configPath, Path srxFilePath) {
+        try {
+            if (srxFilePath.toFile().exists()) {
+                Files.delete(srxFilePath);
+            }
+            File srxParent = srxFilePath.getParent().toFile();
+            SRX srx = loadConfFile(configPath.toFile());
+            SRX.saveToSrx(srx, srxParent);
+            return srx;
+        } catch (Exception e) {
+            LOGGER.error("Error occurred during conversion!", e);
+        }
+        return null;
+    }
+
+    /**
+     * Loads segmentation rules from an XML file.
+     */
+    private static SRX loadConfFile(File configFile) throws IOException {
+        SRX res;
+        MyExceptionListener myel = new MyExceptionListener();
+        // Need to use the vulnerable java.beans.XMLDecoder method for compatibility.
+        try (XMLDecoder xmldec = new XMLDecoder(new FileInputStream(configFile), null, myel, SRX.class.getClassLoader())) {
+            res = (SRX) xmldec.readObject();
+        }
+        if (myel.isExceptionOccured()) {
+            StringBuilder sb = new StringBuilder();
+            for (Exception ex : myel.getExceptionsList()) {
+                sb.append("    ");
+                sb.append(ex);
+                sb.append("\n");
+            }
+            throw new IllegalStateException(sb.toString());
+        }
+        return res;
+    }
+
+    /**
+     * My Own Class to listen to exceptions, occured while loading filters
+     * configuration.
+     */
+    static class MyExceptionListener implements ExceptionListener {
+        private final List<Exception> exceptionsList = new ArrayList<>();
+        private boolean exceptionOccured = false;
+
+        public void exceptionThrown(Exception e) {
+            exceptionOccured = true;
+            exceptionsList.add(e);
+        }
+
+        /**
+         * Returns whether any exceptions occured.
+         */
+        public boolean isExceptionOccured() {
+            return exceptionOccured;
+        }
+
+        /**
+         * Returns the list of occured exceptions.
+         */
+        public List<Exception> getExceptionsList() {
+            return exceptionsList;
+        }
+    }
+}

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -497,7 +497,7 @@ public class ProjectProperties {
      * Loads segmentation.conf if found in the /omegat folder of the project
      */
     public void loadProjectSRX() {
-        this.projectSRX = SRX.loadSRX(new File(getProjectInternal(), SRX.CONF_SENTSEG));
+        this.projectSRX = SRX.loadFromDir(new File(getProjectInternal()));
     }
 
     public Filters getProjectFilters() {

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -256,7 +256,7 @@ public class RealProject implements IProject {
     public void saveProjectProperties() throws Exception {
         unlockProject();
         try {
-            SRX.saveTo(config.getProjectSRX(), new File(config.getProjectInternal(), SRX.CONF_SENTSEG));
+            SRX.saveToSrx(config.getProjectSRX(), Paths.get(config.getProjectInternal()).toFile());
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);

--- a/src/org/omegat/core/segmentation/LanguageCodes.java
+++ b/src/org/omegat/core/segmentation/LanguageCodes.java
@@ -26,10 +26,10 @@
 
 package org.omegat.core.segmentation;
 
+import org.omegat.util.OStrings;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import org.omegat.util.OStrings;
 
 /**
  * Code-Key mappings for segmentation code.
@@ -43,7 +43,7 @@ public final class LanguageCodes {
     private LanguageCodes() {
     }
 
-    // Language Codes
+    // Codes of "languagerulename".
     public static final String CATALAN_CODE = "Catalan";
     public static final String CZECH_CODE = "Czech";
     public static final String GERMAN_CODE = "German";
@@ -84,7 +84,25 @@ public final class LanguageCodes {
     public static final String F_HTML_KEY = "CORE_SRX_RULES_FORMATTING_HTML";
 
     /** A Map from language codes to language keys. */
-    private static Map<String, String> codeKeyHash = new HashMap<String, String>();
+    private static final Map<String, String> codeKeyHash = new HashMap<>();
+
+    private static final String CATALAN_PATTERN = "CA.*";
+    private static final String CZECH_PATTERN = "CS.*";
+    private static final String GERMAN_PATTERN = "DE.*";
+    private static final String ENGLISH_PATTERN = "EN.*";
+    private static final String SPANISH_PATTERN = "ES.*";
+    private static final String FINNISH_PATTERN = "FI.*";
+    private static final String FRENCH_PATTERN = "FR.*";
+    private static final String ITALIAN_PATTERN = "IT.*";
+    private static final String JAPANESE_PATTERN = "JA.*";
+    private static final String DUTCH_PATTERN = "NL.*";
+    private static final String POLISH_PATTERN = "PL.*";
+    private static final String RUSSIAN_PATTERN = "RU.*";
+    private static final String SWEDISH_PATTERN = "SV.*";
+    private static final String SLOVAK_PATTERN = "SK.*";
+    private static final String CHINESE_PATTERN = "ZH.*";
+
+    private static final Map<String, String> patternHash = new HashMap<>();
 
     static {
         codeKeyHash.put(CATALAN_CODE, CATALAN_KEY);
@@ -105,6 +123,21 @@ public final class LanguageCodes {
         codeKeyHash.put(DEFAULT_CODE, DEFAULT_KEY);
         codeKeyHash.put(F_TEXT_CODE, F_TEXT_KEY);
         codeKeyHash.put(F_HTML_CODE, F_HTML_KEY);
+        patternHash.put(CATALAN_PATTERN, CATALAN_CODE);
+        patternHash.put(CZECH_PATTERN, CZECH_CODE);
+        patternHash.put(GERMAN_PATTERN, GERMAN_CODE);
+        patternHash.put(ENGLISH_PATTERN, ENGLISH_CODE);
+        patternHash.put(SPANISH_PATTERN, SPANISH_CODE);
+        patternHash.put(FINNISH_PATTERN, FINNISH_CODE);
+        patternHash.put(FRENCH_PATTERN, FRENCH_CODE);
+        patternHash.put(ITALIAN_PATTERN, ITALIAN_CODE);
+        patternHash.put(JAPANESE_PATTERN, JAPANESE_CODE);
+        patternHash.put(DUTCH_PATTERN, DUTCH_CODE);
+        patternHash.put(POLISH_PATTERN, POLISH_CODE);
+        patternHash.put(RUSSIAN_PATTERN, RUSSIAN_CODE);
+        patternHash.put(SWEDISH_PATTERN, SWEDISH_CODE);
+        patternHash.put(SLOVAK_PATTERN, SLOVAK_CODE);
+        patternHash.put(CHINESE_PATTERN, CHINESE_CODE);
     }
 
     /**
@@ -119,5 +152,31 @@ public final class LanguageCodes {
         }
         String key = codeKeyHash.get(code);
         return OStrings.getString(key);
+    }
+
+    public static boolean isLanguageCodeKnown(String code) {
+        return codeKeyHash.containsKey(code);
+    }
+
+    public static String getLanguageCodeByName(String name) {
+        if (name == null) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : codeKeyHash.entrySet()) {
+            if (OStrings.getString(entry.getValue()).equals(name)) {
+                return entry.getKey();
+            }
+        }
+        // migration heuristics: Germany translation changed in v5.5.
+        // See:
+        // https://github.com/omegat-org/omegat/pull/1158#issuecomment-2448788253
+        if (name.contains("Textdateien")) {
+            return LanguageCodes.F_TEXT_CODE;
+        }
+        return null;
+    }
+
+    public static String getLanguageCodeByPattern(String pattern) {
+        return patternHash.get(pattern);
     }
 }

--- a/src/org/omegat/core/segmentation/MapRule.java
+++ b/src/org/omegat/core/segmentation/MapRule.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2000-2006 Keith Godfrey and Maxym Mykhalchuk
+               2024 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,13 +26,14 @@
 
 package org.omegat.core.segmentation;
 
+import org.omegat.util.Log;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import org.omegat.util.StringUtil;
 
 /**
  * A class representing the language rules and their mapping to the segmentation
@@ -43,40 +45,98 @@ public class MapRule implements Serializable {
 
     private static final long serialVersionUID = -5868132953113679291L;
 
-    /** creates a new empty MapRule */
-    public MapRule() {
-    }
-
-    /** creates an initialized MapRule */
-    public MapRule(String language, String pattern, List<Rule> rules) {
-        this.setLanguage(language);
-        this.setPattern(pattern);
-        this.setRules(rules);
-    }
+    private static final Logger LOGGER = Logger.getLogger(MapRule.class.getName());
 
     /** Language Name */
     private String languageCode;
 
+    /**
+     * Creates a new empty MapRule.
+     * <p>
+     * When SRX.loadSrxFile loads segmentation.conf, java.beans.XMLDecoder
+     * create an empty object, then calls setLanguage and setPattern methods.
+     * </p>
+     */
+    public MapRule() {
+    }
+
+    /**
+     * Create initialized MapRule object.
+     * 
+     * @param language
+     *            localized language name (from segmentation.conf), or language
+     *            code (from SRX)
+     * @param pattern
+     *            language pattern such as "EN.*" or ".*"
+     * @param rules
+     *            segmentation rules.
+     */
+    public MapRule(String language, String pattern, List<Rule> rules) {
+        String code = LanguageCodes.getLanguageCodeByPattern(pattern);
+        this.setLanguage(code != null ? code : language);
+        this.setPattern(pattern);
+        this.setRules(rules);
+    }
+
     /** Returns Language Name (to display it in a dialog). */
-    public String getLanguage() {
+    public String getLanguageName() {
+        /*
+         * When there has already migrated a SRX file store, languageCode fields
+         * has a name defined as "LanguageCodes.*_CODE". Otherwise, MapRule
+         * object is created from "segmentation.conf" java beans file, so it is
+         * localized name of language. We first assume the latter. If res is
+         * empty, the object is created from a SRX file, then return
+         * languageCode itself.
+         */
         String res = LanguageCodes.getLanguageName(languageCode);
-        return StringUtil.isEmpty(res) ? languageCode : res;
+        if (res == null || res.isEmpty()) {
+            res = languageCode;
+        }
+        return res;
     }
 
-    /** Sets Language Name */
-    public void setLanguage(String language) {
-        this.languageCode = language;
+    /** Sets Language Code */
+    public void setLanguage(String code) {
+        /*
+         * setLanguage method is called from XmlDecoder of a Java beans library
+         * when migrating from "segmentation.conf" beans file. An argument will
+         * be localized name of language. When the object is created from a
+         * standard SRX file, the argument will be standard language name,
+         * defined as "LanguageCodes.*_CODE". The behavior was changed in OmegaT
+         * 6.0.0 release in 2023. We first detect whether the argument is
+         * standard code. If the code is not a standard code, then try to find a
+         * localized name of the language name. When you believe all the OmegaT
+         * 4.x and 5.x users are migrated to OmegaT 6.x or later, you may want
+         * to remove the workaround here.
+         */
+        if (!LanguageCodes.isLanguageCodeKnown(code)) {
+            String alt = LanguageCodes.getLanguageCodeByName(code);
+            if (alt != null) {
+                languageCode = alt;
+                return;
+            } else {
+                Log.logDebug(LOGGER, "Unknown languagerulename '{0}'", code);
+            }
+        }
+        languageCode = code;
     }
 
-    /** Returns Language Code for programmatic usage. */
-    public String getLanguageCode() {
+    /**
+     * Returns Language Code for programmatic usage.
+     */
+    public String getLanguage() {
         return languageCode;
     }
 
-    /** Pattern for the language/country ISO code (of a form LL-CC). */
+    /*
+     * Pattern for the language/country ISO code (of a form LL-CC). It is like
+     * "EN.*".
+     */
     private Pattern pattern;
 
-    /** Returns Pattern for the language/country ISO code (of a form LL-CC). */
+    /**
+     * Returns Pattern for the language/country ISO code (of a form LL-CC).
+     */
     public String getPattern() {
         if (pattern != null) {
             return pattern.pattern();
@@ -93,14 +153,24 @@ public class MapRule implements Serializable {
         return pattern;
     }
 
-    /** Sets Pattern for the language/country ISO code (of a form LL-CC). */
+    /**
+     * Sets Pattern for the language/country ISO code (of a form LL-CC).
+     * 
+     * @param pattern
+     *            pattern string such as "EN.*"
+     */
     public void setPattern(String pattern) throws PatternSyntaxException {
         // Fix for bug [1643500]
-        // language code in segmentation rule is case sensitive
+        // language code in segmentation rule is a case-sensitive
         // Correction contributed by Tiago Saboga.
         this.pattern = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
     }
 
+    /**
+     * Deep copy of the object, mandatory for java beans.
+     * 
+     * @return new MapRule object
+     */
     public MapRule copy() {
         MapRule result = new MapRule();
         result.languageCode = languageCode;
@@ -125,23 +195,28 @@ public class MapRule implements Serializable {
         this.rules = rules;
     }
 
-    /** Indicates whether some other MapRule is "equal to" this one. */
+    /**
+     * Indicates whether some other MapRule is "equal to" this one.
+     */
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof MapRule)) {
+        if (!(obj instanceof MapRule)) {
             return false;
         }
         MapRule that = (MapRule) obj;
-        return this.getPattern().equals(that.getPattern())
-                && this.getLanguage().equals(that.getLanguage())
+        return this.getPattern().equals(that.getPattern()) && this.getLanguage().equals(that.getLanguage())
                 && this.getRules().equals(that.getRules());
     }
 
-    /** Returns a hash code value for the object. */
+    /**
+     * Returns a hash code value for the object.
+     */
     public int hashCode() {
         return this.getPattern().hashCode() + this.getLanguage().hashCode() + this.getRules().hashCode();
     }
 
-    /** Returns a string representation of the MapRule for debugging purposes. */
+    /**
+     * Returns a string representation of the MapRule for debugging purposes.
+     */
     public String toString() {
         return getLanguage() + " (" + getPattern() + ") " + getRules().toString();
     }

--- a/src/org/omegat/util/OStrings.java
+++ b/src/org/omegat/util/OStrings.java
@@ -28,6 +28,7 @@ package org.omegat.util;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.function.Function;
@@ -71,14 +72,24 @@ public final class OStrings {
         IS_BETA = !b.getString("beta").isEmpty();
     }
 
+    private static final String BASENAME = "org/omegat/Bundle";
+
     /** Resource bundle that contains all the strings */
-    private static ResourceBundle bundle = ResourceBundle.getBundle("org/omegat/Bundle");
+    private static ResourceBundle bundle = ResourceBundle.getBundle(BASENAME);
 
     /**
      * Returns resource bundle.
      */
     public static ResourceBundle getResourceBundle() {
         return bundle;
+    }
+
+    /**
+     * Loads resources with the specified locale.
+     * @param locale Locale to load.
+     */
+    public static void loadBundle(Locale locale) {
+        bundle = ResourceBundle.getBundle(BASENAME, locale);
     }
 
     /**

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -39,6 +39,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 import org.omegat.core.segmentation.SRX;
@@ -675,9 +676,8 @@ public final class Preferences {
         SRX oldValue = srx;
         srx = newSrx;
 
-        File srxFile = new File(StaticUtils.getConfigDir() + SRX.CONF_SENTSEG);
         try {
-            SRX.saveTo(srx, srxFile);
+            SRX.saveToSrx(srx, Paths.get(StaticUtils.getConfigDir()).toFile());
         } catch (IOException ex) {
             ex.printStackTrace();
         }
@@ -764,8 +764,8 @@ public final class Preferences {
         }
         didInitSegmentation = true;
 
-        File srxFile = new File(StaticUtils.getConfigDir(), SRX.CONF_SENTSEG);
-        SRX s = SRX.loadSRX(srxFile);
+        File srxDir = new File(StaticUtils.getConfigDir());
+        SRX s = SRX.loadFromDir(srxDir);
         if (s == null) {
             s = SRX.getDefault();
         }

--- a/src/org/omegat/util/ValidationResult.java
+++ b/src/org/omegat/util/ValidationResult.java
@@ -1,0 +1,51 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.util;
+
+public class ValidationResult {
+    private final boolean valid;
+    private final String errorMessage;
+
+    public ValidationResult(boolean valid, String errorMessage) {
+        this.valid = valid;
+        this.errorMessage = errorMessage;
+    }
+
+    public static ValidationResult success() {
+        return new ValidationResult(true, null);
+    }
+
+    public static ValidationResult failure(String errorMessage) {
+        return new ValidationResult(false, errorMessage);
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/test/data/segmentation/locale_de_54/segmentation.conf
+++ b/test/data/segmentation/locale_de_54/segmentation.conf
@@ -1,0 +1,28039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<java version="17.0.12" class="java.beans.XMLDecoder">
+ <object class="org.omegat.core.segmentation.SRX" id="SRX0">
+  <void property="mappingRules">
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Katalanisch</string>
+     </void>
+     <void property="pattern">
+      <string>CA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pàg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ptes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>màx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdora\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Emm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excma\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>espf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. de C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>et al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>maj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>núm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pta\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Czech</string>
+     </void>
+     <void property="pattern">
+      <string>CS.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚŮŘ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Č(?i)S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)část\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)češ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)říj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řidč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.\sprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)švýc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žert\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBcA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bCSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDiS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bJUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPřísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhMr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRSDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bTh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.\ssl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akc\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arm\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bělor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.\sk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)boh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brig\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)círk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)citosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)děj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dějep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dět\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dřev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)des\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)euf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)event\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)folk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genmjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genpor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hanl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jad\.fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kožel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kupř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lékár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lék\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)loď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)marx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mazl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mlyn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mysl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námoř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)něm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)např\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nejč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)novin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)npor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nrtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nstržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\sp\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přít\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)před\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přivl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peněž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pořek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)po\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pohád\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poněk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)popř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prům\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)růz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.-uh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)raket\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rybn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sděl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sklář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soudr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)souhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)táz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)těl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)technol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uměl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vůb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\so\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)var\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veř\.\sobch\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sjm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vztaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zájm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbož\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zejm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zhrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpříd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)způs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpodst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zprav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvěr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.\s(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Deutsch</string>
+     </void>
+     <void property="pattern">
+      <string>DE.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.*</string>
+         </void>
+         <void property="beforebreak">
+          <string>www\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.at</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.de</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.a\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>abzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>am\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>amtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ank\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.Rh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Aufl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>beil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Best\.-Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Betr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bhf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\smed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\sphil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dtzd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ehem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>eigtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>evtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>exkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>F\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ffm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Forts\.\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Frl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>frz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Gebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gedr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gesch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hbf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>hpts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hptst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrsg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>inkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jhrl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.u\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>led\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MwSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>näml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Obb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Reg\.-Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.-k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.-kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schwäb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schweiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>So\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>StR\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>südd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tägl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.A\.w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>usw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vorm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.R\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>wg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Hd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ztr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>spez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sempf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Co\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>insg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Std\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>glw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stellv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>stv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.\sh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\p{Lu}\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>iqpr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Altb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ausst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>App\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Blk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bezugsf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hzg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>freist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mitben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gehob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Grdst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>incl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Di\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Do\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jährl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kaut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einstpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ki\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kinderfreundl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kochgel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kpl.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lux\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>neuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ren\.-bed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>selbst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Terr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Umgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.-Anb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Wohnfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\sf\.\sBaubiologie</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSachverst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ökol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>versch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>landwirtsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Tl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\schem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sStat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wvolksw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJhdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMagnet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUmgebungstemp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssynth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Phys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kurat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allerg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sTl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sArch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>extr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Petrochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bauaufs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sichtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>weibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>männl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMär\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sApr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sOkt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\[u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbiol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Werkstoffnr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svon\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sder\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bayer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Englisch</string>
+     </void>
+     <void property="pattern">
+      <string>EN.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>U\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)e\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)fig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[apAP]\.?[mM]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s\d</string>
+         </void>
+         <void property="beforebreak">
+          <string>No\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Aa]pprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\smi?n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[vV][sS]?\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Spanisch</string>
+     </void>
+     <void property="pattern">
+      <string>ES.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pág\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rte\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admón\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>EE\.UU\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>izq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Srta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Uds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Apdo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CC\.AA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entlo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excmo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>FF\.CC\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.V\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dcha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Da\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sto\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. C\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Finnisch</string>
+     </void>
+     <void property="pattern">
+      <string>FI.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-zäö]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ao\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ns\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>synt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vrt\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Französisch</string>
+     </void>
+     <void property="pattern">
+      <string>FR.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^a-z]p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>([A-Z]\.){2,}</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>^M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MM\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^A-Z]M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mme\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mlle\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.\sA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\d+</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Vv]ol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[\u00A0\s]»</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!][\u00A0\s]»</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Italienisch</string>
+     </void>
+     <void property="pattern">
+      <string>IT.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sacc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sagg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sartt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d&apos;a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.v\.d</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scondiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdeterm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdimostr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdipart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiplom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Amm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Can\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.\ Civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ d\.\ lav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ internaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ priv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ proces\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ rom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\secc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\seccl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sedit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ses\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sescl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simper\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simperf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simpers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sling\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.\ div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\socc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soccult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soculist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sogg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.\ scol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.es\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlcu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\squalif\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srifl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssecc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sseg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssegg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssigg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svol\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Japanisch</string>
+     </void>
+     <void property="pattern">
+      <string>JA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[）)]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Niederländisch</string>
+     </void>
+     <void property="pattern">
+      <string>NL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanw\. vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.C\.I\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.h\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.h\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.I\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\samb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sambt\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sanat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\santrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sapoth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarcheol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.a\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.u\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.B\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbetr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbez\.vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.g\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.L\.E\.V\.E</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sblz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.T\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.z\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.C\.E\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scentr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.E\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.F\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sComp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sderg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.w\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\senz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\set al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sE\.&amp;O\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sexcl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.A\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sget\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.G\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sg\.g\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sh\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.i\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sincl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sintern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.p\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.z\.g\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjkvr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sKon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.v\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sll\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.a\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.h\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.u\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B(r\.)</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.Br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.o\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.t\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sobl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.e\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sonov\.ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sopm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sov\.cmpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.Z\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spenn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sP\.T\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sresp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sR\.I\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.s\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.A\.B\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSecr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.P\.Q\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.v\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.V\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.h\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.n\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\suitsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.v\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svnl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svoorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.V\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sVz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.v\.t\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sX\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.M\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.W\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.Em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.h\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.O\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.L\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.v\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Polnisch</string>
+     </void>
+     <void property="pattern">
+      <string>PL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŁŚŻŹĆŃ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-złśzźćń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łuk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)św\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)źr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żeń\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żegl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)A\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)Urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)P\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.u\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absolw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)acc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aero\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ags\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aku\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alchem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arcyks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)austral\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)błp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bajk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bdb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezwzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białorus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)blp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bryt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bułg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.b\.d\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cbdu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cdn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chłodn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cieśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cnd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)col\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cybern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cykl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)daw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)diag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dolnośl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)drewn.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dyr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dziec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)egz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elakust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)emg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)europ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fizjol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)flam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)funt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)górn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)giełd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gleb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)godz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)grub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)h\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hand\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)handl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hiszp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hitl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hutn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydrogeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)im\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)izol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jęz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)j\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jeźdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jwt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)karc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kark\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kasz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kier\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kolej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kompl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)księg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kulin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ldz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)leśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lekceważ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)licz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lotn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)małop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)masz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mies\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mkw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nadzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nawig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ndzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieżyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niesygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nlb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)norw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)np\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nukl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)num\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)numiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ośw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obraźl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ocean\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ochr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)półn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.r\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paliw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pedag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)petr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszczot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pocz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podgat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podkarp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pograd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poprz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)port\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pouf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)powł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)praw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawdop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)proc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prz\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysłów\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ps\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psychol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psycht\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)qu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.ż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ros\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)słow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)san\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)serb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sierż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)siln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)socjal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spój\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spaw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szczec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szwajc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tatrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teatr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)techn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)term\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)transp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tw\.szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tyg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ubezp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uczn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzęd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uzbr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wędr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)węg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włók\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włókn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)warm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiertn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.-kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)woj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wojsk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wroc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ws\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wybuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wydz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wykrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wytrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzbog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)xx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ząbk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zagr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zaim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zazw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ziel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zootech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMojż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bS\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSz\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.\s(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Russisch</string>
+     </void>
+     <void property="pattern">
+      <string>RU.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.е\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.к\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.ст\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.\sст\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Schwedisch</string>
+     </void>
+     <void property="pattern">
+      <string>SV.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dvs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.v\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>el\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>enl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>feb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>febr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fr\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>forts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>st\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lör\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.fl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mån\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>okt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>osv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.s\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pga\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.g\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>plur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sön\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.ex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\säv\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Slovak</string>
+     </void>
+     <void property="pattern">
+      <string>SK.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ázij\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)číslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)š\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)švéd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)j\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>DrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>JUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>L\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mgr\.art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PeadDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhD\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>RNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zb\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)účt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ľud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i) podst\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)admin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akuz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)argot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ban\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezpredm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)burž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)charakt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cirk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrovar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)defekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)det\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)distrib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)duš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dvojčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektrotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)evid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)garb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréckokat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)graf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hlav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hromad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hypok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inštr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indik\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.vr\.riad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhových\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhozáp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)koef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kozmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krajč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kresť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)latinskoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lingv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)míl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)medzinár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)napr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)naznač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niž\.hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odkaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ods\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oslab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)osob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ovoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)označ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)písm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôdohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peňaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)penaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)politol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)porov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)použ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prír\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)predl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pren\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)priraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)privl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rádiotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)róm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)relat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhlas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozlič\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozpráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rumun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)súvzť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)severoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skup\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sloven\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sociol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spôs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoloč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoluhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)správ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stĺ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)star\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starogréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starorím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)strv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teoret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)turist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)umel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vôb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vých\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtvar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)všeob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veter\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)viď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vnút\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vodohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vonk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vymedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vysokoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vzťaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)západoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zápor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastaráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zjemn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zried\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bboh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bdom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.\s(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Chinesisch</string>
+     </void>
+     <void property="pattern">
+      <string>ZH.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[’”&quot;」）』？—]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！—]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[、,.．]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Standard</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\p{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>^\s*\p{Nd}+[\p{Nd}\.\)\]]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Segmentierung der Textdateien</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string> +</string>
+         </void>
+         <void property="beforebreak">
+          <string>\n</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Segmentierung von HTML-, XHTML-, ODF- und Infix-Dateien</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>&lt;br\d+/?&gt;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+  </void>
+  <void property="version">
+   <string>0.2.2</string>
+  </void>
+ </object>
+</java>

--- a/test/data/segmentation/locale_en/segmentation.conf
+++ b/test/data/segmentation/locale_en/segmentation.conf
@@ -1,0 +1,28039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<java version="11.0.16.1" class="java.beans.XMLDecoder">
+ <object class="org.omegat.core.segmentation.SRX" id="SRX0">
+  <void property="mappingRules">
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Catalan</string>
+     </void>
+     <void property="pattern">
+      <string>CA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pàg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ptes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>màx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdora\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Emm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excma\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>espf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. de C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>et al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>maj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>núm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pta\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>チェコ語（Czech）</string>
+     </void>
+     <void property="pattern">
+      <string>CS.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚŮŘ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Č(?i)S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)část\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)češ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)říj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řidč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.\sprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)švýc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žert\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBcA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bCSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDiS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bJUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPřísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhMr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRSDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bTh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.\ssl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akc\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arm\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bělor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.\sk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)boh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brig\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)círk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)citosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)děj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dějep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dět\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dřev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)des\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)euf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)event\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)folk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genmjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genpor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hanl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jad\.fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kožel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kupř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lékár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lék\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)loď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)marx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mazl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mlyn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mysl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námoř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)něm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)např\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nejč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)novin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)npor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nrtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nstržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\sp\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přít\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)před\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přivl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peněž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pořek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)po\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pohád\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poněk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)popř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prům\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)růz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.-uh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)raket\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rybn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sděl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sklář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soudr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)souhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)táz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)těl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)technol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uměl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vůb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\so\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)var\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veř\.\sobch\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sjm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vztaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zájm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbož\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zejm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zhrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpříd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)způs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpodst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zprav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvěr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.\s(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>German</string>
+     </void>
+     <void property="pattern">
+      <string>DE.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.*</string>
+         </void>
+         <void property="beforebreak">
+          <string>www\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.at</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.de</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.a\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>abzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>am\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>amtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ank\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.Rh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Aufl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>beil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Best\.-Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Betr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bhf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\smed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\sphil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dtzd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ehem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>eigtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>evtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>exkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>F\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ffm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Forts\.\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Frl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>frz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Gebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gedr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gesch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hbf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>hpts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hptst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrsg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>inkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jhrl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.u\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>led\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MwSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>näml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Obb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Reg\.-Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.-k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.-kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schwäb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schweiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>So\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>StR\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>südd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tägl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.A\.w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>usw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vorm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.R\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>wg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Hd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ztr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>spez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sempf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Co\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>insg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Std\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>glw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stellv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>stv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.\sh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\p{Lu}\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>iqpr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Altb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ausst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>App\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Blk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bezugsf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hzg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>freist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mitben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gehob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Grdst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>incl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Di\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Do\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jährl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kaut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einstpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ki\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kinderfreundl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kochgel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kpl.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lux\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>neuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ren\.-bed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>selbst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Terr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Umgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.-Anb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Wohnfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\sf\.\sBaubiologie</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSachverst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ökol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>versch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>landwirtsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Tl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\schem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sStat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wvolksw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJhdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMagnet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUmgebungstemp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssynth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Phys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kurat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allerg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sTl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sArch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>extr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Petrochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bauaufs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sichtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>weibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>männl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMär\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sApr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sOkt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\[u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbiol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Werkstoffnr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svon\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sder\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bayer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>English</string>
+     </void>
+     <void property="pattern">
+      <string>EN.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>U\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)e\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)fig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[apAP]\.?[mM]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s\d</string>
+         </void>
+         <void property="beforebreak">
+          <string>No\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Aa]pprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\smi?n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[vV][sS]?\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Spanish</string>
+     </void>
+     <void property="pattern">
+      <string>ES.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pág\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rte\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admón\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>EE\.UU\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>izq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Srta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Uds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Apdo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CC\.AA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entlo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excmo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>FF\.CC\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.V\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dcha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Da\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sto\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. C\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Finnish</string>
+     </void>
+     <void property="pattern">
+      <string>FI.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-zäö]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ao\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ns\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>synt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vrt\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>French</string>
+     </void>
+     <void property="pattern">
+      <string>FR.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^a-z]p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>([A-Z]\.){2,}</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>^M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MM\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^A-Z]M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mme\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mlle\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.\sA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\d+</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Vv]ol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[\u00A0\s]»</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!][\u00A0\s]»</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Italian</string>
+     </void>
+     <void property="pattern">
+      <string>IT.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sacc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sagg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sartt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d&apos;a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.v\.d</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scondiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdeterm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdimostr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdipart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiplom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Amm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Can\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.\ Civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ d\.\ lav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ internaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ priv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ proces\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ rom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\secc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\seccl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sedit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ses\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sescl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simper\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simperf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simpers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sling\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.\ div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\socc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soccult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soculist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sogg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.\ scol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.es\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlcu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\squalif\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srifl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssecc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sseg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssegg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssigg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svol\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Japanese</string>
+     </void>
+     <void property="pattern">
+      <string>JA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[）)]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Dutch</string>
+     </void>
+     <void property="pattern">
+      <string>NL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanw\. vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.C\.I\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.h\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.h\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.I\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\samb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sambt\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sanat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\santrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sapoth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarcheol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.a\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.u\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.B\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbetr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbez\.vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.g\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.L\.E\.V\.E</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sblz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.T\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.z\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.C\.E\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scentr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.E\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.F\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sComp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sderg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.w\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\senz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\set al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sE\.&amp;O\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sexcl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.A\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sget\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.G\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sg\.g\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sh\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.i\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sincl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sintern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.p\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.z\.g\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjkvr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sKon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.v\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sll\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.a\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.h\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.u\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B(r\.)</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.Br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.o\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.t\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sobl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.e\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sonov\.ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sopm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sov\.cmpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.Z\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spenn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sP\.T\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sresp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sR\.I\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.s\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.A\.B\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSecr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.P\.Q\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.v\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.V\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.h\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.n\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\suitsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.v\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svnl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svoorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.V\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sVz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.v\.t\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sX\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.M\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.W\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.Em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.h\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.O\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.L\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.v\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Polish</string>
+     </void>
+     <void property="pattern">
+      <string>PL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŁŚŻŹĆŃ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-złśzźćń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łuk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)św\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)źr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żeń\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żegl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)A\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)Urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)P\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.u\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absolw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)acc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aero\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ags\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aku\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alchem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arcyks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)austral\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)błp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bajk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bdb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezwzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białorus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)blp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bryt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bułg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.b\.d\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cbdu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cdn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chłodn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cieśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cnd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)col\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cybern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cykl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)daw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)diag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dolnośl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)drewn.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dyr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dziec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)egz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elakust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)emg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)europ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fizjol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)flam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)funt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)górn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)giełd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gleb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)godz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)grub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)h\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hand\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)handl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hiszp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hitl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hutn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydrogeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)im\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)izol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jęz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)j\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jeźdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jwt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)karc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kark\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kasz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kier\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kolej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kompl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)księg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kulin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ldz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)leśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lekceważ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)licz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lotn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)małop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)masz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mies\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mkw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nadzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nawig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ndzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieżyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niesygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nlb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)norw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)np\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nukl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)num\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)numiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ośw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obraźl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ocean\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ochr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)półn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.r\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paliw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pedag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)petr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszczot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pocz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podgat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podkarp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pograd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poprz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)port\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pouf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)powł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)praw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawdop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)proc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prz\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysłów\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ps\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psychol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psycht\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)qu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.ż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ros\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)słow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)san\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)serb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sierż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)siln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)socjal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spój\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spaw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szczec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szwajc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tatrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teatr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)techn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)term\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)transp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tw\.szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tyg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ubezp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uczn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzęd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uzbr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wędr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)węg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włók\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włókn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)warm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiertn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.-kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)woj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wojsk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wroc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ws\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wybuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wydz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wykrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wytrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzbog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)xx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ząbk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zagr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zaim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zazw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ziel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zootech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMojż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bS\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSz\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.\s(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Russian</string>
+     </void>
+     <void property="pattern">
+      <string>RU.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.е\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.к\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.ст\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.\sст\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Swedish</string>
+     </void>
+     <void property="pattern">
+      <string>SV.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dvs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.v\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>el\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>enl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>feb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>febr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fr\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>forts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>st\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lör\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.fl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mån\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>okt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>osv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.s\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pga\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.g\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>plur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sön\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.ex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\säv\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Slovak</string>
+     </void>
+     <void property="pattern">
+      <string>SK.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ázij\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)číslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)š\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)švéd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)j\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>DrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>JUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>L\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mgr\.art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PeadDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhD\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>RNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zb\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)účt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ľud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i) podst\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)admin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akuz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)argot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ban\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezpredm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)burž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)charakt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cirk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrovar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)defekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)det\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)distrib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)duš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dvojčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektrotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)evid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)garb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréckokat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)graf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hlav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hromad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hypok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inštr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indik\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.vr\.riad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhových\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhozáp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)koef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kozmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krajč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kresť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)latinskoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lingv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)míl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)medzinár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)napr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)naznač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niž\.hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odkaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ods\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oslab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)osob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ovoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)označ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)písm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôdohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peňaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)penaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)politol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)porov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)použ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prír\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)predl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pren\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)priraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)privl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rádiotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)róm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)relat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhlas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozlič\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozpráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rumun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)súvzť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)severoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skup\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sloven\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sociol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spôs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoloč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoluhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)správ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stĺ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)star\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starogréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starorím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)strv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teoret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)turist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)umel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vôb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vých\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtvar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)všeob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veter\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)viď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vnút\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vodohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vonk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vymedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vysokoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vzťaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)západoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zápor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastaráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zjemn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zried\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bboh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bdom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.\s(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Chinese</string>
+     </void>
+     <void property="pattern">
+      <string>ZH.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[’”&quot;」）』？—]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！—]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[、,.．]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Default</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\p{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>^\s*\p{Nd}+[\p{Nd}\.\)\]]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>Text</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string> +</string>
+         </void>
+         <void property="beforebreak">
+          <string>\n</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>HTML</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>&lt;br\d+/?&gt;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+  </void>
+  <void property="version">
+   <string>0.2.2</string>
+  </void>
+ </object>
+</java>

--- a/test/data/segmentation/locale_ja/segmentation.conf
+++ b/test/data/segmentation/locale_ja/segmentation.conf
@@ -1,0 +1,28039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<java version="11.0.16.1" class="java.beans.XMLDecoder">
+ <object class="org.omegat.core.segmentation.SRX" id="SRX0">
+  <void property="mappingRules">
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>カタルーニャ語</string>
+     </void>
+     <void property="pattern">
+      <string>CA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pàg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ptes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>màx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdora\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Emm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excma\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>espf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. de C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admdor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>et al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\. e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>maj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>núm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pta\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>チェコ語（Czech）</string>
+     </void>
+     <void property="pattern">
+      <string>CS.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚŮŘ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úř\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Č(?i)S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)část\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)č\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)češ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)říj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)řidč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)škpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)šprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.\sprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)švýc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žert\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bBcA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bCSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDiS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bDrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bJUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPřísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bP\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPhMr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bPharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bRSDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bTh\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.\ssl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akc\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arm\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bělor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.\sk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)boh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brig\.\sgen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)brit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)círk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)citosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)děj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dějep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dět\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dřev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)des\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)euf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)event\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)folk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genmjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genpor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hanl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)horol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jad\.fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kožel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kupř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lékár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lék\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)loď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)marx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mazl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mlyn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mysl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námoř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)něm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)např\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nejč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)novin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)npor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nrtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nstržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\sp\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)příp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přít\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)př\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)před\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)předp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)přivl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\sn\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peněž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pořek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)po\sKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pohád\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poněk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)popř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pprap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prům\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)růz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rak\.-uh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)raket\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rybn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sděl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sklář\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soudr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)souhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.\s</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.\ss\sr\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)střv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stržm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)táz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)těl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)technol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uměl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vůb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\so\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.\sv\.\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)var\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veř\.\sobch\.\sspol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sjm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vztaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zájm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zř\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbož\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zejm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeměp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zhrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpříd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)způs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zpodst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zprav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvěr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.\s(?i)[a-zšžčňľáúůř]??(?i)[a-zšžčňľáúůř]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>ドイツ語</string>
+     </void>
+     <void property="pattern">
+      <string>DE.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.*</string>
+         </void>
+         <void property="beforebreak">
+          <string>www\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.at</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\.de</string>
+         </void>
+         <void property="beforebreak">
+          <string>.*</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.a\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Abt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>abzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>am\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>amtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ank\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Anm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\.Rh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Aufl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>beil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Best\.-Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Betr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bhf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dipl\.-Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\smed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.\sphil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dtzd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ehem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>eigtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Erw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>evtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>exkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>F\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ffm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Forts\.\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Frl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>frz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Gebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gedr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gesch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hbf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>hpts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hptst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hrsg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.J\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>inkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jhrl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>k\.u\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>led\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MwSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>näml\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Obb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.Adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Reg\.-Bez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>r\.-k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>röm\.-kath\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schwäb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>schweiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>So\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>StR\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>südd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tägl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.Ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.A\.w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>usw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vorm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.R\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.u\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>wg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Hd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ztr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>spez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mio\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sempf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Co\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>engl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>insg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Std\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>glw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stellv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>stv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sT\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.\sh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\p{Lu}\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>iqpr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Altb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ausst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>App\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Blk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bezugsf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hzg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>erl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>freist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mitben\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>geh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>gehob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Grdst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ges\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Hdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>incl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Di\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Do\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stck\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jährl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kaut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einstpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ki\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kinderfreundl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kochgel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kpl.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>möbl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lux\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>neuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Nfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ren\.-bed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>selbst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Stud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Terr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Umgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.-Anb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Verk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Wohnfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>verm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Jg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\sf\.\sBaubiologie</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSachverst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ökol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>versch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>landwirtsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.Tl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\schem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sStat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s\Wvolksw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJhdt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMagnet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUmgebungstemp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s%\s\?</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssynth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Phys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Österr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Kurat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>allerg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.ä\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>z\.\sTl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sArch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>extr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Biolog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Petrochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bauaufs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Entspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sichtl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>weibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>männl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ggfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMär\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sApr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sOkt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\[u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\(d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Einschl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbiol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Werkstoffnr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svon\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sder\setwa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bayer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>u\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>英語</string>
+     </void>
+     <void property="pattern">
+      <string>EN.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>U\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)e\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)fig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[apAP]\.?[mM]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s\d</string>
+         </void>
+         <void property="beforebreak">
+          <string>No\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Aa]pprox\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\smi?n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[vV][sS]?\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>スペイン語</string>
+     </void>
+     <void property="pattern">
+      <string>ES.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\. ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pág\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>av\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Rte\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>admón\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>EE\.UU\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>izq\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Srta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Vds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Ud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Uds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.ej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Apdo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CC\.AA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>entlo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Excmo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>FF\.CC\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>V\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>S\.A\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.V\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dcha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Da\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>P\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Pts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sta\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Sto\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>a\. C\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>フィンランド語</string>
+     </void>
+     <void property="pattern">
+      <string>FI.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-zäö]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\d.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ao\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>esim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ns\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>synt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>vrt\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>フランス語</string>
+     </void>
+     <void property="pattern">
+      <string>FR.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^a-z]p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>([A-Z]\.){2,}</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>^M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MM\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[^A-Z]M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mme\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mlle\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>réf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>C\.\sA\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[A-Z]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>cf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\d+</string>
+         </void>
+         <void property="beforebreak">
+          <string>(A|a)rt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[Vv]ol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>i\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>St\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s[a-z]</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[\u00A0\s]»</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!][\u00A0\s]»</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>イタリア語</string>
+     </void>
+     <void property="pattern">
+      <string>IT.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sacc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sagg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sartt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.d&apos;a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.v\.d</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scod\.\ proc\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scondiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdeterm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdimostr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdipart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiplom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Amm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ Can\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Dir\.\ Civ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ d\.\ lav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ internaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ it\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ priv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ proces\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ pub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDir\.\ rom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\secc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\seccl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sedit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ses\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sescl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simper\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simperf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\simpers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sling\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sloc\.\ div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sneol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\socc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soccult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\soculist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sogg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sord\.\ scol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sott\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.es\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlco\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sqlcu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\squalif\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sreg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srifl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\srom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssecc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sseg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssegg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssigg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspett\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svol\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>日本語</string>
+     </void>
+     <void property="pattern">
+      <string>JA.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[）)]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。．？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>オランダ語</string>
+     </void>
+     <void property="pattern">
+      <string>NL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saanw\. vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\saardr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sabstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.C\.I\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.d\.h\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sadm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safk\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\safl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.h\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.I\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\salg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\samb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sambt\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sanat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\santrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sapoth\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sAr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sarcheol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.s\.a\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sa\.u\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sA\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.B\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbetr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbez\.vnw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.g\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbijz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.L\.E\.V\.E</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sblz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.T\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sB\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sb\.z\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.C\.E\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scentr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.E\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\scfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sconf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sCie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.F\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sC\.I\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sComp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sderg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdiv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdra\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sD\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sd\.w\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.c\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\senz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\setc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\set al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sE\.&amp;O\.E\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\se\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sexcl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sFa\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.o\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.A\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgeb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sget\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.G\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sg\.g\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sgld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sG\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sh\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sH\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.c\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.h\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.i\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sincl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sintern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.p\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.v\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\si\.z\.g\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sJ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjkvr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sjr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sk\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sKon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\skt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sK\.v\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sll\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sL\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\slt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.a\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMevr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.h\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smi\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.m\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\smr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sm\.u\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sMw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.B(r\.)</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.Br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNdl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.N\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sNo\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.o\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\snrs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.t\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sn\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sN\.W\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sobl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.d\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.e\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.i\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.l\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.L\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\song\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sonov\.ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sopm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sov\.cmpl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\so\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sO\.Z\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.a</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spenn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\splv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sPres\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprof\.em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sprov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sp\.st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sP\.T\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.q\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sq\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sref\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sresp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sR\.I\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sr\.s\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.A\.B\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSecr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sspec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ssp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.P\.Q\.R\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sSt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.s\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.v\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sS\.V\.Z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.a\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.g\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.h\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\stk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.k\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.n\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.o\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.w\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\st\.z\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sUed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\suitsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.N\.O\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sU\.S\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\su\.v\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svnl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\svoorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.t\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.v\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sV\.V\.V\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sv\.w\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sVz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sW\.L\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sw\.v\.t\.t\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sX\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.M\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sY\.W\.C\.A\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.B\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.b\.b\.h\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.Em\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\szgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.g\.a\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.h\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.K\.H\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.O\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sZ\.M\.L\.K\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.o\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.s\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sz\.v\.v\.a\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>ポーランド語</string>
+     </void>
+     <void property="pattern">
+      <string>PL.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŁŚŻŹĆŃ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-złśzźćń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)łuk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)śr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)środ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)św\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)źr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żarg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żeń\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żegl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)żyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)A\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)U\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)Dz\.(?i)Urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)P\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.t\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)a\.u\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absolw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)acc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aero\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ags\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aku\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alchem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)apost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arcyks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)asp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)austral\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)błp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bajk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bdb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezwzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białorus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)białost\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biochem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)blp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)br\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bryt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bułg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)c\.b\.d\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cbdu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cdn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chłodn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cieśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cnd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)col\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cybern\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cykl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)czyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)daw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dgn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)diag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dolnośl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)drewn.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ds\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dyr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dziec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)e\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)egz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekspr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)el\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elakust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)emg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)europ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ew\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fant\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fizjol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)flam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)funt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)górn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)giełd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gleb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)godz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gorz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)grub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)h\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hand\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)handl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hiszp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hitl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hutn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hydrogeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ibid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)im\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)itp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)izol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jęz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)j\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jeźdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jwt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)k\.(?i)p\.(?i)c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)karc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kard\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kark\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kasz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kier\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kolej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kompl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kosmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kpt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)książk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)księg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kulin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.dz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)l\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ldz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)leśn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.dent\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lekceważ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)licz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lmn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lotn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.in\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)małop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maks\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)masz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mies\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mit\.gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mkw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.w\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.med\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.p\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nadzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nawig\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ndzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieżyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nieos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niesygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nlb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)norw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)np\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nukl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)num\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)numiz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ośw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obraźl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ocean\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ochr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)półn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)płn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.C\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.f\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.n\.e\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.p\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.r\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paleont\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)paliw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pedag\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)petr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pieszczot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pocz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podgat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podkarp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poez\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pograd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poprz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)por\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)port\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pouf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)powł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pow\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ppor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)praw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawdop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prawn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)proc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prz\.Chr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przest\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przyp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysłów\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)przysz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ps\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pseud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psychol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psycht\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pszcz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)qu\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.ż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)red\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ros\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozdz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rtm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rzem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)słow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)san\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)serb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sierż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)siln\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)socjal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spój\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spaw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sygn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szczec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szkol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)szwajc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tabl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tatrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teatr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)techn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telegr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)term\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tow\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)transp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tw\.szt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tyg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ub\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ubezp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uczn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzęd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urzecz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ust\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uw\.tłum\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)uzbr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wędr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)węg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włók\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)włókn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)w\.g\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)warm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wiertn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wlkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wod\.-kan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)woj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wojsk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wroc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ws\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wsp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ww\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wybuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wydz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wyk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wykrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wytrz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzbog\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)wzgl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)xx\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ząbk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zł\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zagr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zaim\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zazw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zbroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zeg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ziel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zootech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zw\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bMojż\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bN\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bS\.T\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bSz\.P\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.\s(?i)[a-zżśćźń]??(?i)[a-zżśćźń]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>ロシア語</string>
+     </void>
+     <void property="pattern">
+      <string>RU.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.е\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)т\.к\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.ст\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>рт\.\sст\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>スウェーデン語</string>
+     </void>
+     <void property="pattern">
+      <string>SV.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>adr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>aug\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>bl\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>b\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sbv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>dvs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>d\.v\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>el\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>enl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>etc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>e\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ff\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>feb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>febr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.n\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>f\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fr\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>forts\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>fre\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>st\.f\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>jfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>kl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>lör\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.fl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mha\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.h\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>mån\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>n\.b\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>nov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.dyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>okt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ons\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>osv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>o\.s\.v\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>pga\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>p\.g\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\spl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>plur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\ss\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sept\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>sön\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>s\.k\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\sst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.ex\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>t\.o\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>tors\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\säv\.</string>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>スロバキア語（Slovak）</string>
+     </void>
+     <void property="pattern">
+      <string>SK.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[0-9]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b[A-ZŠŽČŇĽÁÚ]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\s[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ázij\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)číslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.d\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)č\.u\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)čs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)š\.p\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šach\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)škol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)špan\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)šport\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)štyl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)švéd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)žid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.a\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.h\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)a\.s\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)ing\.(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)j\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>A\.D\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Bc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>CSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>DrSc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>JUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>L\.S\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MDDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MUDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>MVDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Mgr\.art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PeadDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhD\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PhDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>PharmDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>RNDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>ThDr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>Zb\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)účt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)úct\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)čes\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ľud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)špec\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)št\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)žen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)živ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i) podst\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)absol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)abstr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)admin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)adv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)afr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)akuz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)al\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)alch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)amer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)angl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anglosas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)anorg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)antrop\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archeol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)archit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)arg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)argot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astrol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)astron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)atď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)att\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)aut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)býv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.c\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)b\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ban\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)belg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bezpredm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bibl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)biol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)bulh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)burž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cca\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)charakt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)chorv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cirk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)csl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)cukrovar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dór\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)defekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dej\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)det\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dial\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dipl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)distrib\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)div\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)doc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dopr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dosl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)druh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)duš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)dvojčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ekon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)elektrotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)energet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)epic\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)est\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)etnonym\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eufem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)eur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)evid\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)expr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fín\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)farm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fax\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)feud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)film\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)filoz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)form\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fot\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)franc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fraz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)fyziol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)garb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gen\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)genet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)geom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)germ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gréckokat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)graf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)gram\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hebr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)herald\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hlav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hromad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hrub\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hut\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hyd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)hypok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ión\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ie\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)imp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)impf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inštr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ind\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indik\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)indoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)inform\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ing\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)instr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)int\.vr\.riad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)interj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)iron\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)jedn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhových\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)juhozáp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kanc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kap\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kapit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kart\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)katalán\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ker\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)klas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kniž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)knih\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)koef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)komp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)konkr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kozmet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)krajč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kraj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kresť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kuch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)kult\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)latinskoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lek\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)les\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)let\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lingv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)liturg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)log\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)lud\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)míl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)m\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)maď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)max\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)medzinár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)meteor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)metr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mgr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mil\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)min\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)miner\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mld\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)motor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ms\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)muž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mytol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)mz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)náb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)námor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nár\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nás\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)n\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)napr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)naznač\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)než\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neživ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nedok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neklas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nem\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neodb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neos\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neskl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nesklon\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nespráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neurc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)neved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niž\.hovor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)niekt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)nom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.i\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)o\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obuv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)obyc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)odkaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ods\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ojed\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)op\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opak\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)opyt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)org\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)os\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oslab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)osob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ovoc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)označ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)oznam\.tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pís\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)písm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôdohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pôv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)p\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)par\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)part\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)peňaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ped\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pejor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)penaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pers\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)phdr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)piv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)plpf\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľno\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poľov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pošt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podčl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pod\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)podst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polit\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)politol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polnohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)polygr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pomn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)poraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)porov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)posch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)potrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)použ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pplk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)práv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príd\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prír\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prísl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)príslov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pr\.n\.l\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prac\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)predl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)pren\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prep\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prir\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)priraď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)privl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)prof\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)psych\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)publ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rádiotech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)róm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rad\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rcsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)refl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)reg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)relat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)resp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rkp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)roc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozhlas\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozlič\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rozpráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rumun\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)rus\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ryb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)súvzť\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)s\.r\.o\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)samohl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)severoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)skup\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slang\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)slov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sloven\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)soch\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sociol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sov\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spôs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoloč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)spoluhl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)správ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)srb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stĺ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)st\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)star\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starogréc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)starorím\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stfr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)str\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stred\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stredoamer\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stroj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)strv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)stsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subšt\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)subst\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)superl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)svet\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)sz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.č\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.j\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.m\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)t\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tab\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tech\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telef\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teles\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)telev\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)teoret\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)text\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tis\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)trans\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)turist\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)typogr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)tzv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ukaz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ul\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)umel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)univ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urč\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)urc\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vôb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vých\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výsl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)výtvar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)význ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)včel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vš\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)všeob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)v\.r\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vedľ\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ved\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)ver\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)verb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)veter\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)viď\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vin\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vl\.\sm\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vnút\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vodohosp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)voj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vok\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vonk\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vs\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vulg\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vyj\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vymedz\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vys\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vysokoškol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)vzťaž\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záhr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zákl\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zám\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)záp\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)západoeur\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zápor\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)z\.z\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zahr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zal\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zast\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastaráv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zastar\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zb\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrav\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zdrob\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zjemn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zlom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zn\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zool\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zried\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zv\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvel\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvol\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)zvrat\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bKr\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bboh\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\bdom\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>art\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\b(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.\s(?i)[a-zšžčňľáú]??(?i)[a-zšžčňľáú]\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\?\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>\!\&quot;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>中国語（Chinese）</string>
+     </void>
+     <void property="pattern">
+      <string>ZH.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>[’”&quot;」）』？—]</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！—]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[、,.．]</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>[。？！]</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>初期値</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\P{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>\.\.\.</string>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s+\p{Lu}</string>
+         </void>
+         <void property="beforebreak">
+          <string>^\s*\p{Nd}+[\p{Nd}\.\)\]]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>\s</string>
+         </void>
+         <void property="beforebreak">
+          <string>[\.\?\!]+</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>テキストファイル</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string> +</string>
+         </void>
+         <void property="beforebreak">
+          <string>\n</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+   <void method="add">
+    <object class="org.omegat.core.segmentation.MapRule">
+     <void property="language">
+      <string>HTML, XHTML, ODF と Infix ファイル</string>
+     </void>
+     <void property="pattern">
+      <string>.*</string>
+     </void>
+     <void property="rules">
+      <object class="java.util.ArrayList">
+       <void method="add">
+        <object class="org.omegat.core.segmentation.Rule">
+         <void property="afterbreak">
+          <string>.</string>
+         </void>
+         <void property="beforebreak">
+          <string>&lt;br\d+/?&gt;</string>
+         </void>
+         <void property="breakRule">
+          <boolean>true</boolean>
+         </void>
+        </object>
+       </void>
+      </object>
+     </void>
+    </object>
+   </void>
+  </void>
+  <void property="version">
+   <string>0.2.2</string>
+  </void>
+ </object>
+</java>

--- a/test/src/org/omegat/convert/segmentation/SegmentationConfMigratorTest.java
+++ b/test/src/org/omegat/convert/segmentation/SegmentationConfMigratorTest.java
@@ -1,0 +1,161 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2016 Aaron Madlon-Kay
+               2024-2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.convert.segmentation;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.omegat.core.segmentation.LanguageCodes;
+import org.omegat.core.segmentation.MapRule;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.util.LocaleRule;
+import org.omegat.util.OStrings;
+import org.omegat.util.ValidationResult;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
+ */
+@RunWith(Enclosed.class)
+public final class SegmentationConfMigratorTest {
+
+    private static final String SEGMENT_CONF_BASE = "test/data/segmentation/";
+
+    public static class SRXMigrateTest {
+
+        @org.junit.Rule
+        public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+
+        @org.junit.Rule
+        public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
+
+        @Test
+        public void testSrxMigration() throws Exception {
+            File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_en", "segmentation.conf").toFile();
+            File configDir = folder.newFolder();
+            SegmentationConfMigratorTest.testSrxMigration(segmentConf, configDir);
+        }
+    }
+
+    public static class SRXMigrateJaTest {
+
+        @org.junit.Rule
+        public final LocaleRule localeRule = new LocaleRule(new Locale("ja"));
+
+        @org.junit.Rule
+        public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
+
+        @Test
+        public void testSrxMigration() throws Exception {
+            File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_ja", "segmentation.conf").toFile();
+            File configDir = folder.newFolder();
+            SegmentationConfMigratorTest.testSrxMigration(segmentConf, configDir);
+        }
+    }
+
+    public static class SRXMigrateOldDeTest {
+
+        @org.junit.Rule
+        public final LocaleRule localeRule = new LocaleRule(new Locale("de"));
+
+        @org.junit.Rule
+        public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
+
+        @Test
+        public void testSrxMigration() throws Exception {
+            File segmentConf = Paths.get(SEGMENT_CONF_BASE, "locale_de_54", "segmentation.conf").toFile();
+            File configDir = folder.newFolder();
+            SegmentationConfMigratorTest.testSrxMigration(segmentConf, configDir);
+        }
+    }
+
+    /**
+     * Test SRX writer/reader.
+     * <p>
+     * Previous versions have a bug when saving segmentation.conf file. It is
+     * better to save language property using language code defined in
+     * LanguageCode class. Unfortunately, OmegaT 6.0 and before produce a
+     * localized language name for the property. The test case here trys reading
+     * a segmentation.conf file that is produced by OmegaT in English
+     * environment and Japanese environment.
+     */
+    public static void testSrxMigration(File segmentConf, File configDir) {
+        File segmentSrx = new File(configDir, "segmentation.srx");
+        // load from conf file
+        assertTrue(segmentConf.exists());
+        assertTrue(segmentConf.isFile());
+        ValidationResult result = SegmentationConfMigrator.checkConfigFile(segmentConf.toPath());
+        assertTrue(result.isValid());
+        SRX srxOrig = SegmentationConfMigrator.convertToSrx(segmentConf.toPath(), segmentSrx.toPath());
+        assertNotNull(srxOrig);
+        List<MapRule> mapRuleList = srxOrig.getMappingRules();
+        assertNotNull(mapRuleList);
+        assertEquals(18, mapRuleList.size());
+        for (MapRule mapRule : mapRuleList) {
+            if (mapRule.getPattern().equals("JA.*")) {
+                Assert.assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguage());
+                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
+            } else if (mapRule.getLanguage().equals("Text")) {
+                assertEquals(OStrings.getString(LanguageCodes.F_TEXT_KEY), mapRule.getLanguageName());
+            }
+        }
+        // load from srx file
+        assertTrue(segmentSrx.exists());
+        assertTrue(segmentSrx.isFile());
+        SRX srx1 = SRX.loadSrxFile(segmentSrx.toURI());
+        assertNotNull(srx1);
+        mapRuleList = srx1.getMappingRules();
+        assertNotNull(mapRuleList);
+        assertEquals(18, mapRuleList.size());
+        for (MapRule mapRule : mapRuleList) {
+            if (mapRule.getPattern().equals("JA.*")) {
+                assertEquals(LanguageCodes.JAPANESE_CODE, mapRule.getLanguage());
+                assertEquals(OStrings.getString(LanguageCodes.JAPANESE_KEY), mapRule.getLanguageName());
+            } else if (mapRule.getLanguage().equals("Text")) {
+                assertEquals(LanguageCodes.F_TEXT_CODE, mapRule.getLanguage());
+                assertEquals(OStrings.getString(LanguageCodes.F_TEXT_KEY), mapRule.getLanguageName());
+            }
+        }
+        assertEquals("2.0", srx1.getVersion());
+        assertTrue(srx1.isCascade());
+        assertTrue(srx1.isSegmentSubflows());
+    }
+
+    private SegmentationConfMigratorTest() {
+    }
+}

--- a/test/src/org/omegat/util/LocaleRule.java
+++ b/test/src/org/omegat/util/LocaleRule.java
@@ -1,0 +1,67 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.Locale;
+
+/**
+ * Locale rule to force specific runtime locale.
+ * <p>
+ * <code>
+ *      @Rule
+ *      public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+ * </code>
+ */
+public class LocaleRule implements TestRule {
+    private final Locale testLocale;
+    private Locale originalLocale;
+
+    public LocaleRule(Locale locale) {
+        this.testLocale = locale;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                originalLocale = Locale.getDefault();
+                Locale.setDefault(testLocale);
+                OStrings.loadBundle(testLocale);
+                try {
+                    base.evaluate();
+                } finally {
+                    Locale.setDefault(originalLocale);
+                    OStrings.loadBundle(originalLocale);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Add support SRX standard format and migrate segmentation.conf to segmentation.srx

This is a preparation of the security fix.

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

## What does this PR change?

- Introduce `org.omegat.convert.segmentation.SegmentationConfMigrator` class
- Refactor `org.omegat.core.segmentation.SRX` class
- Add SRX migration tests

## Other information

