### PR TITLE
chore(ci): tweak to split dists and docs tasks

### DIFF
--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -27,7 +27,13 @@ steps:
       path: '$(GRADLE_USER_HOME)'
   - task: Gradle@3
     inputs:
-      tasks: 'clean sourceDistZip distZip mac linux win javadoc manualHtmls'
+      tasks: 'clean javadoc manualHtmls'
+      options: '--build-cache -PenvIsCi'
+      jdkVersionOption: '1.17'
+    displayName: 'Build docs'
+  - task: Gradle@3
+    inputs:
+      tasks: 'sourceDistZip distZip mac linux win'
       options: '--build-cache -PenvIsCi --scan -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.17'
-    displayName: 'Build distribution packages and docs'
+    displayName: 'Build distribution packages'


### PR DESCRIPTION
Interim fix of the problem on weekly release.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Split CI job to docs and dists

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
