### PR TITLE
[6.0][BUGS#1293] chore: Bump dependencies to avoid vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     if (providedLibsDir.directory) {
         implementation fileTree(dir: providedLibsDir, include: '**/*.jar')
     } else {
-        implementation 'commons-io:commons-io:2.11.0'
+        implementation 'commons-io:commons-io:2.14.0'
         implementation 'commons-lang:commons-lang:2.6'
         implementation 'commons-validator:commons-validator:1.7'
         implementation 'commons-codec:commons-codec:1.16.1'
@@ -156,20 +156,20 @@ dependencies {
         implementation "org.apache.lucene:lucene-analyzers-stempel:${luceneVersion}"
 
         // Team project server support
-        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.1.202206130422-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r'
         // Original JSch is unmaintained and dead, so we use forked version, mwiede/jsch
         // to fix BUGS#1075, and to support elliptic curve ciphers and improved ssh agent
         implementation 'com.github.mwiede:jsch:0.2.3'
         // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.ssh.jsch
-        implementation ('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.13.1.202206130422-r') {
+        implementation ('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.13.3.202401111512-r') {
             exclude module: 'jsch'
         }
         // For ed25519 and ecdsa support of jsch, java16+ or BC
-        implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
+        implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
         // For ssh agent support of jsch, Java16+ or junixsocket
         implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.10.1'
         // For gpg signing
-        implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:5.11.1.202105131744-r'
+        implementation 'org.eclipse.jgit:org.eclipse.jgit.gpg.bc:5.13.3.202401111512-r'
         // For subversion
         implementation 'org.tmatesoft.svnkit:svnkit:1.10.9'
 
@@ -185,7 +185,7 @@ dependencies {
             transitive = true
         }
         runtimeOnly 'org.codehaus.groovy:groovy-dateutil:3.0.9'
-        runtimeOnly 'org.apache.ivy:ivy:2.5.1'
+        runtimeOnly 'org.apache.ivy:ivy:2.5.3'
 
         // Javascript used for scripts
         implementation 'org.openjdk.nashorn:nashorn-core:15.4'

--- a/build.gradle
+++ b/build.gradle
@@ -939,7 +939,7 @@ task spotlessChangedApply {
 }
 
 jacoco {
-    toolVersion="0.8.6"
+    toolVersion="0.8.8"
 }
 
 tasks.jacocoTestReport {

--- a/release/changes.txt
+++ b/release/changes.txt
@@ -3,7 +3,7 @@
 ----------------------------------------------------------------------
 
   2 Enhancement
-  7 Bug fixes
+  8 Bug fixes
   0 Localisation updates
 ----------------------------------------------------------------------
 
@@ -16,6 +16,9 @@
   https://sourceforge.net/p/omegat/feature-requests/484/
 
   Bug fixes:
+
+  - [6.0] [Security] vulnerability on dependencies
+  https://sourceforge.net/p/omegat/bugs/1293/
 
   - Preferences/CustomColorSelector don't show notification immediately when modifying color
   https://sourceforge.net/p/omegat/bugs/1273/

--- a/src/org/omegat/util/MagicComment.java
+++ b/src/org/omegat/util/MagicComment.java
@@ -67,7 +67,7 @@ public class MagicComment {
     public static Map<String, String> parse(File file) throws IOException  {
         String line;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                BOMInputStream.builder().setFile(file).setCharset(StandardCharsets.US_ASCII).get()))) {
+                BOMInputStream.builder().setFile(file).get(), StandardCharsets.US_ASCII))) {
             line = reader.readLine();
         }
         if (line != null && line.startsWith("#")) {

--- a/src/org/omegat/util/MagicComment.java
+++ b/src/org/omegat/util/MagicComment.java
@@ -26,7 +26,6 @@ package org.omegat.util;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -64,15 +63,11 @@ public class MagicComment {
 
     /**
      * Extract the first line of the file and parse with {@code #parse(String)}
-     *
-     * @param file
-     * @return
-     * @throws IOException
      */
     public static Map<String, String> parse(File file) throws IOException  {
         String line;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                new BOMInputStream(new FileInputStream(file)), StandardCharsets.US_ASCII))) {
+                BOMInputStream.builder().setFile(file).setCharset(StandardCharsets.US_ASCII).get()))) {
             line = reader.readLine();
         }
         if (line != null && line.startsWith("#")) {

--- a/src/org/omegat/util/TMXReader2.java
+++ b/src/org/omegat/util/TMXReader2.java
@@ -106,7 +106,7 @@ public class TMXReader2 {
      * Detects charset of XML file.
      */
     public static String detectCharset(File file) throws IOException {
-        try (XmlStreamReader rd = new XmlStreamReader(file)) {
+        try (XmlStreamReader rd = XmlStreamReader.builder().setFile(file).get()) {
             return rd.getEncoding();
         }
     }


### PR DESCRIPTION
Bump dependencies which has vulnerbility

## Pull request type

Please mark github LABEL of the type of change your PR introduces:
- refactor
- dependency

## Which ticket is resolved?
 
- [6.0] [Security] vulnerability on dependencies
- https://sourceforge.net/p/omegat/bugs/1293/

## What does this PR change?

- Bump commons-io, ivy, jgit and bouncycastle
- replace deprecated constructor in commons-io methods with recommended builder
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
