### PR TITLE
chore(gradle): remove unused exclusion rule in `manualZip` task

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -142,7 +142,6 @@ manualLangsProvider.get().each { lang ->
 
     def zipTask= tasks.register("manualZip${lang.capitalize()}", Zip) {
         from fileTree(dir: layout.buildDirectory.file("docs/manual/${lang}"))
-        exclude 'docs/manual/index.html'
         from fileTree(dir: "src_docs/${lang}", include: '**/version*.properties')
         archiveFileName = "${lang}.zip"
         destinationDirectory = file(layout.buildDirectory.dir("docs/manuals/"))


### PR DESCRIPTION

## Pull request type

- build/release for documentation

## What does this PR change?

- remove exclution of 'index.html' in manualZip tasks
- Solve the build error by recursive dependency with `copyDocIndex` task


## Other information

Fix error on weekly release