### PR TITLE
fix(autocompleter/glossary): remove "Sort by Source Alphabetically" feature

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -2408,7 +2408,6 @@ AC_OPTIONS_DISPLAY_SOURCE=Displa&y source terms
 AC_OPTIONS_DISPLAY_SOURCE_TOOLTIP=When checked, the items in the glossary auto-completer view will also contain the source text.
 AC_OPTIONS_SORT_BY_LENGTH=Show &longer target terms first
 AC_OPTIONS_SORT_BY_LENGTH_TOOLTIP=If checked, the longer entries are placed on the list first.
-AC_OPTIONS_SORT_SOURCE_ALPHABETICALLY=Sort by source term &alphabetically
 AC_OPTIONS_SORT_TARGET_ALPHABETICALLY=Sort tar&get terms alphabetically
 AC_OPTIONS_SORT_ALPHABETICALLY_TOOLTIP=If checked, the entries are sorted alphabetically.
 AC_OPTIONS_GLOSSARY_FRAME=Glossary auto-completer options

--- a/src/org/omegat/gui/glossary/GlossaryAutoCompleterView.java
+++ b/src/org/omegat/gui/glossary/GlossaryAutoCompleterView.java
@@ -165,7 +165,6 @@ public class GlossaryAutoCompleterView extends AutoCompleterListView {
 
     static class GlossaryComparator implements Comparator<AutoCompleterItem> {
 
-        private final boolean bySource = Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_BY_SOURCE);
         private final boolean byLength = Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_BY_LENGTH);
         private final boolean alphabetically = Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_ALPHABETICALLY);
 
@@ -196,14 +195,6 @@ public class GlossaryAutoCompleterView extends AutoCompleterListView {
                     return -1;
                 } else if (!o1IsOriginal && o2IsOriginal) {
                     return 1;
-                }
-            }
-
-            // Sort alphabetically by source term
-            if (bySource) {
-                int result = o1.extras[0].compareTo(o2.extras[0]);
-                if (result != 0) {
-                    return result;
                 }
             }
 

--- a/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsController.java
+++ b/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsController.java
@@ -64,7 +64,6 @@ public class GlossaryAutoCompleterOptionsController extends BasePreferencesContr
     }
 
     private void activateSourceItems(boolean activate) {
-        panel.sortBySourceCheckBox.setEnabled(activate);
         panel.sourceFirstRadioButton.setEnabled(activate);
         panel.targetFirstRadioButton.setEnabled(activate);
     }
@@ -76,7 +75,6 @@ public class GlossaryAutoCompleterOptionsController extends BasePreferencesContr
                 .setSelected(!Preferences.isPreference(Preferences.AC_GLOSSARY_SHOW_TARGET_BEFORE_SOURCE));
         panel.targetFirstRadioButton
                 .setSelected(Preferences.isPreference(Preferences.AC_GLOSSARY_SHOW_TARGET_BEFORE_SOURCE));
