### PR TITLE
refactor(core/threads): modernize threading framework with `LongProcessExecutor`

### DIFF
--- a/src/org/omegat/core/Core.java
+++ b/src/org/omegat/core/Core.java
@@ -49,6 +49,7 @@ import org.omegat.core.spellchecker.SpellCheckerManager;
 import org.omegat.core.tagvalidation.ITagValidation;
 import org.omegat.core.tagvalidation.TagValidationTool;
 import org.omegat.core.threads.IAutoSave;
+import org.omegat.core.threads.LongProcessExecutor;
 import org.omegat.filters2.IFilter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
@@ -250,6 +251,10 @@ public final class Core {
 
         coreState.initializeSaveThread();
         coreState.initializeVersionCheckThread();
+    }
+
+    public static LongProcessExecutor getLongProcessExecutor() {
+        return CoreState.getInstance().getExecutor();
     }
 
     /**

--- a/src/org/omegat/core/data/CoreState.java
+++ b/src/org/omegat/core/data/CoreState.java
@@ -33,6 +33,7 @@ import org.omegat.core.spellchecker.ISpellChecker;
 import org.omegat.core.spellchecker.SpellCheckerManager;
 import org.omegat.core.tagvalidation.ITagValidation;
 import org.omegat.core.threads.IAutoSave;
+import org.omegat.core.threads.LongProcessExecutor;
 import org.omegat.core.threads.SaveThread;
 import org.omegat.core.threads.VersionCheckThread;
 import org.omegat.filters2.master.FilterMaster;
@@ -59,6 +60,8 @@ public class CoreState {
 
     protected static volatile CoreState instance = new CoreState();
 
+    private final LongProcessExecutor executor = new LongProcessExecutor("omegat-longprocess");
+
     private IAutoSave saveThread;
 
     protected CoreState() {
@@ -66,14 +69,16 @@ public class CoreState {
     }
 
     public void initializeSaveThread() {
-        SaveThread th = new SaveThread();
-        saveThread = th;
-        th.start();
+        saveThread = new SaveThread();
     }
 
     public void initializeVersionCheckThread() {
         VersionCheckThread th = new VersionCheckThread(10);
         th.start();
+    }
+
+    public LongProcessExecutor getExecutor() {
+        return executor;
     }
 
     public IAutoSave getAutoSave() {

--- a/src/org/omegat/core/threads/CancellationToken.java
+++ b/src/org/omegat/core/threads/CancellationToken.java
@@ -1,0 +1,58 @@
+/*
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.core.threads;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Cooperative cancellation token for long-running tasks.
+ * Task code should call {@link #throwIfCancelled()} at safe points.
+ */
+public class CancellationToken {
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    void cancel() {
+        cancelled.set(true);
+    }
+
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    public void throwIfCancelled() throws LongProcessInterruptedException {
+        if (isCancelled() || Thread.currentThread().isInterrupted()) {
+            throw new LongProcessInterruptedException();
+        }
+    }
+
+    public static CancellationToken none() {
+        return new CancellationToken();
+    }
+
+    @Override
+    public String toString() {
+        return "CancellationToken(cancelled=" + cancelled.get() + ")";
+    }
+}

