### PR TITLE
fix(core): clear `projectTMX` before loading new TMX file

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -1225,6 +1225,7 @@ public class RealProject implements IProject {
         try {
             Core.getMainWindow().showStatusMessageRB("CT_LOAD_TMX");
             synchronized (projectTMX) {
+                projectTMX.clear();
                 projectTMX.load(config.getSourceLanguage(), config.getTargetLanguage(),
                         config.isSentenceSegmentingEnabled(), file, Core.getSegmenter());
             }


### PR DESCRIPTION
Fix a potential issue and reflect review comment in dev-ML.

## Pull request type

- Bug fix -> [bug]

## What does this PR change?

- insert `projectTMX.clear()` before `projectTMX#load`

## Other information
https://sourceforge.net/p/omegat/mailman/message/59208342/

This change should be #1564, but it is in #1566, it is a mistake when my making PRs. 