-        panel.sortBySourceCheckBox.setSelected(Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_BY_SOURCE));
         panel.longerFirstCheckBox.setSelected(Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_BY_LENGTH));
         panel.sortEntriesCheckBox.setSelected(Preferences.isPreference(Preferences.AC_GLOSSARY_SORT_ALPHABETICALLY));
         panel.enabledCheckBox.setSelected(Preferences.isPreferenceDefault(Preferences.AC_GLOSSARY_ENABLED,
@@ -90,7 +88,6 @@ public class GlossaryAutoCompleterOptionsController extends BasePreferencesContr
         panel.displaySourceCheckBox.setSelected(false);
         panel.sourceFirstRadioButton.setSelected(true);
         panel.targetFirstRadioButton.setSelected(false);
-        panel.sortBySourceCheckBox.setSelected(false);
         panel.longerFirstCheckBox.setSelected(false);
         panel.sortEntriesCheckBox.setSelected(false);
         panel.enabledCheckBox.setSelected(Preferences.AC_GLOSSARY_ENABLED_DEFAULT);
@@ -109,7 +106,6 @@ public class GlossaryAutoCompleterOptionsController extends BasePreferencesContr
         if (panel.displaySourceCheckBox.isSelected()) {
             Preferences.setPreference(Preferences.AC_GLOSSARY_SHOW_TARGET_BEFORE_SOURCE,
                     panel.targetFirstRadioButton.isSelected());
-            Preferences.setPreference(Preferences.AC_GLOSSARY_SORT_BY_SOURCE, panel.sortBySourceCheckBox.isSelected());
         }
         Preferences.setPreference(Preferences.AC_GLOSSARY_SORT_BY_LENGTH, panel.longerFirstCheckBox.isSelected());
         Preferences.setPreference(Preferences.AC_GLOSSARY_SORT_ALPHABETICALLY, panel.sortEntriesCheckBox.isSelected());

--- a/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.form
+++ b/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.form
@@ -140,17 +140,6 @@
                 </Component>
               </SubComponents>
             </Container>
-            <Component class="javax.swing.JCheckBox" name="sortBySourceCheckBox">
-              <Properties>
-                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-                  <ResourceString bundle="org/omegat/Bundle.properties" key="AC_OPTIONS_SORT_SOURCE_ALPHABETICALLY" replaceFormat="java.util.ResourceBundle.getBundle(&quot;{bundleNameSlashes}&quot;).getString(&quot;{key}&quot;)"/>
-                </Property>
-                <Property name="alignmentY" type="float" value="0.0"/>
-              </Properties>
-              <AuxValues>
-                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
-              </AuxValues>
-            </Component>
           </SubComponents>
         </Container>
       </SubComponents>

--- a/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.java
+++ b/src/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.java
@@ -60,7 +60,6 @@ public class GlossaryAutoCompleterOptionsPanel extends javax.swing.JPanel {
         jPanel2 = new javax.swing.JPanel();
         sourceFirstRadioButton = new javax.swing.JRadioButton();
         targetFirstRadioButton = new javax.swing.JRadioButton();
-        sortBySourceCheckBox = new javax.swing.JCheckBox();
         filler2 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 10), new java.awt.Dimension(0, 10), new java.awt.Dimension(32767, 10));
         jPanel1 = new javax.swing.JPanel();
         longerFirstCheckBox = new javax.swing.JCheckBox();
@@ -95,7 +94,7 @@ public class GlossaryAutoCompleterOptionsPanel extends javax.swing.JPanel {
 
         sourceButtonGroup.add(sourceFirstRadioButton);
         org.openide.awt.Mnemonics.setLocalizedText(sourceFirstRadioButton, OStrings.getString("AC_OPTIONS_SOURCE_FIRST")); // NOI18N
-        sourceFirstRadioButton.setToolTipText(OStrings.getString("AC_OPTIONS_SOURCE_FIRST_TOOLTIP")); // NOI18N
+        sourceFirstRadioButton.setToolTipText(OStrings.getString("AC_OPTIONS_SOURCE_FIRST")); // NOI18N
         jPanel2.add(sourceFirstRadioButton);
 
         sourceButtonGroup.add(targetFirstRadioButton);
@@ -104,11 +103,6 @@ public class GlossaryAutoCompleterOptionsPanel extends javax.swing.JPanel {
         jPanel2.add(targetFirstRadioButton);
 
         jPanel3.add(jPanel2);
-
-        java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("org/omegat/Bundle"); // NOI18N
-        org.openide.awt.Mnemonics.setLocalizedText(sortBySourceCheckBox, bundle.getString("AC_OPTIONS_SORT_SOURCE_ALPHABETICALLY")); // NOI18N
-        sortBySourceCheckBox.setAlignmentY(0.0F);
-        jPanel3.add(sortBySourceCheckBox);
 
         optionsPanel.add(jPanel3);
 
@@ -142,7 +136,6 @@ public class GlossaryAutoCompleterOptionsPanel extends javax.swing.JPanel {
     private javax.swing.JPanel jPanel3;
     javax.swing.JCheckBox longerFirstCheckBox;
     javax.swing.JPanel optionsPanel;
-    javax.swing.JCheckBox sortBySourceCheckBox;
     javax.swing.JCheckBox sortEntriesCheckBox;
     private javax.swing.ButtonGroup sourceButtonGroup;
     javax.swing.JRadioButton sourceFirstRadioButton;

--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -451,7 +451,6 @@ public final class Preferences {
     public static final boolean AC_GLOSSARY_ENABLED_DEFAULT = true;
     public static final String AC_GLOSSARY_SHOW_SOURCE = "ac_glossary_show_source";
     public static final String AC_GLOSSARY_SHOW_TARGET_BEFORE_SOURCE = "ac_glossary_show_target_before_source";
-    public static final String AC_GLOSSARY_SORT_BY_SOURCE = "ac_glossary_sort_by_source";
     public static final String AC_GLOSSARY_SORT_BY_LENGTH = "ac_glossary_sort_by_length";
     public static final String AC_GLOSSARY_SORT_ALPHABETICALLY = "ac_glossary_sort_alphabetically";
     public static final String AC_GLOSSARY_CAPITALIZE = "ac_glossary_capitalize";


### PR DESCRIPTION

## Pull request type


- Bug fix -> [bug]

## Which ticket is resolved?

- Auto-completion list of glossary terms appears alphabetically even with the relevant setting unchecked
- https://sourceforge.net/p/omegat/bugs/1307/


## What does this PR change?

- Auto-completion use a sorted glossary list of glossary pane.  
- Now glossary pane is basically sorted alphabetically in default.
- This confuses user to feel sorted even when option is not checked
- As a solutin, we remove the option  

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
