### PR TITLE
fix: Enhance error handling for HTTP response exceptions

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2342,6 +2342,11 @@ TEAM_OPEN=Opening team project
 TEAM_NETWORK_ERROR=Remote repository network communication error: {0}
 TEAM_UPDATE_REPO_ERROR=Error updating repository. Skipping. Error: {0}
 
+TEAM_HTTP_FORBIDDEN=Access to {0} is forbidden.
+TEAM_HTTP_UNAUTHORIZED=Access to {0} is rejected by authentication error.
+TEAM_HTTP_NOT_FOUND=Contents at {0} is not found.
+TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} response with code: {2}
+
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options
 PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2343,9 +2343,9 @@ TEAM_NETWORK_ERROR=Remote repository network communication error: {0}
 TEAM_UPDATE_REPO_ERROR=Error updating repository. Skipping. Error: {0}
 
 TEAM_HTTP_FORBIDDEN=Access to {0} is forbidden.
-TEAM_HTTP_UNAUTHORIZED=Access to {0} is rejected by authentication error.
-TEAM_HTTP_NOT_FOUND=Contents at {0} is not found.
-TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} response with code: {2}
+TEAM_HTTP_UNAUTHORIZED=Authentication error when trying to access {0}.
+TEAM_HTTP_NOT_FOUND=No content found at {0}.
+TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} responded with code: {2}.
 
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options

--- a/src/org/omegat/core/team2/IRemoteRepository2.java
+++ b/src/org/omegat/core/team2/IRemoteRepository2.java
@@ -125,5 +125,9 @@ public interface IRemoteRepository2 {
         public NetworkException(Throwable ex) {
             super(ex);
         }
+
+        public NetworkException(String message) {
+            super(message);
+        }
     }
 }

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -190,11 +190,12 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
         }
     }
 
+    private static final String HEADER_ETAG = "ETag";
+    private static final String HEADER_IF_NONE_MATCH = "If-None-Match";
+
     protected void retrieve(Properties etags, String fileName, String fileUrl, final File outputFile)
             throws IOException, NetworkException {
 
-        final String HEADER_ETAG = "ETag";
-        final String HEADER_IF_NONE_MATCH = "If-None-Match";
         String currentEtag = etags.getProperty(fileName);
 
         logger.atDebug().setMessage("Retrieve {0} into {1} with ETag={2}")

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -218,14 +218,13 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 logger.atDebug().setMessage("Retrieve {0}: not modified").addArgument(url).log();
                 return;
             case HttpURLConnection.HTTP_FORBIDDEN:
-                throw new NetworkException(MessageFormat.format("Access to {0} is forbidden.", url));
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_FORBIDDEN", url));
             case HttpURLConnection.HTTP_UNAUTHORIZED:
-                throw new NetworkException(MessageFormat.format("Access to {0} is rejected by authentication error.", url));
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_UNAUTHORIZED", url));
             case HttpURLConnection.HTTP_NOT_FOUND:
-                throw new NetworkException(MessageFormat.format("Contents at {0} is not found.", url));
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_NOT_FOUND", url));
             default:
-                throw new NetworkException(String.format("HTTP connection %s response with code: %d", url,
-                        conn.getResponseCode()));
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_OTHER_ERRORS", url, conn.getResponseCode()));
             }
 
             // load into .tmp file

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -217,7 +217,8 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 logger.atDebug().setMessage("Retrieve {0}: not modified").addArgument(url).log();
                 return;
             default:
-                throw new RuntimeException("HTTP response code: " + conn.getResponseCode());
+                throw new NetworkException(String.format("HTTP connection %s response with code: %d", url,
+                        conn.getResponseCode()));
             }
 
             // load into .tmp file

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -36,6 +36,7 @@ import java.net.SocketException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.security.MessageDigest;
+import java.text.MessageFormat;
 import java.util.Formatter;
 import java.util.Properties;
 
@@ -216,6 +217,12 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 // not modified - just return
                 logger.atDebug().setMessage("Retrieve {0}: not modified").addArgument(url).log();
                 return;
