### PR TITLE
chore(ci): Qodana workflow to generate source before run

### DIFF
--- a/.github/workflows/qodana-code-quality.yml
+++ b/.github/workflows/qodana-code-quality.yml
@@ -17,6 +17,16 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v5
+        name: Setup Gradle
+        id: setup-gradle
+      - name: Run gradle to generate sources
+        run: ./gradlew genJAXB
+        id: gradle
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2025.3
         env:

--- a/.github/workflows/qodana-code-quality.yml
+++ b/.github/workflows/qodana-code-quality.yml
@@ -32,9 +32,9 @@ jobs:
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:
-          linter: jetbrains/qodana-jvm-community:2025.3
           pr-mode: false
           use-caches: true
+          cache-default-branch-only: true
           use-annotations: true
           upload-result: true
           args: --baseline,qodana.sarif.json


### PR DESCRIPTION
Improve CI flow

## Pull request type

- Other (describe below)
CI


## What does this PR change?

- Fix qodana parameter warning
- Generate JAXB sources before running qodana

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
