### PR TITLE
fix(filter): `MozillaDTDFilter` field access

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -182,7 +182,6 @@
     <!-- should be fixed the writing to static field from instance -->
     <Match>
         <Or>
-            <Class name="org.omegat.filters2.mozdtd.MozillaDTDFilter"/>
             <Class name="org.omegat.gui.editor.ViewLabel"/>
             <Class name="~org\.omegat\.gui\.scripting.*"/>
             <Class name="org.omegat.util.gui.OSXIntegration"/>

--- a/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jetbrains.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -65,7 +66,7 @@ public class MozillaDTDFilter extends AbstractFilter {
 
     public static final String OPTION_REMOVE_STRINGS_UNTRANSLATED = "unremoveStringsUntranslated";
 
-    protected static final Pattern RE_ENTITY = Pattern.compile("<\\!ENTITY\\s+(\\S+)\\s+([\"'])(.+)\\2\\s*>",
+    protected static final Pattern RE_ENTITY = Pattern.compile("<!ENTITY\\s+(\\S+)\\s+([\"'])(.+)\\2\\s*>",
             Pattern.DOTALL);
 
     protected Map<String, String> align;
@@ -73,7 +74,7 @@ public class MozillaDTDFilter extends AbstractFilter {
     /**
      * If true, will remove non-translated segments in the target files
      */
-    public static boolean removeStringsUntranslated = false;
+    public boolean removeStringsUntranslated = false;
 
     /**
      * Register plugin into OmegaT.
@@ -189,8 +190,8 @@ public class MozillaDTDFilter extends AbstractFilter {
     @Override
     protected void alignFile(BufferedReader sourceFile, BufferedReader translatedFile, FilterContext fc)
             throws Exception {
-        Map<String, String> source = new HashMap<String, String>();
-        Map<String, String> translated = new HashMap<String, String>();
+        Map<String, String> source = new HashMap<>();
+        Map<String, String> translated = new HashMap<>();
 
         align = source;
         processFile(sourceFile, new NullBufferedWriter(), fc);
@@ -210,7 +211,7 @@ public class MozillaDTDFilter extends AbstractFilter {
     }
 
     @Override
-    public Map<String, String> changeOptions(Window parent, Map<String, String> config) {
+    public @Nullable Map<String, String> changeOptions(Window parent, Map<String, String> config) {
         try {
             MozillaDTDOptionsDialog dialog = new MozillaDTDOptionsDialog(parent, config);
             dialog.setVisible(true);
@@ -220,8 +221,7 @@ public class MozillaDTDFilter extends AbstractFilter {
                 return null;
             }
         } catch (Exception e) {
-            Log.log(OStrings.getString("MOZDTD_FILTER_EXCEPTION"));
-            Log.log(e);
+            Log.logErrorRB(e, "MOZDTD_FILTER_EXCEPTION");
             return null;
         }
     }


### PR DESCRIPTION
Fix a logic error that static variable was updated from an instance method

## Pull request type


- Bug fix -> [bug]
- Other (describe below)
refactor


## What does this PR change?

- Removed MozillaDTDFilter class from the SpotBugs exclusion list in exclude.xml.
- Updated the MozillaDTDFilter class:
    - Added @Nullable annotation to methods for better nullability understanding.
- Converted raw type HashMap<String, String> initialization into a diamond operator (<>) syntax for cleaner code.
- Changed the removeStringsUntranslated field from static to non-static for better encapsulation.
- Improved logging by replacing Log.log with Log.logErrorRB for better error reporting.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
