### PR TITLE
fix: replace `\n` with `%n` in exception message for platform compatibility

### DIFF
--- a/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -226,7 +226,7 @@ public class GITCredentialsProvider extends CredentialsProvider {
                 String promptedFingerprint = extractFingerprint(promptText);
                 if (promptedFingerprint == null) {
                     throw new UnsupportedCredentialItem(uri, String.format(
-                            "Unknown pattern to ask acceptance of host key fingerprint \n%s", promptText));
+                            "Unknown pattern to ask acceptance of host key fingerprint %n%s", promptText));
                 }
                 if (predefinedFingerprint != null) {
                     ((CredentialItem.YesNoType) item)


### PR DESCRIPTION


- Updated exception string formatting in `GITCredentialsProvider` to use `%n` for platform-independent line breaks.



## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
