### PR TITLE
chore(gradle): improve a windows-conventions to evaluate in the configuration stage for cache support

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
@@ -31,17 +31,20 @@ ext.getInnoSetupCustomMessages = {
     // Sort files to ensure English comes first, to set fallback
     fileTree(dir: 'release/win32-specific', include: 'CustomMessages*.ini')
             .sort()
-            .collect { file ->
+            .collectMany { file ->
                 def match = file.name =~ /CustomMessages_?([^\.]*).ini/
                 if (match) {
                     def capture = match.group(1)
                     def lang = capture.empty ? 'en' : capture
                     if (!blacklist.contains(lang)) {
-                        file.text.replaceAll(/(?m)^([^=]+)/) { "$lang.${it[0]}" }
+                        // This more specific regex avoids modifying comments and section headers.
+                        // It finds keys that are followed by an '=' sign and ignores lines starting with ';', '#', or '['.
+                        def newContent = file.text.replaceAll(/(?m)^(?!\s*[;\[#])([^=]+?)\s*(?==)/) { m -> "$lang.${m[1].trim()}" }
+                        return [newContent]
                     }
                 }
-            }.findAll()
-            .join(System.lineSeparator())
+                return []
+            }.join(System.lineSeparator())
 }
 
 /*

--- a/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
@@ -84,21 +84,27 @@ ext.makeWinTask = { args ->
     def fullVersion = project.version + omtVersion.beta
     def installerBasename = "OmegaT_${fullVersion}_${args.suffix}"
     def installerWinExe = base.distsDirectory.file("${installerBasename}.exe")
+    def cleanDistsTaskName = "${args.name}Clean"
     def prepDistsTaskName = "${args.name}Prep"
     def genDistsTaskName = "${args.name}Gen"
     def distsTaskName = "${args.name}"
 
+    def targetJar = layout.buildDirectory.file("innosetup/${args.name}/OmegaT.jar")
+    def originJar = layout.buildDirectory.file('libs/OmegaT.jar')
+
+    def cleanDistsTask = tasks.register(cleanDistsTaskName, Delete) {
+        delete layout.buildDirectory.file("innosetup/${args.name}/jre")
+        delete installerWinExe
+    }
+
     tasks.register(prepDistsTaskName, Sync) {
-        doFirst {
-            delete "$destinationDir/jre"
-            delete installerWinExe
-        }
         with distributions.main.contents
+        dependsOn cleanDistsTask
         destinationDir = file(layout.buildDirectory.file("innosetup/${args.name}"))
         outputs.upToDateWhen {
+            def f1 = targetJar.get().asFile
+            def f2 = originJar.get().asFile
             // detect up-to-date when OmegaT.jar exists and newer than libs/OmegaT.jar
-            def f1 = layout.buildDirectory.file("innosetup/${args.name}/OmegaT.jar").get().asFile
-            def f2 = base.libsDirectory.file('OmegaT.jar').get().asFile
             f1.exists() && f2.exists() && f1.lastModified() > f2.lastModified()
         }
         from('release/win32-specific') {
@@ -127,6 +133,9 @@ ext.makeWinTask = { args ->
         dependsOn createAllExecutables
     }
 
+    def exe = layout.projectDirectory.file('ci/iscc')
+    def iss = layout.buildDirectory.file("innosetup/${args.name}/OmegaT.iss").get().asFile
+
     tasks.register(genDistsTaskName, Exec) {
         dependsOn prepDistsTaskName
         inputs.files(
@@ -136,16 +145,9 @@ ext.makeWinTask = { args ->
         )
         // You'd think we could just set the PATH, but there be dragons here
         // https://github.com/palantir/gradle-docker/issues/162
-        def exe = exePresent('iscc') ? 'iscc' : file('ci/iscc')
-        def iss = layout.buildDirectory.file("innosetup/${args.name}/OmegaT.iss").get().asFile
         logging.captureStandardOutput LogLevel.INFO
         commandLine exe, '/Qp', iss
         outputs.file layout.buildDirectory.file("innosetup/${args.name}/${installerBasename}.exe")
-        doLast {
-            println ""
-            def f3 = layout.buildDirectory.file("innosetup/${args.name}/${installerBasename}.exe").get().asFile
-            logger.info('Built ' + f3.toString() + "(" + f3.length() + ")")
-        }
     }
 
     tasks.register(distsTaskName, Copy) {


### PR DESCRIPTION
## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Added a clean task to remove outdated distribution files before preparation.
- Refined up-to-date checks for `OmegaT.jar' with configuration phase file path evaluation.
- Adjusted task dependencies for better build flow.
- Simplified executable detection in `genDists` task.

 chore(gradle): refine Windows conventions for InnoSetup custom messages processing

- Enhanced regex to avoid capture comments in `CustomMessages*.ini`.
- Updated file content processing to ensure accurate key prefixing with language codes.
- Improve list processing to replace `collect` with `collectMany` which do `filter and map` operation in Groovy idiom.

-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
