### PR TITLE
chore(gradle): set runner JVM parameters

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,7 @@ org.omegat.developer.name=OmegaT Developers
 org.omegat.omegatJarFilename=OmegaT.jar
 org.omegat.manualLangs=ca,de,en,fr,it,ja,nl
 org.omegat.firstStepLangs=ca,co,de,en,fr,ia,it,ja,nl,pt_BR,zh_CN
+
+# JVM settings for run and test tasks
+runMaxHeapSize=1024M
+testMaxHeapSize=2048M

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,26 +1,3 @@
-## Windows code signing
-# ex.
-# pkcs11engine=/usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
-#
-## when using Certum
-# pkcs11module=/usr/lib/libcrypto3PKCS.so
-## when using Safenet e-token/Digicert
-## see https://www.digicert.com/StaticFiles/SAC_10_7_Linux_GA.zip
-# pkcs11module=/usr/lib64/libeToken.so
-#
-# winCodesignTimestampUrl=http://time.certum.pl/
-# winCodesignTimestampUrl=http://timestamp.digicert.com
-# pkcs11cert='pkcs11:type=cert'
-# winCodesignCert=/home/user/a-provided-certification.pem
-#
-# mandatory
-pkcs11module=
-winCodesignPassword=
-# optional
-pkcs11cert=
-winCodesignCert=
-winCodesignTimestampUrl=
-
 ## Mac code signing
 macCodesignIdentity=
 
@@ -28,8 +5,8 @@ macCodesignIdentity=
 macNotarizationUsername=
 
 ## Sonatype OSSRH publishing (synced to Maven Central)
-ossrhUser=
-ossrhKey=
+ossrhUsername=
+ossrhPassword=
 
 ## Signing for Maven Central
 #


### PR DESCRIPTION
This PR to set Gradle parameters of JVM heap memory for run and test tasks. An acceptance test requires more memory than Gradle default.

## Pull request type
- Build and release changes -> [build/release]

## What does this PR change?

- Update gradle.properties to add JVM parameters for run and test tasks
- Deprecate Windows signing parameters in local settings placeholders
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
