### PR TITLE
test(acceptance): Project Properties dialog handling

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -233,3 +233,25 @@ tasks.register('testAcceptance', Test) {
     dependsOn firstSteps
     dependsOn ':aligner:jar'
 }
+
+tasks.register('jacocoAcceptanceReport', JacocoReport) {
+    dependsOn(tasks.testAcceptance)
+    executionData(tasks.testAcceptance)
+    sourceSets(sourceSets.main)
+    group = 'verification'
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.register('jacocoIntegrationReport', JacocoReport) {
+    dependsOn(tasks.testIntegration)
+    executionData(tasks.testIntegration)
+    sourceSets(sourceSets.main)
+    group = 'verification'
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}

--- a/src/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -128,7 +128,7 @@ public class ProjectPropertiesDialog extends JDialog {
      */
     private final Mode dialogType;
 
-    private final ProjectPropertiesDialogController controller;
+    private final transient ProjectPropertiesDialogController controller;
 
     /**
      * Creates a dialog to create a new project / edit folders of existing one.
@@ -197,10 +197,10 @@ public class ProjectPropertiesDialog extends JDialog {
         getContentPane().add(scrollPane, "Center");
 
         Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK"));
-        setName(OK_BUTTON_NAME);
+        okButton.setName(OK_BUTTON_NAME);
         getRootPane().setDefaultButton(okButton);
         Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL"));
-        setName(CANCEL_BUTTON_NAME);
+        cancelButton.setName(CANCEL_BUTTON_NAME);
 
         Box southBox = Box.createHorizontalBox();
         southBox.setBorder(new EmptyBorder(5, 5, 5, 5));

--- a/src/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.AbstractAction;
+import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
@@ -252,9 +253,9 @@ public class ProjectPropertiesDialogController {
         OmegaTFileChooser browser = new OmegaTFileChooser();
         browser.setDialogTitle(title);
         if (fileMode) {
-            browser.setFileSelectionMode(OmegaTFileChooser.FILES_ONLY);
+            browser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         } else {
-            browser.setFileSelectionMode(OmegaTFileChooser.DIRECTORIES_ONLY);
+            browser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         }
 
         // check if the current directory as specified by the field exists
@@ -264,7 +265,7 @@ public class ProjectPropertiesDialogController {
         int action = browser.showOpenDialog(dialog);
 
         // check if the selection has been approved
-        if (action != javax.swing.JFileChooser.APPROVE_OPTION) {
+        if (action != JFileChooser.APPROVE_OPTION) {
             return;
         }
 
@@ -327,6 +328,10 @@ public class ProjectPropertiesDialogController {
         // if all fails, get last used dir from preferences
         if (!curDirCheck.exists() || !curDirCheck.isDirectory()) {
             curDir = getDirFromPreference(browseTarget);
+        }
+
+        if (curDir == null) {
+            curDir = Preferences.getPreferenceDefault(Preferences.CURRENT_FOLDER, ".");
         }
 
         if (fileMode) {

--- a/src/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -217,6 +217,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         projectCompileMenuItem = createMenuItem("TF_MENU_FILE_COMPILE");
         projectSingleCompileMenuItem = createMenuItem("TF_MENU_FILE_SINGLE_COMPILE");
         projectEditMenuItem = createMenuItem("MW_PROJECTMENU_EDIT");
+        projectEditMenuItem.setName(PROJECT_EDIT_MENUITEM);
         viewFileListMenuItem = createMenuItem("TF_MENU_FILE_PROJWIN");
 
         projectAccessProjectFilesMenu = createMenu("TF_MENU_FILE_ACCESS_PROJECT_FILES",
@@ -1151,6 +1152,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     public static final String HELP_MENU = "help_menu";
     public static final String PROJECT_OPEN_RECENT_SUBMENU = "project_open_recent_submenu";
     public static final String PROJECT_ACCESS_PROJECT_FILES_SUBMENU = "project_access_project_files_submenu";
+    public static final String PROJECT_EDIT_MENUITEM = "project_edit_menuitem";
     public static final String SELECT_FUZZY_SUBMENU = "select_fuzzy_submenu";
     public static final String INSERT_CHARS_SUBMENU = "insert_chars_submenu";
     public static final String SWITCH_CASE_SUBMENU = "switch_case_submenu";

--- a/src/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/org/omegat/gui/main/ProjectUICommands.java
@@ -846,23 +846,22 @@ public final class ProjectUICommands {
         if (!Core.getProject().isProjectLoaded()) {
             return;
         }
+        var frame = Core.getMainWindow().getApplicationFrame();
 
         // commit the current entry first
         Core.getEditor().commitAndLeave();
 
         // displaying the dialog to change paths and other properties
         final ProjectProperties newProps =
-                ProjectPropertiesDialogController.showDialog(Core.getMainWindow().getApplicationFrame(),
-                Core.getProject().getProjectProperties(),
+                ProjectPropertiesDialogController.showDialog(frame, Core.getProject().getProjectProperties(),
                 Core.getProject().getProjectProperties().getProjectName(),
                 ProjectPropertiesDialog.Mode.EDIT_PROJECT);
         if (newProps == null) {
             return;
         }
 
-        int res = JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
-                OStrings.getString("MW_REOPEN_QUESTION"), OStrings.getString("MW_REOPEN_TITLE"),
-                JOptionPane.YES_NO_OPTION);
+        int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
+                OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
             return;
         }

--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -144,12 +144,12 @@ public class AlignerWindowTest extends TestCoreGUI {
         FileUtils.forceDeleteOnExit(tmpDir);
         // Start aligner
         JFrame frame = GuiActionRunner.execute(() -> {
-            AlignFilePickerController picker = new AlignFilePickerController();
-            picker.setSourceDefaultDir(tmpDir.toPath().resolve("source").toString());
-            picker.setDefaultSaveDir(tmpDir.toPath().resolve("tm").toString());
-            picker.setSourceLanguage(new Language("en"));
-            picker.setTargetLanguage(new Language("fr"));
-            return picker.initGUI(window.target());
+            AlignFilePickerController alignFilePickerController = new AlignFilePickerController();
+            alignFilePickerController.setSourceDefaultDir(tmpDir.toPath().resolve("source").toString());
+            alignFilePickerController.setDefaultSaveDir(tmpDir.toPath().resolve("tm").toString());
+            alignFilePickerController.setSourceLanguage(new Language("en"));
+            alignFilePickerController.setTargetLanguage(new Language("fr"));
+            return alignFilePickerController.initGUI(window.target());
         });
         picker = new FrameFixture(robot(), Objects.requireNonNull(frame));
         picker.show();

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -1,0 +1,85 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.dialogs;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.omegat.gui.main.BaseMainWindowMenu;
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.tokenizer.LuceneFrenchTokenizer;
+import org.omegat.util.Language;
+import org.omegat.util.LocaleRule;
+import org.omegat.util.OStrings;
+import org.omegat.util.gui.LanguageComboBoxRenderer;
+import org.openide.awt.Mnemonics;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+public class ProjectPropertiesDialogTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
+
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+
+    @Test
+    public void testProjectPropertiesDialog() throws Exception {
+        openSampleProject(PROJECT_PATH);
+        robot().waitForIdle();
+        //
+        window.menuItem(BaseMainWindowMenu.PROJECT_MENU).click();
+        window.menuItem(BaseMainWindowMenu.PROJECT_EDIT_MENUITEM).click();
+        robot().waitForIdle();
+        // Project Properties dialog is modal and visible
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).requireModal();
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).requireVisible();
+        // check source and target language
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).comboBox(ProjectPropertiesDialog.SOURCE_LOCALE_CB_NAME)
+                .requireEditable();
+        Language srcLang = new Language("en");
+        Language targetLang = new Language("fr");
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).comboBox(ProjectPropertiesDialog.SOURCE_LOCALE_CB_NAME)
+                .requireSelection(srcLang.getLocaleCode() + " - " + srcLang.getDisplayName());
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).comboBox(ProjectPropertiesDialog.TARGET_LOCALE_CB_NAME)
+                .requireSelection(targetLang.getLocaleCode() + " - " + targetLang.getDisplayName());
+        // check source and target tokenizer
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).comboBox(ProjectPropertiesDialog.SOURCE_TOKENIZER_FIELD_NAME)
+                .requireSelection(LuceneEnglishTokenizer.class.getSimpleName());
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).comboBox(ProjectPropertiesDialog.TARGET_TOKENIZER_FIELD_NAME)
+                .requireSelection(LuceneFrenchTokenizer.class.getSimpleName());
+        // Check sentence setmenting
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).checkBox(ProjectPropertiesDialog.SENTENCE_SEGMENTING_CB_NAME)
+                .requireText(Mnemonics.removeMnemonics(OStrings.getString("PP_SENTENCE_SEGMENTING")));
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).checkBox(ProjectPropertiesDialog.SENTENCE_SEGMENTING_CB_NAME)
+                .requireNotSelected();
+        // click cancel and close project
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).button(ProjectPropertiesDialog.CANCEL_BUTTON_NAME).click();
+        closeProject();
+    }
+}

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -37,7 +37,6 @@ import org.omegat.util.OStrings;
 import org.openide.awt.Mnemonics;
 
 import javax.swing.JButton;
-import javax.swing.JLabel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -24,19 +24,20 @@
  **************************************************************************/
 package org.omegat.gui.dialogs;
 
+import org.assertj.swing.core.GenericTypeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.BaseMainWindowMenu;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.tokenizer.LuceneFrenchTokenizer;
 import org.omegat.util.Language;
 import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
-import org.omegat.util.gui.LanguageComboBoxRenderer;
 import org.openide.awt.Mnemonics;
 
+import javax.swing.JButton;
+import javax.swing.JLabel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
@@ -49,7 +50,7 @@ public class ProjectPropertiesDialogTest extends TestCoreGUI {
     public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
-    public void testProjectPropertiesDialog() throws Exception {
+    public void testProjectPropertiesDialogShowAndOk() throws Exception {
         openSampleProject(PROJECT_PATH);
         robot().waitForIdle();
         //
@@ -78,7 +79,31 @@ public class ProjectPropertiesDialogTest extends TestCoreGUI {
                 .requireText(Mnemonics.removeMnemonics(OStrings.getString("PP_SENTENCE_SEGMENTING")));
         window.dialog(ProjectPropertiesDialog.DIALOG_NAME).checkBox(ProjectPropertiesDialog.SENTENCE_SEGMENTING_CB_NAME)
                 .requireNotSelected();
-        // click cancel and close project
+        // click Ok
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).button(ProjectPropertiesDialog.OK_BUTTON_NAME).click();
+        // Click No for restart dialog
+        robot().waitForIdle();
+        window.dialog().button(new GenericTypeMatcher<>(JButton.class, true) {
+            @Override
+            protected boolean isMatching(JButton btn) {
+                return btn.getText().equals("No");
+            }
+        }).click();
+        closeProject();
+    }
+
+    @Test
+    public void testProjectPropertiesDialogShowAndCancel() throws Exception {
+        openSampleProject(PROJECT_PATH);
+        robot().waitForIdle();
+        //
+        window.menuItem(BaseMainWindowMenu.PROJECT_MENU).click();
+        window.menuItem(BaseMainWindowMenu.PROJECT_EDIT_MENUITEM).click();
+        robot().waitForIdle();
+        // Project Properties dialog is modal and visible
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).requireModal();
+        window.dialog(ProjectPropertiesDialog.DIALOG_NAME).requireVisible();
+        // click cancel and close the project
         window.dialog(ProjectPropertiesDialog.DIALOG_NAME).button(ProjectPropertiesDialog.CANCEL_BUTTON_NAME).click();
         closeProject();
     }

--- a/test-acceptance/src/org/omegat/gui/main/TestMainWindowMenuHandler.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestMainWindowMenuHandler.java
@@ -70,6 +70,11 @@ public class TestMainWindowMenuHandler extends BaseMainWindowMenuHandler {
         mainWindow.getApplicationFrame().setEnabled(false);
     }
 
+    /** Edits project's properties */
+    public void projectEditMenuItemActionPerformed() {
+        ProjectUICommands.projectEditProperties();
+    }
+
     public void viewFileListMenuItemActionPerformed() {
         IProjectFilesList projWin = Core.getProjectFilesList();
         if (projWin == null) {


### PR DESCRIPTION


Add acceptance test for Project Properties dialog.
During work, I found small bug that the component name is wrong, that is a testing purpose.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]
- Build and release changes -> [build/release]
- Other (describe below)
refactor

## Which ticket is resolved?

There is no issue to point
## What does this PR change?

- Logical and Functional Improvements:
    - Refactored directory and file handling to improve robustness in ProjectPropertiesDialogController.
    - Adjusted the code to streamline project property editing (e.g., reusing application frame variables).
- Build Configuration: 
    - Added jacocoAcceptanceReport and jacocoIntegrationReport tasks for code coverage reporting.
- UI Updates:
    -  Updated GUI components in the ProjectPropertiesDialog and added identifiers for better testing and accessibility.
- Testing:
     - Added a new acceptance test (ProjectPropertiesDialogTest) covering the ProjectPropertiesDialog functionality.
    - Introduced a new action (projectEditMenuItemActionPerformed) to handle project editing in TestMainWindowMenuHandler.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
