### PR TITLE
refactor(ui/plugin): enhance plugin management and table views

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
@@ -19,7 +19,8 @@ ext.makeModuleTask = { moduleProp ->
                     'Plugin-Version': moduleProp.Version,
                     'Plugin-Name': moduleProp.Name,
                     'Plugin-Category': moduleProp.Category,
-                    'Plugin-Link': 'https://www.omegat.org/',
+                    'Plugin-Link': 'https://sourceforge.net/p/omegat/wiki/Bundled%20Plugins/',
+                    'Plugin-Bundled': 'true',
                     'Plugin-Description': moduleProp.Description
             )
         }

--- a/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
@@ -19,6 +19,7 @@ ext.makeModuleTask = { moduleProp ->
                     'Plugin-Version': moduleProp.Version,
                     'Plugin-Name': moduleProp.Name,
                     'Plugin-Category': moduleProp.Category,
+                    'Plugin-Link': 'https://www.omegat.org/',
                     'Plugin-Description': moduleProp.Description
             )
         }

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -68,7 +68,7 @@
     <suppress checks="LineLength" files="(CreateGlossaryEntry|FilterBarReplace|FilterEditor|InstanceEditor|NewTeamProject|ProjectFilesList)\.java"/>
 
     <!-- Suppress for readability -->
