### PR TITLE
fix(ExternalFinder): remove detection of GUI environment

### DIFF
--- a/src/org/omegat/externalfinder/ExternalFinder.java
+++ b/src/org/omegat/externalfinder/ExternalFinder.java
@@ -90,7 +90,6 @@ public final class ExternalFinder {
      */
     public static void loadPlugins() {
         CoreEvents.registerApplicationEventListener(generateIApplicationEventListener());
-        CoreEvents.registerProjectChangeListener(generateIProjectEventListener());
     }
 
     private static IProjectEventListener generateIProjectEventListener() {
@@ -144,6 +143,7 @@ public final class ExternalFinder {
 
             @Override
             public void onApplicationStartup() {
+                CoreEvents.registerProjectChangeListener(generateIProjectEventListener());
                 Core.getEditor().registerPopupMenuConstructors(getGlobalConfig().getPriority(),
                         new ExternalFinderItemPopupMenuConstructor());
             }

--- a/src/org/omegat/externalfinder/ExternalFinder.java
+++ b/src/org/omegat/externalfinder/ExternalFinder.java
@@ -58,7 +58,6 @@ import org.omegat.externalfinder.item.IExternalFinderItemMenuGenerator;
 import org.omegat.util.StaticUtils;
 import org.omegat.util.gui.MenuExtender;
 import org.omegat.util.gui.MenuItemPager;
-import org.omegat.util.gui.StaticUIUtils;
 
 /**
  * Entry point for ExternalFinder functionality.
@@ -90,11 +89,8 @@ public final class ExternalFinder {
      * OmegaT will call this method when loading.
      */
     public static void loadPlugins() {
-        // register listeners when GUI environment
-        if (StaticUIUtils.isGUI()) {
-            CoreEvents.registerApplicationEventListener(generateIApplicationEventListener());
-            CoreEvents.registerProjectChangeListener(generateIProjectEventListener());
-        }
+        CoreEvents.registerApplicationEventListener(generateIApplicationEventListener());
+        CoreEvents.registerProjectChangeListener(generateIProjectEventListener());
     }
 
     private static IProjectEventListener generateIProjectEventListener() {

--- a/src/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
+++ b/src/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
@@ -77,6 +77,7 @@ public class ExternalFinderItemMenuGenerator implements IExternalFinderItemMenuG
 
             JMenuItem item = new JMenuItem();
             Mnemonics.setLocalizedText(item, finderItem.getName());
+            item.setName(finderItem.getName());
 
             // set keyboard shortcut
             if (!popup) {

--- a/test-acceptance/data/config/finder.xml
+++ b/test-acceptance/data/config/finder.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<items priority="50">
+    <item>
+        <name>Eng-Esp Trifecta</name>
+        <url encoding="default" target="both">http://www.wordreference.com/es/translation.asp?tranword={target}</url>
+        <url encoding="default" target="both">https://www.linguee.com/english-spanish/search?source=english&amp;query={target}</url>
+        <url encoding="default" target="both">http://www.proz.com/search/?term={target}&amp;from=eng&amp;to=esl</url>
+        <keystroke>shift ctrl pressed Y</keystroke>
+    </item>
+    <item>
+        <name>Esp-Eng Trifecta</name>
+        <url encoding="default" target="both">http://www.wordreference.com/es/en/translation.asp?spen={target}</url>
+        <url encoding="default" target="both">https://www.linguee.com/english-spanish/search?source=spanish&amp;query={target}</url>
+        <url encoding="default" target="both">https://www.proz.com/search/?term={target}&amp;from=esl&amp;to=eng</url>
+        <keystroke>shift ctrl pressed E</keystroke>
+    </item>
+</items>

--- a/test-acceptance/plugins.properties
+++ b/test-acceptance/plugins.properties
@@ -1,6 +1,7 @@
 plugin=org.omegat.filters2.text.bundles.ResourceBundleFilter \
     org.omegat.filters2.text.TextFilter \
     org.omegat.tokenizer.LuceneEnglishTokenizer \
+    org.omegat.externalfinder.ExternalFinder \
     org.omegat.gui.editor.mark.WhitespaceMarker
 machinetranslator=org.omegat.machinetranslators.dummy.DummyMachineTranslator
 tokenizer=org.omegat.tokenizer.DefaultTokenizer \

--- a/test-acceptance/src/org/omegat/externalfinder/ExternalFinderTest.java
+++ b/test-acceptance/src/org/omegat/externalfinder/ExternalFinderTest.java
@@ -1,0 +1,65 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.externalfinder;
+
+import org.junit.Test;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IProjectEventListener;
+import org.omegat.gui.main.TestCoreGUI;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalFinderTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
+
+    @Test
+    public void testConfigLoadedAndMenuAdded() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        CoreEvents.registerProjectChangeListener(eventType -> {
+            if (eventType == IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD) {
+                latch.countDown();
+            }
+        });
+        openSampleProject(PROJECT_PATH);
+        robot().waitForIdle();
+        assertNotNull(window);
+
+        try {
+            assertTrue(latch.await(60, TimeUnit.SECONDS));
+        } catch (InterruptedException ignored) {
+        }
+        robot().waitForIdle();
+
+        window.menuItem("Eng-Esp Trifecta").requireEnabled();
+        window.menuItem("Esp-Eng Trifecta").requireEnabled();
+    }
+}


### PR DESCRIPTION
ExternalFinder does not add menu.
Because it detects GUI in very early stage of OmegaT start, the module skip to add menu item of defined items from finder.xml.

## Pull request type

- Bug fix -> [bug]
- Add test

## Which ticket is resolved?


- External search not working in v 6.1.0
- https://sourceforge.net/p/omegat/bugs/1318/


## What does this PR change?

- Extend ExternalFinderItemMenuGenerator to add name of the menu item for test.
- Add acceptance test case to check menu item additions.
- 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
