### PR TITLE
fix(comments): always shows the "Comments:" label

### DIFF
--- a/src/org/omegat/gui/comments/CommentsTextArea.java
+++ b/src/org/omegat/gui/comments/CommentsTextArea.java
@@ -112,35 +112,30 @@ public class CommentsTextArea extends EntryInfoPane<SourceTextEntry> implements 
         }
     }
 
-    static final ICommentProvider ENTRY_COMMENT_PROVIDER = new ICommentProvider() {
-        public String getComment(SourceTextEntry newEntry) {
-            StringBuilder text = new StringBuilder(1024);
-            if (newEntry.getKey().id != null) {
-                text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_ID"));
-                text.append(' ');
-                text.append(newEntry.getKey().id);
-                text.append('\n');
-            }
-            if (newEntry.getKey().path != null) {
-                text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Path"));
-                text.append(' ');
-                text.append(newEntry.getKey().path);
-                text.append('\n');
-            }
-            if (newEntry.getSourceTranslation() != null) {
-                text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Translation"));
-                text.append(' ');
-                text.append(newEntry.getSourceTranslation());
-                text.append('\n');
-            }
-            if (newEntry.getComment() != null) {
-                text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Comment"));
-                text.append('\n');
-                text.append(newEntry.getComment());
-                text.append('\n');
-            }
-            return text.toString();
+    static final ICommentProvider ENTRY_COMMENT_PROVIDER = newEntry -> {
+        StringBuilder text = new StringBuilder(1024);
+        if (newEntry.getKey().id != null) {
+            text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_ID"));
+            text.append(' ');
+            text.append(newEntry.getKey().id);
+            text.append('\n');
         }
+        if (newEntry.getKey().path != null) {
+            text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Path"));
+            text.append(' ');
+            text.append(newEntry.getKey().path);
+            text.append('\n');
+        }
+        if (newEntry.getSourceTranslation() != null) {
+            text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Translation"));
+            text.append(' ');
+            text.append(newEntry.getSourceTranslation());
+            text.append('\n');
+        }
+        text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Comment"));
+        text.append('\n');
+        text.append(newEntry.getComment() == null ? "" : newEntry.getComment());
+        return text.toString();
     };
 
     public void onNewFile(String activeFileName) {


### PR DESCRIPTION
Implements RFE#1786

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- The Comment pane always shows the "Comment:" field title even when no comment for clarification
- https://sourceforge.net/p/omegat/feature-requests/1786/


## What does this PR change?

- refactor `CommentsTextArea#ENTRY_COMMENT_PROVIDER` using lambda
- Always show "Comments:" label

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
