### PR TITLE
fix(filters3): avoid uninitialized read of field `encoding` in XMLReader

### DIFF
--- a/src/org/omegat/filters3/xml/XMLReader.java
+++ b/src/org/omegat/filters3/xml/XMLReader.java
@@ -58,7 +58,7 @@ import org.omegat.util.PatternConsts;
  */
 public class XMLReader extends Reader {
     /** Inner reader */
-    private BufferedReader reader;
+    private final BufferedReader reader;
 
     /** Inner encoding. */
     private String encoding;
@@ -84,7 +84,7 @@ public class XMLReader extends Reader {
      *            the InputStream instance to read
      */
     public XMLReader(InputStream is) throws IOException {
-        reader = createReader(is, encoding);
+        reader = createReader(is, null);
     }
 
     /**


### PR DESCRIPTION
This Pull Request fix the reference to the uninitialized field `encoding` in constructor.

## Pull request type

- Bug fix

## Which ticket is resolved?
There is no issue to point
## What does this PR change?


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
