### PR TITLE
chore(gradle): fix distribution task to place OmegaT.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -381,6 +381,7 @@ distributions {
             }
             eachFile {
                 // Move main JAR up one level from lib.
+                def omegatJarFilename = project.property('org.omegat.omegatJarFilename')
                 if (it.name == omegatJarFilename) {
                     it.relativePath = it.relativePath.parent.parent.append(true, omegatJarFilename)
                 }


### PR DESCRIPTION
- Fix distribution task to move OmegaT.jar to dist folder root
- Fix the degraded tasks by PR#1632

## Pull request type

- Build and release changes -> [build/release]
- Fix the gradle task bug that caused the failure of weekly release

## What does this PR change?

- Update build.gradle to use `project.property('org.omegat.omegatJarFilename')` instead of direct reference of the property 'omegatJarFilename'
- Here is a missing part when PR#1632 updated

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
