### PR TITLE
[6.0] fix(filters): disabled by default for OpenXmlFilter

### DIFF
--- a/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -26,6 +26,7 @@
 package org.omegat.filters4.xml.openxml;
 
 import java.awt.Window;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -120,15 +121,22 @@ public class MsOfficeFileFilter extends AbstractZipFilter {
 
     public MsOfficeFileFilter() {
         super();
-        defineDOCUMENTSOptions(new HashMap<String, String>()); // Define the
-                                                               // documents to
-                                                               // read
+        defineDOCUMENTSOptions(new HashMap<>());
     }
 
     @Override
     public boolean isFileSupported(java.io.File inFile, Map<String, String> config, FilterContext context) {
-        defineDOCUMENTSOptions(config); // Define the documents to read
+        defineDOCUMENTSOptions(config);
         return super.isFileSupported(inFile, config, context);
+    }
+
+    /**
+     * Disabled by default, because of the known bug.
+     * @return false
+     */
+    @Override
+    public boolean isEnabledInDefault() {
+        return false;
     }
 
     @Override

--- a/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
+++ b/src/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
@@ -89,8 +89,16 @@ class OpenXmlFilter extends AbstractXmlFilter {
         return inFile.getName().toLowerCase().endsWith(".xml");
     }
 
-    // ----------------------------- AbstractXmlFilter part
-    // ----------------------
+    /**
+     * Disabled by default, because of the known bug.
+     * @return false
+     */
+    @Override
+    public boolean isEnabledInDefault() {
+        return false;
+    }
+
+    // ------------- AbstractXmlFilter part -------------------
 
     private QName OOXML_MAIN_PARA_ELEMENT = null;
 


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## What does this PR change?

- Add `isEnabledInDefault` method to the filters.

```java
    public boolean isEnabledInDefault() {
        return false;
    }
```

## Other information

