### PR TITLE
feat(util): introduce `getPluginsClassLoader` method in PluginUtils

### DIFF
--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -169,6 +169,8 @@ public final class PluginUtils {
     private static final MainClassLoader THEME_CLASSLOADER;
     private static final MainClassLoader LANGUAGE_CLASSLOADER;
 
+    private static MainClassLoader pluginsClassLoader;
+
     static {
         ClassLoader cl = PluginUtils.class.getClassLoader();
         THEME_CLASSLOADER = new MainClassLoader(cl);
@@ -206,7 +208,7 @@ public final class PluginUtils {
         boolean foundMain = false;
         // look on all manifests
         ClassLoader cl = PluginUtils.class.getClassLoader();
-        MainClassLoader pluginsClassLoader = new MainClassLoader(urlList.toArray(new URL[0]), cl);
+        pluginsClassLoader = new MainClassLoader(urlList.toArray(new URL[0]), cl);
         try {
             Enumeration<URL> mlist = pluginsClassLoader.getResources(MANIFEST_MF);
             while (mlist.hasMoreElements()) {
@@ -496,6 +498,10 @@ public final class PluginUtils {
 
     public static ClassLoader getLanguageClassLoader() {
         return LANGUAGE_CLASSLOADER;
+    }
+
+    public static ClassLoader getPluginsClassLoader() {
+        return pluginsClassLoader;
     }
 
     private static final List<Class<?>> FILTER_CLASSES = new ArrayList<>();


### PR DESCRIPTION
This Pull Request introduces a change in PluginUtils.java to improve the management of the pluginsClassLoader. A static instance of pluginsClassLoader is introduced and an accessor method is added.


## Pull request type

- refactor

## Which ticket is resolved?

There is no issue to point

## What does this PR change?

- Added a private static pluginsClassLoader field to the PluginUtils class.
-  Modified the initialization of pluginsClassLoader to ensure it is shared.
-  Introduced a public static method getPluginsClassLoader() to allow safe access to the pluginsClassLoader.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
