### PR TITLE
Clean character attributes in notes pane before update

### DIFF
--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -223,6 +223,7 @@ public final class JTextPaneLinkifier {
                 // URL detection
                 URLCodec codec = new URLCodec("UTF-8");
                 UrlValidator urlValidator = new UrlValidator();
+                doc.setCharacterAttributes(0, doc.getLength(), new SimpleAttributeSet(), true);
                 for (Pattern pattern : urlPatterns) {
                     int shift = 0;
                     final String text = doc.getText(0, doc.getLength());


### PR DESCRIPTION

## Pull request type


- Bug fix -> [bug]

## Which ticket is resolved?

- Notes and Glossary panes keep HTML link styling
- https://sourceforge.net/p/omegat/bugs/1252/

## What does this PR change?

- Clear all links on the pane before putting hyper links
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
