### PR TITLE
refactor(core): remove Hungarian notation from field names in `Searcher` and `SearchResultEntry` class

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -130,9 +130,7 @@
     <suppress files="GITExternalGpgSigner\.java" checks="ConstantName" lines="74-84"/>
 
     <!-- Searcher -->
-    <suppress files="Searcher\.java"
-              checks="(LineLength|MemberName|ParameterNumber|MissingSwitchDefault|InnerAssignment)"
-         lines="90,91,92,96,100,104,105,107,264,275,276,284,286,293,294,308,309,359,361,449,495,605,674,710"/>
+    <suppress files="Searcher\.java" checks="(LineLength|ParameterNumber|MissingSwitchDefault|InnerAssignment)"/>
 
     <!-- matching -->
     <suppress files="NearString\.java" checks="TypeName" lines="50-70"/>

--- a/src/org/omegat/core/search/SearchResultEntry.java
+++ b/src/org/omegat/core/search/SearchResultEntry.java
@@ -50,17 +50,17 @@ public class SearchResultEntry {
     public SearchResultEntry(int num, String preamble, String srcPrefix, String src, String target,
             String note, String properties, SearchMatch[] srcMatch, SearchMatch[] targetMatch,
             SearchMatch[] noteMatch, SearchMatch[] propertiesMatch) {
-        m_num = num;
-        m_preamble = preamble;
-        m_srcPrefix = srcPrefix;
-        m_src = src;
-        m_target = target;
-        m_note = note;
-        m_properties = properties;
-        m_srcMatch = srcMatch;
-        m_targetMatch = targetMatch;
-        m_noteMatch = noteMatch;
-        m_propertiesMatch = propertiesMatch;
+        entryNum = num;
+        preambleText = preamble;
+        this.srcPrefix = srcPrefix;
+        sourceText = src;
+        targetText = target;
+        this.note = note;
+        propertiesString = properties;
+        this.srcMatch = srcMatch;
+        this.targetMatch = targetMatch;
+        this.noteMatch = noteMatch;
+        this.propertiesMatch = propertiesMatch;
     }
 
     /**
@@ -71,66 +71,144 @@ public class SearchResultEntry {
      * directory)
      */
     public int getEntryNum() {
-        return (m_num);
+        return (entryNum);
     }
 
     /** Returns information about where this entry comes from. */
     public String getPreamble() {
-        return (m_preamble);
+        return (preambleText);
     }
 
     public void setPreamble(String preamble) {
-        m_preamble = preamble;
+        preambleText = preamble;
     }
 
     /** Returns the source text of the corresponding entry within a project. */
     public String getSrcText() {
-        return (m_src);
+        return (sourceText);
     }
 
     /** Returns the target text of the corresponding entry within a project. */
     public String getTranslation() {
-        return (m_target);
+        return (targetText);
     }
 
     /** Returns the note text of the corresponding entry within a project. */
     public String getNote() {
-        return (m_note);
+        return (note);
     }
 
     public String getProperties() {
-        return m_properties;
+        return propertiesString;
     }
 
     public String getSrcPrefix() {
-        return m_srcPrefix;
+        return srcPrefix;
     }
 
     public SearchMatch[] getSrcMatch() {
-        return m_srcMatch;
+        return srcMatch;
     }
 
     public SearchMatch[] getTargetMatch() {
-        return m_targetMatch;
+        return targetMatch;
     }
 
     public SearchMatch[] getNoteMatch() {
-        return m_noteMatch;
+        return noteMatch;
     }
 
     public SearchMatch[] getPropertiesMatch() {
-        return m_propertiesMatch;
+        return propertiesMatch;
     }
 
-    private int m_num;
-    private String m_preamble;
-    private String m_srcPrefix;
-    private String m_src;
-    private String m_target;
-    private String m_note;
-    private String m_properties;
-    private SearchMatch[] m_srcMatch;
-    private SearchMatch[] m_targetMatch;
-    private SearchMatch[] m_noteMatch;
-    private SearchMatch[] m_propertiesMatch;
+    private final int entryNum;
+    private String preambleText;
+    private final String srcPrefix;
+    private final String sourceText;
+    private final String targetText;
+    private final String note;
+    private final String propertiesString;
+    private final SearchMatch[] srcMatch;
+    private final SearchMatch[] targetMatch;
+    private final SearchMatch[] noteMatch;
+    private final SearchMatch[] propertiesMatch;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int entryNum;
+        private String preambleText;
+        private String srcPrefix;
+        private String sourceText;
+        private String targetText;
+        private String note;
+        private String propertiesString;
+        private SearchMatch[] srcMatch;
+        private SearchMatch[] targetMatch;
+        private SearchMatch[] noteMatch;
+        private SearchMatch[] propertiesMatch;
+
+        public Builder entryNum(int entryNum) {
+            this.entryNum = entryNum;
+            return this;
+        }
+
+        public Builder preambleText(String preambleText) {
+            this.preambleText = preambleText;
+            return this;
+        }
+
+        public Builder srcPrefix(String srcPrefix) {
+            this.srcPrefix = srcPrefix;
+            return this;
+        }
+
+        public Builder sourceText(String sourceText) {
+            this.sourceText = sourceText;
+            return this;
+        }
+
+        public Builder targetText(String targetText) {
+            this.targetText = targetText;
+            return this;
+        }
+
+        public Builder note(String note) {
+            this.note = note;
+            return this;
+        }
+
+        public Builder propertiesString(String propertiesString) {
+            this.propertiesString = propertiesString;
+            return this;
+        }
+
+        public Builder srcMatch(SearchMatch[] srcMatch) {
+            this.srcMatch = srcMatch;
+            return this;
+        }
+
+        public Builder targetMatch(SearchMatch[] targetMatch) {
+            this.targetMatch = targetMatch;
+            return this;
+        }
+
+        public Builder noteMatch(SearchMatch[] noteMatch) {
+            this.noteMatch = noteMatch;
+            return this;
+        }
+
+        public Builder propertiesMatch(SearchMatch[] propertiesMatch) {
+            this.propertiesMatch = propertiesMatch;
+            return this;
+        }
+
+        public SearchResultEntry build() {
+            return new SearchResultEntry(entryNum, preambleText, srcPrefix, sourceText, targetText,
+                    note, propertiesString, srcMatch, targetMatch, noteMatch, propertiesMatch);
+        }
+    }
 }

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -259,13 +259,7 @@ public class Searcher {
     // ////////////////////////////////////////////////////////////
     // internal functions
 
-    private void addEntry(int num, String preamble, String srcPrefix, String src, String target, String note,
-            String property, SearchMatch[] srcMatch, SearchMatch[] targetMatch, SearchMatch[] noteMatch,
-            SearchMatch[] propertyMatch) {
-        SearchResultEntry entry = SearchResultEntry.builder().entryNum(num).preambleText(preamble)
-                .srcPrefix(srcPrefix).sourceText(src).targetText(target).note(note).propertiesString(property)
-                .srcMatch(srcMatch).targetMatch(targetMatch).noteMatch(noteMatch)
-                .propertiesMatch(propertyMatch).build();
+    private void addEntry(SearchResultEntry entry) {
         searchResults.add(entry);
         numFinds++;
     }
@@ -286,16 +280,18 @@ public class Searcher {
         } else if (entryNum == ENTRY_ORIGIN_TRANSLATION_MEMORY) {
             addTranslationMemoryEntry(entryNum, intro, src, target, note, property, srcMatches, targetMatches, noteMatches, propertyMatches, key);
         } else {
-            addEntry(entryNum, intro, null, src, target, note, property,
-                    srcMatches, targetMatches, noteMatches, propertyMatches);
+            addEntry(SearchResultEntry.builder().entryNum(entryNum).preambleText(intro).srcPrefix(null).sourceText(src)
+                    .targetText(target).note(note).propertiesString(property).srcMatch(srcMatches)
+                    .targetMatch(targetMatches).noteMatch(noteMatches).propertiesMatch(propertyMatches).build());
         }
     }
 
     private void addTranslationMemoryEntry(int entryNum, String intro, String src, String target, String note, String property,
                                            SearchMatch[] srcMatches, SearchMatch[] targetMatches, SearchMatch[] noteMatches, SearchMatch[] propertyMatches, String key) {
         if (!tmxMap.containsKey(key) || searchExpression.allResults) {
-            addEntry(entryNum, intro, null, src, target, note, property,
-                    srcMatches, targetMatches, noteMatches, propertyMatches);
+            addEntry(SearchResultEntry.builder().entryNum(entryNum).preambleText(intro).srcPrefix(null).sourceText(src)
+                    .targetText(target).note(note).propertiesString(property).srcMatch(srcMatches).targetMatch(targetMatches)
+                    .noteMatch(noteMatches).propertiesMatch(propertyMatches).build());
             if (!searchExpression.allResults) {
                 // first occurrence
                 tmxMap.put(key, 0);
@@ -312,8 +308,10 @@ public class Searcher {
             // HP, duplicate entry prevention
             // entries are referenced at offset 1 but stored at offset 0
             String file = searchExpression.fileNames ? getFileForEntry(entryNum + 1) : null;
-            addEntry(entryNum + 1, file, (entryNum + 1) + "> ", src, target,
-                    note, property, srcMatches, targetMatches, noteMatches, propertyMatches);
+            addEntry(SearchResultEntry.builder().entryNum(entryNum + 1).preambleText(file).srcPrefix((entryNum + 1) + "> ")
+                    .sourceText(src).targetText(target).note(note).propertiesString(property)
+                    .srcMatch(srcMatches).targetMatch(targetMatches).noteMatch(noteMatches)
+                    .propertiesMatch(propertyMatches).build());
             if (!searchExpression.allResults) { // If we filter results
                 entryMap.put(key, 0); // HP
             }

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -87,24 +87,24 @@ import org.omegat.util.StringUtil;
  */
 public class Searcher {
 
-    private volatile List<SearchResultEntry> m_searchResults;
-    private boolean m_preprocessResults;
-    private final IProject m_project;
+    private volatile List<SearchResultEntry> searchResults;
+    private boolean preprocessResults;
+    private final IProject project;
     /**
      * keeps track of previous results not from project memory
      */
-    private Map<String, Integer> m_tmxMap;
+    private Map<String, Integer> tmxMap;
     /**
      * HP: keeps track of previous results, to avoid duplicate entries
      */
-    private Map<String, Integer> m_entryMap;
+    private Map<String, Integer> entryMap;
     /**
      * HP: contains a matcher for each search string (multiple if keyword search)
      */
-    private List<Matcher> m_matchers;
-    private Matcher m_author;
+    private List<Matcher> matchers;
+    private Matcher author;
 
-    private int m_numFinds;
+    private int numFinds;
 
     private final SearchExpression searchExpression;
     private LongProcessThread checkStop;
@@ -126,7 +126,7 @@ public class Searcher {
      *            Current project
      */
     public Searcher(final IProject project, final SearchExpression searchExpression) {
-        this.m_project = project;
+        this.project = project;
         this.searchExpression = searchExpression;
     }
 
@@ -145,27 +145,27 @@ public class Searcher {
      * Returns list of search results
      */
     public List<SearchResultEntry> getSearchResults() {
-        if (m_preprocessResults) {
+        if (preprocessResults) {
             // function can be called multiple times after search
             // results preprocess should occur only one time
-            m_preprocessResults = false;
+            preprocessResults = false;
             if (!searchExpression.allResults) {
-                for (SearchResultEntry entry : m_searchResults) {
+                for (SearchResultEntry entry : searchResults) {
                     String key = entry.getSrcText() + entry.getTranslation();
                     if (entry.getEntryNum() == ENTRY_ORIGIN_TRANSLATION_MEMORY) {
-                        if (m_tmxMap.containsKey(key) && (m_tmxMap.get(key) > 0)) {
-                            entry.setPreamble(updatePreamble(entry, m_tmxMap.get(key)));
+                        if (tmxMap.containsKey(key) && (tmxMap.get(key) > 0)) {
+                            entry.setPreamble(updatePreamble(entry, tmxMap.get(key)));
                         }
                     } else if (entry.getEntryNum() > ENTRY_ORIGIN_PROJECT_MEMORY) {
                         // at this stage each PM entry num is increased by 1
-                        if (m_entryMap.containsKey(key) && (m_entryMap.get(key) > 0)) {
-                            entry.setPreamble(updatePreamble(entry, m_entryMap.get(key)));
+                        if (entryMap.containsKey(key) && (entryMap.get(key) > 0)) {
+                            entry.setPreamble(updatePreamble(entry, entryMap.get(key)));
                         }
                     }
                 }
             }
         }
-        return m_searchResults;
+        return searchResults;
     }
 
     private String updatePreamble(SearchResultEntry entry, int matchNumber) {
@@ -181,22 +181,20 @@ public class Searcher {
      * @throws Exception when searching files goes wrong
      */
     public void search() throws Exception {
-        String text = searchExpression.text;
-        String author = searchExpression.author;
+        String searchTextExpression = searchExpression.text;
+        String authorSearchExpression = searchExpression.author;
 
-        m_searchResults = new ArrayList<>();
-        m_numFinds = 0;
+        searchResults = new ArrayList<>();
+        numFinds = 0;
         // ensures that results will be preprocessed only one time
-        m_preprocessResults = true;
+        preprocessResults = true;
 
-        m_entryMap = null; // HP
+        entryMap = new HashMap<>(); // HP
 
-        m_entryMap = new HashMap<>(); // HP
-
-        m_tmxMap = new HashMap<>();
+        tmxMap = new HashMap<>();
 
         // create a list of matchers
-        m_matchers = new ArrayList<>();
+        matchers = new ArrayList<>();
 
         // determine pattern matching flags
         int flags = searchExpression.caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
@@ -205,7 +203,7 @@ public class Searcher {
         // Then, instead of modifying the regex, we also normalize the
         // comparison strings later on.
         if (searchExpression.widthInsensitive) {
-            text = StringUtil.normalizeWidth(text);
+            searchTextExpression = StringUtil.normalizeWidth(searchTextExpression);
         }
 
         // if exact search, just use the entire search string as a single
@@ -217,36 +215,36 @@ public class Searcher {
         default:
             // escape the search string, it's not supposed to be a regular
             // expression
-            text = StaticUtils.globToRegex(text, searchExpression.spaceMatchNbsp);
+            searchTextExpression = StaticUtils.globToRegex(searchTextExpression, searchExpression.spaceMatchNbsp);
 
             // create a matcher for the search string
-            m_matchers.add(Pattern.compile(text, flags).matcher(""));
+            matchers.add(Pattern.compile(searchTextExpression, flags).matcher(""));
             break;
         case KEYWORD:
             // break the search string into keywords,
             // each of which is a separate search string
-            Pattern.compile(" ").splitAsStream(text.trim()).filter(word -> !word.isEmpty()).map(word -> {
+            Pattern.compile(" ").splitAsStream(searchTextExpression.trim()).filter(word -> !word.isEmpty()).map(word -> {
                 String glob = StaticUtils.globToRegex(word, false);
                 return Pattern.compile(glob, flags).matcher("");
-            }).forEach(m_matchers::add);
+            }).forEach(matchers::add);
             break;
         case REGEXP:
             // space match nbsp (\u00a0)
             if (searchExpression.spaceMatchNbsp) {
-                text = text.replaceAll(" ", "( |\u00A0)");
-                text = text.replaceAll("\\\\s", "(\\\\s|\u00A0)");
+                searchTextExpression = searchTextExpression.replaceAll(" ", "( |\u00A0)");
+                searchTextExpression = searchTextExpression.replaceAll("\\\\s", "(\\\\s|\u00A0)");
             }
 
             // create a matcher for the search string
-            m_matchers.add(Pattern.compile(text, flags).matcher(""));
+            matchers.add(Pattern.compile(searchTextExpression, flags).matcher(""));
             break;
         }
         // create a matcher for the author search string
         if (searchExpression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP) {
-            author = StaticUtils.globToRegex(author, searchExpression.spaceMatchNbsp);
+            authorSearchExpression = StaticUtils.globToRegex(authorSearchExpression, searchExpression.spaceMatchNbsp);
         }
 
-        m_author = Pattern.compile(author, flags).matcher("");
+        this.author = Pattern.compile(authorSearchExpression, flags).matcher("");
 
 
         if (searchExpression.rootDir == null) {
@@ -265,8 +263,8 @@ public class Searcher {
             String note, String property, SearchMatch[] srcMatch, SearchMatch[] targetMatch, SearchMatch[] noteMatch, SearchMatch[] propertyMatch) {
         SearchResultEntry entry = new SearchResultEntry(num, preamble, srcPrefix,
                 src, target, note, property, srcMatch, targetMatch, noteMatch, propertyMatch);
-        m_searchResults.add(entry);
-        m_numFinds++;
+        searchResults.add(entry);
+        numFinds++;
     }
 
     /**
@@ -274,7 +272,7 @@ public class Searcher {
      */
     private void foundString(int entryNum, String intro, String src, String target, String note, String property,
             SearchMatch[] srcMatches, SearchMatch[] targetMatches, SearchMatch[] noteMatches, SearchMatch[] propertyMatches) {
-        if (m_numFinds >= searchExpression.numberOfResults) {
+        if (numFinds >= searchExpression.numberOfResults) {
             return;
         }
 
@@ -292,38 +290,38 @@ public class Searcher {
 
     private void addTranslationMemoryEntry(int entryNum, String intro, String src, String target, String note, String property,
                                            SearchMatch[] srcMatches, SearchMatch[] targetMatches, SearchMatch[] noteMatches, SearchMatch[] propertyMatches, String key) {
-        if (!m_tmxMap.containsKey(key) || searchExpression.allResults) {
+        if (!tmxMap.containsKey(key) || searchExpression.allResults) {
             addEntry(entryNum, intro, null, src, target, note, property,
                     srcMatches, targetMatches, noteMatches, propertyMatches);
             if (!searchExpression.allResults) {
                 // first occurrence
-                m_tmxMap.put(key, 0);
+                tmxMap.put(key, 0);
             }
         } else {
             // next occurrence
-            m_tmxMap.put(key, m_tmxMap.get(key) + 1);
+            tmxMap.put(key, tmxMap.get(key) + 1);
         }
     }
 
     private void addProjectMemoryEntry(int entryNum, String src, String target, String note, String property,
                                        SearchMatch[] srcMatches, SearchMatch[] targetMatches, SearchMatch[] noteMatches, SearchMatch[] propertyMatches, String key) {
-        if (!m_entryMap.containsKey(key) || searchExpression.allResults) {
+        if (!entryMap.containsKey(key) || searchExpression.allResults) {
             // HP, duplicate entry prevention
             // entries are referenced at offset 1 but stored at offset 0
             String file = searchExpression.fileNames ? getFileForEntry(entryNum + 1) : null;
             addEntry(entryNum + 1, file, (entryNum + 1) + "> ", src, target,
                     note, property, srcMatches, targetMatches, noteMatches, propertyMatches);
             if (!searchExpression.allResults) { // If we filter results
-                m_entryMap.put(key, 0); // HP
+                entryMap.put(key, 0); // HP
             }
         } else {
-            m_entryMap.put(key, m_entryMap.get(key) + 1);
+            entryMap.put(key, entryMap.get(key) + 1);
         }
     }
 
     private void searchProject() {
         // reset the number of search hits
-        m_numFinds = 0;
+        numFinds = 0;
 
         try {
             searchMemory();
@@ -341,7 +339,7 @@ public class Searcher {
             for (GlossaryEntry en : entries) {
                 checkEntry(en.getSrcText(), en.getLocText(), null, null, null, ENTRY_ORIGIN_GLOSSARY, intro);
                 // stop searching if the max. nr of hits has been reached
-                if (m_numFinds >= searchExpression.numberOfResults) {
+                if (numFinds >= searchExpression.numberOfResults) {
                     throw new SearchLimitReachedException();
                 }
                 checkStop.checkInterrupted();
@@ -355,14 +353,14 @@ public class Searcher {
             // Search TM entries, unless we search for date or author.
             // They are not loaded from external TM, so skip the search in
             // that case.
-            Path projectRoot = Paths.get(m_project.getProjectProperties().getProjectRoot());
+            Path projectRoot = Paths.get(project.getProjectProperties().getProjectRoot());
             if (!searchExpression.searchAuthor && !searchExpression.searchDateAfter && !searchExpression.searchDateBefore) {
-                for (Map.Entry<String, ExternalTMX> tmEn : m_project.getTransMemories().entrySet()) {
+                for (Map.Entry<String, ExternalTMX> tmEn : project.getTransMemories().entrySet()) {
                     final String fileTM = searchExpression.fileNames ? projectRoot.relativize(Paths.get(tmEn.getKey())).toString() : null;
                     searchEntries(tmEn.getValue().getEntries(), ENTRY_ORIGIN_TRANSLATION_MEMORY, fileTM);
                     checkStop.checkInterrupted();
                 }
-                for (Map.Entry<Language, ProjectTMX> tmEn : m_project.getOtherTargetLanguageTMs().entrySet()) {
+                for (Map.Entry<Language, ProjectTMX> tmEn : project.getOtherTargetLanguageTMs().entrySet()) {
                     final Language langTM = tmEn.getKey();
                     searchEntries(tmEn.getValue().getDefaults(), ENTRY_ORIGIN_ALTERNATIVE, langTM.getLanguage());
                     searchEntries(tmEn.getValue().getAlternatives(), ENTRY_ORIGIN_ALTERNATIVE, langTM.getLanguage());
@@ -376,15 +374,15 @@ public class Searcher {
         // search the Memory, if requested
         if (searchExpression.memory) {
             // search through all project entries
-            List<SourceTextEntry> allEntries = m_project.getAllEntries();
+            List<SourceTextEntry> allEntries = project.getAllEntries();
             for (int i = 0; i < allEntries.size(); i++) {
                 // stop searching if the max. nr of hits has been reached
-                if (m_numFinds >= searchExpression.numberOfResults) {
+                if (numFinds >= searchExpression.numberOfResults) {
                     throw new SearchLimitReachedException();
                 }
                 // get the source and translation of the next entry
                 SourceTextEntry ste = allEntries.get(i);
-                TMXEntry te = m_project.getTranslationInfo(ste);
+                TMXEntry te = project.getTranslationInfo(ste);
 
                 checkEntry(ste.getSrcText(), te.translation, te.note, ste.getRawProperties(), te, i, null);
                 checkStop.checkInterrupted();
@@ -392,31 +390,31 @@ public class Searcher {
 
             // search in orphaned
             if (!searchExpression.excludeOrphans) {
-                m_project.iterateByDefaultTranslations(new IProject.DefaultTranslationsIterator() {
+                project.iterateByDefaultTranslations(new IProject.DefaultTranslationsIterator() {
                     final String file = OStrings.getString("CT_ORPHAN_STRINGS");
 
                     public void iterate(String source, TMXEntry en) {
                         // stop searching if the max. nr of hits has been reached
-                        if (m_numFinds >= searchExpression.numberOfResults) {
+                        if (numFinds >= searchExpression.numberOfResults) {
                             return;
                         }
                         checkStop.checkInterrupted();
-                        if (m_project.isOrphaned(source)) {
+                        if (project.isOrphaned(source)) {
                             checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
                         }
                     }
                 });
-                m_project.iterateByMultipleTranslations(new IProject.MultipleTranslationsIterator() {
+                project.iterateByMultipleTranslations(new IProject.MultipleTranslationsIterator() {
                     final String file = OStrings.getString("CT_ORPHAN_STRINGS");
 
                     public void iterate(EntryKey source, TMXEntry en) {
                         // stop searching if the max. nr of hits has been
                         // reached
-                        if (m_numFinds >= searchExpression.numberOfResults) {
+                        if (numFinds >= searchExpression.numberOfResults) {
                             return;
                         }
                         checkStop.checkInterrupted();
-                        if (m_project.isOrphaned(source)) {
+                        if (project.isOrphaned(source)) {
                             checkEntry(en.source, en.translation, en.note, null, en, ENTRY_ORIGIN_ORPHAN, file);
                         }
                     }
@@ -449,7 +447,7 @@ public class Searcher {
     private void searchEntries(Iterable<? extends ITMXEntry> tmEn, int origin, final String tmxID) throws SearchLimitReachedException {
         for (ITMXEntry tm : tmEn) {
             // stop searching if the max. nr of hits has been reached
-            if (m_numFinds >= searchExpression.numberOfResults) {
+            if (numFinds >= searchExpression.numberOfResults) {
                 throw new SearchLimitReachedException();
             }
 
@@ -562,7 +560,7 @@ public class Searcher {
 
         FilterMaster fm = Core.getFilterMaster();
 
-        final SearchCallback searchCallback = new SearchCallback(m_project.getProjectProperties());
+        final SearchCallback searchCallback = new SearchCallback(project.getProjectProperties());
 
         int depth = searchExpression.recursive ? Integer.MAX_VALUE : 0;
         Files.walk(root, depth, FileVisitOption.FOLLOW_LINKS).forEach(path -> {
@@ -573,7 +571,7 @@ public class Searcher {
 
             searchCallback.setCurrentFile(fi);
             try {
-                fm.loadFile(filename, new FilterContext(m_project.getProjectProperties()), searchCallback);
+                fm.loadFile(filename, new FilterContext(project.getProjectProperties()), searchCallback);
             } catch (TranslationException | IOException ex) {
                 Log.log(ex);
             }
@@ -636,7 +634,7 @@ public class Searcher {
      * @return True if the text string contains all search strings
      */
     public boolean searchString(String origText, boolean collapseResults) {
-        if (origText == null || m_matchers == null || m_matchers.isEmpty()) {
+        if (origText == null || matchers == null || matchers.isEmpty()) {
             return false;
         }
 
@@ -645,7 +643,7 @@ public class Searcher {
         foundMatches.clear();
         // check the text against all matchers
         OUT_LOOP:
-        for (Matcher matcher : m_matchers) {
+        for (Matcher matcher : matchers) {
             // check the text against the current matcher
             // if one of the search strings is not found, don't
             // bother looking for the rest of the search strings
@@ -713,7 +711,7 @@ public class Searcher {
                             replaceMatcher.reset(repl);
                         }
                         foundMatches.add(new SearchMatch(start, end, StringUtil.replaceCase(repl,
-                                m_project.getProjectProperties().getTargetLanguage().getLocale())));
+                                project.getProjectProperties().getTargetLanguage().getLocale())));
                     } else {
                         foundMatches.add(new SearchMatch(start, end, searchExpression.replacement));
                     }
@@ -777,25 +775,25 @@ public class Searcher {
      * @return True if the text string contains the search string
      */
     private boolean searchAuthor(TMXEntry te) {
-        if (te == null || m_author == null) {
+        if (te == null || author == null) {
             return false;
         }
 
-        if (m_author.pattern().pattern().equals("")) {
+        if (author.pattern().pattern().equals("")) {
             // Handle search for null author.
             return te.changer == null && te.creator == null;
         }
 
         if (te.changer != null) {
-            m_author.reset(te.changer);
-            if (m_author.find()) {
+            author.reset(te.changer);
+            if (author.find()) {
                 return true;
             }
         }
 
         if (te.creator != null) {
-            m_author.reset(te.creator);
-            if (m_author.find()) {
+            author.reset(te.creator);
+            if (author.find()) {
                 return true;
             }
         }
@@ -808,7 +806,7 @@ public class Searcher {
 
     public void searchText(String seg, String translation, String filename) {
         // don't look further if the max. nr of hits has been reached
-        if (m_numFinds >= searchExpression.numberOfResults) {
+        if (numFinds >= searchExpression.numberOfResults) {
             return;
         }
 

--- a/src/org/omegat/core/search/Searcher.java
+++ b/src/org/omegat/core/search/Searcher.java
@@ -259,10 +259,13 @@ public class Searcher {
     // ////////////////////////////////////////////////////////////
     // internal functions
 
-    private void addEntry(int num, String preamble, String srcPrefix, String src, String target,
-            String note, String property, SearchMatch[] srcMatch, SearchMatch[] targetMatch, SearchMatch[] noteMatch, SearchMatch[] propertyMatch) {
-        SearchResultEntry entry = new SearchResultEntry(num, preamble, srcPrefix,
-                src, target, note, property, srcMatch, targetMatch, noteMatch, propertyMatch);
+    private void addEntry(int num, String preamble, String srcPrefix, String src, String target, String note,
+            String property, SearchMatch[] srcMatch, SearchMatch[] targetMatch, SearchMatch[] noteMatch,
+            SearchMatch[] propertyMatch) {
+        SearchResultEntry entry = SearchResultEntry.builder().entryNum(num).preambleText(preamble)
+                .srcPrefix(srcPrefix).sourceText(src).targetText(target).note(note).propertiesString(property)
+                .srcMatch(srcMatch).targetMatch(targetMatch).noteMatch(noteMatch)
+                .propertiesMatch(propertyMatch).build();
         searchResults.add(entry);
         numFinds++;
     }


### PR DESCRIPTION
- Replaced variables prefixed with "m_" with descriptive camelCase names.
- Improved code readability and alignment with modern Java conventions.
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Refactor

## Which ticket is resolved?

There is no issue to point

## What does this PR change?
- Refactoring SearchResultEntry:
    - Renames member variables, removing prefixes (m_) for improved readability.
    - Updates all class methods and references to align with the new variable names.
    - Implements a Builder pattern for constructing SearchResultEntry objects, enhancing flexibility and clarity.
- Refactoring Searcher:
    - Renames variables, similarly removing prefixes (m_) for consistency.
    - Simplifies internal methods by reducing redundancy in how entries are added and matched against search criteria.
- No significant new functionality or bug fixes were introduced; changes focus solely on refactoring.
- Checkstyle Configuration Update: Updated suppressions.xml by reducing suppressed checks in Searcher.java and narrowing unnecessary exclusions.
- Split renaming from PR #1431

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
