### PR TITLE
test: add null checks for `window` in GUI tests to improve robustness

### DIFF
--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -147,6 +147,7 @@ public class AlignerWindowTest extends TestCoreGUI {
         FileUtils.copyDirectory(projSrc, tmpDir);
         FileUtils.forceDeleteOnExit(tmpDir);
         // Start aligner
+        assertNotNull(window);
         JFrame frame = GuiActionRunner.execute(() -> {
             AlignFilePickerController alignFilePickerController = new AlignFilePickerController();
             alignFilePickerController.setSourceDefaultDir(tmpDir.toPath().resolve("source").toString());

--- a/test-acceptance/src/org/omegat/gui/dialogs/AboutDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/AboutDialogTest.java
@@ -25,6 +25,7 @@
 
 package org.omegat.gui.dialogs;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
@@ -45,6 +46,7 @@ public class AboutDialogTest extends TestCoreGUI {
 
     @Test
     public void testAboutDialog() {
+        assertNotNull(window);
         window.menuItem(BaseMainWindowMenu.HELP_MENU).click();
         window.menuItem(BaseMainWindowMenu.HELP_ABOUT_MENUITEM).click();
         // Check about dialog

--- a/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ConflictDialogTest extends TestCoreGUI {
 
@@ -49,6 +50,7 @@ public class ConflictDialogTest extends TestCoreGUI {
         final String baseText = "base text";
         final String remoteText = "remote text";
         final String localText = "local text";
+        assertNotNull(window);
         JFrame parent = (JFrame) window.target();
         ConflictDialogController controller = new ConflictDialogController(parent);
         SwingUtilities.invokeLater(() -> controller.show(baseText, remoteText, localText));
@@ -83,6 +85,7 @@ public class ConflictDialogTest extends TestCoreGUI {
         final String baseText = "base text";
         final String remoteText = "remote text";
         final String localText = "local text";
+        assertNotNull(window);
         JFrame parent = (JFrame) window.target();
         ConflictDialogController controller = new ConflictDialogController(parent);
         SwingUtilities.invokeLater(() -> controller.show(baseText, remoteText, localText));

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -41,6 +41,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
+import static org.junit.Assert.assertNotNull;
+
 public class ProjectPropertiesDialogTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
@@ -53,6 +55,7 @@ public class ProjectPropertiesDialogTest extends TestCoreGUI {
         openSampleProject(PROJECT_PATH);
         robot().waitForIdle();
         //
+        assertNotNull(window);
         window.menuItem(BaseMainWindowMenu.PROJECT_MENU).click();
         window.menuItem(BaseMainWindowMenu.PROJECT_EDIT_MENUITEM).click();
         robot().waitForIdle();
@@ -102,6 +105,7 @@ public class ProjectPropertiesDialogTest extends TestCoreGUI {
         openSampleProject(PROJECT_PATH);
         robot().waitForIdle();
         //
+        assertNotNull(window);
         window.menuItem(BaseMainWindowMenu.PROJECT_MENU).click();
         window.menuItem(BaseMainWindowMenu.PROJECT_EDIT_MENUITEM).click();
         robot().waitForIdle();

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextAreaIntroTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextAreaIntroTest.java
@@ -33,6 +33,8 @@ import org.omegat.gui.main.TestCoreGUI;
 import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
+import static org.junit.Assert.assertNotNull;
+
 public class EditorTextAreaIntroTest extends TestCoreGUI {
 
     @Rule
@@ -40,6 +42,7 @@ public class EditorTextAreaIntroTest extends TestCoreGUI {
 
     @Test
     public void testIntroPaneExist() {
+        assertNotNull(window);
         window.panel(OStrings.getString("DOCKING_FIRST_STEPS_TITLE")).requireEnabled();
         window.panel(OStrings.getString("DOCKING_FIRST_STEPS_TITLE")).scrollPane("EditorScrollPane").requireEnabled();
         window.panel(OStrings.getString("DOCKING_FIRST_STEPS_TITLE")).scrollPane("EditorScrollPane")

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class EditorTextLoadedTest extends TestCoreGUI {
 
@@ -71,6 +72,7 @@ public class EditorTextLoadedTest extends TestCoreGUI {
         awaitLatch(initialLoadLatch);
         verifyInitialTextSelection();
         Point clickPoint = calculateTargetPoint();
+        assertNotNull(window);
         JTextComponent editPane = window.panel(EDITOR_TITLE).textBox().target();
         robot().click(editPane, clickPoint);
         awaitLatch(selectionChangeLatch);
@@ -92,6 +94,7 @@ public class EditorTextLoadedTest extends TestCoreGUI {
     }
 
     private Point calculateTargetPoint() throws BadLocationException {
+        assertNotNull(window);
         String fullText = window.panel(EDITOR_TITLE).textBox().text();
         int newCaretPos = fullText.indexOf(TARGET_TEXT);
         JTextComponent editPane = window.panel(EDITOR_TITLE).textBox().target();

--- a/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
@@ -26,6 +26,7 @@
 package org.omegat.gui.editor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Paths;
@@ -60,6 +61,7 @@ public final class EditorUtilsGUITest {
         @Test
         public void testEditorUtilsGetWordFirstSteps() throws BadLocationException {
             int offs = 518;
+            assertNotNull(window);
             JTextComponent editPane = window.panel("First Steps").textBox("IntroPane").target();
             int posStart = EditorUtils.getWordStart(editPane, offs, Locale.ENGLISH);
             int posEnd = EditorUtils.getWordEnd(editPane, offs, Locale.ENGLISH);
@@ -81,6 +83,7 @@ public final class EditorUtilsGUITest {
         @Test
         public void testEditorUtilsGetWordLoadedProject() throws Exception {
             openSampleProject(Paths.get("test-acceptance/data/project_CN_JP/"));
+            assertNotNull(window);
             final JTextComponent editPane = window.panel("Editor - source.txt").textBox().target();
             int length = editPane.getDocument().getLength();
             assertTrue(length > 0);

--- a/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
@@ -34,6 +34,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
+import static org.junit.Assert.assertNotNull;
+
 public class GlossaryTextTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
@@ -46,6 +48,7 @@ public class GlossaryTextTest extends TestCoreGUI {
         // load project
         openSampleProjectWaitGlossary(PROJECT_PATH);
         robot().waitForIdle();
+        assertNotNull(window);
         window.textBox("glossary_text_area").requireVisible();
         window.textBox("glossary_text_area").requireNotEditable();
         window.textBox("glossary_text_area").requireText("Error = エラー\n\n");

--- a/test-acceptance/src/org/omegat/gui/issues/IssuesPanelTest.java
+++ b/test-acceptance/src/org/omegat/gui/issues/IssuesPanelTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class IssuesPanelTest extends TestCoreGUI {
@@ -53,6 +54,7 @@ public class IssuesPanelTest extends TestCoreGUI {
         openSampleProject(PROJECT_PATH);
         robot().waitForIdle();
         //
+        assertNotNull(window);
         IssuesPanelControllerMock issuesPanelController = new IssuesPanelControllerMock(window.target());
         CountDownLatch latch = new CountDownLatch(2);
         // watch for panel visible

--- a/test-acceptance/src/org/omegat/gui/main/TestMainWindowMenuHandler.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestMainWindowMenuHandler.java
@@ -190,12 +190,6 @@ public class TestMainWindowMenuHandler extends BaseMainWindowMenuHandler {
         }
         Core.getGlossary().showCreateGlossaryEntryDialog(Core.getMainWindow().getApplicationFrame());
     }
-    @Override
-    public void editFindInProjectMenuItemActionPerformed() {
-    }
-    @Override
-    void findInProjectReuseLastWindow() {
-    }
 
     public void editReplaceInProjectMenuItemActionPerformed() {
     }

--- a/test-acceptance/src/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
@@ -57,6 +57,7 @@ public class FuzzyMatchesSegmentsTest extends TestCoreGUI {
         robot().waitForIdle();
 
         // check a fuzzy match panel
+        assertNotNull(window);
         window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
         window.textBox("matches_pane").requireVisible();
         window.textBox("matches_pane").requireNotEditable();
@@ -81,6 +82,7 @@ public class FuzzyMatchesSegmentsTest extends TestCoreGUI {
         robot().waitForIdle();
 
         // check a fuzzy match panel
+        assertNotNull(window);
         window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
         window.textBox("matches_pane").requireVisible();
         window.textBox("matches_pane").requireNotEditable();

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextExternalTmTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextExternalTmTest.java
@@ -38,6 +38,8 @@ import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import static org.junit.Assert.assertNotNull;
+
 public class MatchesTextExternalTmTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project_external_tm/");
@@ -51,6 +53,7 @@ public class MatchesTextExternalTmTest extends TestCoreGUI {
         openSampleProjectWaitMatches(PROJECT_PATH);
         robot().waitForIdle();
         // check a fuzzy match pane
+        assertNotNull(window);
         window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
         final String matchesPane = "matches_pane";
         window.textBox(matchesPane).requireVisible();

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
@@ -39,6 +39,8 @@ import org.omegat.gui.main.TestCoreGUI;
 import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
+import static org.junit.Assert.assertNotNull;
+
 public class MatchesTextTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
@@ -52,6 +54,7 @@ public class MatchesTextTest extends TestCoreGUI {
         openSampleProjectWaitMatches(PROJECT_PATH);
         robot().waitForIdle();
         // check a fuzzy match pane
+        assertNotNull(window);
         window.scrollPane(OStrings.getString("GUI_MATCHWINDOW_SUBWINDOWTITLE_Fuzzy_Matches")).requireVisible();
         window.textBox("matches_pane").requireVisible();
         window.textBox("matches_pane").requireNotEditable();

--- a/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
+++ b/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 public class SegmentPropertiesAreaTest extends TestCoreGUI {
 
@@ -54,6 +55,7 @@ public class SegmentPropertiesAreaTest extends TestCoreGUI {
         openSampleProjectWaitPropertyPane(PROJECT_PATH);
         robot().waitForIdle();
         // check a segment properties pane
+        assertNotNull(window);
         window.scrollPane("Segment Properties").requireEnabled();
         window.scrollPane("Segment Properties").requireVisible();
         // Check a table content


### PR DESCRIPTION
This Pull Request adds assertNotNull(window) checks to multiple test files to ensure that the window object is properly initialized during GUI testing.


## Pull request type

- Other (describe below)
refactor

## What does this PR change?

- Added assertNotNull(window) assertions to 14 test files across various GUI-related test classes.
- Minor code cleanup in TestMainWindowMenuHandler.java by removing unused overridden methods.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