-    <suppress files="PluginInformation\.java" checks="NeedBraces" lines="167-192"/>
+    <suppress files="PluginInformation\.java" checks="NeedBraces" lines="190-250"/>
     <!-- core/data/* -->
     <suppress checks="ParameterNumber" files="PluginInformation\.java" lines="60"/>
     <suppress checks="ParameterNumber" files="ParseEntry\.java" lines="130-150,200-277"/>

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1099,11 +1099,11 @@ SW_NR_OF_RESULTS=Matching segments: {0}
 
 SW_GLOSSARY_RESULT=Glossary
 # 0 Number of search results. There is a non-breaking space between {0} and matches.
-SW_NR_MATCHES={0}\u00A0matches
+SW_NR_MATCHES={0}\u00a0matches
 # 0 Search result preamble (usually filename)
 # 1 Number of additional search results.
 # There is a non-breaking space between {1} and more.
-SW_FILE_AND_NR_OF_MORE={0} +{1}\u00A0more
+SW_FILE_AND_NR_OF_MORE={0} +{1}\u00a0more
 
 SW_FILE_MENU=File
 SW_FILE_MENU_CLOSE=&Close
@@ -1539,7 +1539,7 @@ ABOUTDIALOG_BRAND_VERSION_REVISION={0} version {1} ({2})
 ABOUTDIALOG_BRAND_VERSION_UPDATE_REVISION={0} version {1}, update {2} ({3})
 
 ABOUTDIALOG_TITLE=About OmegaT
-ABOUTDIALOG_COPYRIGHT=Copyright \u00A9 2000-2022 Keith Godfrey, Maxym Mykhalchuk and others
+ABOUTDIALOG_COPYRIGHT=Copyright \u00a9 2000-2022 Keith Godfrey, Maxym Mykhalchuk and others
 
 ABOUTDIALOG_LICENSE_BUTTON=&License
 ABOUTDIALOG_CONTRIBUTORS=\
@@ -2135,7 +2135,7 @@ MATCHES_PROJECTS=Found in:
 MATCHES_THIS_PROJECT=This project
 
 # 0 Number of additional matches. There is a non-break space between {0} and more
-MATCHES_MULTI_FILE_HINT=(+{0}\u00A0more)
+MATCHES_MULTI_FILE_HINT=(+{0}\u00a0more)
 
 MATCHES_OPEN_PREFERENCES=TM Matching Options
 
@@ -2658,9 +2658,9 @@ ISSUES_SPELLING_PROVIDER_NAME=Spelling Issues
 ISSUES_SPELLING_TYPE=Spelling
 ISSUES_SPELLING_WORD_DELIMITER=,\ 
 # 0: Misspelled word
-ISSUES_SPELLING_LEARN_ITEM=Add to Dictionary: \u201C{0}\u201D
+ISSUES_SPELLING_LEARN_ITEM=Add to Dictionary: \u201c{0}\u201d
 # 0: Misspelled word
-ISSUES_SPELLING_IGNORE_ITEM=Ignore: \u201C{0}\u201D
+ISSUES_SPELLING_IGNORE_ITEM=Ignore: \u201c{0}\u201d
 ISSUES_TAGS_PROVIDER_NAME=Tag Issues
 ISSUES_TAGS_TYPE=Tags
 # 0: Tag error description ("Missing", "Duplicate", etc.)
@@ -2671,23 +2671,23 @@ ISSUES_TAGS_BUTTON_APPLY_FIX=Apply &Fix
 ISSUES_LANGUAGETOOL_PROVIDER_NAME=LanguageTool Issues
 ISSUES_LT_TYPE=LanguageTool
 # 0: Rule description
-ISSUES_LT_DISABLE_RULE=Disable rule \u201C{0}\u201D
+ISSUES_LT_DISABLE_RULE=Disable rule \u201c{0}\u201d
 ISSUES_TERMINOLOGY_PROVIDER_NAME=Terminology Issues
 ISSUES_TERMINOLOGY_TYPE=Terminology
 # 0: Origin glossaries for matched term
 # 1: Matched glossary source term
 # 2: Unmatched target term
-ISSUES_TERMINOLOGY_DESCRIPTION=[{0}] \u201C{1}\u201D in source; expected \u201C{2}\u201D in target
+ISSUES_TERMINOLOGY_DESCRIPTION=[{0}] \u201c{1}\u201d in source; expected \u201c{2}\u201d in target
 # 0: Origin glossaries for matched term
 # 1: Matched glossary source term
 # 2: Unmatched target terms
-ISSUES_TERMINOLOGY_DESCRIPTION_MULTI=[{0}] \u201C{1}\u201D in source; expected one of {2} in target
+ISSUES_TERMINOLOGY_DESCRIPTION_MULTI=[{0}] \u201c{1}\u201d in source; expected one of {2} in target
 ISSUES_TERMINOLOGY_ORIGIN_DELIMITER=,\ 
 # 0: Term
-ISSUES_TERMINOLOGY_TERM_TEMPLATE=\u201C{0}\u201D
+ISSUES_TERMINOLOGY_TERM_TEMPLATE=\u201c{0}\u201d
 # 0: Term
 # 1: List of indicies indicating origin glossaries
-ISSUES_TERMINOLOGY_TERM_MULTIORIGIN_TEMPLATE=\u201C{0}\u201D ({1})
+ISSUES_TERMINOLOGY_TERM_MULTIORIGIN_TEMPLATE=\u201c{0}\u201d ({1})
 ISSUES_TERMINOLOGY_TERM_DELIMITER=,\ 
 ISSUES_TERMINOLOGY_TERM_ORIGIN_INDEX_DELIMITER=,\ 
 # 0: Glossary source term
@@ -2893,12 +2893,6 @@ PREFS_TITLE_PLUGINS=Plugins
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
 PREFS_PLUGINS_DETAILS_explanation=Show plugin details
-PREFS_PLUGINS_COL_STAT=Status
-PREFS_PLUGINS_COL_CATEGORY=Category
-PREFS_PLUGINS_COL_NAME=Name
-PREFS_PLUGINS_COL_VERSION=Version
-PREFS_PLUGINS_UPDATE=Update
-PREFS_PLUGINS_INSTALL=Install
 
 PLUGIN_STATUS_BUNDLED=Bundled
 PLUGIN_STATUS_UPDATABLE=Udate available
@@ -2914,11 +2908,18 @@ PLUGIN_TYPE_GLOSSARY=Glossary plugin
 PLUGIN_TYPE_TOKENIZER=Tokenizer
 PLUGIN_TYPE_DICTIONARY=Dictionary
 PLUGIN_TYPE_MACHINETRANSLATOR=Machine Translation connector
+PLUGIN_TYPE_LANGUAGE=Language
 PLUGIN_TYPE_UNKNOWN=Unknown
 
 PREFS_PLUGINS_BROWSE_ONLINE=&Browse Online
 PREFS_PLUGINS_AVAILABLE_ONLINE=Other plugins are available online.
 PREFS_PLUGINS_LIST=Installed plugins:
+PREFS_PLUGINS_SHOW_BUNDLED=Show bundled plugins
+PREFS_PLUGINS_COL_NAME=Name
+PREFS_PLUGINS_COL_VERSION=Version
+PREFS_PLUGINS_COL_AUTHOR=Author
+PREFS_PLUGINS_COL_STAT=Status
+PREFS_PLUGINS_COL_CATEGORY=Category
 PREFS_PLUGINS_INSTALL_FROM_DISK=&Install plugin from disk
 PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Install Plugin
 PREFS_PLUGINS_TITLE_CONFIRM_UPGRADE=Upgrade Plugin

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -4,7 +4,7 @@
 #          glossaries, and translation leveraging into updated projects.
 #
 # Copyright (C) 2000-2006 Keith Godfrey, Maxym Mykhalchuk, and Henry Pijffers
-#               2007 Didi- Briel, Zoltan Bartko, Martin Fleurke
+#               2007 Didier Briel, Zoltan Bartko, Martin Fleurke
 #               2008 Andrzej Sawula, Alex Buloichik, Didier Briel, Martin Fleurke
 #               2009 Didier Briel, Alex Buloichik, Martin Fleurke
 #               2010 Didier Briel, Wildrich Fourie, Martin Fleurke,
@@ -2891,14 +2891,34 @@ PREFS_SECURE_STORAGE_RESET_MASTER_PASSWORD_MESSAGE=Are you sure you want to rese
 # PREFERENCES - PLUGINS
 PREFS_TITLE_PLUGINS=Plugins
 
+# org.omegat.gui.dialogs.PluginInstallerDialog
+PREFS_PLUGINS_DETAILS_explanation=Show plugin details
+PREFS_PLUGINS_COL_STAT=Status
+PREFS_PLUGINS_COL_CATEGORY=Category
+PREFS_PLUGINS_COL_NAME=Name
+PREFS_PLUGINS_COL_VERSION=Version
+PREFS_PLUGINS_UPDATE=Update
+PREFS_PLUGINS_INSTALL=Install
+
+PLUGIN_STATUS_BUNDLED=Bundled
+PLUGIN_STATUS_UPDATABLE=Udate available
+PLUGIN_STATUS_UNINSTALLED=Uninstalled
+PLUGIN_STATUS_INSTALLED=Installed
+PLUGIN_STATUS_NEW=New
+PLUGIN_TYPE_BASE=Base plugin
+PLUGIN_TYPE_FILTER=Filter
+PLUGIN_TYPE_THEME=Theme plugin
+PLUGIN_TYPE_MISC=Misc plugin
+PLUGIN_TYPE_MARKER=Marker plugin
+PLUGIN_TYPE_GLOSSARY=Glossary plugin
+PLUGIN_TYPE_TOKENIZER=Tokenizer
+PLUGIN_TYPE_DICTIONARY=Dictionary
+PLUGIN_TYPE_MACHINETRANSLATOR=Machine Translation connector
+PLUGIN_TYPE_UNKNOWN=Unknown
+
 PREFS_PLUGINS_BROWSE_ONLINE=&Browse Online
 PREFS_PLUGINS_AVAILABLE_ONLINE=Other plugins are available online.
 PREFS_PLUGINS_LIST=Installed plugins:
-PREFS_PLUGINS_COL_CLASS=Class
-PREFS_PLUGINS_COL_NAME=Name
-PREFS_PLUGINS_COL_VERSION=Version
-PREFS_PLUGINS_COL_AUTHOR=Author
-PREFS_PLUGINS_COL_DESCRIPTION=Description
 PREFS_PLUGINS_INSTALL_FROM_DISK=&Install plugin from disk
 PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION=Install Plugin
 PREFS_PLUGINS_TITLE_CONFIRM_UPGRADE=Upgrade Plugin
@@ -2909,7 +2929,7 @@ PREFS_PLUGINS_CONFIRM_OVERWRITE=Version {1} is already installed.\n\
    Reinstall the {0} plugin?
 PREFS_PLUGINS_CONFIRM_INSTALL=Install the {0} {1} plugin?
 PREFS_PLUGINS_INSTALLATION_FAILED=Plugin installation failed.
-PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin installation successful. Restart OmegaT to activate it.
+PREFS_PLUGINS_INSTALLATION_SUCCEED=Plugin is successfully installed. Restart OmegaT to activate it.
 PREFS_PLUGINS_UNKNOWN_ARCHIVE=This file is not a plugin archive.
 PREFS_PLUGINS_TITLE_NAME=Plugin Name
 PREFS_PLUGINS_TITLE_CURRENT_VERSION=Installed

--- a/src/org/omegat/core/data/PluginInformation.java
+++ b/src/org/omegat/core/data/PluginInformation.java
@@ -27,7 +27,6 @@
 package org.omegat.core.data;
 
 import java.net.URL;
-import java.util.Map;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -84,7 +83,6 @@ public final class PluginInformation {
     private String link;
     private URL url;
     private Status status;
-
 
     /* The class is recommended to build from builder. */
     private PluginInformation() {
@@ -245,6 +243,7 @@ public final class PluginInformation {
         private static final String BUNDLE_VERSION = "Bundle-Version";
         private static final String BUNDLE_NAME = "Bundle-Name";
         private static final String BUILT_BY = "Built-By";
+        private static final String PLUGIN_BUNDLED = "Plugin-Bundled";
 
         /**
          * Disable default constructor.
@@ -265,12 +264,12 @@ public final class PluginInformation {
          *            metadata of plugin.
          * @param mu
          *            URL of manifest
-         * @param status
+         * @param defaultStatus
          *            Plugin status, bundled or installed
          * @return PluginInformation object.
          */
         public static PluginInformation fromManifest(final String className, final Manifest manifest,
-                final URL mu, final Status status) {
+                final URL mu, final Status defaultStatus) {
             Attributes targetAttrs = new Attributes(manifest.getMainAttributes());
             String packageName = className == null ? ""
                     : className.substring(0, className.lastIndexOf(".") + 1).replace(".", "/");
@@ -288,6 +287,14 @@ public final class PluginInformation {
             if (attrs != null) {
                 targetAttrs.putAll(attrs);
             }
+            // bundled modules detection
+            Status status;
+            if ("true".equalsIgnoreCase(lookupAttribute(targetAttrs, PLUGIN_BUNDLED))) {
+                status = Status.BUNDLED;
+            } else {
+                status = defaultStatus;
+            }
+            // create the object.
             PluginInformation result = new PluginInformation();
             result.className = className;
             result.name = findName(className, targetAttrs);
@@ -384,21 +391,6 @@ public final class PluginInformation {
                 }
             }
             return null;
-        }
-
-        public static PluginInformation fromMap(Map<String, String> attr) {
-            PluginUtils.PluginType cate = PluginUtils.PluginType.getTypeByValue(attr.get("Category"));
-            PluginInformation result = new PluginInformation();
-            result.className = attr.get("Class-Name");
-            result.name = attr.get("Name");
-            result.version = attr.get("Version");
-            result.author = attr.get("Author");
-            result.description = attr.getOrDefault("Description", "");
-            result.category = cate;
-            result.link = attr.getOrDefault("Link", "");
-            result.url = null;
-            result.status = Status.UNINSTALLED;
-            return result;
         }
     }
 }

