### PR TITLE
refactor(gui): add `instanceof` check for safer casting in cell renderers

### DIFF
--- a/src/org/omegat/gui/properties/MultilineCellRenderer.java
+++ b/src/org/omegat/gui/properties/MultilineCellRenderer.java
@@ -66,12 +66,14 @@ class MultilineCellRenderer extends JTextArea implements TableCellRenderer {
         } else {
             setBorder(new CompoundBorder(marginBorder, noFocusBorder));
         }
-        FlashingTable fTable = (FlashingTable) table;
-        FlashColorInterpolator flasher = fTable.getFlasher();
-        if (flasher != null) {
-            flasher.mark();
-            if (fTable.isHighlightedRow(row) && !isSelected) {
-                setBackground(flasher.getColor());
+        if (table instanceof FlashingTable) {
+            FlashingTable fTable = (FlashingTable) table;
+            FlashColorInterpolator flasher = fTable.getFlasher();
+            if (flasher != null) {
+                flasher.mark();
+                if (fTable.isHighlightedRow(row) && !isSelected) {
+                    setBackground(flasher.getColor());
+                }
             }
         }
         setFont(table.getFont());

--- a/src/org/omegat/gui/properties/SingleLineCellRenderer.java
+++ b/src/org/omegat/gui/properties/SingleLineCellRenderer.java
@@ -69,12 +69,14 @@ class SingleLineCellRenderer extends DefaultTableCellRenderer {
         } else {
             result.setBorder(new CompoundBorder(marginBorder, noFocusBorder));
         }
-        FlashingTable fTable = (FlashingTable) table;
-        FlashColorInterpolator flasher = fTable.getFlasher();
-        if (flasher != null) {
-            flasher.mark();
-            if (fTable.isHighlightedRow(row) && !isSelected) {
-                setBackground(flasher.getColor());
+        if (table instanceof FlashingTable) {
+            FlashingTable fTable = (FlashingTable) table;
+            FlashColorInterpolator flasher = fTable.getFlasher();
+            if (flasher != null) {
+                flasher.mark();
+                if (fTable.isHighlightedRow(row) && !isSelected) {
+                    setBackground(flasher.getColor());
+                }
             }
         }
         result.setFont(table.getFont());


### PR DESCRIPTION


## Pull request type
refactor
## Which ticket is resolved?
there is no issue to point

## What does this PR change?

- MultilineCellRenderer:
    - Added a check using instanceof to verify if the table is of type FlashingTable before proceeding with typecasting.
- SingleLineCellRenderer:
    - Similarly added an instanceof check before casting the table to FlashingTable.


## Other information

#1296