### PR TITLE
refactor(languagetools): enhance `LanguageToolNetworkBridge` stop logic and remove unused SpotBugs exclusions

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -158,7 +158,6 @@
             <Package name="org.omegat.core.threads"/>
             <Class name="org.omegat.core.data.RealProject"/>
             <Class name="org.omegat.gui.dialogs.NewTeamProjectController"/>
-            <Class name="org.omegat.languagetools.LanguageToolNetworkBridge"/>
         </Or>
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>


### PR DESCRIPTION
This Pull Request includes both the removal of a class from a configuration and significant refactoring in the LanguageToolNetworkBridge class to improve code clarity and server termination handling.

## type of PR
- refactor
- 
## What does this PR change?

- Update to exclude.xml:
     - Removed exclusion for org.omegat.languagetools.LanguageToolNetworkBridge.
- Refactoring of LanguageToolNetworkBridge.java:
    - Removed localPort field and associated logic for local server socket termination.
    - Refactored fields for better readability by splitting declarations into separate lines.
- Enhanced the stop method for improved server shutdown handling:
    - Added checks for server liveness (isAlive).
    - Employed timeout mechanisms and forceful destruction for smoother termination.
    - Minor formatting and restructuring for clarity.## Pull request type


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
