### PR TITLE
refactor(build-logic): encapsulate task properties with getter methods

### DIFF
--- a/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
@@ -4,23 +4,45 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 
 @CompileStatic
 abstract class AbstractDocumentTask  extends DefaultTask implements DocConfigurable {
 
+    private final DirectoryProperty styleDir = project.objects.directoryProperty()
+    private final DirectoryProperty docRoot = project.objects.directoryProperty()
+    private final DirectoryProperty outputRoot = project.objects.directoryProperty()
+    private final Property<LogLevel> logLevel = project.objects.property(LogLevel)
+
     @InputDirectory
-    final DirectoryProperty styleDir = project.objects.directoryProperty()
+    DirectoryProperty getStyleDir() {
+        return styleDir
+    }
 
     /**
      * Sources root for the documentation
      */
     @Internal
-    final DirectoryProperty docRoot = project.objects.directoryProperty()
+    DirectoryProperty getDocRoot() {
+        return docRoot
+    }
 
     @Internal
-    final DirectoryProperty outputRoot = project.objects.directoryProperty()
+    DirectoryProperty getOutputRoot() {
+        return outputRoot
+    }
+
+    @Internal
+    Property<LogLevel> getLogLevel() {
+        return logLevel
+    }
+
+    AbstractDocumentTask() {
+        logLevel.convention(LogLevel.INFO)
+        logLevel.set(project.gradle.startParameter.logLevel)
+    }
 
     @Override
     void configureWith(DocConfigExtension extension) {

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -18,14 +18,24 @@ import javax.xml.transform.stream.StreamResult
 @CompileStatic
 class TransformationTask extends AbstractTransformationTask {
 
+    private final Provider<RegularFile> styleSheetFile = project.objects.fileProperty()
+    private final Provider<RegularFile> outputFile = project.objects.fileProperty()
+    private final Property<RegularFile> inputFile = project.objects.fileProperty()
+
     @InputFile
-    Provider<RegularFile> styleSheetFile = project.objects.fileProperty()
+    Provider<RegularFile> getStyleSheetFile() {
+        return styleSheetFile
+    }
 
     @OutputFile
-    Provider<RegularFile> outputFile = project.objects.fileProperty()
+    Provider<RegularFile> getOutputFile() {
+        return outputFile
+    }
 
     @InputFile
-    final Property<RegularFile> inputFile = project.objects.fileProperty()
+    Property<RegularFile> getInputFile() {
+        return inputFile
+    }
 
     TransformationTask() {
     }

--- a/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
@@ -15,33 +15,57 @@ import org.gradle.api.tasks.options.Option
 @CompileStatic
 class WhcTask extends AbstractDocumentTask {
 
+    private final Provider<RegularFile> inputFile = project.objects.fileProperty()
+    private final Provider<FileTree> contentFiles = project.objects.property(FileTree)
+    private final Provider<RegularFile> tocFile = project.objects.fileProperty()
+    private final Provider<RegularFile> headerFile = project.objects.fileProperty()
+    private final Provider<Directory> outputDirectory = project.objects.directoryProperty()
+    private final ListProperty<String> parameterList = project.objects.listProperty(String)
+    private final Property<String> documentLayout = project.objects.property(String)
+    private final Property<Boolean> localJQuery = project.objects.property(Boolean)
+
     @InputFile
-    final Provider<RegularFile> inputFile = project.objects.fileProperty()
+    Provider<RegularFile> getInputFile() {
+        return inputFile
+    }
 
     @InputFiles
-    final Provider<FileTree> contentFiles = project.objects.property(FileTree)
+    Provider<FileTree> getContentFiles() {
+        return contentFiles
+    }
 
     @InputFile
-    final Provider<RegularFile> tocFile = project.objects.fileProperty()
+    Provider<RegularFile> getTocFile() {
+        return tocFile
+    }
 
     @InputFile
-    final Provider<RegularFile> headerFile = project.objects.fileProperty()
+    Provider<RegularFile> getHeaderFile() {
+        return headerFile
+    }
 
     @OutputDirectory
-    final Provider<Directory> outputDirectory = project.objects.directoryProperty()
+    Provider<Directory> getOutputDirectory() {
+        return outputDirectory
+    }
 
     @Input
     @Option
-    final ListProperty<String> parameterList = project.objects.listProperty(String)
+    ListProperty<String> getParameterList() {
+        return parameterList
+    }
 
     @Input
     @Option
-    final Property<String> documentLayout = project.objects.property(String)
+    Property<String> getDocumentLayout() {
+        return documentLayout
+    }
 
     @Input
     @Option
-    final Property<Boolean> localJQuery = project.objects.property(Boolean)
-
+    Property<Boolean> getLocalJQuery() {
+        return localJQuery
+    }
 
     @TaskAction
     void transform() {


### PR DESCRIPTION
Improve build-logic for build document. This improve a support for configuration cache feature of Gradle.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- Define properties with getter based on a best practice of Gradle
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
