### PR TITLE
fix(threading): mark `start` field as `volatile` in `ScriptWorker`

### DIFF
--- a/src/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/org/omegat/gui/scripting/ScriptingWindow.java
@@ -556,7 +556,7 @@ public class ScriptingWindow {
         private final String scriptString;
         private final ScriptItem scriptItem;
         private final Map<String, Object> bindings;
-        private long start;
+        private volatile long start;
 
         ScriptWorker(String scriptString, ScriptItem scriptItem, Map<String, Object> bindings) {
             this.scriptString = scriptString;


### PR DESCRIPTION
- Ensures proper visibility and thread-safety for the `start` variable in multi-threaded environments.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

Fix the threading issue

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
