### PR TITLE
chore(gradle): disable error-prone checks for aligner

### DIFF
--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -23,4 +23,8 @@ dependencies {
     testImplementation(libs.commons.io)
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone.enabled = false
+}
+
 makeModuleTask(loadProperties(file('plugin.properties')))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Disable errorprone plugin for aligner module
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
