### PR TITLE
fix(core): improve project file validation and error messages

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1168,6 +1168,13 @@ PM_ERROR_BACKING_UP_PREFS_FILE=Failed to back up preferences file.
 
 # {0} - the version, which we don't support
 PFR_ERROR_UNSUPPORTED_PROJECT_VERSION=Unsupported project file version ({0})!
+PFR_ERROR_MISSING_PROJECT_TAG=omegat.project don't have a project tag
+PFR_ERROR_MISSING_PROJECT_VERSION_TAG=omegat.project don't have version tag
+PFR_ERROR_EMPTY_PROJECT_VERSION_TAG=omegat.project have empty version tag
+PFR_ERROR_MISSING_PROJECT_SOURCE_LANG_TAG=omegat.project has no source language code
+PFR_ERROR_EMPTY_PROJECT_SOURCE_LANG_TAG=omegat.project has an empty version tag
+PFR_ERROR_MISSING_PROJECT_TARGET_LANG_TAG=omegat.project has no target language code
+PFR_ERROR_EMPTY_PROJECT_TARGET_LANG_TAG=omegat.project has an empty target language
 
 # TMXReader
 

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
@@ -80,6 +81,7 @@ public class ProjectProperties {
     /**
      * Constructor for tests only.
      */
+    @VisibleForTesting
     protected ProjectProperties() {
     }
 

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -117,7 +117,29 @@ public final class ProjectFileStorage {
     }
 
     public static Omegat parseProjectFile(byte[] projectFile) throws Exception {
-        return mapper.readValue(projectFile, Omegat.class);
+        Omegat om = mapper.readValue(projectFile, Omegat.class);
+        if (om.getProject() == null) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_MISSING_PROJECT_TAG"));
+        }
+        if (om.getProject().getVersion() == null) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_MISSING_PROJECT_VERSION_TAG"));
+        }
+        if (om.getProject().getVersion().isEmpty()) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_EMPTY_PROJECT_VERSION_TAG"));
+        }
+        if (om.getProject().getSourceLang() == null) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_MISSING_PROJECT_SOURCE_LANG_TAG"));
+        }
+        if (om.getProject().getSourceLang().isEmpty()) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_EMPTY_PROJECT_SOURCE_LANG_TAG"));
+        }
+        if (om.getProject().getTargetLang() == null) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_MISSING_PROJECT_TARGET_LANG_TAG"));
+        }
+        if (om.getProject().getTargetLang().isEmpty()) {
+            throw new TranslationException(OStrings.getString("PFR_ERROR_EMPTY_PROJECT_TARGET_LANG_TAG"));
+        }
+        return om;
     }
 
     /**
@@ -132,7 +154,6 @@ public final class ProjectFileStorage {
      * @param projectDir
      *            The directory of the project
      * @return The loaded project properties
-     * @throws Exception
      */
     public static ProjectProperties loadProjectProperties(File projectDir) throws Exception {
         return loadPropertiesFile(projectDir, new File(projectDir, OConsts.FILE_PROJECT));
@@ -150,7 +171,6 @@ public final class ProjectFileStorage {
      * @param projectFile
      *            The project properties file to load
      * @return The loaded project properties
-     * @throws Exception
      */
     public static ProjectProperties loadPropertiesFile(File projectDir, File projectFile) throws Exception {
         if (!projectFile.isFile()) {
@@ -350,7 +370,7 @@ public final class ProjectFileStorage {
                 //
                 result = absPath.toString();
             }
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException ignored) {
         }
         return normalizeSlashes(result);
     }


### PR DESCRIPTION
Improve project loader to validate `omegat.project` strictly.

## Pull request type

- Bug fix -> [bug]
- Enhancement

## Which ticket is resolved?

- Lack of language codes does not trigger error 
- https://sourceforge.net/p/omegat/bugs/465/

## What does this PR change?

- `o.o.u.ProjectFileStorage#parseProjectFile` to check mandatory property should not be null or empty

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