+            case HttpURLConnection.HTTP_FORBIDDEN:
+                throw new NetworkException(MessageFormat.format("Access to {0} is forbidden.", url));
+            case HttpURLConnection.HTTP_UNAUTHORIZED:
+                throw new NetworkException(MessageFormat.format("Access to {0} is rejected by authentication error.", url));
+            case HttpURLConnection.HTTP_NOT_FOUND:
+                throw new NetworkException(MessageFormat.format("Contents at {0} is not found.", url));
             default:
                 throw new NetworkException(String.format("HTTP connection %s response with code: %d", url,
                         conn.getResponseCode()));

--- a/test/src/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
+++ b/test/src/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
@@ -1,0 +1,131 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2.impl;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import gen.core.project.ObjectFactory;
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+import org.junit.Test;
+import org.omegat.core.TestCoreWireMock;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class HTTPRemoteRepositoryTest extends TestCoreWireMock {
+
+    @Test
+    public void testRetrieveRetrievesFileSuccessfully() throws Exception {
+        HTTPRemoteRepository repository = new HTTPRemoteRepository();
+        RepositoryDefinition mockConfig = new RepositoryDefinition();
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/repository/", port);
+        mockConfig.setUrl(url);
+
+        Path tempDir = Files.createTempDirectory("omegat");
+        repository.init(mockConfig, tempDir.toFile(), null);
+        Properties etags = new Properties();
+        etags.setProperty("file.txt", "TestETag");
+        File outputFile = tempDir.resolve("file.txt").toFile();
+
+        WireMock.stubFor(WireMock.head(WireMock.anyUrl())
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("ETag", "TestETag")
+                        .withHeader("Content-Type", "text/plain")));
+        WireMock.stubFor(WireMock.get(WireMock.anyUrl())
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withHeader("ETag", "TestETag")
+                        .withBody("Test file contents")));
+
+        // Mock URL connection for successful retrieval
+        repository.retrieve(etags, "file.txt", url + "file.txt", outputFile);
+
+        assertTrue("File should exist after retrieve", outputFile.exists());
+        assertEquals("File contents should match", "Test file contents", Files.readString(outputFile.toPath()));
+    }
+
+    @Test
+    public void testSwitchToVersionThrowsExceptionWhenVersionIsNotNull() throws Exception {
+        HTTPRemoteRepository repository = new HTTPRemoteRepository();
+        RepositoryDefinition mockConfig = new RepositoryDefinition();
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/repository/", port);
+        mockConfig.setUrl(url);
+        Path tempDir = Files.createTempDirectory("omegat");
+        repository.init(mockConfig, tempDir.toFile(), null);
+
+        Exception exception = null;
+
+        try {
+            repository.switchToVersion("1.0");
+        } catch (RuntimeException e) {
+            exception = e;
+        }
+
+        assertNotNull("Expected RuntimeException to be thrown", exception);
+        assertEquals("Not supported", exception.getMessage());
+    }
+
+    @Test
+    public void testSwitchToVersionUpdatesToLatest() throws Exception {
+        HTTPRemoteRepository repository = new HTTPRemoteRepository();
+        RepositoryDefinition mockConfig = new RepositoryDefinition();
+        int port = wireMockRule.port();
+        String url = String.format("http://localhost:%d/repository/", port);
+        mockConfig.setUrl(url);
+        //
+        ObjectFactory factory = new ObjectFactory();
+        RepositoryMapping mapping = factory.createRepositoryMapping();
+        mapping.setRepository("file.txt");
+        mapping.setLocal("file.txt");
+        //
+        mockConfig.getMapping().add(mapping);
+        //
+        Path tempDir = Files.createTempDirectory("omegat");
+        repository.init(mockConfig, tempDir.toFile(), null);
+
+        WireMock.stubFor(WireMock.head(WireMock.anyUrl())
+                        .willReturn(WireMock.aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.anyUrl())
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Test file contents")));
+
+        // Simulate calling switchToVersion
+        repository.switchToVersion(null);
+
+        File outputFile = tempDir.resolve("file.txt").toFile();
+        assertTrue("File should exist after retrieve", outputFile.exists());
+        assertEquals("File contents should match", "Test file contents", Files.readString(outputFile.toPath()));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- When mapping contents not exist, the error message does not provide enough information.
- https://sourceforge.net/p/omegat/bugs/1295/


## What does this PR change?

- Improve error handling of http remote repository access.
- use NetworkException instead of generic RuntimeException

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
