### PR TITLE
refactor(build): introduce error-prone system

### DIFF
--- a/.github/workflows/checkstyle-annotate.yml
+++ b/.github/workflows/checkstyle-annotate.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: create annotation
       run: echo "::add-matcher::${{ github.workspace }}/ci/github/problem-matcher.json"
     - name: setup gradle

--- a/.github/workflows/spotbugs-annotate.yml
+++ b/.github/workflows/spotbugs-annotate.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: create annotation
       run: echo "::add-matcher::${{ github.workspace }}/ci/github/problem-matcher.json"
     - name: setup gradle

--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     }
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,16 +72,16 @@ stages:
   - job: TestOnJava11
     displayName: on Java 11
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 1
         fetchTags: false
-      - template: ci/azure-pipelines/test_steps.yml
+      - template: ci/azure-pipelines/test_java11_steps.yml
   - job: TestOnJava17
     displayName: on Java 17
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 1
@@ -112,13 +112,13 @@ stages:
   - job: CheckForWeekly
     displayName: Test and Check
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - template: ci/azure-pipelines/check_steps.yml
   - job: IntegrationTestForWeekly
     displayName: Integration Test
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 1
@@ -133,7 +133,7 @@ stages:
       - CheckForWeekly
       - IntegrationTestForWeekly
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 1
@@ -164,14 +164,14 @@ stages:
   - job: CheckForRelease
     displayName: Test and Check
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 2
       - template: ci/azure-pipelines/check_steps.yml
   - job: ReleaseBuild
     pool:
-      vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - checkout: self
         fetchDepth: 0

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:7.0.4'
     implementation 'edu.sc.seis.launch4j:launch4j:3.0.6'
     implementation 'org.hidetake.ssh:org.hidetake.ssh.gradle.plugin:2.11.2'
+    implementation 'net.ltgt.gradle:gradle-errorprone-plugin:4.2.0'
 
     // dependencies on Maven
     implementation 'xerces:xercesImpl:2.12.2'

--- a/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
@@ -7,13 +7,11 @@ plugins {
     id 'com.diffplug.spotless'
     id 'com.github.spotbugs'
     id 'org.omegat.common-utilities'
+    id 'net.ltgt.errorprone'
 }
 
 // Definition of OmegaT versioning
 def localPropsFile = file('local.properties')
-
-// Define target Java version to compatible.
-def javaVersion = 11
 
 // Flag to detect CI/CD environment
 def envIsCi = project.hasProperty('envIsCi') as Boolean