--- a/src/org/omegat/core/threads/LongProcessExecutor.java
+++ b/src/org/omegat/core/threads/LongProcessExecutor.java
@@ -1,0 +1,105 @@
+/*
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.core.threads;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Centralized executor for long-running background work.
+ * <p>
+ * Why this exists:
+ * - Avoids ad-hoc Thread subclasses
+ * - Provides a uniform cancellation and completion story
+ * - Makes testing and waiting consistent (via CompletableFuture)
+ */
+public final class LongProcessExecutor implements AutoCloseable {
+
+    private static final int CORE_POOL_SIZE = 5;
+    private static final int MAX_POOL_SIZE = 20;
+    private static final long KEEP_ALIVE_SECONDS = 60L;
+
+    @FunctionalInterface
+    public interface CancellableSupplier<T> {
+        T get(CancellationToken token) throws Exception;
+    }
+
+    private final ExecutorService executor;
+
+    public LongProcessExecutor(String threadNamePrefix) {
+        Objects.requireNonNull(threadNamePrefix, "threadNamePrefix");
+        this.executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_SECONDS,
+                TimeUnit.SECONDS, new SynchronousQueue<>(), new NamedThreadFactory(threadNamePrefix));
+    }
+
+    public <T> LongProcessHandle<T> submit(CancellableSupplier<T> work) {
+        Objects.requireNonNull(work, "work");
+
+        CancellationToken token = new CancellationToken();
+        CompletableFuture<T> completion = new CompletableFuture<>();
+
+        Future<?> future = executor.submit(() -> {
+            try {
+                T result = work.get(token);
+                completion.complete(result);
+            } catch (Throwable t) {
+                completion.completeExceptionally(t);
+            }
+        });
+
+        return new LongProcessHandle<>(token, future, completion);
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * Custom thread factory for debugging and monitoring.
+     */
+    private static class NamedThreadFactory implements ThreadFactory {
+        private final AtomicInteger counter = new AtomicInteger(0);
+        private final String prefix;
+
+        NamedThreadFactory(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, prefix + "-" + counter.incrementAndGet());
+            t.setDaemon(true);  // Don't prevent JVM shutdown
+            return t;
+        }
+    }
+}

--- a/src/org/omegat/core/threads/LongProcessHandle.java
+++ b/src/org/omegat/core/threads/LongProcessHandle.java
@@ -1,0 +1,61 @@
+/*
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.core.threads;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * A handle returned to callers when a long-running task is started.
+ * Provides a single, consistent way to cancel and to await completion.
+ */
+public final class LongProcessHandle<T> {
+    private final CancellationToken token;
+    private final Future<?> future;
+    private final CompletableFuture<T> completion;
+
+    LongProcessHandle(CancellationToken token, Future<?> future, CompletableFuture<T> completion) {
+        this.token = Objects.requireNonNull(token, "token");
+        this.future = Objects.requireNonNull(future, "future");
+        this.completion = Objects.requireNonNull(completion, "completion");
+    }
+
+    public CancellationToken token() {
+        return token;
+    }
+
+    public CompletableFuture<T> completion() {
+        return completion;
+    }
+
+    /**
+     * Requests cancellation cooperatively and interrupts the worker thread.
+     */
+    public void cancel() {
+        token.cancel();
+        future.cancel(true);
+    }
+}

--- a/src/org/omegat/core/threads/SearchTask.java
+++ b/src/org/omegat/core/threads/SearchTask.java
@@ -1,0 +1,88 @@
+/*
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.core.threads;
+
+import java.util.Objects;
+import java.util.regex.PatternSyntaxException;
+
+import org.omegat.core.Core;
+import org.omegat.gui.search.SearchWindowController;
+import org.omegat.core.search.Searcher;
+import org.omegat.util.Log;
+
+/**
+ * Modern replacement for SearchThread.
+ * Executed by {@link LongProcessExecutor}.
+ */
+public final class SearchTask {
+
+    private final SearchWindowController window;
+    private final Searcher searcher;
+
+    public SearchTask(SearchWindowController window, Searcher searcher) {
+        this.window = Objects.requireNonNull(window, "window");
+        this.searcher = Objects.requireNonNull(searcher, "searcher");
+    }
+
+    /**
+     * Executes the search. Returns no value; completion is signaled via the returned future.
+     */
+    public Void run(CancellationToken token) {
+        try {
+            try {
+                searcher.setCancellationToken(token);
+                token.throwIfCancelled();
+
+                searcher.search();
+
+                token.throwIfCancelled();
+
+                window.displaySearchResult(searcher);
+                return null;
+
+            } catch (LongProcessInterruptedException ex) {
+                // cancelled: do nothing (caller can observe via completion future)
+                return null;
+
+            } catch (PatternSyntaxException e) {
+                window.displayErrorRB(e, "ST_REGEXP_ERROR");
+                return null;
+
+            } catch (IndexOutOfBoundsException e) {
+                window.displayErrorRB(e, "ST_REGEXP_REPLACE_ERROR");
+                return null;
+
+            } catch (Exception e) {
+                Log.logErrorRB(e, "ST_FILE_SEARCH_ERROR");
+                Core.getMainWindow().displayErrorRB(e, "ST_FILE_SEARCH_ERROR");
+                return null;
+            }
+        } catch (RuntimeException re) {
+            Log.logErrorRB(re, "ST_FATAL_ERROR");
+            Core.getMainWindow().displayErrorRB(re, "ST_FATAL_ERROR");
+            throw re;
+        }
+    }
+}

