### PR TITLE
docs: add detailed CI process and guidelines for pull requests

### DIFF
--- a/src_docs/developer/06.GitWorkFlows.md
+++ b/src_docs/developer/06.GitWorkFlows.md
@@ -158,12 +158,118 @@ Tip: You can open a **draft pull request** if you’re still working on it but w
 
 ---
 
-## 💬 Need Help?
+## ✅ After You Open a Pull Request
 
-Feel free to ask on the developers mailing list:  
-👉 http://lists.sourceforge.net/lists/listinfo/omegat-development
+Once you submit a pull request (PR), GitHub will automatically run our Continuous Integration (CI) checks.
 
-We’re happy to support you!
+These checks ensure that your contribution builds successfully and follows the project's standards. If something goes wrong, GitHub will show it — but **you need to check it yourself** and make any necessary fixes.
+
+---
+
+### 📋 Where to Check the CI Results
+
+After opening a PR:
+
+1. Scroll down to the **Checks** section (below the PR description).
+2. Click the **“Details”** link next to any failed check, such as:
+   - `Quality checks`
+   - `BugSpots`
+   - `PMD`
+   - `checkStyle`
+   - `Acceptance Test`
+3. GitHub will open a log page that shows:
+   - What failed
+   - On which file and line
+   - Sometimes with inline annotations
+
+---
+
+### ⚠️ What to Look For
+
+| Check Name        | What It Means                          | Common Fix                                                                  |
+|-------------------|----------------------------------------|-----------------------------------------------------------------------------|
+| `Quality Checks`  | Tests and checks are failed            | It send Gradle Scan(R) to web site. You can open details in Gradle Velocity |
+| `BugSpots`        | Logic uses wrong habit                 | Run `./gradlew spotbugsMain spotbugsTest` and fix issues                    |
+| `PMD`             | Out of the coding best practice        | Change your code according to the annotated suggestions                     |
+| `checkStyle`      | Code violates style rules (Checkstyle) | Run `./gradlew checkStyleMain checkStyleTest` and fix issues                |
+| `Acceptance test` | Acceptance tests failed                | Run `./gradlww testAcceptance` and fix issues                               |
+
+---
+
+### 🛠 Fixing the Issues
+
+If the CI check failed, **you are expected to fix the problem yourself.**
+
+Do not wait for someone to tell you what to do. Use these steps:
+
+1. Read the error message.
+2. Open the file and line number referenced.
+3. Reproduce the issue locally:
+
+```bash
+# Build and test
+./gradlew build
+
+# Run Checkstyle
+./gradlew checkStyleMain checkStyleTest
+```
+
+4. Fix the issue.
+5. Recommit and push:
+
+```bash
+git add .
+git commit -m "Fix checkstyle|sportbugs|unit test errors"
+git push
+```
+
+Pushing a new commit will automatically rerun the checks.
+
+---
+
+### ✨ Code Formatting: Do This Every Time
+
+Before committing your changes, **run this** to auto-format your modified files:
+
+```bash
+./gradlew spotlessChangedApply
+```
+
+This prevents many common CI failures and makes the code easier to review.  
+You can also set up automatic formatting in your IDE using the project's Spotless rules.
+
+---
+
+### 🔁 Re-running CI Manually
+
+If a CI check fails for unrelated reasons (e.g. flaky network or timeout):
+
+1. Go to the **Checks** tab of your pull request.
+2. Click **“Re-run jobs”** > **“Re-run all jobs”** or **“Re-run failed jobs”**.
+
+---
+
+### ✏️ Why This Matters
+
+CI checks **are not optional.** If your PR fails them:
+
+* It will **not** be reviewed until all checks pass.
+* Reviewers are **not responsible** for fixing your code.
+* Ignoring CI feedback delays your contribution and others'.
+
+Learning to understand CI is part of modern software development — and it’s a required skill for contributing to OmegaT.
+
+---
+
+### ❤️ Still Need Help?
+
+If you’ve tried but are stuck:
+
+1. **Copy the exact error message**
+2. **Say what you did** to try to fix it
+3. Ask clearly on the [developer mailing list](http://lists.sourceforge.net/lists/listinfo/omegat-development)
+
+We’ll be glad to help — if you show that you've made an effort first.
 
 ---
 


### PR DESCRIPTION
Sometimes contributors wait for someone to tell waht to do.

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