@@ -38,15 +36,8 @@ repositories {
 java {
     withSourcesJar()
     withJavadocJar()
-    if (isWindows11 && isArm64) {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    } else {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(javaVersion)
-            vendor = JvmVendorSpec.ADOPTIUM
-        }
-    }
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.named("test", Test) {
@@ -75,7 +66,14 @@ javadoc {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
-    options.compilerArgs.addAll '-Xlint', '-Werror'
+    options.compilerArgs.addAll '-Xlint'
+    options.errorprone.disableWarningsInGeneratedCode = true
+}
+
+tasks {
+    compileTestJava {
+        options.errorprone.enabled = false
+    }
 }
 
 spotbugs {

--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -95,10 +95,10 @@ tasks.register('runDebugger', JavaExec) {
     dependsOn subprojects.collect {it.tasks.withType(Jar)}
 }
 
-tasks.register('runOnJava17', JavaExec) {
-    description = 'Runs application on Java 17.'
+tasks.register('runOnJava11', JavaExec) {
+    description = 'Runs application on Java 11.'
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(11)
         vendor = JvmVendorSpec.ADOPTIUM
     }
     mainClass.set application.mainClass
@@ -153,19 +153,6 @@ tasks.register('testIntegration', JavaExec) {
     maxHeapSize = findProperty('runMaxHeapSize')
     // Ask modules to be up-to-date before run task executed
     dependsOn subprojects.collect {it.tasks.withType(Jar)}
-}
-
-tasks.register('testOnJava17', Test) {
-    description = 'Runs test cases on Java 17.'
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(17)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-    if (project.hasProperty('headless')) {
-        systemProperty 'java.awt.headless', 'true'
-    }
-    systemProperty 'java.util.logging.config.file', "${rootDir}/config/test/logger.properties"
-    group = 'verification'
 }
 
 tasks.register('testOnJava21', Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ dependencies {
         // for architectures other than x86_64 on linux
         launch4jBin 'org.omegat:launch4j:3.55:workdir-linux'
     }
-
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
     subprojects.findAll { it.getSubprojects().isEmpty()}.collect {jacocoAggregation it}
 }
 
@@ -505,3 +505,13 @@ remotes {
 }
 publishAtomically(name: 'webManual', sourceTask: manualHtmls)
 publishAtomically(name: 'javadoc', sourceTask: javadoc)
+
+allprojects {
+    afterEvaluate {
+        tasks.findByName('compileJava')?.configure {
+            if (project == rootProject) {
+                options.errorprone.allErrorsAsWarnings = true
+            }
+        }
+    }
+}

--- a/ci/azure-pipelines/test_java11_steps.yml
+++ b/ci/azure-pipelines/test_java11_steps.yml
@@ -6,9 +6,9 @@ steps:
       path: '$(GRADLE_USER_HOME)'
   - task: Gradle@3
     inputs:
-      tasks: 'test'
+      tasks: 'testOnJava11'
       options: '--build-cache -PenvIsCi'
-      jdkVersionOption: '1.11'
+      jdkVersionOption: '1.17'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results build/test-results/**/TEST-*.xml'
     condition: always()

--- a/ci/azure-pipelines/test_java17_steps.yml
+++ b/ci/azure-pipelines/test_java17_steps.yml
@@ -9,7 +9,7 @@ steps:
       path: '$(GRADLE_USER_HOME)'
   - task: Gradle@3
     inputs:
-      tasks: 'testOnJava17'
+      tasks: 'test'
       options: '--build-cache -PenvIsCi'
       jdkVersionOption: '1.17'
   - script: |

--- a/language-modules/ar/build.gradle
+++ b/language-modules/ar/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation(project(":spellchecker:hunspell"))
     testRuntimeOnly(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ast/build.gradle
+++ b/language-modules/ast/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:morfologik")
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/be/build.gradle
+++ b/language-modules/be/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/br/build.gradle
+++ b/language-modules/br/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation(project(":spellchecker:hunspell"))
     testImplementation project(":spellchecker:morfologik")
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ca/build.gradle
+++ b/language-modules/ca/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testRuntimeOnly(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/da/build.gradle
+++ b/language-modules/da/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation(project(":spellchecker:hunspell"))
     testRuntimeOnly(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/de/build.gradle
+++ b/language-modules/de/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/el/build.gradle
+++ b/language-modules/el/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/en/build.gradle
+++ b/language-modules/en/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/eo/build.gradle
+++ b/language-modules/eo/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/es/build.gradle
+++ b/language-modules/es/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/fa/build.gradle
+++ b/language-modules/fa/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/fr/build.gradle
+++ b/language-modules/fr/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ga/build.gradle
+++ b/language-modules/ga/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/gl/build.gradle
+++ b/language-modules/gl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/it/build.gradle
+++ b/language-modules/it/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/km/build.gradle
+++ b/language-modules/km/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/nl/build.gradle
+++ b/language-modules/nl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/pl/build.gradle
+++ b/language-modules/pl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/pt/build.gradle
+++ b/language-modules/pt/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ro/build.gradle
+++ b/language-modules/ro/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(libs.languagetool.core)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ru/build.gradle
+++ b/language-modules/ru/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/sk/build.gradle
+++ b/language-modules/sk/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/sl/build.gradle
+++ b/language-modules/sl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/sv/build.gradle
+++ b/language-modules/sv/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/ta/build.gradle
+++ b/language-modules/ta/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/tl/build.gradle
+++ b/language-modules/tl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:morfologik")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/uk/build.gradle
+++ b/language-modules/uk/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation project(":spellchecker:hunspell")
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/language-modules/zh/build.gradle
+++ b/language-modules/zh/build.gradle
@@ -37,5 +37,6 @@ dependencies {
     testRuntimeOnly(libs.json)
     testRuntimeOnly(libs.protobuf)
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.jackson.core)
     testImplementation(libs.jackson.databind)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         compileOnly(libs.jackson.databind)
     }
     testImplementation(testFixtures(project.rootProject))
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/dummy/build.gradle
+++ b/machinetranslators/dummy/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(project.rootProject)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 jar {

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.jackson.core)
     testImplementation(libs.jackson.databind)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.jackson.core)
     testImplementation(libs.jackson.databind)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.jackson.core)
     testImplementation(libs.jackson.databind)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.jackson.core)
     testImplementation(libs.jackson.databind)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testImplementation(project(":language-modules:de"))
     testImplementation(project(":language-modules:fr"))
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(libs.commons.io)
     testRuntimeOnly(libs.languagetool.en)
     testRuntimeOnly(libs.languagetool.de)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/theme/build.gradle
+++ b/theme/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     }
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
+    errorprone("com.google.errorprone:error_prone_core:2.36.0")
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     } else {
         implementation(libs.tipoftheday)
         compileOnly(libs.jackson.yaml)
+        errorprone("com.google.errorprone:error_prone_core:2.36.0")
     }
 }
 


### PR DESCRIPTION
Google provides an open tool to build Java project error-prone. The tool is provided as a Java Compiler plugin.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

There is no issue to point, but it is a part of the clean code initiative.
## What does this PR change?

- Add Gradle Error Prone plugin@4.2.0
- Add Google Error-Prone@2.36.0
- 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
