### PR TITLE
refactor(core): add dedicated lock for `projectTMX` to improve thread safety

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -156,7 +156,6 @@
     <Match>
         <Or>
             <Package name="org.omegat.core.threads"/>
-            <Class name="org.omegat.core.data.RealProject"/>
             <Class name="org.omegat.gui.dialogs.NewTeamProjectController"/>
             <Class name="org.omegat.languagetools.LanguageToolNetworkBridge"/>
         </Or>

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -194,6 +194,7 @@ public class RealProject implements IProject {
     private Map<Language, ProjectTMX> otherTargetLangTMs = new TreeMap<>();
 
     protected ProjectTMX projectTMX;
+    private final Object projectTMXLock = new Object();
 
     /**
      * True if project loaded successfully.
@@ -935,7 +936,7 @@ public class RealProject implements IProject {
         logger.atDebug().log("Rebase team sync");
         try {
             preparedStatus = PreparedStatus.PREPARED2;
-            synchronized (RealProject.this) {
+            synchronized (projectTMXLock) {
                 projectTMX.save(config, config.getProjectInternal() + OConsts.STATUS_EXTENSION,
                         isProjectModified());
             }
@@ -1483,7 +1484,7 @@ public class RealProject implements IProject {
      * Append new translation from auto TMX.
      */
     void appendFromAutoTMX(ExternalTMX autoTmx, boolean isEnforcedTMX) {
-        synchronized (projectTMX) {
+        synchronized (projectTMXLock) {
             importHandler.process(autoTmx, isEnforcedTMX);
         }
     }
@@ -1511,7 +1512,7 @@ public class RealProject implements IProject {
 
     public AllTranslations getAllTranslations(SourceTextEntry ste) {
         AllTranslations r = new AllTranslations();
-        synchronized (projectTMX) {
+        synchronized (projectTMXLock) {
             r.defaultTranslation = projectTMX.getDefaultTranslation(ste.getSrcText());
             r.alternativeTranslation = projectTMX.getMultipleTranslation(ste.getKey());
             if (r.alternativeTranslation != null) {
@@ -1560,7 +1561,7 @@ public class RealProject implements IProject {
             throw new IllegalArgumentException("RealProject.setTranslation(tr) can't be null");
         }
 
-        synchronized (projectTMX) {
+        synchronized (projectTMXLock) {
             AllTranslations current = getAllTranslations(entry);
             boolean wasAlternative = current.alternativeTranslation.isTranslated();
             if (defaultTranslation) {
@@ -1676,7 +1677,7 @@ public class RealProject implements IProject {
             return;
         }
         Map.Entry<String, TMXEntry>[] entries;
-        synchronized (projectTMX) {
+        synchronized (projectTMXLock) {
             entries = entrySetToArray(projectTMX.defaults.entrySet());
         }
         for (Map.Entry<String, TMXEntry> en : entries) {
@@ -1689,7 +1690,7 @@ public class RealProject implements IProject {
             return;
         }
         Map.Entry<EntryKey, TMXEntry>[] entries;
-        synchronized (projectTMX) {
+        synchronized (projectTMXLock) {
             entries = entrySetToArray(projectTMX.alternatives.entrySet());
         }
         for (Map.Entry<EntryKey, TMXEntry> en : entries) {

--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -151,7 +151,7 @@ public class RealProject implements IProject {
     private volatile RebaseAndCommit.Prepared tmxPrepared;
     private volatile RebaseAndCommit.Prepared glossaryPrepared;
 
-    private boolean isOnlineMode;
+    private volatile boolean isOnlineMode;
 
     private RandomAccessFile raFile;
     private FileChannel lockChannel;
@@ -162,7 +162,7 @@ public class RealProject implements IProject {
     /** List of all segments in project. */
     protected List<SourceTextEntry> allProjectEntries = new ArrayList<>(4096);
 
-    protected ImportFromAutoTMX importHandler;
+    protected volatile ImportFromAutoTMX importHandler;
 
     private final StatisticsInfo hotStat = new StatisticsInfo();
 


### PR DESCRIPTION
## Pull request type

- enhancement for thread safety

## What does this PR change?

- Added a new private final lock object projectTMXLock for thread synchronization.
- Replaced all instances of synchronized (projectTMX) with synchronized (projectTMXLock).
- Ensures better encapsulation and reduces potential risks associated with public object synchronization.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
