### PR TITLE
feat(gradle): implement dependency caching mechanism in integration tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,9 @@ services:
       - type: volume
         source: keygen
         target: /keys
+      - type: volume
+        source: gradle-cache
+        target: /gradle-cache
     tmpfs:
       - /tmp
       - /workdir
@@ -35,3 +38,4 @@ services:
       TYPE: ${TYPE:-GIT}
 volumes:
   keygen:
+  gradle-cache:

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -44,6 +44,7 @@ RUN echo TARGETARCH is ${TARGETARCH} && curl -LO https://packages.adoptium.net/a
     && rm -f adoptium-ca-certificates_${CAVER}_all.deb temurin-${JAVA}-${JDKVER}_${TARGETARCH}.deb
 RUN (cd /opt && curl -LO https://services.gradle.org/distributions/gradle-${GRADLE}-bin.zip \
     && unzip -q gradle-${GRADLE}-bin.zip && rm -f gradle-${GRADLE}-bin.zip) && mv /opt/gradle-${GRADLE} /opt/gradle
+RUN mkdir -p /gradle-cache && chown -R omegat:omegat /gradle-cache
 
 USER omegat
 


### PR DESCRIPTION
Add gradle cache for integration test container

## Pull request type

- Other (describe below)
- Improve test
## Which ticket is resolved?


## What does this PR change?

- Added a new volume, gradle-cache, in compose.yml for Gradle dependency caching.
- Updated the entrypoint.sh script to handle Gradle dependency caching:
    - Set up a GRADLE_USER_HOME environment variable pointing to the cache.
    - Computed a hash based on build configuration files to determine cache validity.
    - Implemented logic to download dependencies if the cache is outdated or missing.
    - Cleaned up old cache markers keeping the most recent three for flexibility.
    - Displayed cache statistics like size and configuration count.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
