### PR TITLE
fix(pofilter): support multi-line msgctxt 

### DIFF
--- a/src/org/omegat/filters2/po/PoFilter.java
+++ b/src/org/omegat/filters2/po/PoFilter.java
@@ -696,7 +696,7 @@ public class PoFilter extends AbstractFilter {
         }
         if (references.length() > 0) {
             sb.append(OStrings.getString("POFILTER_REFERENCES")).append("\n").append(unescape(references
-                            .toString()));
+                            .toString())).append("\n");
         }
         String comments = sb.toString();
         if (comments.isEmpty()) {

--- a/src/org/omegat/filters2/po/PoFilter.java
+++ b/src/org/omegat/filters2/po/PoFilter.java
@@ -62,12 +62,12 @@ import org.omegat.util.TagUtil;
 
 /**
  * Filter to support po files (in various encodings).
- *
+ * <p>
  * Format described on
- * https://www.gnu.org/software/hello/manual/gettext/PO-Files.html
- *
+ * <a href="https://www.gnu.org/software/hello/manual/gettext/PO-Files.html">PO
+ * File format</a>
+ * <p>
  * Filter is not thread-safe !
- *
  * Filter uses msgctx field as path, and plural index as suffix of path.
  *
  * @author Keith Godfrey
@@ -301,7 +301,7 @@ public class PoFilter extends AbstractFilter {
     protected static final Pattern COMMENT_EXTRACTED = Pattern.compile("#\\. (.*)");
     protected static final Pattern COMMENT_REFERENCE = Pattern.compile("#: (.*)");
     protected static final Pattern MSG_ID = Pattern.compile("msgid(_plural)?\\s+\"(.*)\"");
-    protected static final Pattern MSG_STR = Pattern.compile("msgstr(\\[([0-9]+)\\])?\\s+\"(.*)\"");
+    protected static final Pattern MSG_STR = Pattern.compile("msgstr(\\[([0-9]+)])?\\s+\"(.*)\"");
     protected static final Pattern MSG_CTX = Pattern.compile("msgctxt\\s+\"(.*)\"");
     protected static final Pattern MSG_OTHER = Pattern.compile("\"(.*)\"");
     protected static final Pattern PLURAL_FORMS = Pattern
@@ -471,7 +471,7 @@ public class PoFilter extends AbstractFilter {
         path = "";
     }
 
-    private boolean processFuzzy(String line) throws IOException {
+    private boolean processFuzzy(String line) {
         // We have a real fuzzy
         Matcher mTrueFuzzy = COMMENT_FUZZY_MSGID.matcher(line);
         if (mTrueFuzzy.matches()) {
@@ -650,6 +650,7 @@ public class PoFilter extends AbstractFilter {
                 targets[currentPlural].append(text);
                 break;
             case MSGCTX:
+                path += text;
                 eol(s);
                 break;
             default:
@@ -695,7 +696,7 @@ public class PoFilter extends AbstractFilter {
         }
         if (references.length() > 0) {
             sb.append(OStrings.getString("POFILTER_REFERENCES")).append("\n").append(unescape(references
-                            .toString())).append("\n");
+                            .toString()));
         }
         String comments = sb.toString();
         if (comments.isEmpty()) {
@@ -717,11 +718,12 @@ public class PoFilter extends AbstractFilter {
         if (translation.isEmpty()) {
             translation = null;
         }
+        String omtPath = path + pathSuffix;
         if (entryParseCallback != null) {
             if (formatMonolingual) {
                 List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(translation,
                         PatternConsts.PRINTF_VARS, null);
-                entryParseCallback.addEntry(source, translation, null, fuzzy, comments, path + pathSuffix,
+                entryParseCallback.addEntry(source, translation, null, fuzzy, comments, omtPath,
                         this, protectedParts);
             } else {
                 List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(source,
@@ -730,17 +732,17 @@ public class PoFilter extends AbstractFilter {
                     String[] props = { SegmentProperties.COMMENT, comments, SegmentProperties.REFERENCE,
                             "true" };
                     entryParseCallback.addEntryWithProperties(null, sourceFuzzyTrue.toString(), translation,
-                            false, props, path + pathSuffix, this, null);
+                            false, props, omtPath, this, null);
                     fuzzyTrue = false;
                     // Do not load false fuzzy when there is a real one
                     fuzzy = false;
                     translation = null;
                 }
-                entryParseCallback.addEntry(null, source, translation, fuzzy, comments, path + pathSuffix,
+                entryParseCallback.addEntry(null, source, translation, fuzzy, comments, omtPath,
                         this, protectedParts);
             }
         } else if (entryAlignCallback != null) {
-            entryAlignCallback.addTranslation(null, source, translation, fuzzy, path + pathSuffix, this);
+            entryAlignCallback.addTranslation(null, source, translation, fuzzy, omtPath, this);
         }
     }
 

--- a/src/org/omegat/gui/comments/CommentsTextArea.java
+++ b/src/org/omegat/gui/comments/CommentsTextArea.java
@@ -47,6 +47,7 @@ import org.omegat.gui.main.DockableScrollPane;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.util.gui.IPaneMenu;
 import org.omegat.util.gui.JTextPaneLinkifier;
 import org.omegat.util.gui.StaticUIUtils;
@@ -124,7 +125,7 @@ public class CommentsTextArea extends EntryInfoPane<SourceTextEntry> implements 
             if (newEntry.getKey().path != null) {
                 text.append(OStrings.getString("GUI_COMMENTSWINDOW_FIELD_Path"));
                 text.append(' ');
-                text.append(newEntry.getKey().path);
+                text.append(StringUtil.unescapeLinefeed(newEntry.getKey().path));
                 text.append('\n');
             }
             if (newEntry.getSourceTranslation() != null) {

--- a/src/org/omegat/util/StringUtil.java
+++ b/src/org/omegat/util/StringUtil.java
@@ -883,7 +883,7 @@ public final class StringUtil {
      * {@link Character#isWhitespace(int)}, so it does not strip the extra
      * non-breaking whitespace included in {@link #isWhiteSpace(int)}.
      *
-     * @param text
+     * @param text the text to strip
      * @return text with trailing whitespace removed
      */
     public static String rstrip(@NotNull String text) {
@@ -997,7 +997,7 @@ public final class StringUtil {
                 return str;
             }
         }
-        return str.substring(start + Character.charCount(separator), str.length());
+        return str.substring(start + Character.charCount(separator));
     }
 
     /**
@@ -1041,4 +1041,25 @@ public final class StringUtil {
         return sb.toString();
     }
 
+    public static String unescapeLinefeed(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\') {
+                if (++i >= s.length()) {
+                    sb.append('\\');
+                }
+                char next = s.charAt(i);
+                switch (next) {
+                case '\\':
+                    sb.append('\\');
+                    break;
+                case 'n':
+                    sb.append('\n');
+                    break;
+                }
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/test/data/filters/po/file-POFilter-multilines.po
+++ b/test/data/filters/po/file-POFilter-multilines.po
@@ -1,0 +1,19 @@
+#: multiple_lines
+msgid ""
+"Multiline\n"
+"message ID with linefeed character."
+msgstr ""
+
+#: one_line_only_with_ctx
+msgctxt "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident"
+msgid "Long context in only one line."
+msgstr "Placeholder target"
+
+#: multiple_lines_with_ctx
+msgctxt ""
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n"
+"Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\n"
+"Excepteur sint occaecat cupidatat non proident"
+msgid "Long context in several lines."
+msgstr "Placeholder target"

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -197,17 +197,17 @@ public class POFilterTest extends TestFilterBase {
 
         checkMultiStart(fi, f);
         checkMulti("Multiline\nmessage ID with linefeed character.", null, "", null, null,
-                "References:\nmultiple_lines\n");
+                "References:\nmultiple_lines\n" + "\n");
         checkMulti("Long context in only one line.", null,
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
                         "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
                         "Excepteur sint occaecat cupidatat non proident",
-                null, null, "References:\none_line_only_with_ctx\n");
+                null, null, "References:\none_line_only_with_ctx\n" + "\n");
         checkMulti("Long context in several lines.", null,
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\\n" +
                         "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\\n" +
                         "Excepteur sint occaecat cupidatat non proident",
-                null, null, "References:\nmultiple_lines_with_ctx\n");
+                null, null, "References:\nmultiple_lines_with_ctx\n" + "\n");
         checkMultiEnd();
     }
 

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -204,8 +204,8 @@ public class POFilterTest extends TestFilterBase {
                         "Excepteur sint occaecat cupidatat non proident",
                 null, null, "References:\none_line_only_with_ctx\n");
         checkMulti("Long context in several lines.", null,
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n" +
-                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\n" +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\\n" +
+                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\\n" +
                         "Excepteur sint occaecat cupidatat non proident",
                 null, null, "References:\nmultiple_lines_with_ctx\n");
         checkMultiEnd();

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -68,7 +68,7 @@ public class POFilterTest extends TestFilterBase {
         String comment = OStrings.getString("POFILTER_TRANSLATOR_COMMENTS") + "\n"
                 + "A valid comment\nAnother valid comment\n\n" + OStrings.getString("POFILTER_EXTRACTED_COMMENTS")
                 + "\n" + "Some extracted comments\nMore extracted comments\n\n"
-                + OStrings.getString("POFILTER_REFERENCES") + "\n" + "/my/source/file\n/my/source/file2\n\n";
+                + OStrings.getString("POFILTER_REFERENCES") + "\n" + "/my/source/file\n/my/source/file2\n";
 
         checkMultiStart(fi, f);
         checkMulti("source1", null, "some context", null, null, comment);
@@ -148,7 +148,7 @@ public class POFilterTest extends TestFilterBase {
         checkMulti("Changed %d keys", null, "[3]", null, null,
                 OStrings.getString("POFILTER_PLURAL_FORM_COMMENT", 3) + "\n");
         checkMulti("../foo/boo.c, 123", null, "", null, null,
-                OStrings.getString("POFILTER_REFERENCES") + "\n" + "../foo/boo.c, 123\n" + "\n");
+                OStrings.getString("POFILTER_REFERENCES") + "\n" + "../foo/boo.c, 123" + "\n");
         checkMultiEnd();
     }
 

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -68,7 +68,7 @@ public class POFilterTest extends TestFilterBase {
         String comment = OStrings.getString("POFILTER_TRANSLATOR_COMMENTS") + "\n"
                 + "A valid comment\nAnother valid comment\n\n" + OStrings.getString("POFILTER_EXTRACTED_COMMENTS")
                 + "\n" + "Some extracted comments\nMore extracted comments\n\n"
-                + OStrings.getString("POFILTER_REFERENCES") + "\n" + "/my/source/file\n/my/source/file2\n";
+                + OStrings.getString("POFILTER_REFERENCES") + "\n" + "/my/source/file\n/my/source/file2\n\n";
 
         checkMultiStart(fi, f);
         checkMulti("source1", null, "some context", null, null, comment);
@@ -148,7 +148,7 @@ public class POFilterTest extends TestFilterBase {
         checkMulti("Changed %d keys", null, "[3]", null, null,
                 OStrings.getString("POFILTER_PLURAL_FORM_COMMENT", 3) + "\n");
         checkMulti("../foo/boo.c, 123", null, "", null, null,
-                OStrings.getString("POFILTER_REFERENCES") + "\n" + "../foo/boo.c, 123" + "\n");
+                OStrings.getString("POFILTER_REFERENCES") + "\n" + "../foo/boo.c, 123\n" + "\n");
         checkMultiEnd();
     }
 

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -189,6 +189,28 @@ public class POFilterTest extends TestFilterBase {
         compareBinary(new File("test/data/filters/po/file-POFilter-fuzzyCtx-plural.po"), outFile);
     }
 
+    @Test
+    public void testMultiLines() throws Exception {
+        String f = "test/data/filters/po/file-POFilter-multilines.po";
+        Map<String, String> options = new HashMap<>();
+        TestFileInfo fi = loadSourceFiles(new PoFilter(), f, options);
+
+        checkMultiStart(fi, f);
+        checkMulti("Multiline\nmessage ID with linefeed character.", null, "", null, null,
+                "References:\nmultiple_lines\n");
+        checkMulti("Long context in only one line.", null,
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
+                        "Excepteur sint occaecat cupidatat non proident",
+                null, null, "References:\none_line_only_with_ctx\n");
+        checkMulti("Long context in several lines.", null,
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n" +
+                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\n" +
+                        "Excepteur sint occaecat cupidatat non proident",
+                null, null, "References:\nmultiple_lines_with_ctx\n");
+        checkMultiEnd();
+    }
+
     @Override
     protected void translate(AbstractFilter filter, String filename, Map<String, String> config) throws Exception {
         translate(filter, filename, config, Collections.emptyMap(),


### PR DESCRIPTION
This PR is intended to reproduce BUGS#1305 and set proper target behavior for the multi-line continuation of the PO file format.

## Pull request type

- Bug fix -> [bug]
- Refactor

## Which ticket is resolved?
- .PO filter bug: display issue when a msgctxt spans several lines
- https://sourceforge.net/p/omegat/bugs/1305/
## What does this PR change?

- refactor `POoFilter#processPoFile` private method to split multiple internal methods with the single purpose method principle.
- Add test data and reproducible of the BUGS#1305
- The test case also includes a check for multiline msgid
- Add behavior check for '\n' in multiline messages

## Other information

- The second commit should be failed.
- https://www.gnu.org/software/gettext/manual/html_node/More-Details.html
