### PR TITLE
refactor(mt): adjust constructor visibility and remove redundant javadoc in BaseTranslate

### DIFF
--- a/src/org/omegat/core/machinetranslators/BaseTranslate.java
+++ b/src/org/omegat/core/machinetranslators/BaseTranslate.java
@@ -58,7 +58,7 @@ public abstract class BaseTranslate implements IMachineTranslation {
     protected boolean enabled;
     protected IMTGlossarySupplier glossarySupplier;
 
-    public BaseTranslate() {
+    protected BaseTranslate() {
         // Options menu item
         JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem();
         Mnemonics.setLocalizedText(menuItem, getName());
@@ -76,34 +76,22 @@ public abstract class BaseTranslate implements IMachineTranslation {
         });
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean isEnabled() {
         return enabled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
         Preferences.setPreference(getPreferenceName(), enabled);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setGlossarySupplier(IMTGlossarySupplier glossarySupplier) {
         this.glossarySupplier = glossarySupplier;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getTranslation(Language sLang, Language tLang, String text) throws Exception {
         if (enabled) {
@@ -113,9 +101,6 @@ public abstract class BaseTranslate implements IMachineTranslation {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getCachedTranslation(Language sLang, Language tLang, String text) {
         return null;


### PR DESCRIPTION

- Changed `BaseTranslate` constructor from `public` to `protected` for encapsulation.
- Removed redundant `{@inheritDoc}` javadoc annotations from overridden methods.


## Pull request type
- Other (describe below)
refactor
## Which ticket is resolved?
There is no issue to point

## What does this PR change?

-
-
-

## Other information

#1296
