### PR TITLE
fix: team/HTTPRemoteRepository: handle HTTP_NOT_MODIFIED response correctly

### DIFF
--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -198,10 +198,8 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
 
         String currentEtag = etags.getProperty(fileName);
 
-        logger.atDebug().setMessage("Retrieve {0} into {1} with ETag={2}")
-                .addArgument(fileUrl)
-                .addArgument(outputFile::getAbsolutePath)
-                .addArgument(currentEtag).log();
+        logger.atDebug().setMessage("Retrieve {0} into {1} with ETag={2}").addArgument(fileUrl)
+                .addArgument(outputFile::getAbsolutePath).addArgument(currentEtag).log();
 
         if (!outputFile.getParentFile().mkdirs()) {
             throw new IOException("Failed to create directory " + outputFile.getParentFile());
@@ -214,23 +212,25 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 connection.setRequestProperty(HEADER_IF_NONE_MATCH, currentEtag);
             }
 
-            // Handles the HTTP response code and performs necessary actions based on the code.
+            // Handles the HTTP response code and performs necessary actions
+            // based on the code.
             switch (connection.getResponseCode()) {
-                case HttpURLConnection.HTTP_OK:
-                    logger.atDebug().setMessage("Retrieve {0}: 200 OK").addArgument(fileUrl).log();
-                    break;
-                case HttpURLConnection.HTTP_NOT_MODIFIED:
-                    // not modified - just return
-                    logger.atDebug().setMessage("Retrieve {0}: not modified").addArgument(fileUrl).log();
-                    return;
-                case HttpURLConnection.HTTP_FORBIDDEN:
-                    throw new NetworkException(OStrings.getString("TEAM_HTTP_FORBIDDEN", fileUrl));
-                case HttpURLConnection.HTTP_UNAUTHORIZED:
-                    throw new NetworkException(OStrings.getString("TEAM_HTTP_UNAUTHORIZED", fileUrl));
-                case HttpURLConnection.HTTP_NOT_FOUND:
-                    throw new NetworkException(OStrings.getString("TEAM_HTTP_NOT_FOUND", fileUrl));
-                default:
-                    throw new NetworkException(OStrings.getString("TEAM_HTTP_OTHER_ERRORS", fileUrl, connection.getResponseCode()));
+            case HttpURLConnection.HTTP_OK:
+                logger.atDebug().setMessage("Retrieve {0}: 200 OK").addArgument(fileUrl).log();
+                break;
+            case HttpURLConnection.HTTP_NOT_MODIFIED:
+                // not modified - just return
+                logger.atDebug().setMessage("Retrieve {0}: not modified").addArgument(fileUrl).log();
+                return;
+            case HttpURLConnection.HTTP_FORBIDDEN:
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_FORBIDDEN", fileUrl));
+            case HttpURLConnection.HTTP_UNAUTHORIZED:
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_UNAUTHORIZED", fileUrl));
+            case HttpURLConnection.HTTP_NOT_FOUND:
+                throw new NetworkException(OStrings.getString("TEAM_HTTP_NOT_FOUND", fileUrl));
+            default:
+                throw new NetworkException(
+                        OStrings.getString("TEAM_HTTP_OTHER_ERRORS", fileUrl, connection.getResponseCode()));
             }
 
             // Load into .tmp file
