### PR TITLE
chore(test-integ/container): Enforce operations in UTF-8

### DIFF
--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -31,7 +31,7 @@ ARG JAVA=17
 ARG JDKVER=jdk_17.0.14.0.0+7-1
 ARG GRADLE=8.13
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git inotify-tools curl subversion unzip rsync  \
- java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit
+ java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit locales
 RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh
 RUN chown -R omegat.omegat /home/omegat
 COPY --chown=omegat ssh_config /home/omegat/.ssh/config
@@ -45,7 +45,14 @@ RUN echo TARGETARCH is ${TARGETARCH} && curl -LO https://packages.adoptium.net/a
 RUN (cd /opt && curl -LO https://services.gradle.org/distributions/gradle-${GRADLE}-bin.zip \
     && unzip -q gradle-${GRADLE}-bin.zip && rm -f gradle-${GRADLE}-bin.zip) && mv /opt/gradle-${GRADLE} /opt/gradle
 RUN mkdir -p /gradle-cache && chown -R omegat:omegat /gradle-cache
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen &&  locale-gen
 
 USER omegat
+
+# Configure locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 
 ENTRYPOINT /usr/local/bin/entrypoint.sh

--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -25,6 +25,11 @@
 #
 export GRADLE_USER_HOME=/gradle-cache
 
+# Ensure UTF-8 encoding for all operations
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+export LANGUAGE=en_US:en
+
 # Create hash of all build configuration files including version catalogs
 BUILD_FILES_HASH=$(find /code/ -name "*.gradle*" -o -name "gradle.properties" -o -name "libs.versions.toml" \) \
     -not -path "./build/*" -not -path "./.gradle/*" -not -path "./.git/*" | \


### PR DESCRIPTION
This PR intend to add locales with UTF-8 in a container configuration on the integration test.
A current source tree have a non-ascii path name, which cause compile error on ASCII environment.
This fix the issue.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Add locales package in the client container
- Generate `en_US.UTF-8` locale
- Enforce locale to be `en_US.UTF-8`

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
