### PR TITLE
refactor(test): centralize `LocaleRule` setup in `TestCoreGUI`

### DIFF
--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -45,7 +45,6 @@ import org.junit.Test;
 
 import org.omegat.gui.main.TestCoreGUI;
 import org.omegat.util.Language;
-import org.omegat.util.LocaleRule;
 
 import static org.junit.Assert.assertNotNull;
 

--- a/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
+++ b/test-acceptance/src/org/omegat/gui/align/AlignerWindowTest.java
@@ -28,7 +28,6 @@ package org.omegat.gui.align;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -42,7 +41,6 @@ import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.timing.Timeout;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.gui.main.TestCoreGUI;
@@ -58,9 +56,6 @@ public class AlignerWindowTest extends TestCoreGUI {
     private static final String PROJECT_PATH = "test-acceptance/data/project/";
     private static final String SOURCE_PATH = "source/parseSource.txt";
     private static final String TARGET_PATH = "target/parseTarget.txt";
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     // the test case is flaky.
     @Test

--- a/test-acceptance/src/org/omegat/gui/dialogs/AboutDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/AboutDialogTest.java
@@ -28,21 +28,15 @@ package org.omegat.gui.dialogs;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Locale;
 import java.util.regex.Pattern;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.gui.main.BaseMainWindowMenu;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
 public class AboutDialogTest extends TestCoreGUI {
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testAboutDialog() {

--- a/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ConflictDialogTest.java
@@ -25,15 +25,12 @@
 
 package org.omegat.gui.dialogs;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import java.io.IOException;
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -43,9 +40,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ConflictDialogTest extends TestCoreGUI {
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testConflictDialogLocal() throws IOException {

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -31,7 +31,6 @@ import org.omegat.gui.main.TestCoreGUI;
 import org.omegat.tokenizer.LuceneEnglishTokenizer;
 import org.omegat.tokenizer.LuceneFrenchTokenizer;
 import org.omegat.util.Language;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 import org.openide.awt.Mnemonics;
 

--- a/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/test-acceptance/src/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -25,7 +25,6 @@
 package org.omegat.gui.dialogs;
 
 import org.assertj.swing.core.GenericTypeMatcher;
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.BaseMainWindowMenu;
 import org.omegat.gui.main.TestCoreGUI;
@@ -39,16 +38,12 @@ import org.openide.awt.Mnemonics;
 import javax.swing.JButton;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 
 import static org.junit.Assert.assertNotNull;
 
 public class ProjectPropertiesDialogTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testProjectPropertiesDialogShowAndOk() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextAreaIntroTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextAreaIntroTest.java
@@ -24,21 +24,14 @@
  **************************************************************************/
 package org.omegat.gui.editor;
 
-import java.util.Locale;
-
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
 import static org.junit.Assert.assertNotNull;
 
 public class EditorTextAreaIntroTest extends TestCoreGUI {
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testIntroPaneExist() {

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
@@ -24,13 +24,11 @@
  **************************************************************************/
 package org.omegat.gui.editor;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.Preferences;
 
 import javax.swing.text.BadLocationException;
@@ -41,7 +39,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -60,9 +57,6 @@ public class EditorTextLoadedTest extends TestCoreGUI {
     private final List<SourceTextEntry> selectedEntries = new ArrayList<>();
     private final CountDownLatch initialLoadLatch = new CountDownLatch(1);
     private final CountDownLatch selectionChangeLatch = new CountDownLatch(2);
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testEditorTextLoaded() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
@@ -42,7 +42,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 
 /**
  * @author Hiroshi Miura
@@ -54,9 +53,6 @@ public final class EditorUtilsGUITest {
     }
 
     public static class EditorUtilsFirstStepsTest extends TestCoreGUI {
-
-        @Rule
-        public final LocaleRule localeRule = new LocaleRule(Locale.ENGLISH);
 
         @Test
         public void testEditorUtilsGetWordFirstSteps() throws BadLocationException {
@@ -73,9 +69,6 @@ public final class EditorUtilsGUITest {
     }
 
     public static class EditorUtilsLoadedProjectTest extends TestCoreGUI {
-
-        @Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
         @Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();

--- a/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/glossary/GlossaryTextTest.java
@@ -25,23 +25,17 @@
 
 package org.omegat.gui.glossary;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 
 import static org.junit.Assert.assertNotNull;
 
 public class GlossaryTextTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testGlossarySearch() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +48,8 @@ import org.assertj.swing.image.ScreenshotTaker;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.omegat.TestMainInitializer;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
@@ -61,6 +64,7 @@ import org.omegat.gui.dictionaries.DictionariesTextArea;
 import org.omegat.gui.glossary.GlossaryTextArea;
 import org.omegat.gui.matches.MatchesTextArea;
 import org.omegat.gui.properties.SegmentPropertiesArea;
+import org.omegat.util.LocaleRule;
 import org.omegat.util.Preferences;
 import org.omegat.util.RuntimePreferences;
 import org.omegat.util.gui.UIDesignManager;
@@ -217,6 +221,7 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
         TestCoreState.resetState();
         initialize();
         mainWindow = GuiActionRunner.execute(() -> {
+            UIDesignManager.initialize();
             TestMainWindow mw = new TestMainWindow(TestMainWindowMenuHandler.class);
             TestCoreInitializer.initMainWindow(mw);
             CoreEvents.fireApplicationStartup();
@@ -253,7 +258,6 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
         Preferences.initFilters();
         Preferences.initSegmentation();
         // should be called after Preferences.init
-        UIDesignManager.initialize();
         TestCoreState.getInstance().setProject(new NotLoadedProject());
         TestCoreState.initAutoSave(autoSave);
     }
@@ -308,4 +312,15 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
         Files.deleteIfExists(image);
         screenShotTaker.saveDesktopAsPng(image.toString());
     }
+
+    @BeforeClass
+    public static void beforeClass() {
+        LocaleRule.applyLocaleForClass(new Locale("en"));
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        LocaleRule.restoreLocaleForClass(Locale.getDefault());
+    }
+
 }

--- a/test-acceptance/src/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
@@ -26,17 +26,14 @@
 package org.omegat.gui.matches;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -45,9 +42,6 @@ import static org.junit.Assert.assertTrue;
 public class FuzzyMatchesSegmentsTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project_fuzzy/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testFuzzyMatchesSubsegments() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextExternalTmTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextExternalTmTest.java
@@ -26,16 +26,13 @@
 package org.omegat.gui.matches;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertNotNull;
@@ -43,9 +40,6 @@ import static org.junit.Assert.assertNotNull;
 public class MatchesTextExternalTmTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project_external_tm/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testFuzzyMatches() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
+++ b/test-acceptance/src/org/omegat/gui/matches/MatchesTextTest.java
@@ -28,15 +28,12 @@ package org.omegat.gui.matches;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
 
 import static org.junit.Assert.assertNotNull;
@@ -44,9 +41,6 @@ import static org.junit.Assert.assertNotNull;
 public class MatchesTextTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testFuzzyMatches() throws Exception {

--- a/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
+++ b/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
@@ -26,10 +26,8 @@ package org.omegat.gui.properties;
 
 import org.assertj.swing.data.TableCell;
 import org.assertj.swing.fixture.JTableFixture;
-import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.LocaleRule;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,9 +43,6 @@ import static org.junit.Assert.assertNotNull;
 public class SegmentPropertiesAreaTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
-
-    @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
 
     @Test
     public void testSegmentPropertiesPaneExist() throws Exception {

--- a/test/fixtures/org/omegat/util/LocaleRule.java
+++ b/test/fixtures/org/omegat/util/LocaleRule.java
@@ -65,4 +65,26 @@ public class LocaleRule implements TestRule {
             }
         };
     }
+
+    /**
+     * Apply locale rule for class initialization.
+     * This method should be called in @BeforeClass methods.
+     *
+     * @param locale the locale to set
+     */
+    public static void applyLocaleForClass(@NotNull Locale locale) {
+        Locale.setDefault(locale);
+        OStrings.loadBundle(locale);
+    }
+
+    /**
+     * Restore original locale for class teardown.
+     * This method should be called in @AfterClass methods.
+     *
+     * @param originalLocale the original locale to restore
+     */
+    public static void restoreLocaleForClass(@NotNull Locale originalLocale) {
+        Locale.setDefault(originalLocale);
+        OStrings.loadBundle(originalLocale);
+    }
 }


### PR DESCRIPTION
This Pull Request removes the use of the LocaleRule from unit tests. Instead, methods to set and restore the locale at the class level (applyLocaleForClass and restoreLocaleForClass) were introduced in LocaleRule.java. Relevant adjustments have been made in TestCoreGUI to integrate these new methods.


## Pull request type
- refactor

## What does this PR change?

- Removed @Rule annotations and LocaleRule instances from individual test files.
- Added applyLocaleForClass and restoreLocaleForClass methods in LocaleRule.java to manage locale setup and restoration at the class level.
- Integrated the applyLocaleForClass and restoreLocaleForClass methods into TestCoreGUI with @BeforeClass and @AfterClass annotations.
- move calls to UIDesignManager.initialize in Swing thread

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