@@ -258,7 +258,8 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
     }
 
     /**
-     * Safely renames the temporary file to the output file, ensuring no remnants of old files.
+     * Safely renames the temporary file to the output file, ensuring no
+     * remnants of old files.
      */
     private void safelyRenameFile(File tempFile, File outputFile) throws IOException {
         if (outputFile.exists()) {

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -54,7 +54,7 @@ import gen.core.project.RepositoryMapping;
 
 /**
  * HTTP/HTTPS repository connection implementation.
- *
+ * <p>
  * It can be used as read-only repository for retrieve sources, external TMX,
  * glossaries, etc. Since HTTP protocol doesn't support multiple files, each URL
  * should be mapped to separate file, i.e. directory mapping is not supported.
@@ -156,7 +156,7 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
     }
 
     @Override
-    public String[] getRecentlyDeletedFiles() throws Exception {
+    public String[] getRecentlyDeletedFiles() {
         return new String[0];
     }
 
@@ -203,7 +203,9 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
                 .addArgument(outputFile::getAbsolutePath)
                 .addArgument(currentEtag).log();
 
-        outputFile.getParentFile().mkdirs();
+        if (!outputFile.getParentFile().mkdirs()) {
+            throw new IOException("Failed to create directory " + outputFile.getParentFile());
+        }
 
         HttpURLConnection connection = (HttpURLConnection) new URL(fileUrl).openConnection();
         try {

--- a/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -201,7 +201,8 @@ public class HTTPRemoteRepository implements IRemoteRepository2 {
         logger.atDebug().setMessage("Retrieve {0} into {1} with ETag={2}").addArgument(fileUrl)
                 .addArgument(outputFile::getAbsolutePath).addArgument(currentEtag).log();
 
-        if (!outputFile.getParentFile().mkdirs()) {
+        // When parent directory doesn't exist, create it.
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
             throw new IOException("Failed to create directory " + outputFile.getParentFile());
         }
 

--- a/test/src/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
+++ b/test/src/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
@@ -57,21 +57,18 @@ public class HTTPRemoteRepositoryTest extends TestCoreWireMock {
         etags.setProperty("file.txt", "TestETag");
         File outputFile = tempDir.resolve("file.txt").toFile();
 
-        WireMock.stubFor(WireMock.head(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(200)
-                        .withHeader("ETag", "TestETag")
-                        .withHeader("Content-Type", "text/plain")));
+        WireMock.stubFor(WireMock.head(WireMock.anyUrl()).willReturn(WireMock.aResponse().withStatus(200)
+                .withHeader("ETag", "TestETag").withHeader("Content-Type", "text/plain")));
         WireMock.stubFor(WireMock.get(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(200)
-                        .withHeader("Content-Type", "text/plain")
-                        .withHeader("ETag", "TestETag")
-                        .withBody("Test file contents")));
+                .willReturn(WireMock.aResponse().withStatus(200).withHeader("Content-Type", "text/plain")
+                        .withHeader("ETag", "TestETag").withBody("Test file contents")));
 
         // Mock URL connection for successful retrieval
         repository.retrieve(etags, "file.txt", url + "file.txt", outputFile);
 
         assertTrue("File should exist after retrieve", outputFile.exists());
-        assertEquals("File contents should match", "Test file contents", Files.readString(outputFile.toPath()));
+        assertEquals("File contents should match", "Test file contents",
+                Files.readString(outputFile.toPath()));
     }
 
     @Test
@@ -114,19 +111,17 @@ public class HTTPRemoteRepositoryTest extends TestCoreWireMock {
         Path tempDir = Files.createTempDirectory("omegat");
         repository.init(mockConfig, tempDir.toFile(), null);
 
-        WireMock.stubFor(WireMock.head(WireMock.anyUrl())
-                        .willReturn(WireMock.aResponse().withStatus(200)));
-        WireMock.stubFor(WireMock.get(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(200)
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody("Test file contents")));
+        WireMock.stubFor(WireMock.head(WireMock.anyUrl()).willReturn(WireMock.aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.anyUrl()).willReturn(WireMock.aResponse().withStatus(200)
+                .withHeader("Content-Type", "text/plain").withBody("Test file contents")));
 
         // Simulate calling switchToVersion
         repository.switchToVersion(null);
 
         File outputFile = tempDir.resolve("file.txt").toFile();
         assertTrue("File should exist after retrieve", outputFile.exists());
-        assertEquals("File contents should match", "Test file contents", Files.readString(outputFile.toPath()));
+        assertEquals("File contents should match", "Test file contents",
+                Files.readString(outputFile.toPath()));
     }
 
     @Test
@@ -145,15 +140,14 @@ public class HTTPRemoteRepositoryTest extends TestCoreWireMock {
         Files.writeString(outputFile.toPath(), "Existing content");
 
         WireMock.stubFor(WireMock.head(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(304)
-                        .withHeader("ETag", "TestETag")));
+                .willReturn(WireMock.aResponse().withStatus(304).withHeader("ETag", "TestETag")));
         WireMock.stubFor(WireMock.get(WireMock.anyUrl())
-                .willReturn(WireMock.aResponse().withStatus(304)
-                        .withHeader("ETag", "TestETag")));
+                .willReturn(WireMock.aResponse().withStatus(304).withHeader("ETag", "TestETag")));
 
         repository.retrieve(etags, "file.txt", url + "file.txt", outputFile);
 
         assertTrue("File should exist after retrieve", outputFile.exists());
-        assertEquals("File contents should not change", "Existing content", Files.readString(outputFile.toPath()));
+        assertEquals("File contents should not change", "Existing content",
+                Files.readString(outputFile.toPath()));
     }
 }


### PR DESCRIPTION
Fix the issue I entered in last change for HTTPRemoteRepository class.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?
There is no issue to point
## What does this PR change?

- Fix the handling of 304 http response:
    - Consolidated HTTP error response handling into the main method instead of a separate function.
    - Just return when 304 HTTP response from the main method.
- Simplification of logging and exception mechanisms:
    - Refactored logging for better readability and debugging support.
    - Improved consistency in method formatting and indentation.
- Improve error handling
    - Added a check for directory creation failure with an appropriate exception. 
- Enhancements in unit tests (HTTPRemoteRepositoryTest):
    - Added test cases to verify retrieve handling of "304 Not Modified" responses.
    - Modified existing test cases to improve structuring and maintain readability.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