--- a/src/org/omegat/core/data/PluginInformation.java
+++ b/src/org/omegat/core/data/PluginInformation.java
@@ -27,7 +27,6 @@
 package org.omegat.core.data;
 
 import java.net.URL;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.jar.Attributes;

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -190,9 +190,12 @@ public final class PluginUtils {
                 return OStrings.getString("PLUGIN_TYPE_DICTIONARY");
             case MACHINETRANSLATOR:
                 return OStrings.getString("PLUGIN_TYPE_MACHINETRANSLATOR");
+            case LANGUAGE:
+                return OStrings.getString("PLUGIN_TYPE_LANGUAGE");
             case UNKNOWN:
-            default:
                 return OStrings.getString("PLUGIN_TYPE_UNKNOWN");
+            default:
+                return getTypeValue();
             }
         }
     }

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -327,7 +327,7 @@ public final class PluginUtils {
             if (OMEGAT_MAIN_CLASS.equals(manifest.getMainAttributes().getValue(MAIN_CLASS))) {
                 isMainManifestFound = true;
                 MainClassLoader pluginsClassLoader = MAINCLASSLOADERS.get(PluginType.UNKNOWN);
-                loadFromManifest(manifest, pluginsClassLoader, manifestUrl);
+                loadFromManifest(manifest, pluginsClassLoader, manifestUrl, true);
             }
 
             // Process plugin based on category
@@ -336,7 +336,7 @@ public final class PluginUtils {
                 if (type != PluginType.UNKNOWN && isUrlInList(manifestUrl, pluginUrls)) {
                     MainClassLoader categoryLoader = MAINCLASSLOADERS.get(type);
                     addUrlToClasspath(manifestUrl, pluginUrls, categoryLoader);
-                    loadFromManifest(manifest, categoryLoader, manifestUrl);
+                    loadFromManifest(manifest, categoryLoader, manifestUrl, false);
                 }
             }
         }
