### PR TITLE
refactor(filters): improve JavaDoc and remove unused `throws` clauses

### DIFF
--- a/src/org/omegat/filters2/AbstractOptions.java
+++ b/src/org/omegat/filters2/AbstractOptions.java
@@ -65,10 +65,12 @@ public abstract class AbstractOptions {
     }
 
     /**
-     * Save boolean value to string option.
+     * Sets the value of a specific option to a boolean value.
      *
      * @param key
+     *            the key for the option to be updated
      * @param value
+     *            the boolean value to set for the specified option
      */
     protected void setBoolean(String key, boolean value) {
         options.put(key, Boolean.toString(value));
@@ -89,10 +91,12 @@ public abstract class AbstractOptions {
     }
 
     /**
-     * Save string value to string option.
+     * Sets the value of a specific option as a string.
      *
      * @param key
+     *            the key for the option to be updated
      * @param value
+     *            the string value to set for the specified option
      */
     protected void setString(String key, String value) {
         options.put(key, value);
@@ -117,10 +121,15 @@ public abstract class AbstractOptions {
     }
 
     /**
-     * Save string value to string option.
+     * Sets the value of a specific option as the name of an enum constant.
      *
+     * @param <T>
+     *            the type of the enum
      * @param key
+     *            the key for the option to be updated
      * @param value
+     *            the enum constant whose name will be set for the specified
+     *            option
      */
     protected <T extends Enum<T>> void setEnum(String key, T value) {
         options.put(key, value.name());

--- a/src/org/omegat/filters2/IFilter.java
+++ b/src/org/omegat/filters2/IFilter.java
@@ -130,7 +130,6 @@ public interface IFilter {
      *            processing context
      * @param callback
      *            callback for parsed data
-     * @throws Exception
      */
     void parseFile(File inFile, Map<String, String> config, FilterContext context, IParseCallback callback)
             throws Exception;
@@ -148,7 +147,6 @@ public interface IFilter {
      *            processing context
      * @param callback
      *            callback for get translation
-     * @throws Exception
      */
     void translateFile(File inFile, File outFile, Map<String, String> config, FilterContext context,
             ITranslateCallback callback) throws Exception;

--- a/src/org/omegat/filters2/Instance.java
+++ b/src/org/omegat/filters2/Instance.java
@@ -28,7 +28,12 @@ package org.omegat.filters2;
 import java.io.Serializable;
 
 /**
- *
+ * Represents an instance of a filter configuration with attributes such as
+ * source filename mask, source encoding, target encoding, and target filename
+ * pattern. This class is used to define how files are handled during a
+ * filtering process. It supports several constructors allowing different levels
+ * of initialization.
+ * 
  * @author Maxym Mykhalchuk
  */
 public class Instance implements Serializable {

--- a/src/org/omegat/filters2/html2/HTMLOptions.java
+++ b/src/org/omegat/filters2/html2/HTMLOptions.java
@@ -254,46 +254,69 @@ public class HTMLOptions extends AbstractOptions {
         setString(OPTION_SKIP_META, skipMeta);
     }
 
-   /**
-     * @return the attribute key-value pairs for which tags should not be translated
+    /**
+     * Retrieves the tags to be ignored during the processing of HTML content.
+     *
+     * @return the attribute key-value pairs for which tags should not be
+     *         translated
      */
     public String getIgnoreTags() {
         return getString(OPTION_IGNORE_TAGS, "");
     }
 
     /**
-     * Sets the attribute key-value pairs for which tags should not be translated
-     * @param ignoreTags The strings containing the key-value pairs
+     * Sets the attribute key-value pairs for which tags should not be
+     * translated
+     * 
+     * @param ignoreTags
+     *            The strings containing the key-value pairs
      */
     public void setIgnoreTags(String ignoreTags) {
         setString(OPTION_IGNORE_TAGS, ignoreTags);
     }
 
     /**
-     * @return Returns whether comments should be removed from the HTML document on generating target documents.
+     * Retrieves the configuration setting that indicates whether comments
+     * should be removed from the HTML document when generating target
+     * documents.
+     *
+     * @return Returns whether comments should be removed from the HTML document
+     *         on generating target documents.
      */
     public boolean getRemoveComments() {
         return getBoolean(OPTION_REMOVE_COMMENTS, false);
     }
 
     /**
-     * Sets whether the comments should be removed from the HTML document on generating target documents.
+     * Sets whether comments should be removed from the HTML document when
+     * generating target documents.
+     *
      * @param removeComments
+     *            a boolean indicating whether comments should be removed from
+     *            the HTML content
      */
     public void setRemoveComments(boolean removeComments) {
         setBoolean(OPTION_REMOVE_COMMENTS, removeComments);
     }
 
     /**
-     * @return Returns whether whitespace should be compressed in the HTML document on generating target documents.
+     * Retrieves the configuration setting that indicates whether whitespace
+     * should be compressed in the HTML document during processing.
+     *
+     * @return Returns whether whitespace should be compressed in the HTML
+     *         document on generating target documents.
      */
     public boolean getCompressWhitespace() {
         return getBoolean(OPTION_COMPRESS_WHITESPACE, false);
     }
 
     /**
-     * Sets whether whitespace should be compressed in the HTML document on generating target documents.
+     * Sets whether whitespace in the HTML document should be compressed during
+     * processing. This affects how the output HTML is formatted by removing
+     * redundant whitespace.
+     *
      * @param compressWhitespace
+     *            a boolean indicating whether whitespace should be compressed
      */
     public void setCompressWhitespace(boolean compressWhitespace) {
         setBoolean(OPTION_COMPRESS_WHITESPACE, compressWhitespace);

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -452,7 +452,11 @@ public class FilterMaster {
      * Loads information about the filters from an XML file. If there's an error
      * loading a file, it calls <code>setupDefaultFilters</code>.
      *
-     * @throws IOException
+     * @param configFile the file from which the filter configuration is to be loaded
+     * @return an instance of {@code Filters} containing the loaded configuration,
+     *         or a new {@code Filters} instance if an error occurs or a new configuration
+     *         is generated
+     * @throws IOException if an I/O error occurs while reading the configuration file
      */
     public static Filters loadConfig(File configFile) throws IOException {
         if (!configFile.exists()) {
@@ -475,9 +479,13 @@ public class FilterMaster {
     }
 
     /**
-     * Saves information about the filters to an XML file.
+     * Saves information about the filters to an XML file. If the configuration is null,
+     * the file will be deleted. The configuration is written in a pretty-printed format.
      *
-     * @throws IOException
+     * @param config The configuration object to be saved. If null, the file is deleted.
+     * @param configFile The file to save the configuration to.
+     * @throws IOException If an error occurs while saving the configuration or deleting
+     *         the file.
      */
     public static void saveConfig(Filters config, File configFile) throws IOException {
         if (config == null) {
@@ -527,18 +535,14 @@ public class FilterMaster {
     }
 
     /**
-     * Calculate the target path corresponding to the given source file.
+     * Determines the target file path for a given source file path.
      *
-     * @param sourceDir
-     *            Path to the project's <code>source</code> dir
-     * @param srcRelPath
-     *            Relative path under <code>sourceDir</code> of the source file
-     * @param fc
-     *            Filter context
-     * @return The relative path under <code>target</code> of the corresponding
-     *         target file
-     * @throws IOException
-     * @throws TranslationException
+     * @param sourceDir the root directory of the source file
+     * @param srcRelPath the relative path of the source file within the source directory
+     * @param fc the filter context containing relevant translation parameters
+     * @return the target file path corresponding to the source file
+     * @throws TranslationException if an error occurs during the translation processing
+     * @throws IllegalArgumentException if the specified sourceDir and srcRelPath do not point to an existing file
      */
     public String getTargetForSource(String sourceDir, String srcRelPath, FilterContext fc)
             throws TranslationException {

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -199,10 +199,20 @@ public class MozillaLangFilter extends AbstractFilter {
     }
 
     /**
+     * Aligns a source text with its translation and associates optional
+     * comments.
+     * <p>
+     * This method handles the mapping of source text and translations,
+     * potentially with comments, using two callback mechanisms:
+     * entryParseCallback and entryAlignCallback.
      *
      * @param source
+     *            The source string to be aligned.
      * @param translation
+     *            The translated string corresponding to the source.
      * @param comments
+     *            An optional comment associated with the source and
+     *            translation.
      */
     protected void align(String source, String translation, String comments) {
         if (entryParseCallback != null) {

--- a/src/org/omegat/filters2/xtagqxp/XtagFilter.java
+++ b/src/org/omegat/filters2/xtagqxp/XtagFilter.java
@@ -112,8 +112,6 @@ public class XtagFilter extends AbstractFilter {
      *            Source document
      * @param outFile
      *            Target document
-     * @throws java.io.IOException
-     * @throws org.omegat.filters2.TranslationException
      */
     private void processXtagFile(BufferedReader inFile, Writer outFile) throws IOException,
             TranslationException {
@@ -178,7 +176,7 @@ public class XtagFilter extends AbstractFilter {
     /**
      * Receives a character, and convert it to the Xtag equivalent if necessary
      *
-     * @param c
+     * @param cp
      *            A character
      * @return either the original character, or an Xtag version of that
      *         character
@@ -219,7 +217,7 @@ public class XtagFilter extends AbstractFilter {
                 state = stateCollectTag;
                 // Possible end of a tag
                 // Exception for <\>>, which is how CopyFlow stores a >
-            } else if ((cp == '>') && (tag.lastIndexOf("\\") != tag.offsetByCodePoints(tag.length(), -1))) {
+            } else if (cp == '>' && tag.lastIndexOf("\\") != tag.offsetByCodePoints(tag.length(), -1)) {
                 num++;
                 Xtag oneTag = new Xtag(tag.toString(), num);
                 changedString.append(oneTag.toShortcut());

--- a/src/org/omegat/util/OConsts.java
+++ b/src/org/omegat/util/OConsts.java
@@ -98,7 +98,7 @@ public final class OConsts {
     /** Project subfolder for exported translation memories. */
     public static final String DEFAULT_EXPORT_TM = "";
     /**
-     * Translation memory levels, space-separated string, to include zero or more of the following values: "omegat",
+     * Translation memory levels, space-separated lowercase string, to include zero or more of the following values: "omegat",
      * "level1" and/or "level2").
      */
     public static final String DEFAULT_EXPORT_TM_LEVELS = "omegat level1 level2";


### PR DESCRIPTION
There are many space to improve JavaDoc in filters.
## Pull request type


- Documentation

## Which ticket is resolved?
There is no feature issue to point

## What does this PR change?

-
-
-

## Other information

#1496 detect many places where should be improved