### PR TITLE
docs: enhance Javadoc for `FindMatches` class

### DIFF
--- a/src/org/omegat/core/statistics/FindMatches.java
+++ b/src/org/omegat/core/statistics/FindMatches.java
@@ -132,6 +132,21 @@ public class FindMatches {
 
     private final Segmenter segmenter;
 
+    /**
+     * Constructs a FindMatches instance for finding fuzzy matched translation memories.
+     *
+     * @param project
+     *        OmegaT project.
+     * @param maxCount
+     *        Limits the maximum count of the results.
+     * @param allowSeparateSegmentMatch
+     *        Specifies whether to allow separate segment matching.
+     * @param searchExactlyTheSame
+     *        Allows searching for similarities with the exact same text as the source segment.
+     *        This mode is used specifically for separate sentence match in paragraph-based projects,
+     *        where the source is part of the current segment.
+     * @deprecated
+     */
     @Deprecated(since = "6.1.0")
     public FindMatches(IProject project, int maxCount, boolean allowSeparateSegmentMatch,
             boolean searchExactlyTheSame) {
@@ -167,6 +182,26 @@ public class FindMatches {
         this.fuzzyMatchThreshold = threshold;
     }
 
+    /**
+     * Searches for translation matches in the translation memory.
+     *
+     * @param searchText
+     *        The target segment or term to search for.
+     * @param requiresTranslation
+     *        Indicates whether only translations are required during the search.
+     * @param fillSimilarityData
+     *        Specifies whether similarity data should be included in the resulting
+     *        NearString objects.
+     * @param stop
+     *        The IStopped callback object to handle cancellation of the search
+     *        process.
+     * @return
+     *        A list of NearString objects representing the matched translation
+     *        entries.
+     * @throws StoppedException
+     *        Thrown if the search process is stopped by the IStopped callback.
+     * @deprecated
+     */
     @Deprecated(since = "6.1.0")
     public List<NearString> search(final String searchText, final boolean requiresTranslation,
             final boolean fillSimilarityData, final IStopped stop) throws StoppedException {
@@ -177,9 +212,10 @@ public class FindMatches {
      * Search Translation memories.
      *
      * @param searchText
-     *        target segment or term to search.
+     *        The target segment or term to search for.
      * @param fillSimilarityData
-     *        fill similarity data into the result of NearString objects.
+     *        Specifies whether similarity data should be filled into the result
+     *        of NearString objects.
      * @param stop
      *        IStopped callback object to indicate cancel operation.
      * @return


### PR DESCRIPTION
- Added detailed Javadoc comments for constructor and methods with explanation of parameters and behavior.
- Marked newly documented methods as `@Deprecated` since version 6.1.0 for clarity.
- Spin off from PR#963
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

THere is no issue to point
## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
