### PR TITLE
fix: SRXTest: Copy file in temp dir first, so that the full test runs in the temp dir

### DIFF
--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -186,7 +186,9 @@ public final class SRXTest {
      * environment and Japanese environment.
      */
     public static void testSrxMigration(File segmentConf, File configDir) throws Exception {
-        File segmentSrx = new File(configDir, "segmentation.srx");
+        // ensures the full test runs in temp directory
+        Files.copy(segmentConf.toPath(), Paths.get(configDir.getAbsolutePath(), segmentConf.getName()));
+        segmentConf = new File(configDir, segmentConf.getName());
         // load from conf file
         SRX srxOrig = SRX.loadConfFile(segmentConf, configDir);
         assertNotNull(srxOrig);
@@ -202,6 +204,7 @@ public final class SRXTest {
             }
         }
         // load from srx file
+        File segmentSrx = new File(configDir, "segmentation.srx");
         assertTrue(segmentSrx.exists());
         SRX srx1 = SRX.loadFromDir(configDir);
         assertNotNull(srx1);


### PR DESCRIPTION
When testing SRX migration, ensure the full migration runs in the temporary directory (else it may delete file from repository)

## Pull request type

Bug