### PR TITLE
chore(gradle): avoid circular dependencies on spellchecker

### DIFF
--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -23,8 +23,7 @@ dependencies {
     }
     testImplementation(libs.languagetool.core)
     testImplementation(libs.commons.io)
-    testImplementation(project(":language-modules:de"))
-    testImplementation(project(":language-modules:fr"))
+    testImplementation(libs.languagetool.de)
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
     testRuntimeOnly(libs.languagetool.en)
-    testRuntimeOnly(libs.languagetool.de)
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))


### PR DESCRIPTION

This PR fixes the problem on build configuration that causes failure in buildNeeded task.


## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?


## What does this PR change?

- Remove hunspell -> language:fr -> hunspell circular dependency
- clean up dependencies for tests

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
