### PR TITLE
fix(core): [BUGS#909] update editor title to indicate loading state

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1930,6 +1930,7 @@ GUI_COMMENTSWINDOW_SETTINGS_NOTIFICATIONS=Notify Me When a Segment Has Comments
 
 # 0 - filename
 GUI_SUBWINDOWTITLE_Editor=Editor - {0}
+GUI_SUBWINDOWTITLE_Editor_Loading=Editor - LOADING NOW...
 
 DOCKING_HINT_DOCK=Dock
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -491,9 +491,7 @@ public class EditorController implements IEditor {
             updatedTitle = emptyProjectPaneTitle;
             break;
         case FIRST_ENTRY:
-            displayedFileIndex = 0;
-            displayedEntryIndex = 0;
-            updatedTitle = OStrings.getString("GUI_SUBWINDOWTITLE_Editor", getCurrentFile());
+            updatedTitle = OStrings.getString("GUI_SUBWINDOWTITLE_Editor_Loading");
             data = editor;
             SwingUtilities.invokeLater(() -> {
                 // need to run later because some other event listeners

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
@@ -29,7 +29,6 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.gui.main.TestCoreGUI;
-import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 
 import javax.swing.text.BadLocationException;

--- a/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorTextLoadedTest.java
@@ -29,6 +29,7 @@ import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IEntryEventListener;
 import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 
 import javax.swing.text.BadLocationException;
@@ -44,12 +45,13 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class EditorTextLoadedTest extends TestCoreGUI {
 
     private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
 
-    private static final int TIMEOUT_SECONDS = 10;
+    private static final int TIMEOUT_SECONDS = 15;
     private static final String INITIAL_TEXT = "Error {0}: {1}";
     private static final String TARGET_TEXT = "API key (optional)";
     private static final String EDITOR_TITLE = "Editor - Bundle.properties";
@@ -63,22 +65,22 @@ public class EditorTextLoadedTest extends TestCoreGUI {
         CoreEvents.registerEntryEventListener(new EditorEntryListener(selectedEntries, initialLoadLatch,
                 selectionChangeLatch));
         openSampleProject(PROJECT_PATH);
-        awaitLatch(initialLoadLatch);
+        awaitLatch("Wait inital loading", initialLoadLatch);
         verifyInitialTextSelection();
         Point clickPoint = calculateTargetPoint();
         assertNotNull(window);
         JTextComponent editPane = window.panel(EDITOR_TITLE).textBox().target();
         robot().click(editPane, clickPoint);
-        awaitLatch(selectionChangeLatch);
+        awaitLatch("Wait entry selection", selectionChangeLatch);
         SourceTextEntry newEntry = selectedEntries.get(selectedEntries.size() - 1);
         assertEquals(TARGET_TEXT, newEntry.getSrcText());
     }
 
-    private void awaitLatch(CountDownLatch latch) {
+    private void awaitLatch(String message, CountDownLatch latch) {
         try {
-            latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (InterruptedException ignored) {
-            // ignore timeout
+            assertTrue(message, latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        } catch (InterruptedException ex) {
+            Log.log(ex, message);
         }
     }
 


### PR DESCRIPTION
Update editor title to be special when first time loading to fix the BUGS#909.


## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?


- Wrong file name in the editor pane
- https://sourceforge.net/p/omegat/bugs/909/
## What does this PR change?

- Added a new string resource GUI_SUBWINDOWTITLE_Editor_Loading to Bundle.properties for displaying a user-friendly loading message.
- Updated the editor title handling logic in EditorController.java to use the new string resource. 
- Removing updating of the entry number variables and call for `getCurrentFile`. This causes a selection change in the source file list dialog.
- Update acceptance test timeout to increase 15 seconds from 10.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
