### PR TITLE
chore(build): update publishing plugins and migrate repository configs to Nexus

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
@@ -38,9 +38,9 @@ ext.makeModuleTask = { moduleProp ->
                     description = moduleProp.Description
                     url = 'https://omegat.org'
                     scm {
-                        connection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                        developerConnection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                        url = "https://sourceforge.net/p/omegat/code/"
+                        connection = "scm:git:https://github.com/omegat-org/omegat"
+                        developerConnection = "scm:git:https://github.com/omegat-org/omegat"
+                        url = "https://sourceforge.net/p/omegat/"
                     }
                     licenses {
                         license {
@@ -55,15 +55,6 @@ ext.makeModuleTask = { moduleProp ->
                             email = 'info@omegat.org'
                         }
                     }
-                }
-            }
-        }
-        repositories {
-            maven {
-                url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-                credentials(PasswordCredentials) {
-                    username = findProperty('ossrhUsername')
-                    password = findProperty('ossrhPassword')
                 }
             }
         }

--- a/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
@@ -1,5 +1,6 @@
 
 plugins {
+    id 'org.omegat.version-conventions'
     id 'maven-publish'
     id 'signing'
     id 'org.hidetake.ssh'
@@ -49,9 +50,9 @@ publishing {
                 description = distDescription
                 url = 'https://omegat.org'
                 scm {
-                    connection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                    developerConnection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                    url = "https://sourceforge.net/p/omegat/code/"
+                    connection = "scm:git:https://github.com/omegat-org/omegat"
+                    developerConnection = "scm:git:https://github.com/omegat-org/omegat"
+                    url = "https://sourceforge.net/p/omegat/"
                 }
                 licenses {
                     license {
@@ -66,15 +67,6 @@ publishing {
                         email = 'info@omegat.org'
                     }
                 }
-            }
-        }
-    }
-    repositories {
-        maven {
-            url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            credentials(PasswordCredentials) {
-                username = findProperty('ossrhUsername')
-                password = findProperty('ossrhPassword')
             }
         }
     }

--- a/build-logic/src/main/groovy/org.omegat.version-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.version-conventions.gradle
@@ -14,8 +14,7 @@ ext {
         }
         "_${update}"
     }
-
-    mavenStyleVersion = version.replace('_', '-')
+    mavenStyleVersion = omtVersion.version + getUpdateSuffix(omtVersion.update).replace('_', '-')
 }
 
 tasks.register('printVersion') {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'jvm-test-suite'
     id 'java-test-fixtures'
     id 'com.google.osdetector' version '1.7.3'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 application {
@@ -505,3 +506,12 @@ remotes {
 }
 publishAtomically(name: 'webManual', sourceTask: manualHtmls)
 publishAtomically(name: 'javadoc', sourceTask: javadoc)
+
+nexusPublishing.repositories {
+    sonatype {
+        nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+        snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        username = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('SONATYPE_USER')
+        password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('SONATYPE_PASS')
+    }
+}


### PR DESCRIPTION
Sonatype changes the publish procedure to use OSSRH portal API and deprecate previous `oss.sonatype.org` site in 30, June. 2025. This PR update build configuration to publish omegat core library and modules onto Maven central. 
## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