--- a/src/org/omegat/core/threads/SearchThread.java
+++ b/src/org/omegat/core/threads/SearchThread.java
@@ -49,6 +49,7 @@ import org.omegat.util.Log;
  * @author Antonio Vilei
  * @author Thomas Cordonnier
  */
+@Deprecated(since = "6.1.0")
 public class SearchThread extends LongProcessThread {
     /**
      * Starts a new search. To search a current project only, set rootDir to
@@ -101,6 +102,6 @@ public class SearchThread extends LongProcessThread {
         }
     }
 
-    private SearchWindowController window;
-    private Searcher searcher;
+    private final SearchWindowController window;
+    private final Searcher searcher;
 }

--- a/test/src/org/omegat/core/search/SearcherTest.java
+++ b/test/src/org/omegat/core/search/SearcherTest.java
@@ -52,7 +52,7 @@ import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.ProjectTMX;
 import org.omegat.core.data.RealProject;
 import org.omegat.core.data.SourceTextEntry;
-import org.omegat.core.threads.LongProcessThread;
+import org.omegat.core.threads.CancellationToken;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.util.LocaleRule;
 import org.omegat.util.OStrings;
@@ -90,7 +90,8 @@ public class SearcherTest {
     @Test
     public void testSearchCheckEntrySrcText() {
         addSTE(fi, "id1", "OmegaT is great", null);
-        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, true, false);
+        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                true, false);
         Searcher searcher = new Searcher(proj, s);
         searcher.addToMatcher("OmegaT is great");
         searcher.checkEntry("OmegaT is great", null, null, null, null, 0, "");
@@ -100,7 +101,8 @@ public class SearcherTest {
     @Test
     public void testSearchCheckEntryLocalizedText() {
         addSTE(fi, "id1", "OmegaT is great", null);
-        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, true, false);
+        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                true, false);
         Searcher searcher = new Searcher(proj, s);
         searcher.addToMatcher("OmegaT is great");
         searcher.checkEntry("", "OmegaT is great", null, null, null, 0, "");
@@ -175,7 +177,8 @@ public class SearcherTest {
     @Test
     public void testSearchStringKeywordMatch() throws Exception {
         addSTE(fi, "id1", "OmegaT is great software", null);
-        SearchExpression s = createSearchExpression("great software", SearchExpressionType.KEYWORD, false, false);
+        SearchExpression s = createSearchExpression("great software", SearchExpressionType.KEYWORD,
+                false, false);
         Searcher searcher = startSearcher(s);
         assertTrue(searcher.searchString("great software"));
         assertTrue(searcher.searchString("OmegaT is great software"));
@@ -216,7 +219,7 @@ public class SearcherTest {
 
     private List<SearchMatch> executeSearchReplace(String inputText, SearchExpression s) throws Exception {
         Searcher searcher = new Searcher(proj, s);
-        searcher.setThread(new SearchTestThread());
+        searcher.setCancellationToken(new CancellationToken());
         searcher.search();
         searcher.searchString(inputText);
         return searcher.getFoundMatches();
@@ -225,7 +228,8 @@ public class SearcherTest {
     @Test
     public void testSearchStringRegexMatch() throws Exception {
         addSTE(fi, "id1", "OmegaT version 4.3.2", null);
-        SearchExpression s = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP, false, false);
+        SearchExpression s = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP,
+                false, false);
         Searcher searcher = startSearcher(s);
         assertTrue(searcher.searchString("OmegaT version 4.3.2"));
         assertFalse(searcher.searchString("OmegaT version 4.3")); // incomplete match
@@ -234,7 +238,8 @@ public class SearcherTest {
     @Test
     public void testSearchStringWidthInsensitive() throws Exception {
         addSTE(fi, "id1", "OmegaT\u2009is\u2009great", null); // Using narrow no-break spaces
-        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, false, true); // width-insensitive
+        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                false, true); // width-insensitive
         Searcher searcher = startSearcher(s);
         assertTrue(searcher.searchString("OmegaT is great")); // width-insensitive match
     }
@@ -242,7 +247,8 @@ public class SearcherTest {
     @Test
     public void testSearch() throws Exception {
         addSTE(fi, "id1", "List of sections in %s", "Liste des sections de %s");
-        SearchExpression s = createSearchExpression("list", SearchExpressionType.KEYWORD, false, true);
+        SearchExpression s = createSearchExpression("list", SearchExpressionType.KEYWORD,
+                false, true);
         Searcher searcher = startSearcher(s);
         List<SearchResultEntry> result = searcher.getSearchResults();
         assertEquals(1, result.size());
@@ -250,35 +256,40 @@ public class SearcherTest {
 
     @Test
     public void testGetExpressionExactMatch() throws Exception {
-        SearchExpression expression = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, true, false);
+        SearchExpression expression = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                true, false);
         Searcher searcher = startSearcher(expression);
         assertSame(expression, searcher.getExpression());
     }
 
     @Test
     public void testGetExpressionKeywordMatch() throws Exception {
-        SearchExpression expression = createSearchExpression("great software", SearchExpressionType.KEYWORD, false, false);
+        SearchExpression expression = createSearchExpression("great software", SearchExpressionType.KEYWORD,
+                false, false);
         Searcher searcher = startSearcher(expression);
         assertSame(expression, searcher.getExpression());
     }
 
     @Test
     public void testGetExpressionRegexMatch() throws Exception {
-        SearchExpression expression = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP, false, true);
+        SearchExpression expression = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP,
+                false, true);
         Searcher searcher = startSearcher(expression);
         assertSame(expression, searcher.getExpression());
     }
 
     @Test
     public void testSearchStringEmptyInput() throws Exception {
-        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, true, false);
+        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                true, false);
         Searcher searcher = startSearcher(s);
         assertFalse(searcher.searchString("")); // Should return false for empty input
     }
 
     @Test
     public void testSearchStringNullInput() throws Exception {
-        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT, true, false);
+        SearchExpression s = createSearchExpression("OmegaT is great", SearchExpressionType.EXACT,
+                true, false);
         Searcher searcher = startSearcher(s);
         assertFalse(searcher.searchString(null)); // Should return false for null input
     }
@@ -294,7 +305,8 @@ public class SearcherTest {
     @Test
     public void testSearchStringPartialRegexMatch() throws Exception {
         addSTE(fi, "id1", "OmegaT version 4.3.2-beta", null);
-        SearchExpression s = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP, false, false);
+        SearchExpression s = createSearchExpression("version \\d+\\.\\d+\\.\\d+", SearchExpressionType.REGEXP,
+                false, false);
         Searcher searcher = startSearcher(s);
         assertTrue(searcher.searchString("OmegaT version 4.3.2-beta")); // Partial version match is valid
     }
@@ -425,7 +437,7 @@ public class SearcherTest {
 
     private @NotNull Searcher startSearcher(SearchExpression s) throws Exception {
         Searcher searcher = new Searcher(proj, s);
-        searcher.setThread(new SearchTestThread());
+        searcher.setCancellationToken(new CancellationToken());
         searcher.search();
         return searcher;
     }
@@ -463,17 +475,6 @@ public class SearcherTest {
 
         public List<FileInfo> getProjectFilesList() {
             return projectFilesList;
-        }
-    }
-
-    static class SearchTestThread extends LongProcessThread {
-        @Override
-        public void run() {
-            try {
-                checkInterrupted();
-            } catch (Exception ignored) {
-                // do not raise exception for the test
-            }
         }
     }
 }


### PR DESCRIPTION
## Pull request type

- Other (describe below)
refactor


## What does this PR change?

- Introduce `LongProcessExecutor` as core feature for long running tasks
- Extend CoreState to hold `LongProcessExecutor` object and `Core.getLongProcessExecutor` to return the executor
- Migrate `SaveThread` and `SearchThread` to use modern way 
- Deprecate `SearchThread` and introduce `SearchTask` with new way
- Udpate test cases

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
