### PR TITLE
fix(filters4/xliff1):  fix the anti-pattern that catch the null pointer exception and refactor complex switch-case blocks

### DIFF
--- a/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -145,7 +145,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
         case "group":
             if (startElement.getAttributeByName(new QName(ID_ATTRIBUTE)) != null) {
                 path += "/" + startElement.getAttributeByName(new QName(ID_ATTRIBUTE)).getValue();
-            } else if (startElement.getAttributeByName(new QName("resname")) != null){
+            } else if (startElement.getAttributeByName(new QName("resname")) != null) {
                 path += "/" + startElement.getAttributeByName(new QName("resname")).getValue();
             } else {
                 // generate an unique id:


### PR DESCRIPTION
## Pull request type
- Refactor

## Which ticket is resolved?


## What does this PR change?

- Added helper methods:
    - getRequiredAttribute(): Centralizes and simplifies attribute retrieval, with error handling for mandatory attributes, and replace try-catch-null-exception anti-pattern.
    - handleMrkElement(), handleDefaultElement(), and others: Modularized the processing of XML elements for better readability.
    - Dedicated methods for handling specific end elements (handleFileEndElement, handleGroupEndElement, etc.).
- Improved code clarity:
    - Removed inline verbose switch case logic by delegating to helper methods.
    - Replaced repetitive patterns with reusable functions.
- Minor code cleanup:
    - Removed outdated comments and cleaned unused code.
     - Simplified generics in target initialization (new LinkedList<>()).
- Errors centralized: Introduced better exception handling for mandatory attributes like id and original in XML elements.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
