### PR TITLE
test(gui): extend timeout and add interruption handling in `ConflictDialogTest`

### DIFF
--- a/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ConflictDialogTest extends TestCoreGUI {
 
@@ -73,8 +75,9 @@ public class ConflictDialogTest extends TestCoreGUI {
             }
         });
         try {
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
         } catch (InterruptedException ignored) {
+            fail("Test is interrupted. (timeout 10 sec.)");
         }
         assertEquals("Selection should be local.", localText, controller.getResult());
     }
@@ -104,8 +107,9 @@ public class ConflictDialogTest extends TestCoreGUI {
             }
         });
         try {
-            latch.await(5, TimeUnit.SECONDS);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
         } catch (InterruptedException ignored) {
+            fail("Test is interrupted. (timeout 10 sec.)");
         }
         assertEquals("Selection should be remote", remoteText, controller.getResult());
     }


### PR DESCRIPTION
Fix fraky acceptance test case.
## Pull request type


- Bug fix -> [bug]



## What does this PR change?

- Added assertTrue to verify the correct behavior of latch.await with an increased timeout value (from 5 to 10 seconds).
- Introduced fail statements to handle scenarios where tests are interrupted due to timeouts, providing clearer debugging information.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
