### PR TITLE
fix(gui/main): reset status bar when reload/close project

### DIFF
--- a/src/org/omegat/gui/main/MainWindow.java
+++ b/src/org/omegat/gui/main/MainWindow.java
@@ -62,7 +62,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
-import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.plaf.FontUIResource;
@@ -119,7 +118,7 @@ public class MainWindow implements IMainWindow {
      */
     private FontUIResource font;
 
-    protected MainWindowStatusBar mainWindowStatusBar;
+    private MainWindowStatusBarController mainWindowStatusBarController;
 
     protected DockingDesktop desktop;
 
@@ -247,23 +246,27 @@ public class MainWindow implements IMainWindow {
             }
         });
         applicationFrame.getContentPane().add(desktop, BorderLayout.CENTER);
-        mainWindowStatusBar = new MainWindowStatusBar();
-        applicationFrame.getContentPane().add(mainWindowStatusBar, BorderLayout.SOUTH);
+        mainWindowStatusBarController = new MainWindowStatusBarController();
+        applicationFrame.getContentPane().add(mainWindowStatusBarController.getUI(), BorderLayout.SOUTH);
         applicationFrame.pack();
     }
 
+    @Override
     public JFrame getApplicationFrame() {
         return applicationFrame;
     }
 
+    @Override
     public Font getApplicationFont() {
         return font;
     }
 
+    @Override
     public IMainMenu getMainMenu() {
         return menu;
     }
 
+    @Override
     public void addDockable(Dockable pane) {
         desktop.addDockable(pane);
     }
@@ -361,77 +364,27 @@ public class MainWindow implements IMainWindow {
     }
 
     public void showStatusMessageRB(final String messageKey, final Object... params) {
-        final String msg = getLocalizedString(messageKey, params);
-        UIThreadsUtil.executeInSwingThread(new Runnable() {
-            @Override
-            public void run() {
-                mainWindowStatusBar.setStatusLabel(msg);
-            }
-        });
-    }
-
-    private String getLocalizedString(String messageKey, Object... params) {
-        if (messageKey == null) {
-            return " ";
-        } else if (params == null) {
-            return OStrings.getString(messageKey);
-        } else {
-            return StringUtil.format(OStrings.getString(messageKey), params);
-        }
+        mainWindowStatusBarController.showStatusMessageRB(messageKey, params);
     }
 
     @Override
     public void showTimedStatusMessageRB(String messageKey, Object... params) {
-        showStatusMessageRB(messageKey, params);
-
-        if (messageKey == null) {
-            return;
-        }
-
-        // clear the message after 10 seconds
-        String localizedString = getLocalizedString(messageKey, params);
-        Timer timer = new Timer(10_000, evt -> {
-            String text = mainWindowStatusBar.getStatusLabel();
-            if (localizedString.equals(text)) {
-                mainWindowStatusBar.setStatusLabel(null);
-            }
-        });
-        timer.setRepeats(false); // one-time only
-        timer.start();
+        mainWindowStatusBarController.showTimedStatusMessageRB(messageKey, params);
     }
 
-    /**
-     * Show message in progress bar.
-     *
-     * @param messageText
-     *            message text
-     */
+    @Override
     public void showProgressMessage(String messageText) {
-        mainWindowStatusBar.setProgressLabel(messageText);
+        mainWindowStatusBarController.showProgressMessage(messageText);
     }
 
-    /*
-     * Set progress bar tooltip text.
-     *
-     * @param tooltipText tooltip text
-     */
-    public void setProgressToolTipText(String toolTipText) {
-        mainWindowStatusBar.setProgressToolTip(toolTipText);
-    }
-
-    /**
-     * Show message in length label.
-     *
-     * @param messageText
-     *            message text
-     */
+    @Override
     public void showLengthMessage(String messageText) {
-        mainWindowStatusBar.setLengthLabel(messageText);
+        mainWindowStatusBarController.showLengthMessage(messageText);
     }
 
+    @Override
     public void showLockInsertMessage(String messageText, String toolTip) {
-        mainWindowStatusBar.setLockInsertLabel(messageText);
-        mainWindowStatusBar.setLockInsertToolTipText(toolTip);
+        mainWindowStatusBarController.showLockInsertMessage(messageText, toolTip);
     }
 
     // /////////////////////////////////////////////////////////////
@@ -441,10 +394,12 @@ public class MainWindow implements IMainWindow {
     private JPanel lastDialogText;
     private String lastDialogKey;
 
+    @Override
     public void displayWarningRB(String warningKey, Object... params) {
         displayWarningRB(warningKey, null, params);
-    };
+    }
 
