### PR TITLE
refactor(util): use try-with-resources to safely manage resource bundle loading

### DIFF
--- a/src/org/omegat/util/OStrings.java
+++ b/src/org/omegat/util/OStrings.java
@@ -99,12 +99,10 @@ public final class OStrings {
      */
     public static void loadBundle(String filename) {
         boolean loaded = false;
-        try {
-            // Load the resource bundle
-            FileInputStream in = new FileInputStream(filename);
+        // Load the resource bundle
+        try (FileInputStream in = new FileInputStream(filename)) {
             bundle = new PropertyResourceBundle(in);
             loaded = true;
-            in.close();
         } catch (FileNotFoundException exception) {
             System.err.println("Resource bundle file not found: " + filename);
         } catch (IOException exception) {


### PR DESCRIPTION

The PR refactors the method loadBundle in the OStrings class to use a try-with-resources statement for better handling of resource management and to eliminate the redundant manual closing of the FileInputStream.

## Pull request type

- Bug fix



## What does this PR change?

- Replaced the traditional try-finally block with a try-with-resources statement to ensure the FileInputStream resource is properly and automatically closed.
-  Removed the explicit in.close() call, simplifying the code and making it less error-prone.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
