### PR TITLE
[6.0] chore: Replace OSSRH repository config with Gradle Nexus Publish Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.39.0'
     id 'ru.vyarus.mkdocs' version '3.0.0'
     id 'edu.sc.seis.launch4j' version '3.0.5'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 apply from: 'gradle/utils.gradle'
@@ -1130,9 +1131,9 @@ publishing {
                 description = 'The free translation memory tool'
                 url = 'https://omegat.org'
                 scm {
-                    connection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                    developerConnection = "scm:git:https://git.code.sf.net/p/omegat/code"
-                    url = "https://sourceforge.net/p/omegat/code/"
+                    connection = "scm:git:https://github.com/omegat-org/omegat"
+                    developerConnection = "scm:git:https://github.com/omegat-org/omegat"
+                    url = "https://sourceforge.net/p/omegat/"
                 }
                 licenses {
                     license {
@@ -1150,21 +1151,21 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            credentials(PasswordCredentials) {
-                username findProperty('ossrhUsername')
-                password findProperty('ossrhPassword')
-            }
-        }
-    }
 }
 
 signing {
     sign publishing.publications.mavenJava
     if (!findProperty("signing.keyId")) {
         useGpgCmd()
+    }
+}
+
+nexusPublishing.repositories {
+    sonatype {
+        nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+        snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        username = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('SONATYPE_USER')
+        password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('SONATYPE_PASS')
     }
 }
 


### PR DESCRIPTION
Prepare for publish omegat core library to Maven Central through OSSRH Portal API.

## Pull request type


- Build and release changes -> [build/release]


## Which ticket is resolved?

## What does this PR change?

- Added the io.github.gradle-nexus.publish-plugin with version 2.0.0.
-  Replaced the old repository and credentials configuration for Maven with Nexus publishing configuration.
-  Updated the source control links from SourceForge to GitHub for the project’s Git repository information.
-  Removed legacy Maven repository configuration and introduced a new nexusPublishing.repositories block with conditional username/password handling.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
