### PR TITLE
refactor(core): modularize `RealProject` initialization and orphaned check logic

### DIFF
--- a/test/src/org/omegat/filters/TestFilterBase.java
+++ b/test/src/org/omegat/filters/TestFilterBase.java
@@ -36,11 +36,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -576,12 +573,7 @@ public abstract class TestFilterBase extends TestCore {
                 throws Exception {
             Core.setProject(this);
 
-            Set<String> existSource = new HashSet<String>();
-            Set<EntryKey> existKeys = new HashSet<EntryKey>();
-            Map<String, ExternalTMX> transMemories = new HashMap<>();
-
-            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(existSource, existKeys,
-                    transMemories);
+            LoadFilesCallback loadFilesCallback = new LoadFilesCallback(this, config);
 
             TestFileInfo fi = new TestFileInfo();
             fi.filePath = file;
@@ -592,8 +584,8 @@ public abstract class TestFilterBase extends TestCore {
 
             loadFilesCallback.fileFinished();
 
-            if (!transMemories.isEmpty()) {
-                fi.referenceEntries = transMemories.values().iterator().next();
+            if (!getTransMemories().isEmpty()) {
+                fi.referenceEntries = getTransMemories().values().iterator().next();
             }
 
             return fi;


### PR DESCRIPTION
This PR refactors and enhances the `RealProject` class by introducing a cleaner and more modular design. It replaces the use of existing orphan-checking mechanisms and associated responsibilities with an updated `LoadFilesCallback` class, updates various synchronization points, and adjusts class member visibility for improved testing support and maintainability.


## Pull request type

- Other (describe below)
reafactor

## What does this PR change?

- Update a `LoadFilesCallback` class for handling callback-related functions such as tracking orphaned entries and managing external TM entries. With this change, collections of entries are encapsulated into the single class and the class has a responsible to handle data.
- Refactored `checkOrphanedCallback` functionality into `LoadFilesCallback` to reduce redundancy and promote encapsulation.
 
- Added a new constructor annotated with @VisibleForTesting to facilitate testing scenarios.
- Made the `sourceTokenizer` and `targetTokenizer` modifiable and refactored their initialization into a dedicated method, `initializeTokenizer` for reusable modular method.
- Adjusted synchronization logic, replacing some synchronized blocks for better clarity and granularity.

- Removed unused fields (`existSource` and `existKeys`) from `RealProject` and relocated the logic to `LoadFilesCallback`.
- Enhanced glossary functionality by ensuring a null-safe check for accessing `remoteRepositoryProvider`.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
