### PR TITLE
fix(LT): always load LT English module

### DIFF
--- a/src/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -45,12 +45,13 @@ public class LanguageToolNativeBridge extends BaseLanguageToolBridge {
 
     private final Language sourceLtLang;
     private final Language targetLtLang;
-    private ThreadLocal<JLanguageTool> sourceLt;
+    private final ThreadLocal<JLanguageTool> sourceLt;
     private ThreadLocal<JLanguageTool> targetLt;
     private List<BitextRule> bRules;
 
     public LanguageToolNativeBridge(org.omegat.util.Language sourceLang,
             org.omegat.util.Language targetLang) {
+        LanguageManager.getLTLanguage(new org.omegat.util.Language("en-US"));
         sourceLtLang = getLTLanguage(sourceLang);
         targetLtLang = getLTLanguage(targetLang);
         Log.logInfoRB("LANGUAGE_TOOL_SOURCE", getLanguageToolCode(sourceLtLang));


### PR DESCRIPTION
When loading project without English, OmegaT throws exception in log file.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

-  LanguageTool failed to load en-US when project is other than English
- https://sourceforge.net/p/omegat/bugs/1303/

## What does this PR change?

- Change `LanguageToolNativeBridge` always load English LT module 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