+    @Override
     public void displayWarningRB(final String warningKey, final String supercedesKey,
             final Object... params) {
         UIThreadsUtil.executeInSwingThread(() -> {
@@ -471,13 +426,14 @@ public class MainWindow implements IMainWindow {
             });
             lastDialogKey = warningKey;
 
-            mainWindowStatusBar.setStatusLabel(messages[0]);
+            mainWindowStatusBarController.showStatusMessage(messages[0]);
 
             JOptionPane.showMessageDialog(applicationFrame, lastDialogText, OStrings.getString("TF_WARNING"),
                     JOptionPane.WARNING_MESSAGE);
         });
     }
 
+    @Override
     public void displayErrorRB(final Throwable ex, final String errorKey, final Object... params) {
         UIThreadsUtil.executeInSwingThread(() -> {
             String msg;
@@ -488,7 +444,7 @@ public class MainWindow implements IMainWindow {
             }
 
             String[] messages = msg.split("\\n");
-            mainWindowStatusBar.setStatusLabel(messages[0]);
+            mainWindowStatusBarController.showStatusMessage(messages[0]);
             JPanel pane = new JPanel();
             pane.setLayout(new BoxLayout(pane, BoxLayout.PAGE_AXIS));
             pane.setSize(new Dimension(900, 400));
@@ -530,6 +486,7 @@ public class MainWindow implements IMainWindow {
         });
     }
 
+    @Override
     public void lockUI() {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -553,6 +510,7 @@ public class MainWindow implements IMainWindow {
         }
     }
 
+    @Override
     public void unlockUI() {
         UIThreadsUtil.mustBeSwingThread();
 
@@ -576,9 +534,7 @@ public class MainWindow implements IMainWindow {
         applicationFrame.setEnabled(true);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void showErrorDialogRB(String title, String message, Object... args) {
 
         JOptionPane.showMessageDialog(this.getApplicationFrame(),
@@ -592,18 +548,18 @@ public class MainWindow implements IMainWindow {
      * @see JOptionPane#showConfirmDialog(java.awt.Component, Object, String,
      *      int, int)
      */
+    @Override
     public int showConfirmDialog(Object message, String title, int optionType, int messageType)
             throws HeadlessException {
         return JOptionPane.showConfirmDialog(applicationFrame, message, title, optionType, messageType);
     }
 
+    @Override
     public void showMessageDialog(String message) {
         JOptionPane.showMessageDialog(applicationFrame, message);
     }
 
-    /**
-     * get DockableDesktop object.
-     */
+    @Override
     public DockingDesktop getDesktop() {
         return desktop;
     }

--- a/src/org/omegat/gui/main/MainWindowStatusBar.java
+++ b/src/org/omegat/gui/main/MainWindowStatusBar.java
@@ -35,8 +35,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Font;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -45,22 +43,14 @@ import javax.swing.border.Border;
 
 import org.openide.awt.Mnemonics;
 
-import org.omegat.core.Core;
-import org.omegat.gui.editor.EditorController;
 import org.omegat.util.OStrings;
-import org.omegat.util.Preferences;
 
 @SuppressWarnings("serial")
 public class MainWindowStatusBar extends JPanel {
-    public static final String STATUS_BAR_NAME = "main_window_status_bar";
-    public static final String STATUS_LABEL_NAME = "main_window_status_label";
-    public static final String STATUS_PROGRESS_LABEL_NAME = "main_window_status_progress_label";
-    public static final String LENGTH_LABEL_NAME = "main_window_status_length_label";
-    public static final String LOCK_INSERT_LABEL_NAME = "main_window_status_lock_insert_label";
-    private final JLabel statusLabel = new JLabel();
-    private final JLabel progressLabel = new JLabel();
-    private final JLabel lengthLabel = new JLabel();
-    private final JLabel lockInsertLabel = new JLabel();
+    final JLabel statusLabel = new JLabel();
+    final JLabel progressLabel = new JLabel();
+    final JLabel lengthLabel = new JLabel();
+    final JLabel lockInsertLabel = new JLabel();
 
     public MainWindowStatusBar() {
         super();
@@ -79,51 +69,7 @@ public class MainWindowStatusBar extends JPanel {
         float smallFontSize = defaultFont.getSize() * 0.85f;
         statusLabel.setFont(defaultFont.deriveFont(smallFontSize));
         Border border = UIManager.getBorder("OmegaTStatusArea.border");
-
-        final StatusBarMode progressMode = Preferences.getPreferenceEnumDefault(Preferences.SB_PROGRESS_MODE,
-                StatusBarMode.DEFAULT);
-
-        String statusText;
-        String tooltipText;
-        if (progressMode == StatusBarMode.PERCENTAGE) {
-            statusText = OStrings.getProgressBarDefaultPrecentageText();
-            tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP_PERCENTAGE");
-        } else {
-            statusText = OStrings.getString("MW_PROGRESS_DEFAULT");
-            tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP");
-        }
-        Mnemonics.setLocalizedText(progressLabel, statusText);
-        progressLabel.setToolTipText(tooltipText);
-
         progressLabel.setBorder(border);
-        progressLabel.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                StatusBarMode[] modes = StatusBarMode.values();
-                StatusBarMode progressMode = Preferences
-                        .getPreferenceEnumDefault(Preferences.SB_PROGRESS_MODE, StatusBarMode.DEFAULT);
-                progressMode = modes[(progressMode.ordinal() + 1) % modes.length];
-
-                Preferences.setPreference(Preferences.SB_PROGRESS_MODE, progressMode);
-
-                String statusText;
-                String tooltipText;
-                if (progressMode == StatusBarMode.PERCENTAGE) {
-                    statusText = OStrings.getProgressBarDefaultPrecentageText();
-                    tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP_PERCENTAGE");
-                } else {
-                    statusText = OStrings.getString("MW_PROGRESS_DEFAULT");
-                    tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP");
-                }
-
-                if (Core.getProject().isProjectLoaded()) {
-                    ((EditorController) Core.getEditor()).showStat();
-                } else {
-                    Core.getMainWindow().showProgressMessage(statusText);
-                }
-                ((MainWindow) Core.getMainWindow()).setProgressToolTipText(tooltipText);
-            }
-        });
 
         Mnemonics.setLocalizedText(lengthLabel, OStrings.getString("MW_SEGMENT_LENGTH_DEFAULT"));
         lengthLabel.setToolTipText(OStrings.getString("MW_SEGMENT_LENGTH_TOOLTIP"));
@@ -177,4 +123,12 @@ public class MainWindowStatusBar extends JPanel {
     public enum StatusBarMode {
         DEFAULT, PERCENTAGE,
     }
+
+    // Give names to the components in the status bar.
+    // Visible only for debug
+    public static final String STATUS_BAR_NAME = "main_window_status_bar";
+    public static final String STATUS_LABEL_NAME = "main_window_status_label";
+    public static final String STATUS_PROGRESS_LABEL_NAME = "main_window_status_progress_label";
+    public static final String LENGTH_LABEL_NAME = "main_window_status_length_label";
+    public static final String LOCK_INSERT_LABEL_NAME = "main_window_status_lock_insert_label";
 }

--- a/src/org/omegat/gui/main/MainWindowStatusBarController.java
+++ b/src/org/omegat/gui/main/MainWindowStatusBarController.java
@@ -1,0 +1,151 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2000-2006 Keith Godfrey, Maxym Mykhalchuk, Henry Pijffers,
+               2000-2006 Benjamin Siband, and Kim Bruning
+               2007 Zoltan Bartko
+               2008 Andrzej Sawula, Alex Buloichik
+               2014 Piotr Kulik
+               2015 Aaron Madlon-Kay
+               2023 Jean-Christophe Helary
+               2025 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.main;
+
+import org.omegat.core.Core;
+import org.omegat.gui.editor.EditorController;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
+import org.omegat.util.gui.UIThreadsUtil;
+import org.openide.awt.Mnemonics;
+
+import javax.swing.Timer;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public final class MainWindowStatusBarController {
+    private final MainWindowStatusBar mainWindowStatusBar;
+
+    public MainWindowStatusBarController() {
+        mainWindowStatusBar = new MainWindowStatusBar();
+        updateProgressText(getProgressMode());
+        mainWindowStatusBar.progressLabel.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                MainWindowStatusBar.StatusBarMode[] modes = MainWindowStatusBar.StatusBarMode.values();
+                MainWindowStatusBar.StatusBarMode progressMode = modes[(getProgressMode().ordinal() + 1) % modes.length];
+                Preferences.setPreference(Preferences.SB_PROGRESS_MODE, progressMode);
+                updateProgressText(progressMode);
+            }
+        });
+    }
+
+    private MainWindowStatusBar.StatusBarMode getProgressMode() {
+        return Preferences.getPreferenceEnumDefault(Preferences.SB_PROGRESS_MODE, MainWindowStatusBar.StatusBarMode.DEFAULT);
+    }
+
+    private void updateProgressText(MainWindowStatusBar.StatusBarMode progressMode) {
+        String statusText;
+        String tooltipText;
+        if (progressMode == MainWindowStatusBar.StatusBarMode.PERCENTAGE) {
+            statusText = OStrings.getProgressBarDefaultPrecentageText();
+            tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP_PERCENTAGE");
+        } else {
+            statusText = OStrings.getString("MW_PROGRESS_DEFAULT");
+            tooltipText = OStrings.getString("MW_PROGRESS_TOOLTIP");
+        }
+        if (Core.getProject().isProjectLoaded()) {
+            ((EditorController) Core.getEditor()).showStat();
+        } else {
+            Mnemonics.setLocalizedText(mainWindowStatusBar.progressLabel, statusText);
+        }
+        mainWindowStatusBar.setToolTipText(tooltipText);
+    }
+
+    public MainWindowStatusBar getUI() {
+        return mainWindowStatusBar;
+    }
+
+    public void showStatusMessageRB(final String messageKey, final Object... params) {
+        final String msg = getLocalizedString(messageKey, params);
+        UIThreadsUtil.executeInSwingThread(() -> mainWindowStatusBar.setStatusLabel(msg));
+    }
+
+    private String getLocalizedString(String messageKey, Object... params) {
+        if (messageKey == null) {
+            return " ";
+        } else if (params == null) {
+            return OStrings.getString(messageKey);
+        } else {
+            return StringUtil.format(OStrings.getString(messageKey), params);
+        }
+    }
+    public void showTimedStatusMessageRB(String messageKey, Object... params) {
+        showStatusMessageRB(messageKey, params);
+
+        if (messageKey == null) {
+            return;
+        }
+
+        // clear the message after 10 seconds
+        String localizedString = getLocalizedString(messageKey, params);
+        Timer timer = new Timer(10_000, evt -> {
+            String text = mainWindowStatusBar.getStatusLabel();
+            if (localizedString.equals(text)) {
+                mainWindowStatusBar.setStatusLabel(null);
+            }
+        });
+        timer.setRepeats(false); // one-time only
+        timer.start();
+    }
+
+    /**
+     * Show message in progress bar.
+     *
+     * @param messageText
+     *            message text
+     */
+    public void showProgressMessage(String messageText) {
+        mainWindowStatusBar.setProgressLabel(messageText);
+    }
+
+    /**
+     * Show message in length label.
+     *
+     * @param messageText
+     *            message text
+     */
+    public void showLengthMessage(String messageText) {
+        mainWindowStatusBar.setLengthLabel(messageText);
+    }
+
+    public void showLockInsertMessage(String messageText, String toolTip) {
+        mainWindowStatusBar.setLockInsertLabel(messageText);
+        mainWindowStatusBar.setLockInsertToolTipText(toolTip);
+    }
+
+    public void showStatusMessage(String message) {
+        mainWindowStatusBar.setStatusLabel(message);
+    }
+}

--- a/src/org/omegat/gui/main/MainWindowStatusBarController.java
+++ b/src/org/omegat/gui/main/MainWindowStatusBarController.java
@@ -33,6 +33,8 @@
 package org.omegat.gui.main;
 
 import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IProjectEventListener;
 import org.omegat.gui.editor.EditorController;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -59,6 +61,16 @@ public final class MainWindowStatusBarController {
                 updateProgressText(progressMode);
             }
         });
