### PR TITLE
refactor(git): replace keySet iteration with entrySet in `GITRemoteRepository2`

### DIFF
--- a/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -585,10 +585,10 @@ public class GITRemoteRepository2 implements IRemoteRepository2 {
             if (head.isSymbolic()) {
                 return Repository.shortenRefName(head.getTarget().getName());
             }
-            for (String refname : gitMap.keySet()) {
-                if (refname.startsWith(Constants.R_HEADS)
-                        && head.getObjectId().equals(gitMap.get(refname).getObjectId())) {
-                    return Repository.shortenRefName(refname);
+            for (Map.Entry<String, Ref> entry : gitMap.entrySet()) {
+                if (entry.getKey().startsWith(Constants.R_HEADS)
+                        && head.getObjectId().equals(gitMap.get(entry.getKey()).getObjectId())) {
+                    return Repository.shortenRefName(entry.getKey());
                 }
             }
         } catch (GitAPIException | IOException ignore) {


### PR DESCRIPTION
Fix the spotbugs warning of WMI_WRONG_MAP_ITERATOR: Inefficient use of keySet iterator instead of entrySet iterator

## Pull request type

- Other (describe below)
refactoring
## Which ticket is resolved?

there is no issue to point
## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
