### PR TITLE
refactor(tokenizer): implement `equals` and `hashCode` in `TagJoiningFilter` for better object comparison

### DIFF
--- a/src/org/omegat/tokenizer/LuceneJapaneseTokenizer.java
+++ b/src/org/omegat/tokenizer/LuceneJapaneseTokenizer.java
@@ -29,6 +29,7 @@ import java.io.StringReader;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 
@@ -143,6 +144,24 @@ public class LuceneJapaneseTokenizer extends BaseTokenizer {
                 return true;
             }
             return finishToken();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            TagJoiningFilter that = (TagJoiningFilter) o;
+            return startOffset == that.startOffset && buffering == that.buffering && Objects.equals(termAtt,
+                    that.termAtt) && Objects.equals(offsetAtt, that.offsetAtt) && Objects.equals(buffer, that.buffer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), termAtt, offsetAtt, buffer, startOffset, buffering);
         }
 
         private boolean getNextInput() throws IOException {


### PR DESCRIPTION


## Pull request type

refactor

## Which ticket is resolved?
there is no issue to point
## What does this PR change?

- Added a custom implementation of the equals() method to compare instances of TagJoiningFilter, ensuring all critical fields are checked for equality.
- Added a custom implementation of the hashCode() method to generate hash codes based on relevant fields, aligning with the equals() implementation.
- Included the Objects class in the imports to support the new logic.


## Other information

#1296
