### PR TITLE
[6.0][BUGS#1302] XML filters does not handle DTD path with CJK characters properly 

### DIFF
--- a/release/changes.txt
+++ b/release/changes.txt
@@ -3,7 +3,7 @@
 ----------------------------------------------------------------------
 
   2 Enhancement
-  7 Bug fixes
+  8 Bug fixes
   0 Localisation updates
 ----------------------------------------------------------------------
 
@@ -16,6 +16,9 @@
   https://sourceforge.net/p/omegat/feature-requests/484/
 
   Bug fixes:
+
+  - Unable to import a team project to a path containing Chinese characters
+  https://sourceforge.net/p/omegat/bugs/1302/
 
   - Preferences/CustomColorSelector don't show notification immediately when modifying color
   https://sourceforge.net/p/omegat/bugs/1273/

--- a/src/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/org/omegat/filters3/xml/XMLFilter.java
@@ -178,7 +178,7 @@ public abstract class XMLFilter extends AbstractFilter implements Translator {
             targetLanguage = fc.getTargetLang();
             sourceLanguage = fc.getSourceLang();
             InputSource source = new InputSource(inReader);
-            source.setSystemId(inFile.toURI().toString());
+            source.setSystemId(inFile.toURI().toASCIIString());
             SAXParser parser = parserFactory.newSAXParser();
             Handler handler = new Handler(this, dialect, inFile, outFile, fc);
             parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);

--- a/test/data/xml/文件/test.dtd
+++ b/test/data/xml/文件/test.dtd
@@ -1,0 +1,2 @@
+<!ELEMENT root (body)>
+<!ELEMENT body EMPTY>

--- a/test/data/xml/文件/test.xml
+++ b/test/data/xml/文件/test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE root PUBLIC "-//OASIS//DTD//EN" "test.dtd">
+<root>
+  <body>
+  </body>
+</root>

--- a/test/src/org/omegat/filters3/XMLFilterTest.java
+++ b/test/src/org/omegat/filters3/XMLFilterTest.java
@@ -1,0 +1,62 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.filters3;
+
+import org.junit.Test;
+import org.omegat.filters.TestFilterBase;
+import org.omegat.filters2.Instance;
+import org.omegat.filters3.xml.DefaultXMLDialect;
+import org.omegat.filters3.xml.XMLDialect;
+import org.omegat.filters3.xml.XMLFilter;
+
+import java.io.File;
+
+public class XMLFilterTest extends TestFilterBase {
+
+    @Test
+    public void testLoadCJKPath() throws Exception {
+        TestFilter filter = new TestFilter(new DefaultXMLDialect());
+        String f = "test/data/xml/\u6587\u4EF6/test.xml";
+        File inputFile = new File(f);
+        filter.processFile(inputFile, outFile, context);
+    }
+
+    public static class TestFilter extends XMLFilter {
+        public TestFilter(XMLDialect dialect) {
+            super(dialect);
+        }
+
+        @Override
+        public String getFileFormatName() {
+            return "";
+        }
+
+        @Override
+        public Instance[] getDefaultInstances() {
+            return new Instance[] { new Instance("*.xml", null, null), new Instance("*.dbk", null, null), };
+        }
+    }
+}


### PR DESCRIPTION
OmegaT 6.0.x does not handle path with CJK character properly.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Unable to import a team project to a path containing Chinese characters(
- https://sourceforge.net/p/omegat/bugs/1302/

## What does this PR change?

- Add reproducible as functional test
- `XMLFilter#processFile` to set system ID with URL encoded string.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
