### PR TITLE
feat: bump jaxb library to 4 and schema to version 3.0

### DIFF
--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -7,16 +7,13 @@ dependencies {
     if (providedModuleLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-*.jar', '**/lib-mnemonics*.jar',
             '**/slf4j*.jar', '**/supertmxmerge-*.jar', '**/jaxb-api*.jar'])
-        compileOnly fileTree(dir: providedModuleLibsDir, includes: ['**/maligna-*.jar'])
+        implementation fileTree(dir: providedModuleLibsDir, includes: ['**/maligna-*.jar'])
     } else {
         // Aligner
-        implementation(libs.loomchild.maligna) {
-            exclude module: 'jaxb-api'
-            exclude module: 'jaxb-core'
-            exclude module: 'jaxb-runtime'
-        }
+        implementation(libs.tokyo.northside.maligna)
         implementation(libs.jetbrains.annotations)
-        compileOnly(libs.jaxb.api)
+        compileOnly(libs.jaxb4.api)
+        compileOnly(libs.jaxb4.runtime)
         compileOnly(libs.madlonkay.supertmxmerge)
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.commons.io)

--- a/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
@@ -7,7 +7,9 @@ configurations {
 }
 
 dependencies {
-    jaxb(libs.jaxb.xjc)
+    jaxb(libs.jaxb4.xjc)
+    jaxb(libs.jaxb4.api)
+    jaxb(libs.jaxb4.runtime)
 }
 
 def genjaxb = tasks.register('genJAXB') {

--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,9 @@ dependencies {
         runtimeOnly(libs.slf4j.jdk14)
 
         // jaxb gen compilation
-        implementation(libs.jaxb.api)
-        runtimeOnly(libs.jaxb.core)
-        runtimeOnly(libs.jaxb.runtime)
+        implementation(libs.jaxb4.api)
+        runtimeOnly(libs.jaxb4.core)
+        runtimeOnly(libs.jaxb4.runtime)
 
         // macOS integration
         implementation(libs.madlonkay.desktopsupport)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,21 +38,22 @@ gnudiff = "1.15"
 desktopsupport = "0.6.0"
 protocolhandler = "0.1.4"
 pdfbox = "3.0.5"
-maligna = "3.0.1"
+maligna = "4.0.0"
 trie4j = "0.9.10_1"
 dsl4j = "1.1.2"
 stardict4j = "1.1.0"
 juniversalchardet = "2.5.0"
 mnemonics = "1.2"
 hunspell = "2.1.2"
-xjc = "2.3.9"
+xjc = "4.0.5"
+jaxb4_api = "4.0.2"
+jaxb = "4.0.5"
 jna = "5.13.0"
 jfa = "1.2.0"
 tipoftheday = "0.5.0"
 flatlaf="3.6"
 assertj_swing_junit = "4.0.0-beta-2"
 morfologik = "2.1.9"
-jaxb = "2.3.0"
 swing_extra_locales = "0.3.3"
 mockito = "5.18.0"
 json_java = "20250517"
@@ -121,7 +122,7 @@ ivy = {group = "org.apache.ivy", name = "ivy", version.ref = "ivy"}
 jackson-core = {group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jackson"}
 jackson-databind = {group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson"}
 jackson-xml = {group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-xml", version.ref = "jackson"}
-jackson-jaxb = {group = "com.fasterxml.jackson.module", name = "jackson-module-jaxb-annotations", version.ref = "jackson"}
+jackson-jaxb = {group = "com.fasterxml.jackson.module", name = "jackson-module-jakarta-xmlbind-annotations", version.ref = "jackson"}
 jackson-yaml = {group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson"}
 jgit = {group = "org.eclipse.jgit", name = "org.eclipse.jgit", version.ref = "jgit"}
 jgit-ssh = {group = "org.eclipse.jgit", name = "org.eclipse.jgit.ssh.apache", version.ref = "jgit"}
@@ -154,17 +155,17 @@ omegat-gnudiff4j = {group = "org.omegat", name = "gnudiff4j", version.ref = "gnu
 madlonkay-desktopsupport = {group = "org.madlonkay", name = "desktopsupport", version.ref = "desktopsupport"}
 url-protocol-handler = {group = "tokyo.northside", name = "url-protocol-handler", version.ref = "protocolhandler"}
 apache-pdfbox = {group = "org.apache.pdfbox", name = "pdfbox", version.ref = "pdfbox"}
-loomchild-maligna = {group = "net.loomchild", name = "maligna", version.ref = "maligna"}
+tokyo-northside-maligna = {group = "tokyo.northside", name = "maligna", version.ref = "maligna"}
 trie4j = {group = "tokyo.northside", name = "trie4j", version.ref = "trie4j"}
 dsl4j = {group = "tokyo.northside", name = "dsl4j", version.ref = "dsl4j"}
 stardict4j = {group = "tokyo.northside", name = "stardict4j", version.ref = "stardict4j"}
 juniversal-chardet = {group = "com.github.albfernandez", name = "juniversalchardet", version.ref = "juniversalchardet"}
 omegat-mnemonics = {group = "org.omegat", name = "lib-mnemonics", version.ref = "mnemonics"}
 dumont-hunspell = {group = "com.gitlab.dumonts", name = "hunspell", version.ref = "hunspell"}
-jaxb-api = {group = "javax.xml.bind", name = "jaxb-api", version.ref = "jaxb"}
-jaxb-xjc = {group = "org.glassfish.jaxb", name = "jaxb-xjc", version.ref = "xjc"}
-jaxb-core = {group = "org.glassfish.jaxb", name = "jaxb-core", version.ref = "jaxb"}
-jaxb-runtime = {group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb"}
+jaxb4-api = {group = "jakarta.xml.bind", name = "jakarta.xml.bind-api", version = "jaxb4_api"}
+jaxb4-xjc = {group = "org.glassfish.jaxb", name = "jaxb-xjc", version.ref = "xjc"}
+jaxb4-core = {group = "org.glassfish.jaxb", name = "jaxb-core", version.ref = "jaxb"}
+jaxb4-runtime = {group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb"}
 tipoftheday = {group = "tokyo.northside", name = "tipoftheday", version.ref = "tipoftheday"}
 jna = {group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna"}
 jfa = {group = "de.jangassen", name = "jfa", version.ref = "jfa"}

--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -55,7 +55,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 
 import org.omegat.util.Language;
 import org.omegat.util.Log;
@@ -95,7 +95,7 @@ public class SRX implements Serializable {
         XmlFactory xmlFactory = new XmlFactory(xmlInputFactory);
         mapper = XmlMapper.builder(xmlFactory).defaultUseWrapper(false)
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -48,7 +48,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import org.omegat.util.OStrings;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.gui.TextUtil;
@@ -254,7 +254,7 @@ public class StatsResult {
         setDate();
         XmlMapper mapper = XmlMapper.xmlBuilder().enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME)
                 .build();
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
         return mapper.writeValueAsString(this);
     }
 

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -53,7 +53,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import org.apache.commons.io.FileUtils;
 
 import org.jetbrains.annotations.Nullable;
@@ -122,7 +122,7 @@ public class FilterMaster {
     static {
         mapper = XmlMapper.xmlBuilder().defaultUseWrapper(false)
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);

--- a/src/org/omegat/gui/glossary/GlossaryReaderTBX.java
+++ b/src/org/omegat/gui/glossary/GlossaryReaderTBX.java
@@ -34,13 +34,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -53,7 +53,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -92,7 +92,7 @@ public final class ProjectFileStorage {
         XmlFactory xmlFactory = new XmlFactory(xmlInputFactory);
         mapper = XmlMapper.builder(xmlFactory).defaultUseWrapper(false)
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
         SimpleModule module = new SimpleModule();
         TypeFactory typeFactory = mapper.getTypeFactory();
         final RepositoryDefinition def = new RepositoryDefinition();

--- a/src/schemas/filters.xsd
+++ b/src/schemas/filters.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1"
+	xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0"
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:element name="filters">
 		<xs:annotation>

--- a/src/schemas/tmx14.xjb
+++ b/src/schemas/tmx14.xjb
@@ -1,5 +1,4 @@
-<jaxb:bindings version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
- xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<jaxb:bindings version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<jaxb:bindings schemaLocation="tmx14.xsd">
   
 		<jaxb:bindings node="//xs:element[@name='note']/xs:complexType/xs:attribute[@ref='xml:lang']">

--- a/src/schemas/tmx14.xjb
+++ b/src/schemas/tmx14.xjb
@@ -1,17 +1,18 @@
-<jxb:bindings xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jxb="http://java.sun.com/xml/ns/jaxb" version="2.1">
-	<jxb:bindings schemaLocation="tmx14.xsd">
+<jaxb:bindings version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+ xmlns:xs="http://www.w3.org/2001/XMLSchema" jaxb:extensionBindingPrefixes="xjc">
+	<jaxb:bindings schemaLocation="tmx14.xsd">
   
-		<jxb:bindings node="//xs:element[@name='note']/xs:complexType/xs:attribute[@ref='xml:lang']">
-			<jxb:property name="xmlLang"/>
-		</jxb:bindings>
+		<jaxb:bindings node="//xs:element[@name='note']/xs:complexType/xs:attribute[@ref='xml:lang']">
+			<jaxb:property name="xmlLang"/>
+		</jaxb:bindings>
 
-		<jxb:bindings node="//xs:element[@name='prop']/xs:complexType/xs:attribute[@ref='xml:lang']">
-			<jxb:property name="xmlLang"/>
-		</jxb:bindings>
+		<jaxb:bindings node="//xs:element[@name='prop']/xs:complexType/xs:attribute[@ref='xml:lang']">
+			<jaxb:property name="xmlLang"/>
+		</jaxb:bindings>
 
-		<jxb:bindings node="//xs:element[@name='tuv']/xs:complexType/xs:attribute[@ref='xml:lang']">
-			<jxb:property name="xmlLang"/>
-		</jxb:bindings>
+		<jaxb:bindings node="//xs:element[@name='tuv']/xs:complexType/xs:attribute[@ref='xml:lang']">
+			<jaxb:property name="xmlLang"/>
+		</jaxb:bindings>
     
-	</jxb:bindings>
-</jxb:bindings>
+	</jaxb:bindings>
+</jaxb:bindings>

--- a/src/schemas/tmx14.xjb
+++ b/src/schemas/tmx14.xjb
@@ -1,5 +1,5 @@
 <jaxb:bindings version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
- xmlns:xs="http://www.w3.org/2001/XMLSchema" jaxb:extensionBindingPrefixes="xjc">
+ xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<jaxb:bindings schemaLocation="tmx14.xsd">
   
 		<jaxb:bindings node="//xs:element[@name='note']/xs:complexType/xs:attribute[@ref='xml:lang']">

--- a/test/src/org/omegat/filters2/master/FilterMasterTest.java
+++ b/test/src/org/omegat/filters2/master/FilterMasterTest.java
@@ -38,12 +38,11 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
## Pull request type


- Feature enhancement -> [enhancement]
- Build and release changes -> [build/release]

## Which ticket is resolved?
- Update JAXB code generator to 4.0.x
= https://sourceforge.net/p/omegat/feature-requests/1761/
## What does this PR change?

- Updated schema references to use `jakarta` namespace in compliance with JAXB 3.0.
- Tweak JAXB api package from javax.xml.* to jakarta.xml.*
- Bump maligna@4.0.0 which based on JAXB 4
- Update javax.xml.bind:jaxb.xml.bind-api:2.0.5 to jakarta.xml.bind:jakarta.xml.bind-api:4.0.2
- Update org.glassfish.jaxb:jaxb-xjc:2.3.1 to org.glassfish.jaxb:jaxb-xjc:4.0.5
- Update org.glassfish.jaxb:jaxb-runtime:2.3.0 to org.glassfish.jaxb:jaxb-runtime:4.0.5
- Update com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.16.1 to com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1

## Other information
retry of the #1128