+        CoreEvents.registerProjectChangeListener(eventType -> {
+            if (eventType.equals(IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE)) {
+                updateProgressText(getProgressMode());
+                resetLengthLabel();
+            }
+        });
+    }
+
+    private void resetLengthLabel() {
+        Mnemonics.setLocalizedText(mainWindowStatusBar.lengthLabel, OStrings.getString("MW_SEGMENT_LENGTH_DEFAULT"));
     }
 
     private MainWindowStatusBar.StatusBarMode getProgressMode() {

--- a/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestMainWindow.java
@@ -92,8 +92,8 @@ class TestMainWindow implements IMainWindow {
             }
         });
         applicationFrame.getContentPane().add(desktop, BorderLayout.CENTER);
-        MainWindowStatusBar mainWindowStatusBar = new MainWindowStatusBar();
-        applicationFrame.getContentPane().add(mainWindowStatusBar, BorderLayout.SOUTH);
+        MainWindowStatusBarController mainWindowStatusBarController = new MainWindowStatusBarController();
+        applicationFrame.getContentPane().add(mainWindowStatusBarController.getUI(), BorderLayout.SOUTH);
 
         StaticUIUtils.setWindowIcon(applicationFrame);
 


### PR DESCRIPTION

OmegaT do nothing for the status bar when project closed in previous versions.
Now we reset status bar when project close/reload.
If reloading empty project, status bar remains previous state but now it is fixed to reset.

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Quick stats don't reset if there are no more source files
- https://sourceforge.net/p/omegat/bugs/491/

## What does this PR change?

- Refactor MainWindow and MainWindowProgressBar classes to have MainWindowProgressBarController for modular and clarifications.
- Add project event listener to catch close event and reset status bar

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
