### PR TITLE
chore(spellchecker/test): avoid circular depenency

### DIFF
--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -23,8 +23,7 @@ dependencies {
     }
     testImplementation(libs.languagetool.core)
     testImplementation(libs.commons.io)
-    testImplementation(project(":language-modules:de"))
-    testImplementation(project(":language-modules:fr"))
+    testImplementation(libs.languagetool.de)
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
     testRuntimeOnly(libs.languagetool.en)
-    testRuntimeOnly(libs.languagetool.de)
 }
 
 makeModuleTask(loadProperties(file('plugin.properties')))


### PR DESCRIPTION
Solve the circular dependency problem (  spellchecker test case dependsOn language module, language module test dependsOn spellchecker module).


## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

-  
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
