### PR TITLE
refactor(test): stabilize and modularize CalcMatchStatisticsTest

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -51,7 +51,7 @@
 
     <!-- interfaces -->
     <!-- Keep names for compatibility -->
-    <suppress files="(IParseCallback|CalcMatchStatisticsTest)\.java" checks="ParameterNumber"/>
+    <suppress files="(IParseCallback|TestingParseCallback)\.java" checks="ParameterNumber"/>
     <suppress checks="TypeName" files="IProjectEventListener\.java" lines="35"/>
 
     <!-- ignore Auto generated source files -->

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -43,7 +43,6 @@ import java.util.TimeZone;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import org.omegat.util.OStrings;
@@ -254,9 +255,9 @@ public class StatsResult {
     public String getXmlData() throws JsonProcessingException {
         setDate();
         XmlMapper xmlMapper = XmlMapper.builder()
-                .configure(MapperFeature.USE_ANNOTATIONS, true)
+                .addModule(new JakartaXmlBindAnnotationModule())
                 .configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
-                .configure(SerializationFeature.INDENT_OUTPUT, true)
+                .enable(SerializationFeature.INDENT_OUTPUT)
                 .defaultUseWrapper(false).build();
         return xmlMapper.writeValueAsString(this);
 

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -43,12 +43,12 @@ import java.util.TimeZone;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import org.omegat.util.OStrings;
@@ -106,9 +106,6 @@ public class StatsResult {
 
     @JsonProperty("date")
     private String date;
-
-    public StatsResult() {
-    }
 
     public StatsResult(String projectName, String projectRoot, String sourceLanguage, String targetLanguage,
             String sourceRoot) {
@@ -256,12 +253,11 @@ public class StatsResult {
     @JsonIgnore
     public String getXmlData() throws JsonProcessingException {
         setDate();
-        XmlMapper xmlMapper = new XmlMapper();
-        xmlMapper.registerModule(new JakartaXmlBindAnnotationModule());
-        xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        xmlMapper.enable(SerializationFeature.INDENT_OUTPUT);
-        xmlMapper.setDefaultUseWrapper(false);
-
+        XmlMapper xmlMapper = XmlMapper.builder()
+                .configure(MapperFeature.USE_ANNOTATIONS, true)
+                .configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
+                .configure(SerializationFeature.INDENT_OUTPUT, true)
+                .defaultUseWrapper(false).build();
         return xmlMapper.writeValueAsString(this);
 
     }

--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -68,7 +68,7 @@ public class CalcMatchStatisticsTest {
         CalcMatchStatistics calcMatchStatistics = new CalcMatchStatistics(project, segmenter, testingStatsConsumer, false);
         calcMatchStatistics.start();
         try {
-            assertTrue(latch.await(1, TimeUnit.SECONDS));
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
         } catch (InterruptedException ignored) {
         }
         try {

--- a/test/src/org/omegat/core/statistics/FindMatchesTest.java
+++ b/test/src/org/omegat/core/statistics/FindMatchesTest.java
@@ -91,7 +91,7 @@ public class FindMatchesTest {
      * There are three tmx entries for each sentence.
      */
     @Test
-    public void testSegmented() throws Exception {
+    public void testSegmented() {
         ProjectProperties prop = new ProjectProperties(tmpDir.toFile());
         prop.setSourceLanguage("en");
         prop.setTargetLanguage("ca");
@@ -130,7 +130,7 @@ public class FindMatchesTest {
         List<String> segments = segmenter.segment(prop.getSourceLanguage(), srcText, spaces, brules);
         assertEquals(3, segments.size());
         finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
-        result = finder.search(srcText, false, iStopped);
+        result = finder.search(srcText, false, iStopped, true);
         assertEquals(OConsts.MAX_NEAR_STRINGS, result.size());
         assertEquals("Hit segmented tmx records", 100, result.get(0).scores[0].score);
         assertEquals(100, result.get(0).scores[0].scoreNoStem);
@@ -172,7 +172,7 @@ public class FindMatchesTest {
                 new DefaultTokenizer(), segmenter);
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
-        List<NearString> result = finder.search("XXX", false, iStopped);
+        List<NearString> result = finder.search("XXX", false, iStopped, true);
         // Without the fix, the result has two entries, but it should one.
         assertEquals(1, result.size());
         assertEquals("XXX", result.get(0).source);
@@ -211,7 +211,7 @@ public class FindMatchesTest {
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
         // Search source "XXx" in en-US
-        List<NearString> result = finder.search("XXX", false, iStopped);
+        List<NearString> result = finder.search("XXX", false, iStopped, true);
         // There should be three entries.
         assertEquals(3, result.size());
         assertEquals("XXx", result.get(0).source); // should be en-US.
@@ -239,7 +239,7 @@ public class FindMatchesTest {
         assertEquals(2, segments.size());
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
-        List<NearString> result = finder.search(srcText, false, iStopped);
+        List<NearString> result = finder.search(srcText, false, iStopped, true);
         assertEquals(srcText, result.get(0).source);
         assertEquals(2, result.size());
         // match normal
@@ -270,7 +270,7 @@ public class FindMatchesTest {
         String srcText = ste.getSrcText();
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
-        List<NearString> result = finder.search(srcText, false, iStopped);
+        List<NearString> result = finder.search(srcText, false, iStopped, true);
         assertEquals(1, result.size());
         assertEquals(srcText, result.get(0).source);
         int foreignPenalty = Preferences.PENALTY_FOR_FOREIGN_MATCHES_DEFAULT;
@@ -293,7 +293,7 @@ public class FindMatchesTest {
                 + "Wow! "
                 + "Thanks for expanding the diversity of our community with new members!";
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
-        List<NearString> result = finder.search(srcText, false, iStopped);
+        List<NearString> result = finder.search(srcText, false, iStopped, true);
         assertEquals(2, result.size());
         assertEquals("Hit with segmented tmx record", 35, result.get(0).scores[0].score);
         assertEquals(35, result.get(0).scores[0].score);
@@ -318,7 +318,7 @@ public class FindMatchesTest {
                 new DefaultTokenizer(), segmenter);
         IStopped iStopped = () -> false;
         FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, true, 85);
-        List<NearString> result = finder.search("Other", false, iStopped);
+        List<NearString> result = finder.search("Other", false, iStopped, false);
         assertEquals(3, result.size());
         assertEquals("Other", result.get(0).source);
         assertEquals("Altre", result.get(0).translation); // default

--- a/test/src/org/omegat/core/statistics/TestingParseCallback.java
+++ b/test/src/org/omegat/core/statistics/TestingParseCallback.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023-2025 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package org.omegat.core.statistics;
+
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.filters2.IFilter;
+import org.omegat.filters2.IParseCallback;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestingParseCallback implements IParseCallback {
+
+    private final List<SourceTextEntry> steList;
+
+    public TestingParseCallback(final List<SourceTextEntry> ste) {
+        this.steList = ste;
+    }
+
+    @Override
+    public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
+                                       String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
+        SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path), 1,
+                props, translation, protectedParts);
+        ste.setSourceTranslationFuzzy(isFuzzy);
+        steList.add(ste);
+    }
+
+    @Override
+    public void addEntry(String id, String source, String translation, boolean isFuzzy, String comment,
+                         String path, IFilter filter, List<ProtectedPart> protectedParts) {
+        List<String> propList = new ArrayList<>(2);
+        if (comment != null) {
+            propList.add("comment");
+            propList.add(comment);
+        }
+        String[] props = propList.toArray(new String[0]);
+        addEntryWithProperties(id, source, translation, isFuzzy, props, path, filter, protectedParts);
+    }
+
+    @Override
+    public void linkPrevNextSegments() {
+        // do nothing
+    }
+}

--- a/test/src/org/omegat/core/statistics/TestingProject.java
+++ b/test/src/org/omegat/core/statistics/TestingProject.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023-2025 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package org.omegat.core.statistics;
+
+import org.omegat.core.data.ExternalTMFactory;
+import org.omegat.core.data.ExternalTMX;
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.IFilter;
+import org.omegat.filters2.IParseCallback;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.po.PoFilter;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.Language;
+import org.omegat.util.Log;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class TestingProject extends NotLoadedProject implements IProject {
+    private final ProjectProperties prop;
+
+    private final ProjectTMX projectTMX;
+    private Map<String, ExternalTMX> transMemories;
+    private final Segmenter segmenter;
+    private final FilterMaster filterMaster;
+
+    public TestingProject(Path tmpDir) {
+        super();
+        prop = new TestingProjectProperties(tmpDir);
+        filterMaster = new FilterMaster(FilterMaster.createDefaultFiltersConfig());
+        segmenter = new Segmenter(SRX.getDefault());
+        projectTMX = new ProjectTMX(new Language("en"), new Language("ca"), true,
+                Paths.get("test/data/tmx/empty.tmx").toFile(), null, segmenter);
+    }
+
+    @Override
+    public ProjectProperties getProjectProperties() {
+        return prop;
+    }
+
+    @Override
+    public TMXEntry getTranslationInfo(SourceTextEntry ste) {
+        if (projectTMX == null) {
+            return EMPTY_TRANSLATION;
+        }
+        TMXEntry r = projectTMX.getMultipleTranslation(ste.getKey());
+        if (r == null) {
+            r = projectTMX.getDefaultTranslation(ste.getSrcText());
+        }
+        if (r == null) {
+            r = EMPTY_TRANSLATION;
+        }
+        return r;
+    }
+
+    @Override
+    public List<SourceTextEntry> getAllEntries() {
+        List<SourceTextEntry> ste = new ArrayList<>();
+        IFilter filter = new PoFilter();
+        Path testSource = Paths.get("test/data/filters/po/file-POFilter-match-stat-en-ca.po");
+        IParseCallback testCallback = new TestingParseCallback(ste);
+        FilterContext context = new FilterContext(new Language("en"), new Language("ca"), true);
+        try {
+            filter.parseFile(testSource.toFile(), Collections.emptyMap(), context, testCallback);
+        } catch (Exception e) {
+            Log.log(e);
+        }
+        return ste;
+    }
+
+    @Override
+    public ITokenizer getSourceTokenizer() {
+        return new LuceneEnglishTokenizer();
+    }
+
+    @Override
+    public ITokenizer getTargetTokenizer() {
+        return new DefaultTokenizer();
+    }
+
+    @Override
+    public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public AllTranslations getAllTranslations(SourceTextEntry ste) {
+        TestingAllTranslations r = new TestingAllTranslations();
+        synchronized (projectTMX) {
+            r.setDefaultTranslation(projectTMX.getDefaultTranslation(ste.getSrcText()));
+            r.setAlternativeTranslation(projectTMX.getMultipleTranslation(ste.getKey()));
+            if (r.getAlternativeTranslation() != null) {
+                r.setCurrentTranslation(r.getAlternativeTranslation());
+            } else if (r.getDefaultTranslation() != null) {
+                r.setCurrentTranslation(r.getDefaultTranslation());
+            } else {
+                r.setCurrentTranslation(EMPTY_TRANSLATION);
+            }
+            if (r.getDefaultTranslation() == null) {
+                r.setDefaultTranslation(EMPTY_TRANSLATION);
+            }
+            if (r.getAlternativeTranslation() == null) {
+                r.setAlternativeTranslation(EMPTY_TRANSLATION);
+            }
+        }
+        return r;
+    }
+
+    @Override
+    public Map<String, ExternalTMX> getTransMemories() {
+        synchronized (projectTMX) {
+            if (transMemories == null) {
+                transMemories = new TreeMap<>();
+                try {
+                    ExternalTMX newTMX;
+                    Path testTmx = Paths.get("test/data/tmx/test-match-stat-en-ca.tmx");
+                    newTMX = ExternalTMFactory.load(testTmx.toFile(), prop, segmenter, filterMaster);
+                    transMemories.put(testTmx.toString(), newTMX);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(transMemories);
+    }
+
+    protected static class TestingProjectProperties extends ProjectProperties {
+        TestingProjectProperties(Path tmpDir) {
+            super();
+            setSourceLanguage(new Language("en"));
+            setSourceTokenizer(LuceneEnglishTokenizer.class);
+            setSentenceSegmentingEnabled(false);
+            setTargetLanguage(new Language("ca"));
+            setTargetTokenizer(DefaultTokenizer.class);
+            setProjectRoot(tmpDir.toString());
+        }
+    }
+
+    public static class TestingAllTranslations extends IProject.AllTranslations {
+        public void setAlternativeTranslation(TMXEntry entry) {
+            alternativeTranslation = entry;
+        }
+
+        public void setDefaultTranslation(TMXEntry entry) {
+            defaultTranslation = entry;
+        }
+
+        public void setCurrentTranslation(TMXEntry entry) {
+            currentTranslation = entry;
+        }
+    }
+
+}

--- a/test/src/org/omegat/core/statistics/TestingStatsConsumer.java
+++ b/test/src/org/omegat/core/statistics/TestingStatsConsumer.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2023-2025 Hiroshi Miura
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package org.omegat.core.statistics;
+
+import java.util.concurrent.CountDownLatch;
+
+public class TestingStatsConsumer implements IStatsConsumer {
+    private String[][] result;
+    private final CountDownLatch latch;
+
+    public TestingStatsConsumer(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    public String[][] getTable() {
+        return result;
+    }
+
+    @Override
+    public void appendTextData(final String result) {
+        // do nothing
+    }
+
+    @Override
+    public void appendTable(final String title, final String[] headers, final String[][] data) {
+        // do nothing
+    }
+
+    @Override
+    public void setTextData(final String data) {
+        // do nothing
+    }
+
+    @Override
+    public void setTable(final String[] headers, final String[][] data) {
+        result = data;
+    }
+
+    @Override
+    public void setDataFile(final String path) {
+        // do nothing
+    }
+
+    @Override
+    public void finishData() {
+        latch.countDown();
+    }
+
+    @Override
+    public void showProgress(final int percent) {
+        // do nothing
+    }
+}


### PR DESCRIPTION
`CalcMatchStatisticsTest` is flaky now and many duplications in the code.
This PR eliminate to streamline the test code and improve stability of the test.

## Pull request type

- refactor


## What does this PR change?

- Refactor internal classes of `CalcMatchStasticsTest` to raise upper package. 
- Use `Testing *` class name for implementation of the interface for test.
- Use latch for synchronize threading of the statistics calculation.
- Update `Statistics#writeStat` methods with NIO2 functions for robustness of IO operations

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
