### PR TITLE
Revert "chore(gradle): remove `makeModuleTask` references and replace with `afterEvaluate` logic

### DIFF
--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -26,3 +26,5 @@ dependencies {
 tasks.withType(JavaCompile).configureEach {
     options.errorprone.enabled = false
 }
+
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.module-conventions.gradle
@@ -4,60 +4,55 @@ plugins {
     id 'maven-publish'
 }
 
-afterEvaluate {
-    def pluginPropsFile = file('plugin.properties')
-    if (pluginPropsFile.exists()) {
-        def moduleProp = new Properties()
-        pluginPropsFile.withInputStream { moduleProp.load(it) }
-        jar {
-            archiveFileName = moduleProp.packageName + '.jar'
-            destinationDirectory = rootProject.layout.buildDirectory.dir("modules")
-            outputs.file(destinationDirectory.get().file(archiveFileName.get()))
-            from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-            from sourceSets.main.output
-            manifest {
-                attributes('License': 'GNU Public License version 3 or later',
-                        'Implementation-Version': moduleProp.Version,
-                        'OmegaT-Plugins': moduleProp.Class,
-                        'Plugin-Author': moduleProp.Author,
-                        'Plugin-Version': moduleProp.Version,
-                        'Plugin-Name': moduleProp.Name,
-                        'Plugin-Category': moduleProp.Category,
-                        'Plugin-Description': moduleProp.Description
-                )
-            }
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+ext.makeModuleTask = { moduleProp ->
+    jar {
+        archiveFileName = moduleProp.packageName + '.jar'
+        destinationDirectory = rootProject.layout.buildDirectory.dir("modules")
+        outputs.file(destinationDirectory.get().file(archiveFileName.get()))
+        from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+        from sourceSets.main.output
+        manifest {
+            attributes('License': 'GNU Public License version 3 or later',
+                    'Implementation-Version': moduleProp.Version,
+                    'OmegaT-Plugins': moduleProp.Class,
+                    'Plugin-Author': moduleProp.Author,
+                    'Plugin-Version': moduleProp.Version,
+                    'Plugin-Name': moduleProp.Name,
+                    'Plugin-Category': moduleProp.Category,
+                    'Plugin-Description': moduleProp.Description
+            )
         }
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
-        publishing {
-            publications {
-                mavenJava(MavenPublication) { publication ->
-                    groupId = 'org.omegat'
-                    artifactId = moduleProp.packageName
-                    version = moduleProp.Version
-                    from components.java
+    publishing {
+        publications {
+            mavenJava(MavenPublication) { publication ->
+                groupId = 'org.omegat'
+                artifactId = moduleProp.packageName
+                version = moduleProp.Version
+                from components.java
 
-                    pom {
-                        name = moduleProp.Name
-                        description = moduleProp.Description
-                        url = 'https://omegat.org'
-                        scm {
-                            connection = "scm:git:https://github.com/omegat-org/omegat"
-                            developerConnection = "scm:git:https://github.com/omegat-org/omegat"
-                            url = "https://sourceforge.net/p/omegat/"
+                pom {
+                    name = moduleProp.Name
+                    description = moduleProp.Description
+                    url = 'https://omegat.org'
+                    scm {
+                        connection = "scm:git:https://github.com/omegat-org/omegat"
+                        developerConnection = "scm:git:https://github.com/omegat-org/omegat"
+                        url = "https://sourceforge.net/p/omegat/"
+                    }
+                    licenses {
+                        license {
+                            name = 'The GNU General Public License, Version 3.0'
+                            url = 'https://www.gnu.org/licenses/licenses/gpl-3.0.html'
                         }
-                        licenses {
-                            license {
-                                name = 'The GNU General Public License, Version 3.0'
-                                url = 'https://www.gnu.org/licenses/licenses/gpl-3.0.html'
-                            }
-                        }
-                        developers {
-                            developer {
-                                id = 'omegat'
-                                name = 'OmegaT Developers'
-                                email = 'info@omegat.org'
-                            }
+                    }
+                    developers {
+                        developer {
+                            id = 'omegat'
+                            name = 'OmegaT Developers'
+                            email = 'info@omegat.org'
                         }
                     }
                 }

--- a/language-modules/ar/build.gradle
+++ b/language-modules/ar/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testRuntimeOnly(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ast/build.gradle
+++ b/language-modules/ast/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/be/build.gradle
+++ b/language-modules/be/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/br/build.gradle
+++ b/language-modules/br/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ca/build.gradle
+++ b/language-modules/ca/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testRuntimeOnly(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/da/build.gradle
+++ b/language-modules/da/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testRuntimeOnly(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/de/build.gradle
+++ b/language-modules/de/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/el/build.gradle
+++ b/language-modules/el/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/en/build.gradle
+++ b/language-modules/en/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/eo/build.gradle
+++ b/language-modules/eo/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/es/build.gradle
+++ b/language-modules/es/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/fa/build.gradle
+++ b/language-modules/fa/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/fr/build.gradle
+++ b/language-modules/fr/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ga/build.gradle
+++ b/language-modules/ga/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/gl/build.gradle
+++ b/language-modules/gl/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/it/build.gradle
+++ b/language-modules/it/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation(libs.commons.io)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     useJUnit()

--- a/language-modules/km/build.gradle
+++ b/language-modules/km/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/nl/build.gradle
+++ b/language-modules/nl/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/pl/build.gradle
+++ b/language-modules/pl/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/pt/build.gradle
+++ b/language-modules/pt/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ro/build.gradle
+++ b/language-modules/ro/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ru/build.gradle
+++ b/language-modules/ru/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/sk/build.gradle
+++ b/language-modules/sk/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/sl/build.gradle
+++ b/language-modules/sl/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/sv/build.gradle
+++ b/language-modules/sv/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/ta/build.gradle
+++ b/language-modules/ta/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/tl/build.gradle
+++ b/language-modules/tl/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:morfologik")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/uk/build.gradle
+++ b/language-modules/uk/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":spellchecker:hunspell")
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn tasks.withType(Jar)

--- a/language-modules/zh/build.gradle
+++ b/language-modules/zh/build.gradle
@@ -24,3 +24,4 @@ dependencies {
     testRuntimeOnly(libs.protobuf)
     testImplementation(libs.commons.io)
 }
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/apertium/build.gradle
+++ b/machinetranslators/apertium/build.gradle
@@ -24,3 +24,4 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/belazar/build.gradle
+++ b/machinetranslators/belazar/build.gradle
@@ -23,3 +23,4 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/google/build.gradle
+++ b/machinetranslators/google/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 

--- a/machinetranslators/ibmwatson/build.gradle
+++ b/machinetranslators/ibmwatson/build.gradle
@@ -24,3 +24,4 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/mymemory/build.gradle
+++ b/machinetranslators/mymemory/build.gradle
@@ -24,3 +24,4 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/machinetranslators/yandex/build.gradle
+++ b/machinetranslators/yandex/build.gradle
@@ -25,3 +25,4 @@ dependencies {
     testImplementation(libs.jackson.databind)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(libs.languagetool.de)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn project(':language-modules:de').tasks.withType(Jar)

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testRuntimeOnly(libs.languagetool.en)
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))
 
 test {
     dependsOn project(':language-modules:en').tasks.withType(Jar)

--- a/theme/build.gradle
+++ b/theme/build.gradle
@@ -13,3 +13,5 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
 }
+
+makeModuleTask(loadProperties(file('plugin.properties')))

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -19,3 +19,4 @@ dependencies {
     }
 }
 
+makeModuleTask(loadProperties(file('plugin.properties')))


### PR DESCRIPTION
This reverts commit 13832bb59bf89f039ed318f14626d502cca74c56 in the PR #1628 

It is problematic in IDE loading of the project.

## Pull request type

- Build and release changes -> [build/release]
## What does this PR change?

- Revert the change in previous merge.
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
