### PR TITLE
Describe tmx prop display syntax in the manual.

### DIFF
--- a/src_docs/manual/en/OmegaT_Preferences.xml
+++ b/src_docs/manual/en/OmegaT_Preferences.xml
@@ -1385,8 +1385,21 @@ ${filePath}></programlisting></para>
 					<literal>${targetLanguage}</literal>
 				  </entry>
 				  <entry>The segment target language.</entry>
-				</row>
+        			</row>
+				
+				<row>
+				  <entry>
+					<literal>@[<replaceable role="nobreak">tmxPropType</replaceable>][<replaceable role="nobreak">keyValueSep</replaceable>][<replaceable role="nobreak">valuesSep</replaceable>]</literal>
+				  </entry>
+				  <entry><para>Inserts matching TMX entry property values for the given <literal>type</literal> of <literal>prop</literal>, if any.</para>
 
+				  <example id="dialog.preferences.tm.matches.template.tmxprop.example">
+					  <title id="dialog.preferences.tm.matches.template.tmxprop.example.title">Displaying a property</title>
+					  For example, for a TMX entry property <literal>&lt;prop type="Att::Doc. Type"&gt;Regulation&lt;/prop&gt;</literal>,
+					  the template <literal>[Att::Doc. Type][=][,]</literal> would render as <literal>Att::Doc. Type=Regulation</literal>.
+				  </example>
+				</entry>
+				</row>
 			  </tbody>
 			</tgroup>
 		  </table>

--- a/src_docs/style/omegat.css
+++ b/src_docs/style/omegat.css
@@ -693,6 +693,15 @@ code.filename {
     font-weight: bold;
 }
 
+/* Workaround for below specified 1.3em accumulating when code is nested.
+ * Proper fix would be to rather use rem units (relative to body font size)
+ * instead of em (which is relative to parent). Since docbook can validly
+ * nest code (or other) tags.
+ */
+code code {
+    font-size: 1.0em;
+}
+
 code,
 tt,
 kbd,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

- Documentation -> [documentation]

## Which ticket is resolved?

[https://sourceforge.net/p/omegat/documentation/451/](https://sourceforge.net/p/omegat/documentation/451/)

## What does this PR change?

Describe tmx prop display syntax in the manual.

Since only accidentally found based on code that this exists, and can be useful.

## Other information

Could imagine some follow-up improvements, like including an example template in the dropdown of templates (so people skipping the manual will encounter the syntax too, cf. [https://sourceforge.net/p/omegat/feature-requests/1791/](https://sourceforge.net/p/omegat/feature-requests/1791/)), or adding template syntax enhancement of being able to rename the prop type on display etc. But that's a different topic.

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
After screenshot (with bit of context):

<img width="1816" height="451" alt="image" src="https://github.com/user-attachments/assets/e5971ce3-47fc-4c31-bef5-4bf01088f227" />
