### PR TITLE
feat(core/classloaders): use individual class loader for each plugin types

### DIFF
--- a/src/org/omegat/Main.java
+++ b/src/org/omegat/Main.java
@@ -341,7 +341,7 @@ public final class Main {
      * Execute standard GUI.
      */
     private static int runGUI() {
-        UIManager.put("ClassLoader", PluginUtils.getThemeClassLoader());
+        UIManager.put("ClassLoader", PluginUtils.getClassLoader(PluginUtils.PluginType.THEME));
 
         // macOS-specific - they must be set BEFORE any GUI calls
         if (Platform.isMacOSX()) {

--- a/src/org/omegat/core/spellchecker/SpellCheckerManager.java
+++ b/src/org/omegat/core/spellchecker/SpellCheckerManager.java
@@ -158,7 +158,7 @@ public class SpellCheckerManager {
 
     private static ISpellCheckerDictionary getSpellCheckerDictionary(String className) {
         try {
-            Class<?> aClass = PluginUtils.getLanguageClassLoader().loadClass(className);
+            Class<?> aClass = PluginUtils.getClassLoader(PluginUtils.PluginType.LANGUAGE).loadClass(className);
             Constructor<?> constructor = aClass.getConstructor();
             return (ISpellCheckerDictionary) constructor.newInstance();
         } catch (ClassNotFoundException e) {

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -37,8 +37,6 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,7 +53,6 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
-import java.util.stream.Collectors;
 
 import org.omegat.CLIParameters;
 import org.omegat.MainClassLoader;
@@ -365,17 +362,12 @@ public final class PluginUtils {
 
     private static void initializePluginClassLoaders(List<URL> urlList) {
         ClassLoader cl = PluginUtils.class.getClassLoader();
-        MainClassLoader pluginsClassLoader = AccessController.doPrivileged(
-                (PrivilegedAction<MainClassLoader>) () -> new MainClassLoader(urlList.toArray(new URL[0]),
-                        cl));
-        MAINCLASSLOADERS.put(PluginType.UNKNOWN, pluginsClassLoader);
+        MAINCLASSLOADERS.put(PluginType.UNKNOWN, new MainClassLoader(urlList.toArray(new URL[0]), cl));
         for (PluginType type : PluginType.values()) {
             if (type == PluginType.UNKNOWN) {
                 continue;
             }
-            MainClassLoader klassLoader = AccessController
-                    .doPrivileged((PrivilegedAction<MainClassLoader>) () -> new MainClassLoader(cl));
-            MAINCLASSLOADERS.put(type, klassLoader);
+            MAINCLASSLOADERS.put(type,  new MainClassLoader(cl));
         }
     }
 

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 
 import org.omegat.CLIParameters;
 import org.omegat.MainClassLoader;
@@ -397,11 +398,11 @@ public final class PluginUtils {
      * @param pluginsDirs
      *            List of directories where plugins can be loaded
      */
-    protected static List<URL> populatePluginUrlList(List<File> pluginsDirs) {
+    static List<URL> populatePluginUrlList(List<File> pluginsDirs) {
         // list all jars in /plugins/
         FileFilter jarFilter = pathname -> pathname.getName().endsWith(".jar");
         List<File> fs = pluginsDirs.stream().flatMap(dir -> FileUtil.findFiles(dir, jarFilter).stream())
-                .toList();
+                .collect(Collectors.toList());
         List<URL> urlList = new ArrayList<>();
         for (File f : fs) {
             try {

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -205,6 +205,15 @@ public final class PluginUtils {
      * directories where plugins may be located, including standard installation
      * directories and, if applicable, development build directories. The method
      * returns a list of URLs pointing to these plugin locations.
+     * <p>
+     * We should load all jars from /plugins/ dir first, because some plugin can
+     * use more than one jar. There are three different "plugins" directory, and
+     * one development treatment.
+     * <ul>
+     * <li>(installdir)/core-plugins/ OmegaT genuine sub-component</li>
+     * <li>(installdir/plugins/ System level 3rd party plugins</li>
+     * <li>(configdir)/plugins/ User level 3rd party plugins</li>
+     * </ul>
      *
      * @return a list of URLs representing the locations of plugins.
      */

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -610,14 +610,6 @@ public final class PluginUtils {
         return MAINCLASSLOADERS.get(type);
     }
 
-    public static ClassLoader getThemeClassLoader() {
-        return MAINCLASSLOADERS.get(PluginType.THEME);
-    }
-
-    public static ClassLoader getLanguageClassLoader() {
-        return MAINCLASSLOADERS.get(PluginType.LANGUAGE);
-    }
-
     private static final List<Class<?>> FILTER_CLASSES = new ArrayList<>();
 
     private static final List<Class<?>> TOKENIZER_CLASSES = new ArrayList<>();

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -653,7 +653,7 @@ public final class PluginUtils {
                 }
             }
         }
-        loadFromManifestOld(m, classLoader);
+        loadFromManifestOld(m);
     }
 
     private static void loadFromProperties(Properties props, ClassLoader classLoader)
@@ -673,7 +673,7 @@ public final class PluginUtils {
                 }
             } else {
                 for (String clazz : classes) {
-                    if (loadClassOld(key, clazz, classLoader)) {
+                    if (loadClassOld(key, clazz)) {
                         PLUGIN_INFORMATIONS.add(PluginInformation.Builder.fromProperties(clazz, props, key,
                                 null, PluginInformation.Status.BUNDLED));
                     }
@@ -716,7 +716,7 @@ public final class PluginUtils {
     /**
      * Old-style plugin loading.
      */
-    private static void loadFromManifestOld(final Manifest m, final ClassLoader classLoader)
+    private static void loadFromManifestOld(final Manifest m)
             throws ClassNotFoundException {
         if (m.getMainAttributes().getValue(OMEGAT_PLUGIN) == null) {
             return;
@@ -731,39 +731,39 @@ public final class PluginUtils {
                 // WebStart signing section, or other section
                 continue;
             }
-            if (loadClassOld(sType, key, classLoader)) {
+            if (loadClassOld(sType, key)) {
                 PLUGIN_INFORMATIONS.add(PluginInformation.Builder.fromManifest(key, m, null,
                         PluginInformation.Status.BUNDLED));
             }
         }
     }
 
-    private static boolean loadClassOld(String sType, String key, ClassLoader classLoader)
+    private static boolean loadClassOld(String sType, String key)
             throws ClassNotFoundException {
         boolean loadOk = true;
         switch (PluginType.getTypeByValue(sType)) {
         case FILTER:
-            FILTER_CLASSES.add(classLoader.loadClass(key));
+            FILTER_CLASSES.add(MAINCLASSLOADERS.get(PluginType.FILTER).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         case TOKENIZER:
-            TOKENIZER_CLASSES.add(classLoader.loadClass(key));
+            TOKENIZER_CLASSES.add(MAINCLASSLOADERS.get(PluginType.TOKENIZER).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         case MARKER:
-            MARKER_CLASSES.add(classLoader.loadClass(key));
+            MARKER_CLASSES.add(MAINCLASSLOADERS.get(PluginType.MARKER).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         case MACHINETRANSLATOR:
-            MACHINE_TRANSLATION_CLASSES.add(classLoader.loadClass(key));
+            MACHINE_TRANSLATION_CLASSES.add(MAINCLASSLOADERS.get(PluginType.MACHINETRANSLATOR).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         case BASE:
-            BASE_PLUGIN_CLASSES.add(classLoader.loadClass(key));
+            BASE_PLUGIN_CLASSES.add(MAINCLASSLOADERS.get(PluginType.MISCELLANEOUS).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         case GLOSSARY:
-            GLOSSARY_CLASSES.add(classLoader.loadClass(key));
+            GLOSSARY_CLASSES.add(MAINCLASSLOADERS.get(PluginType.GLOSSARY).loadClass(key));
             Log.logInfoRB("PLUGIN_LOAD_OK", key);
             break;
         default:

--- a/src/org/omegat/languagetools/LanguageClassBroker.java
+++ b/src/org/omegat/languagetools/LanguageClassBroker.java
@@ -33,7 +33,7 @@ public class LanguageClassBroker implements ClassBroker {
     @Override
     public Class<?> forName(String qualifiedName) throws ClassNotFoundException {
         Class<?> clazz;
-        ClassLoader classLoader = PluginUtils.getLanguageClassLoader();
+        ClassLoader classLoader = PluginUtils.getClassLoader(PluginUtils.PluginType.LANGUAGE);
         try {
             clazz = classLoader.loadClass(qualifiedName);
         } catch (ClassNotFoundException e) {

--- a/test-acceptance/src/org/omegat/TestMainInitializer.java
+++ b/test-acceptance/src/org/omegat/TestMainInitializer.java
@@ -35,7 +35,7 @@ public final class TestMainInitializer {
     }
 
     public static void initClassloader() {
-        UIManager.put("ClassLoader", PluginUtils.getThemeClassLoader());
+        UIManager.put("ClassLoader", PluginUtils.getClassLoader(PluginUtils.PluginType.THEME));
     }
 
 }


### PR DESCRIPTION
This Pull Request refactors and enhances the plugin loading mechanism in the PluginUtils class. It replaces individual class loaders for "theme" and "language" and the other plugins with a unified approach using EnumMap for managing multiple types of plugins. Additionally, it improves modularity and readability by introducing helper methods and consolidating repetitive logic.


## Pull request type
- Enhancement
- Refactoring

## Which ticket is resolved?

There is no issue to point

## What does this PR change?

- Refactoring ClassLoader Management:
    - Replaced individual loaders (THEME_CLASSLOADER, LANGUAGE_CLASSLOADER) with an EnumMap (MAINCLASSLOADERS) to manage MainClassLoader instances per PluginType.
- Introduced Improved Plugin Initialization Workflow:
    - Separated logic for locating plugins (initializePluginLocations), processing manifests (processPluginManifests), and handling configurations (processManifest).
    - Added methods to modularize plugin URL processing and manifest handling.
- Enhanced Error Handling:
    - Replaced unspecified Throwable in exception handlers with specific Exception types for improved clarity.
- Code Cleanup:
    - Consolidated repetitive code into helper methods (loadBasePlugin, addUrlToClasspath, etc.).
Streamlined plugin location and ClassLoader initialization logic for better maintainability.
## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
