### PR TITLE
feat(acceptance-test): wait search/matches panes ready and updated

### DIFF
--- a/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -279,6 +279,8 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
     protected void setFoundResult(final SourceTextEntry se, final List<DictionaryEntry> data) {
         UIThreadsUtil.mustBeSwingThread();
 
+        List<String> oldDisplayWords = new ArrayList<>(displayedWords);
+
         clear();
 
         if (data == null) {
@@ -312,6 +314,7 @@ public class DictionariesTextArea extends EntryInfoThreadPane<List<DictionaryEnt
             i++;
         }
         txt.append("</html>");
+        firePropertyChange("displayWords", oldDisplayWords, displayedWords);
         fastReplaceContent(txt.toString());
     }
 

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -46,6 +46,7 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowFocusListener;
 import java.io.File;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -216,6 +217,11 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
     protected void setFoundResult(SourceTextEntry en, List<GlossaryEntry> entries) {
         UIThreadsUtil.mustBeSwingThread();
 
+        List<GlossaryEntry> oldEntries = null;
+        if (processedEntry != null) {
+            oldEntries = new ArrayList<>(nowEntries);
+        }
+
         clear();
 
         if (entries == null) {
@@ -238,6 +244,8 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         for (GlossaryEntry entry : entries) {
             entryRenderer.render(entry, getStyledDocument());
         }
+
+        firePropertyChange("entries", oldEntries, entries);
     }
 
     @Override

--- a/src/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/org/omegat/gui/matches/MatchesTextArea.java
@@ -123,11 +123,11 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
             Styles.EditorColor.COLOR_MATCHES_INS_INACTIVE.getColor(), null, null, null, null, true);
 
     private final DockableScrollPane scrollPane;
-    private final List<NearString> matches = new ArrayList<NearString>();
+    private final List<NearString> matches = new ArrayList<>();
 
-    private final List<Integer> delimiters = new ArrayList<Integer>();
-    private final List<Integer> sourcePos = new ArrayList<Integer>();
-    private final List<Map<Integer, List<TextRun>>> diffInfos = new ArrayList<Map<Integer, List<TextRun>>>();
+    private final List<Integer> delimiters = new ArrayList<>();
+    private final List<Integer> sourcePos = new ArrayList<>();
+    private final List<Map<Integer, List<TextRun>>> diffInfos = new ArrayList<>();
     private int activeMatch = -1;
 
     /** Creates new form MatchGlossaryPane */
@@ -193,9 +193,12 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
     protected void setFoundResult(final SourceTextEntry se, List<NearString> newMatches) {
         UIThreadsUtil.mustBeSwingThread();
 
+        List<NearString> oldMatches = new ArrayList<>(matches);
+
         clear();
 
         if (newMatches == null) {
+            firePropertyChange("matches", oldMatches, newMatches);
             return;
         }
 
@@ -229,6 +232,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
 
         setText(displayBuffer.toString());
         setActiveMatch(0);
+        firePropertyChange("matches", oldMatches, newMatches);
 
         checkForReplaceTranslation();
     }
@@ -430,6 +434,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
             return;
         }
 
+        final int oldActiveMatch = this.activeMatch;
         this.activeMatch = activeMatch;
 
         StyledDocument doc = (StyledDocument) getDocument();
@@ -503,6 +508,8 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
                 setCaretPosition(fstart);
             }
         });
+
+        firePropertyChange("activeMatch", oldActiveMatch, activeMatch);
     }
 
     /** Clears up the pane. */

--- a/test-acceptance/data/project/glossary/glossary.txt
+++ b/test-acceptance/data/project/glossary/glossary.txt
@@ -1,2 +1,3 @@
 # Glossary in tab-separated format -*- coding: utf-8 -*-
 Introduction	紹介
+Error	エラー

--- a/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
@@ -28,34 +28,29 @@ package org.omegat.gui.editor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.Locale;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import org.omegat.core.Core;
-import org.omegat.core.CoreEvents;
-import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.main.TestCoreGUI;
 import org.omegat.util.LocaleRule;
-import org.omegat.util.Preferences;
 
 /**
  * @author Hiroshi Miura
  */
 @RunWith(Enclosed.class)
