### PR TITLE
fix(gradle): `docs` task output distribution

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -53,17 +53,30 @@ tasks.register('manualHtmls') {
 ext.makeDocumentationTasks = { lang ->
     def docbookInclude = tasks.register("docbookInclude${lang.capitalize()}", TransformationTask) {
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/passthrough.xsl"))
-        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.xml"))
+        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_index.xml"))
         inputFile.set(layout.projectDirectory.file("src_docs/manual/${lang}/OmegaTUsersManual_xinclude_full.xml"))
     }
 
     def copyCss = tasks.register("copyCss${lang.capitalize()}", Copy) {
+        description = 'Copies images and CSS files to tmp.'
+        into layout.buildDirectory.dir("tmp/manual/${lang}")
+        from new File(documentRootDir, 'style/omegat.css')
+    }
+
+    def copyImages = tasks.register("copyImages${lang.capitalize()}", Copy) {
+        description 'Copies images and CSS files to tmp.'
+        into layout.buildDirectory.dir("tmp/manual/${lang}/images/")
+        from fileTree(dir: layout.projectDirectory.dir("src_docs/manual/${lang}/images/"), include: "*.png")
+        from layout.projectDirectory.file("images/OmegaT.svg")
+    }
+
+    def copyCssTarget = tasks.register("copyCssTarget${lang.capitalize()}", Copy) {
         description = 'Copies images and CSS files to target.'
         into layout.buildDirectory.dir("docs/manual/${lang}")
         from new File(documentRootDir, 'style/omegat.css')
     }
 
-    def copyImages = tasks.register("copyImages${lang.capitalize()}", Copy) {
+    def copyImagesTarget = tasks.register("copyImagesTarget${lang.capitalize()}", Copy) {
         description 'Copies images and CSS files to target.'
         into layout.buildDirectory.dir("docs/manual/${lang}/images/")
         from fileTree(dir: layout.projectDirectory.dir("src_docs/manual/${lang}/images/"), include: "*.png")
@@ -74,38 +87,39 @@ ext.makeDocumentationTasks = { lang ->
         description = 'Generates a chunked HTML documentation.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/xhtml.xsl"))
         inputFile.set(layout.projectDirectory.file("${documentRootDir}/manual/${lang}/OmegaTUsersManual_xinclude_full.xml"))
-        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
+        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_index.html"))
         dependsOn(docbookInclude, copyImages, copyCss)
     }
 
     def whcToc = tasks.register("whcToc${lang.capitalize()}", TransformationTask) {
         description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-toc.xsl"))
-        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
-        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/toc.xml"))
+        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_index.html"))
+        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/toc.xml"))
         dependsOn(docbookHtml)
     }
 
     def whcIndex = tasks.register("whcIndex${lang.capitalize()}", TransformationTask) {
         description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-index.xsl"))
-        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.html"))
-        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/index.html"))
+        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_index.html"))
+        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/index.html"))
         dependsOn(docbookHtml, whcToc)
     }
 
     def whcHeader = tasks.register("whcHeader${lang.capitalize()}", TransformationTask) {
         description = 'Generates a whc header and index.'
         styleSheetFile.set(layout.projectDirectory.file("${documentRootDir}/xsl/whc-header.xsl"))
-        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_index.xml"))
-        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_header.xhtml"))
+        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_index.xml"))
+        outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_header.xhtml"))
         dependsOn(copyCss, docbookInclude)
     }
+
     def buildDocumentTask = tasks.register("manual${lang.capitalize()}", WhcTask) {
         description = 'Builds the whc contents.'
-        tocFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/toc.xml"))
-        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/index.html"))
-        headerFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_header.xhtml"))
+        tocFile.set(layout.buildDirectory.file("tmp/manual/${lang}/toc.xml"))
+        inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/index.html"))
+        headerFile.set(layout.buildDirectory.file("tmp/manual/${lang}/_header.xhtml"))
         documentLayout.set('simple')
         localJQuery.set(true)
         parameterList.set([
@@ -113,9 +127,9 @@ ext.makeDocumentationTasks = { lang ->
                 '--field-background-color', '#FDFDFD',
                 '--panel-background-color', '#FDFDFD',
         ])
-        contentFiles.set(fileTree(dir: layout.buildDirectory.dir("tmp/manual/${lang}/xhtml5"), include: '*.html', exclude: '_*'))
+        contentFiles.set(fileTree(dir: layout.buildDirectory.dir("tmp/manual/${lang}"), include: '*.html', exclude: '_*'))
         outputDirectory.set(layout.buildDirectory.dir("docs/manual/${lang}"))
-        dependsOn(whcHeader, whcToc, whcIndex)
+        dependsOn(whcHeader, whcToc, whcIndex, copyImagesTarget, copyCssTarget)
         group = 'documentation'
     }
     assemble.dependsOn buildDocumentTask

--- a/build.gradle
+++ b/build.gradle
@@ -336,11 +336,13 @@ distributions {
                 ])
                 filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
             }
-            from(layout.buildDirectory.dir('docs/greetings')) {
-                into 'docs/greetings'
+            into('docs/greetings') {
+                from(tasks.firstSteps)
+                from(layout.buildDirectory.dir('docs/greetings'))
             }
-            from(layout.buildDirectory.dir('docs/manuals')) {
-                into 'docs/manuals'
+            into('docs/manuals') {
+                from(tasks.manualZips)
+                from(layout.buildDirectory.dir('docs/manuals'))
             }
             from(layout.settingsDirectory.dir('scripts')) {
                 into 'scripts'

--- a/build.gradle
+++ b/build.gradle
@@ -336,10 +336,10 @@ distributions {
                 ])
                 filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
             }
-            from('build/docs/greetings') {
+            from(layout.buildDirectory.dir('docs/greetings')) {
                 into 'docs/greetings'
             }
-            from('build/docs/manuals') {
+            from(layout.buildDirectory.dir('docs/manuals')) {
                 into 'docs/manuals'
             }
             from(layout.settingsDirectory.dir('scripts')) {

--- a/build.gradle
+++ b/build.gradle
@@ -336,11 +336,11 @@ distributions {
                 ])
                 filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
             }
-            project.tasks.matching {it.name.startsWith('firstSteps') || it.name.startsWith('instantStart')}.forEach {
-                from(it.outputs) { into 'docs/greetings' }
+            from('build/docs/greetings') {
+                into 'docs/greetings'
             }
-            project.tasks.matching {it.name.startsWith('manualZip')}.forEach {
-                from(it.outputs) { into 'docs/manuals' }
+            from('build/docs/manuals') {
+                into 'docs/manuals'
             }
             from(layout.settingsDirectory.dir('scripts')) {
                 into 'scripts'


### PR DESCRIPTION
Fix bug that build system does not copy document in the distribution

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

- Document the location of the manual
- https://sourceforge.net/p/omegat/documentation/444/

## What does this PR change?

- Update build.gradle 'distributions' section
- Avoid dynamic contents reference
- Temporary fix of the build system bug.

## Other information

