### PR TITLE
test(statistics): extend timeout in `CalcMatchStatisticsTest`

### DIFF
--- a/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/test/src/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -71,6 +71,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class CalcMatchStatisticsTest {
 
+    private static final int TIMEOUT = 15;
+
     private static Path tmpDir;
 
     /*
@@ -95,7 +97,7 @@ public class CalcMatchStatisticsTest {
         TestingStatsConsumer testingStatsConsumer = new TestingStatsConsumer(future);
         CalcMatchStatistics calcMatchStatistics = new CalcMatchStatistics(project, segmenter, testingStatsConsumer, false);
         calcMatchStatistics.start();
-        future.get(5, TimeUnit.SECONDS);
+        future.get(TIMEOUT, TimeUnit.SECONDS);
         String[][] result = testingStatsConsumer.getTable();
         assertNotNull(result);
 


### PR DESCRIPTION
This PR is to stabilize flaky test by extending timeout from 5 to 15 seconds.

## Pull request type

- Other (describe below)
refactor

## What does this PR change?

- Introduced a `TIMEOUT` constant to replace the hardcoded timeout value.
- Updated `future.get` call to use the new `TIMEOUT` for better test stability.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