-public class EditorUtilsGUITest {
+public final class EditorUtilsGUITest {
+
+    private EditorUtilsGUITest() {
+    }
 
     public static class EditorUtilsFirstStepsTest extends TestCoreGUI {
 
@@ -85,25 +80,7 @@ public class EditorUtilsGUITest {
 
         @Test
         public void testEditorUtilsGetWordLoadedProject() throws Exception {
-            // Prepare a sample project
-            File tmpDir = folder.newFolder("omegat-sample-project-");
-            File projSrc = new File("test-acceptance/data/project_CN_JP/");
-            FileUtils.copyDirectory(projSrc, tmpDir);
-            FileUtils.forceDeleteOnExit(tmpDir);
-            Preferences.setPreference(Preferences.PROJECT_FILES_SHOW_ON_LOAD, false);
-            // Load the project and wait a completion
-            CountDownLatch latch = new CountDownLatch(1);
-            CoreEvents.registerProjectChangeListener(eventType -> {
-                if (Core.getProject().isProjectLoaded()) {
-                    latch.countDown();
-                }
-            });
-            SwingUtilities.invokeAndWait(() -> ProjectUICommands.projectOpen(tmpDir, true));
-            try {
-                assertTrue(latch.await(5, TimeUnit.SECONDS));
-            } catch (InterruptedException ignored) {
-            }
-            //
+            openSampleProject(Paths.get("test-acceptance/data/project_CN_JP/"));
             final JTextComponent editPane = window.panel("Editor - source.txt").textBox().target();
             int length = editPane.getDocument().getLength();
             assertTrue(length > 0);

--- a/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
@@ -3,7 +3,7 @@
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2024 Hiroshi Miura
+ Copyright (C) 2025 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -23,23 +23,18 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
 
-package org.omegat.gui.matches;
+package org.omegat.gui.glossary;
 
-import java.nio.file.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.LocaleRule;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
-import org.junit.Test;
-
-import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
-import org.omegat.util.OStrings;
-
-public class MatchesTextAreaTest extends TestCoreGUI {
+public class GlossaryTextTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
 
@@ -47,27 +42,12 @@ public class MatchesTextAreaTest extends TestCoreGUI {
     public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
-    public void testFuzzyMatches() throws Exception {
+    public void testGlossarySearch() throws Exception {
         // load project
-        openSampleProjectWaitMatches(PROJECT_PATH);
+        openSampleProjectWaitGlossary(PROJECT_PATH);
         robot().waitForIdle();
-        // check a fuzzy match pane
-        window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
-        window.textBox("matches_pane").requireVisible();
-        window.textBox("matches_pane").requireNotEditable();
-        Pattern pattern = Pattern.compile("1. Error while reading MT results\\n"
-                + "Erreur lors de la lecture des résultats de TA\\n"
-                + "<\\d+/\\d+/\\d+%\\s*" + OStrings.getString(
-                        "MATCHES_VAR_EXPANSION_MATCH_COMES_FROM_MEMORY") + "\\s*>");
-        window.textBox("matches_pane").requireText(pattern);
-        closeProject();
-    }
-
-    @Override
-    protected void onSetUp() throws Exception {
-        super.onSetUp();
-        tmpDir = Files.createTempDirectory("omegat-sample-project-").toFile();
-        FileUtils.copyDirectory(PROJECT_PATH.toFile(), tmpDir);
-        FileUtils.forceDeleteOnExit(tmpDir);
+        window.textBox("glossary_text_area").requireVisible();
+        window.textBox("glossary_text_area").requireNotEditable();
+        window.textBox("glossary_text_area").requireText("Error = エラー\n\n");
     }
 }

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -25,8 +25,9 @@
 
 package org.omegat.gui.matches;
 
-import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -40,7 +41,7 @@ import org.omegat.util.OStrings;
 
 public class MatchesTextAreaTest extends TestCoreGUI {
 
-    private static final String PROJECT_PATH = "test-acceptance/data/project/";
+    private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
 
     @Rule
     public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
@@ -48,7 +49,7 @@ public class MatchesTextAreaTest extends TestCoreGUI {
     @Test
     public void testFuzzyMatches() throws Exception {
         // load project
-        openSampleProject(PROJECT_PATH);
+        openSampleProjectWaitMatches(PROJECT_PATH);
         robot().waitForIdle();
         // check a fuzzy match pane
         window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
@@ -66,8 +67,7 @@ public class MatchesTextAreaTest extends TestCoreGUI {
     protected void onSetUp() throws Exception {
         super.onSetUp();
         tmpDir = Files.createTempDirectory("omegat-sample-project-").toFile();
-        File projSrc = new File(PROJECT_PATH);
-        FileUtils.copyDirectory(projSrc, tmpDir);
+        FileUtils.copyDirectory(PROJECT_PATH.toFile(), tmpDir);
         FileUtils.forceDeleteOnExit(tmpDir);
     }
 }

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
@@ -1,0 +1,73 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2024-2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.matches;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.LocaleRule;
+import org.omegat.util.OStrings;
+
+public class MatchesTextTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
+
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+
+    @Test
+    public void testFuzzyMatches() throws Exception {
+        // load project
+        openSampleProjectWaitMatches(PROJECT_PATH);
+        robot().waitForIdle();
+        // check a fuzzy match pane
+        window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
+        window.textBox("matches_pane").requireVisible();
+        window.textBox("matches_pane").requireNotEditable();
+        Pattern pattern = Pattern.compile("1. Error while reading MT results\\n"
+                + "Erreur lors de la lecture des résultats de TA\\n"
+                + "<\\d+/\\d+/\\d+%\\s*" + OStrings.getString(
+                        "MATCHES_VAR_EXPANSION_MATCH_COMES_FROM_MEMORY") + "\\s*>");
+        window.textBox("matches_pane").requireText(pattern);
+        closeProject();
+    }
+
+    @Override
+    protected void onSetUp() throws Exception {
+        super.onSetUp();
+        tmpDir = Files.createTempDirectory("omegat-sample-project-").toFile();
+        FileUtils.copyDirectory(PROJECT_PATH.toFile(), tmpDir);
+        FileUtils.forceDeleteOnExit(tmpDir);
+    }
+}


### PR DESCRIPTION
This Pull Request enhances state tracking functionality across several components, adds property change notifications, and introduces modifications to improve test coverage and consistency.

## Pull request type

- refacto ring

## Which ticket is resolved?

## What does this PR change?

- Update TestCoreGUI to wait a finish of the search thread and update of the match pane
- Added property change notifications for state changes (displayWords, entries, matches, activeMatch) in various text area classes.
- Introduced local copies of variables to track old state before updates.
- Simplified the initialization of generic types in MatchesTextArea.java.
- Amended and extended acceptance tests for project handling and fuzzy match functionality.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