@@ -378,7 +378,7 @@ public final class PluginUtils {
                 if (manifests != null) {
                     for (String mf : manifests.split(File.pathSeparator)) {
                         try (InputStream in = Files.newInputStream(Paths.get(mf))) {
-                            loadFromManifest(new Manifest(in), pluginsClassLoader, null);
+                            loadFromManifest(new Manifest(in), pluginsClassLoader, null, true);
                         }
                     }
                 } else {
@@ -708,7 +708,7 @@ public final class PluginUtils {
      * @throws ClassNotFoundException
      *             when plugin class is not found.
      */
-    private static void loadFromManifest(Manifest m, ClassLoader classLoader, URL mu)
+    private static void loadFromManifest(Manifest m, ClassLoader classLoader, URL mu, boolean bundled)
             throws ClassNotFoundException {
         String classes = m.getMainAttributes().getValue(OMEGAT_PLUGINS);
         if (classes != null) {
@@ -717,8 +717,8 @@ public final class PluginUtils {
                     continue;
                 }
                 if (loadClass(clazz, classLoader)) {
-                    if (mu == null) {
-                        PLUGIN_INFORMATIONS.add(PluginInformation.Builder.fromManifest(clazz, m, null,
+                    if (bundled) {
+                        PLUGIN_INFORMATIONS.add(PluginInformation.Builder.fromManifest(clazz, m, mu,
                                 PluginInformation.Status.BUNDLED));
                     } else {
                         PLUGIN_INFORMATIONS.add(PluginInformation.Builder.fromManifest(clazz, m, mu,

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/org/omegat/filters2/master/PluginUtils.java
+++ b/src/org/omegat/filters2/master/PluginUtils.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -162,6 +163,37 @@ public final class PluginUtils {
                 }
             }
             return UNKNOWN;
+        }
+
+        @Override
+        public String toString() {
+            return getTypeValue();
+        }
+
+        public String getLocalizedValue() {
+            switch (this) {
+            case BASE:
+                return OStrings.getString("PLUGIN_TYPE_BASE");
+            case THEME:
+                return OStrings.getString("PLUGIN_TYPE_THEME");
+            case FILTER:
+                return OStrings.getString("PLUGIN_TYPE_FILTER");
+            case MISCELLANEOUS:
+                return OStrings.getString("PLUGIN_TYPE_MISC");
+            case MARKER:
+                return OStrings.getString("PLUGIN_TYPE_MARKER");
+            case GLOSSARY:
+                return OStrings.getString("PLUGIN_TYPE_GLOSSARY");
+            case TOKENIZER:
+                return OStrings.getString("PLUGIN_TYPE_TOKENIZER");
+            case DICTIONARY:
+                return OStrings.getString("PLUGIN_TYPE_DICTIONARY");
+            case MACHINETRANSLATOR:
+                return OStrings.getString("PLUGIN_TYPE_MACHINETRANSLATOR");
+            case UNKNOWN:
+            default:
+                return OStrings.getString("PLUGIN_TYPE_UNKNOWN");
+            }
         }
     }
 

--- a/src/org/omegat/gui/preferences/view/PluginDetailsPane.java
+++ b/src/org/omegat/gui/preferences/view/PluginDetailsPane.java
@@ -1,0 +1,69 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2021-2023 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.preferences.view;
+
+import java.net.URI;
+import javax.swing.JOptionPane;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.html.HTMLDocument;
+
+import org.omegat.core.data.PluginInformation;
+import org.omegat.gui.common.EntryInfoPane;
+import org.omegat.util.OStrings;
+import org.omegat.util.gui.DesktopWrapper;
+import org.omegat.util.gui.StaticUIUtils;
+
+/**
+ * Data pane to show plugin details in formatted text.
+ *
+ * @author Hiroshi Miura
+ */
+public class PluginDetailsPane extends EntryInfoPane<PluginInformation> {
+    private static final long serialVersionUID = 7345812965508717972L;
+
+    private static final String EXPLANATION = OStrings.getString("PREFS_PLUGINS_DETAILS_explanation");
+
+    public PluginDetailsPane() {
+        super(true);
+        setContentType("text/html");
+        ((HTMLDocument) getDocument()).setPreservesUnknownTags(false);
+        setFont(getFont());
+        setEditable(false);
+        StaticUIUtils.makeCaretAlwaysVisible(this);
+        setText(EXPLANATION);
+        addHyperlinkListener(e -> {
+            if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+                try {
+                    DesktopWrapper.browse(URI.create(e.getURL().toString()));
+                } catch (Exception ex) {
+                    JOptionPane.showConfirmDialog(this, ex.getLocalizedMessage(),
+                            OStrings.getString("ERROR_TITLE"), JOptionPane.DEFAULT_OPTION,
+                            JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        });
+    }
+}

--- a/src/org/omegat/gui/preferences/view/PluginInfoTableModel.java
+++ b/src/org/omegat/gui/preferences/view/PluginInfoTableModel.java
@@ -25,34 +25,29 @@
 
 package org.omegat.gui.preferences.view;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.swing.table.DefaultTableModel;
 
 import org.omegat.core.data.PluginInformation;
-import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.OStrings;
+import org.omegat.util.PluginInstaller;
 
 public class PluginInfoTableModel extends DefaultTableModel {
-    private static final long serialVersionUID = 5345248154613009632L;
+    private static final long serialVersionUID = 5345248154613009633L;
 
-    protected static final int COLUMN_NAME = 0;
-    protected static final int COLUMN_CLASS = 1;
-    protected static final int COLUMN_VERSION = 2;
-    protected static final int COLUMN_AUTHOR = 3;
-    protected static final int COLUMN_DESCRIPTION = 4;
+    public static final int COLUMN_STAT = 0;
+    public static final int COLUMN_CATEGORY = 1;
+    public static final int COLUMN_NAME = 2;
+    public static final int COLUMN_VERSION = 3;
 
-    private static final String[] COLUMN_NAMES = { "PREFS_PLUGINS_COL_NAME", "PREFS_PLUGINS_COL_CLASS",
-            "PREFS_PLUGINS_COL_VERSION", "PREFS_PLUGINS_COL_AUTHOR", "PREFS_PLUGINS_COL_DESCRIPTION" };
+    private static final String[] COLUMN_NAMES = { "PREFS_PLUGINS_COL_STAT", "PREFS_PLUGINS_COL_CATEGORY",
+            "PREFS_PLUGINS_COL_NAME", "PREFS_PLUGINS_COL_VERSION"};
 
-    private final List<PluginInformation> listPlugins = new ArrayList<>();
+    private final List<PluginInformation> listPlugins;
 
     public PluginInfoTableModel() {
-        PluginUtils.getPluginInformations().stream()
-                .sorted(Comparator.comparing(PluginInformation::getClassName))
-                .forEach(listPlugins::add);
+        listPlugins = PluginInstaller.getInstance().getPluginList();
     }
 
     @Override
@@ -81,30 +76,31 @@ public class PluginInfoTableModel extends DefaultTableModel {
     }
 
     @Override
-    public Object getValueAt(int rowIndex, int columnIndex) {
-        PluginInformation plugin = listPlugins.get(rowIndex);
-        Object returnValue = null;
+    public Object getValueAt(int row, int column) {
+        PluginInformation plugin = listPlugins.get(row);
+        Object returnValue;
 
-        switch (columnIndex) {
-        case COLUMN_CLASS:
-            returnValue = plugin.getClassName();
-            break;
+        switch (column) {
         case COLUMN_NAME:
             returnValue = plugin.getName();
             break;
         case COLUMN_VERSION:
             returnValue = plugin.getVersion();
             break;
-        case COLUMN_AUTHOR:
-            returnValue = plugin.getAuthor();
+        case COLUMN_CATEGORY:
+            returnValue = plugin.getCategory().getLocalizedValue();
             break;
-        case COLUMN_DESCRIPTION:
-            returnValue = plugin.getDescription();
+        case COLUMN_STAT:
+            returnValue = plugin.getStatus().getLocalizedValue();
             break;
         default:
             throw new IllegalArgumentException("Invalid column index");
         }
 
         return returnValue;
+    }
+
+    public PluginInformation getItemAt(int rowIndex) {
+        return listPlugins.get(rowIndex);
     }
 }

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -57,6 +57,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
     public static final String PLUGINS_WIKI_URL = "https://sourceforge.net/p/omegat/wiki/Plugins/";
     private PluginsPreferencesPanel panel;
     private PluginDetailsPane pluginDetailsPane;
+    private PluginInfoTableModel model;
 
     /**
      * Format plugin information for details pane of UI.
@@ -113,7 +114,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
 
     private void initGui() {
         panel = new PluginsPreferencesPanel();
-        PluginInfoTableModel model = new PluginInfoTableModel();
+        model = new PluginInfoTableModel();
         panel.tablePluginsInfo.setModel(model);
         TableRowSorter<PluginInfoTableModel> sorter = new TableRowSorter<>(model);
         panel.tablePluginsInfo.setRowSorter(sorter);
@@ -148,6 +149,12 @@ public class PluginsPreferencesController extends BasePreferencesController {
                     setRestartRequired(true);
                 }
             }
+        });
+
+        panel.showBundledPluginsCB.addActionListener(e -> {
+            boolean showBundledPlugins = panel.showBundledPluginsCB.isSelected();
+            model.updateModel(showBundledPlugins);
+            panel.tablePluginsInfo.setRowSorter(new TableRowSorter<>(model));
         });
     }
 

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2016 Aaron Madlon-Kay
+               2022,2023 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,33 +26,65 @@
 
 package org.omegat.gui.preferences.view;
 
+import java.awt.Dimension;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
-import javax.swing.table.TableModel;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.event.ListSelectionEvent;
 import javax.swing.table.TableRowSorter;
 
 import org.omegat.core.Core;
+import org.omegat.core.data.PluginInformation;
 import org.omegat.gui.dialogs.ChoosePluginFile;
 import org.omegat.gui.preferences.BasePreferencesController;
 import org.omegat.util.OStrings;
 import org.omegat.util.PluginInstaller;
+import org.omegat.util.gui.DataTableStyling;
 import org.omegat.util.gui.DesktopWrapper;
 import org.omegat.util.gui.TableColumnSizer;
 
 /**
+ * Controller for the Plugins preferences panel.
+ *
  * @author Aaron Madlon-Kay
+ * @author Hiroshi Miura
  */
 public class PluginsPreferencesController extends BasePreferencesController {
 
     public static final String PLUGINS_WIKI_URL = "https://sourceforge.net/p/omegat/wiki/Plugins/";
     private PluginsPreferencesPanel panel;
+    private PluginDetailsPane pluginDetailsPane;
+
+    /**
+     * Format plugin information for details pane of UI.
+     * @param info PluginInformation to show
+     * @return HTML text
+     */
+    private static String formatDetailText(PluginInformation info) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<h1>").append(info.getName()).append("</h1>");
+        sb.append("<h4>Author: ");
+        if (info.getAuthor() != null) {
+            sb.append(info.getAuthor()).append("<br/>");
+        } else {
+            sb.append("Unknown<br/>");
+        }
+        if (info.getVersion() != null) {
+            sb.append("Version: ").append(info.getVersion()).append("<br/>");
+        }
+        sb.append(info.getCategory());
+        sb.append("</h4>");
+        if (info.getDescription() != null) {
+            sb.append("<p>").append(info.getDescription()).append("</p>");
+        }
+        if (info.getLink() != null) {
+            sb.append("<br/><div><a href=\"").append(info.getLink()).append("\">Plugin homepage</a></div>");
+        }
+        return sb.toString();
+    }
 
     @Override
     public JComponent getGui() {
@@ -62,6 +95,17 @@ public class PluginsPreferencesController extends BasePreferencesController {
         return panel;
     }
 
+    final void selectRowAction(ListSelectionEvent evt) {
+        int rowIndex = panel.tablePluginsInfo.getSelectedRow();
+        if (rowIndex == -1) {
+            pluginDetailsPane.setText("");
+        } else {
+            int index = panel.tablePluginsInfo.convertRowIndexToModel(rowIndex);
+            PluginInfoTableModel model = (PluginInfoTableModel) panel.tablePluginsInfo.getModel();
+            pluginDetailsPane.setText(formatDetailText(model.getItemAt(index)));
+        }
+    }
+
     @Override
     public String toString() {
         return OStrings.getString("PREFS_TITLE_PLUGINS");
@@ -69,19 +113,30 @@ public class PluginsPreferencesController extends BasePreferencesController {
 
     private void initGui() {
         panel = new PluginsPreferencesPanel();
-        TableColumnSizer.autoSize(panel.tablePluginsInfo, 0, true);
-        TableRowSorter<TableModel> sorter = new TableRowSorter<>(panel.tablePluginsInfo.getModel());
+        PluginInfoTableModel model = new PluginInfoTableModel();
+        panel.tablePluginsInfo.setModel(model);
+        TableRowSorter<PluginInfoTableModel> sorter = new TableRowSorter<>(model);
         panel.tablePluginsInfo.setRowSorter(sorter);
-        List<RowSorter.SortKey> sortkeys = new ArrayList<>();
-        sortkeys.add(new RowSorter.SortKey(0, SortOrder.ASCENDING));
-        sortkeys.add(new RowSorter.SortKey(1, SortOrder.ASCENDING));
-        sorter.setSortKeys(sortkeys);
+        panel.tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_NAME).setPreferredWidth(100);
+        panel.tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_VERSION).setPreferredWidth(50);
+
+        panel.scrollTable.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        panel.scrollTable.getViewport().setViewSize(new Dimension(250, 350));
+
+        panel.tablePluginsInfo.getSelectionModel().addListSelectionListener(this::selectRowAction);
+        panel.tablePluginsInfo.setPreferredScrollableViewportSize(panel.tablePluginsInfo.getPreferredSize());
+        DataTableStyling.applyFont(panel.tablePluginsInfo, Core.getMainWindow().getApplicationFont());
+        TableColumnSizer.autoSize(panel.tablePluginsInfo, 0, true);
+
+        pluginDetailsPane = new PluginDetailsPane();
+        panel.panelPluginDetails.add(pluginDetailsPane);
+
         panel.browsePluginsButton.addActionListener(e -> {
             try {
                 DesktopWrapper.browse(URI.create(PLUGINS_WIKI_URL));
             } catch (Exception ex) {
-                JOptionPane.showConfirmDialog(panel, ex.getLocalizedMessage(),
-                        OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showConfirmDialog(panel, ex.getLocalizedMessage(), OStrings.getString("ERROR_TITLE"),
+                        JOptionPane.DEFAULT_OPTION, JOptionPane.ERROR_MESSAGE);
             }
         });
 
@@ -89,7 +144,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
             ChoosePluginFile choosePluginFile = new ChoosePluginFile();
             if (JFileChooser.APPROVE_OPTION == choosePluginFile.showOpenDialog(
                     Core.getMainWindow().getApplicationFrame())) {
-                if (PluginInstaller.install(choosePluginFile.getSelectedFile())) {
+                if (PluginInstaller.getInstance().install(choosePluginFile.getSelectedFile())) {
                     setRestartRequired(true);
                 }
             }
@@ -98,6 +153,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
 
     @Override
     protected void initFromPrefs() {
+        panel.tablePluginsInfo.changeSelection(0, 0, false, false);
     }
 
     @Override

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.form
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.form
@@ -20,47 +20,88 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,38,0,0,2,13"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,38,0,0,3,7"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
     <Property name="axis" type="int" value="3"/>
   </Layout>
   <SubComponents>
-    <Container class="javax.swing.JPanel" name="panelInfo">
+    <Container class="javax.swing.JPanel" name="jPanel1">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[65534, 600]"/>
+        </Property>
+        <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[200, 23]"/>
+        </Property>
+      </Properties>
 
-      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
+        <Property name="columns" type="int" value="2"/>
+        <Property name="rows" type="int" value="1"/>
+      </Layout>
       <SubComponents>
-        <Component class="javax.swing.JLabel" name="messageLabel">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="PREFS_PLUGINS_AVAILABLE_ONLINE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-            <Property name="alignmentY" type="float" value="0.0"/>
-          </Properties>
-        </Component>
-        <Component class="javax.swing.Box$Filler" name="filler1">
-          <Properties>
-            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[32767, 5]"/>
-            </Property>
-            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[0, 5]"/>
-            </Property>
-            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[0, 5]"/>
-            </Property>
-          </Properties>
+        <Container class="javax.swing.JPanel" name="panelPluginsInfo">
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
+            <Property name="columns" type="int" value="0"/>
+            <Property name="rows" type="int" value="1"/>
+          </Layout>
+          <SubComponents>
+            <Container class="javax.swing.JScrollPane" name="scrollTable">
+              <Properties>
+                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[452, 452]"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JTable" name="tablePluginsInfo">
+                  <Properties>
+                    <Property name="autoCreateRowSorter" type="boolean" value="true"/>
+                    <Property name="model" type="javax.swing.table.TableModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="new PluginInfoTableModel()" type="code"/>
+                    </Property>
+                    <Property name="tableHeader" type="javax.swing.table.JTableHeader" editor="org.netbeans.modules.form.editors2.JTableHeaderEditor">
+                      <TableHeader reorderingAllowed="true" resizingAllowed="true"/>
+                    </Property>
+                  </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+                  </AuxValues>
+                </Component>
+              </SubComponents>
+            </Container>
+          </SubComponents>
+        </Container>
+        <Container class="javax.swing.JPanel" name="panelPluginDetails">
           <AuxValues>
-            <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.VerticalStrut"/>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
           </AuxValues>
-        </Component>
+
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+            <Property name="axis" type="int" value="3"/>
+          </Layout>
+        </Container>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="jPanel2">
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout">
+        <Property name="alignment" type="int" value="0"/>
+      </Layout>
+      <SubComponents>
         <Component class="javax.swing.JButton" name="browsePluginsButton">
           <Properties>
             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/omegat/Bundle.properties" key="PREFS_PLUGINS_BROWSE_ONLINE" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
             </Property>
-            <Property name="alignmentY" type="float" value="0.0"/>
           </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
@@ -76,78 +117,6 @@
             <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
           </AuxValues>
         </Component>
-      </SubComponents>
-    </Container>
-    <Container class="javax.swing.JPanel" name="panelPluginsInfo">
-
-      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
-      <SubComponents>
-        <Component class="javax.swing.JLabel" name="labelTableTitle">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/omegat/Bundle.properties" key="PREFS_PLUGINS_LIST" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
-            </Property>
-            <Property name="verticalAlignment" type="int" value="1"/>
-          </Properties>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-        </Component>
-        <Container class="javax.swing.JScrollPane" name="scrollTable">
-          <AuxValues>
-            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="0.0"/>
-            </Constraint>
-          </Constraints>
-
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
-          <SubComponents>
-            <Component class="javax.swing.JTable" name="tablePluginsInfo">
-              <Properties>
-                <Property name="autoCreateRowSorter" type="boolean" value="true"/>
-                <Property name="model" type="javax.swing.table.TableModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="new PluginInfoTableModel()" type="code"/>
-                </Property>
-                <Property name="columnModel" type="javax.swing.table.TableColumnModel" editor="org.netbeans.modules.form.editors2.TableColumnModelEditor">
-                  <TableColumnModel selectionModel="0">
-                    <Column maxWidth="-1" minWidth="-1" prefWidth="-1" resizable="true">
-                      <Title/>
-                      <Editor/>
-                      <Renderer/>
-                    </Column>
-                    <Column maxWidth="-1" minWidth="-1" prefWidth="-1" resizable="true">
-                      <Title/>
-                      <Editor/>
-                      <Renderer/>
-                    </Column>
-                    <Column maxWidth="-1" minWidth="-1" prefWidth="-1" resizable="true">
-                      <Title/>
-                      <Editor/>
-                      <Renderer/>
-                    </Column>
-                    <Column maxWidth="-1" minWidth="-1" prefWidth="-1" resizable="true">
-                      <Title/>
-                      <Editor/>
-                      <Renderer/>
-                    </Column>
-                  </TableColumnModel>
-                </Property>
-                <Property name="tableHeader" type="javax.swing.table.JTableHeader" editor="org.netbeans.modules.form.editors2.JTableHeaderEditor">
-                  <TableHeader reorderingAllowed="true" resizingAllowed="true"/>
-                </Property>
-              </Properties>
-              <AuxValues>
-                <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_CLASS).setPreferredWidth(100);&#xd;&#xa;tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_VERSION).setPreferredWidth(50);"/>
-                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
-              </AuxValues>
-            </Component>
-          </SubComponents>
-        </Container>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.form
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.form
@@ -20,7 +20,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,38,0,0,3,7"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,38,0,0,1,-31"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
@@ -81,6 +81,11 @@
           </SubComponents>
         </Container>
         <Container class="javax.swing.JPanel" name="panelPluginDetails">
+          <Properties>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[400, 0]"/>
+            </Property>
+          </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
           </AuxValues>
@@ -111,6 +116,16 @@
           <Properties>
             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/omegat/Bundle.properties" key="PREFS_PLUGINS_INSTALL_FROM_DISK" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="showBundledPluginsCB">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="PREFS_PLUGINS_SHOW_BUNDLED" replaceFormat="java.util.ResourceBundle.getBundle(&quot;{bundleNameSlashes}&quot;).getString(&quot;{key}&quot;)"/>
             </Property>
           </Properties>
           <AuxValues>

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
@@ -59,6 +59,7 @@ public class PluginsPreferencesPanel extends JPanel {
         jPanel2 = new javax.swing.JPanel();
         browsePluginsButton = new javax.swing.JButton();
         installFromDiskButton = new javax.swing.JButton();
+        showBundledPluginsCB = new javax.swing.JCheckBox();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
         setMinimumSize(new java.awt.Dimension(250, 200));
@@ -80,6 +81,7 @@ public class PluginsPreferencesPanel extends JPanel {
 
         jPanel1.add(panelPluginsInfo);
 
+        panelPluginDetails.setPreferredSize(new java.awt.Dimension(400, 0));
         panelPluginDetails.setLayout(new javax.swing.BoxLayout(panelPluginDetails, javax.swing.BoxLayout.PAGE_AXIS));
         jPanel1.add(panelPluginDetails);
 
@@ -93,6 +95,10 @@ public class PluginsPreferencesPanel extends JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(installFromDiskButton, OStrings.getString("PREFS_PLUGINS_INSTALL_FROM_DISK")); // NOI18N
         jPanel2.add(installFromDiskButton);
 
+        java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("org/omegat/Bundle"); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(showBundledPluginsCB, bundle.getString("PREFS_PLUGINS_SHOW_BUNDLED")); // NOI18N
+        jPanel2.add(showBundledPluginsCB);
+
         add(jPanel2);
     }// </editor-fold>//GEN-END:initComponents
 
@@ -104,6 +110,7 @@ public class PluginsPreferencesPanel extends JPanel {
     javax.swing.JPanel panelPluginDetails;
     private javax.swing.JPanel panelPluginsInfo;
     javax.swing.JScrollPane scrollTable;
+    javax.swing.JCheckBox showBundledPluginsCB;
     javax.swing.JTable tablePluginsInfo;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
+++ b/src/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
@@ -26,9 +26,12 @@
 package org.omegat.gui.preferences.view;
 
 import javax.swing.JPanel;
+
 import org.omegat.util.OStrings;
 
 /**
+ * Preferences panel for configuring the plugin preferences.
+ *
  * @author Aaron Madlon-Kay
  * @author Briac Pilpre
  */
@@ -47,72 +50,60 @@ public class PluginsPreferencesPanel extends JPanel {
      */
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
-        java.awt.GridBagConstraints gridBagConstraints;
 
-        panelInfo = new javax.swing.JPanel();
-        messageLabel = new javax.swing.JLabel();
-        filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 5), new java.awt.Dimension(0, 5), new java.awt.Dimension(32767, 5));
-        browsePluginsButton = new javax.swing.JButton();
-        installFromDiskButton = new javax.swing.JButton();
+        jPanel1 = new javax.swing.JPanel();
         panelPluginsInfo = new javax.swing.JPanel();
-        labelTableTitle = new javax.swing.JLabel();
         scrollTable = new javax.swing.JScrollPane();
         tablePluginsInfo = new javax.swing.JTable();
+        panelPluginDetails = new javax.swing.JPanel();
+        jPanel2 = new javax.swing.JPanel();
+        browsePluginsButton = new javax.swing.JButton();
+        installFromDiskButton = new javax.swing.JButton();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
         setMinimumSize(new java.awt.Dimension(250, 200));
         setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.PAGE_AXIS));
 
-        org.openide.awt.Mnemonics.setLocalizedText(messageLabel, OStrings.getString("PREFS_PLUGINS_AVAILABLE_ONLINE")); // NOI18N
-        messageLabel.setAlignmentY(0.0F);
-        panelInfo.add(messageLabel);
-        panelInfo.add(filler1);
+        jPanel1.setMaximumSize(new java.awt.Dimension(65534, 600));
+        jPanel1.setMinimumSize(new java.awt.Dimension(200, 23));
+        jPanel1.setLayout(new java.awt.GridLayout(1, 2));
 
-        org.openide.awt.Mnemonics.setLocalizedText(browsePluginsButton, OStrings.getString("PREFS_PLUGINS_BROWSE_ONLINE")); // NOI18N
-        browsePluginsButton.setAlignmentY(0.0F);
-        panelInfo.add(browsePluginsButton);
+        panelPluginsInfo.setLayout(new java.awt.GridLayout(1, 0));
 
-        org.openide.awt.Mnemonics.setLocalizedText(installFromDiskButton, OStrings.getString("PREFS_PLUGINS_INSTALL_FROM_DISK")); // NOI18N
-        panelInfo.add(installFromDiskButton);
-
-        add(panelInfo);
-
-        panelPluginsInfo.setLayout(new java.awt.GridBagLayout());
-
-        org.openide.awt.Mnemonics.setLocalizedText(labelTableTitle, OStrings.getString("PREFS_PLUGINS_LIST")); // NOI18N
-        labelTableTitle.setVerticalAlignment(javax.swing.SwingConstants.TOP);
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.insets = new java.awt.Insets(4, 0, 4, 0);
-        panelPluginsInfo.add(labelTableTitle, gridBagConstraints);
+        scrollTable.setPreferredSize(new java.awt.Dimension(452, 452));
 
         tablePluginsInfo.setAutoCreateRowSorter(true);
         tablePluginsInfo.setModel(new PluginInfoTableModel());
-        tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_CLASS).setPreferredWidth(100);
-        tablePluginsInfo.getColumnModel().getColumn(PluginInfoTableModel.COLUMN_VERSION).setPreferredWidth(50);
         scrollTable.setViewportView(tablePluginsInfo);
 
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 1.0;
-        panelPluginsInfo.add(scrollTable, gridBagConstraints);
+        panelPluginsInfo.add(scrollTable);
 
-        add(panelPluginsInfo);
+        jPanel1.add(panelPluginsInfo);
+
+        panelPluginDetails.setLayout(new javax.swing.BoxLayout(panelPluginDetails, javax.swing.BoxLayout.PAGE_AXIS));
+        jPanel1.add(panelPluginDetails);
+
+        add(jPanel1);
+
+        jPanel2.setLayout(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
+
+        org.openide.awt.Mnemonics.setLocalizedText(browsePluginsButton, OStrings.getString("PREFS_PLUGINS_BROWSE_ONLINE")); // NOI18N
+        jPanel2.add(browsePluginsButton);
+
+        org.openide.awt.Mnemonics.setLocalizedText(installFromDiskButton, OStrings.getString("PREFS_PLUGINS_INSTALL_FROM_DISK")); // NOI18N
+        jPanel2.add(installFromDiskButton);
+
+        add(jPanel2);
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     javax.swing.JButton browsePluginsButton;
-    private javax.swing.Box.Filler filler1;
     javax.swing.JButton installFromDiskButton;
-    private javax.swing.JLabel labelTableTitle;
-    private javax.swing.JLabel messageLabel;
-    private javax.swing.JPanel panelInfo;
+    private javax.swing.JPanel jPanel1;
+    private javax.swing.JPanel jPanel2;
+    javax.swing.JPanel panelPluginDetails;
     private javax.swing.JPanel panelPluginsInfo;
-    private javax.swing.JScrollPane scrollTable;
+    javax.swing.JScrollPane scrollTable;
     javax.swing.JTable tablePluginsInfo;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/org/omegat/util/PluginInstaller.java
+++ b/src/org/omegat/util/PluginInstaller.java
@@ -72,10 +72,20 @@ public final class PluginInstaller {
 
     private static final String PLUGIN_TYPE = "OmegaT-Plugin";
 
+    private List<PluginInformation> pluginInformationList;
+
+    private static class SingletonHelper {
+        private static final PluginInstaller INSTANCE = new PluginInstaller();
+    }
+
+    public static PluginInstaller getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
     private PluginInstaller() {
     }
 
-    public static boolean install(final File pluginFile) {
+    public boolean install(final File pluginFile) {
         Path pluginJarFile;
         Set<PluginInformation> infoSet;
         try {
@@ -114,7 +124,7 @@ public final class PluginInstaller {
         String version = info.getVersion();
         // detect current installation
         PluginInformation currentInfo = installed.getOrDefault(info.getClassName(), null);
-        String title = "";
+        String title;
         String message;
         if (currentInfo != null) {
             if (currentInfo.getVersion().equals(version)) {
@@ -163,7 +173,7 @@ public final class PluginInstaller {
             }
             JOptionPane.showConfirmDialog(Core.getMainWindow().getApplicationFrame(),
                     OStrings.getString("PREFS_PLUGINS_INSTALLATION_FAILED"),
-                    OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.YES_OPTION,
+                    OStrings.getString("PREFS_PLUGINS_TITLE_CONFIRM_INSTALLATION"), JOptionPane.DEFAULT_OPTION,
                     JOptionPane.ERROR_MESSAGE);
         }
         return false;
@@ -210,6 +220,20 @@ public final class PluginInstaller {
         Path installDir = Paths.get(StaticUtils.installDir()).normalize();
         Path jarPath = jarFile.toPath().normalize();
         return jarPath.startsWith(installDir);
+    }
+
+    /**
+     * Return known available plugins.
+     * It has plugins that have already installed.
+     * @return List of PluginInformation
+     */
+    public List<PluginInformation> getPluginList() {
+        if (pluginInformationList != null) {
+            return pluginInformationList;
+        }
+        Map<String, PluginInformation> listPlugins = getInstalledPlugins();
+        pluginInformationList = new ArrayList<>(listPlugins.values());
+        return pluginInformationList;
     }
 
     /**


### PR DESCRIPTION
Port new preferences/plugins view from PR #226

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Preference->Plugin dialog show plugin information in 3-pain
-    https://sourceforge.net/p/omegat/feature-requests/1549/

- Plugin preference table order (external first)
-   https://sourceforge.net/p/omegat/feature-requests/1545/


## What does this PR change?

- Added a PluginDetailsPane to display detailed plugin information in the preferences UI.
- Refactored the PluginInformation and PluginInstaller functionalities to improve modularity and readability.
- Introduced new plugin statuses (e.g., "updatable", "uninstalled"), and localized their labels.
- Adjusted the PluginsPreferencesPanel layout for improved user interaction.
- Reworked PluginInfoTableModel to simplify plugin info presentation and column management.
- Included new plugin management methods like getPluginList() in PluginInstaller.
- Corrected metadata and documentation strings for better clarity and accuracy.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
