### PR TITLE
chore(core): adopt JSpecify annotations for null-safety

### DIFF
--- a/src/org/omegat/filters3/Element.java
+++ b/src/org/omegat/filters3/Element.java
@@ -25,6 +25,8 @@
 
 package org.omegat.filters3;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Element of the translatable entry. Can be a tag or a piece of text.
  *
@@ -35,6 +37,7 @@ public interface Element {
      * Returns shortcut string representation of the element. E.g. for
      * &lt;strong&gt; tag should return &lt;s3&gt;.
      */
+    @Nullable
     String toShortcut();
 
     /**

--- a/src/org/omegat/filters3/Tag.java
+++ b/src/org/omegat/filters3/Tag.java
@@ -25,7 +25,7 @@
 
 package org.omegat.filters3;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.omegat.util.StaticUtils;
 
 import java.util.Objects;
@@ -197,7 +197,7 @@ public abstract class Tag implements Element {
      * &lt;strong&gt; tag should return &lt;s3&gt;.
      */
     @Override
-    public String toShortcut() {
+    public @Nullable String toShortcut() {
         StringBuilder buf = new StringBuilder();
 
         buf.append('<');

--- a/src/org/omegat/filters3/xml/DefaultXMLDialect.java
+++ b/src/org/omegat/filters3/xml/DefaultXMLDialect.java
@@ -324,7 +324,7 @@ public class DefaultXMLDialect implements XMLDialect {
      * @return <code>true</code> or <code>false</code>
      */
     @Override
-    public Boolean validateTranslatableTag(String tag, Attributes atts) {
+    public Boolean validateTranslatableTag(String tag, @Nullable Attributes atts) {
         return true;
     }
 

--- a/src/org/omegat/filters3/xml/Handler.java
+++ b/src/org/omegat/filters3/xml/Handler.java
@@ -839,7 +839,7 @@ public class Handler extends DefaultHandler implements LexicalHandler, DeclHandl
      *            A tag
      * @return <code>true</code> or <code>false</false>
      */
-    private boolean isPreformattingTag(String tag, org.omegat.filters3.Attributes atts) {
+    private boolean isPreformattingTag(String tag, org.omegat.filters3.@Nullable Attributes atts) {
         if (dialect.getPreformatTags() != null && dialect.getPreformatTags().contains(tag)) {
             return true;
         } else {

--- a/src/org/omegat/filters3/xml/XMLContentBasedTag.java
+++ b/src/org/omegat/filters3/xml/XMLContentBasedTag.java
@@ -33,12 +33,12 @@ import org.jspecify.annotations.Nullable;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class XMLContentBasedTag extends XMLIntactTag {
-    private String shortcut;
+    private @Nullable String shortcut;
     private int shortcutLetter;
     private int shortcutIndex;
 
     /** Creates a new instance of XML Tag */
-    public XMLContentBasedTag(XMLDialect xmlDialect, Handler handler, String tag, String shortcut, Type type,
+    public XMLContentBasedTag(XMLDialect xmlDialect, Handler handler, String tag, @Nullable String shortcut, Type type,
             org.xml.sax.@Nullable Attributes attributes) {
         super(xmlDialect, handler, tag, shortcut, type, attributes);
     }
@@ -47,7 +47,8 @@ public class XMLContentBasedTag extends XMLIntactTag {
         this.shortcut = shortcut;
     }
 
-    public String toShortcut() {
+    @Override
+    public @Nullable String toShortcut() {
         return shortcut;
     }
 

--- a/src/org/omegat/filters3/xml/XMLDialect.java
+++ b/src/org/omegat/filters3/xml/XMLDialect.java
@@ -114,7 +114,7 @@ public interface XMLDialect {
      * the XHTML filter to not translate the value attribute of an
      * input-element, except when it is a button or submit or reset.
      */
-    Boolean validateTranslatableTagAttribute(String tag, String attribute, Attributes atts);
+    Boolean validateTranslatableTagAttribute(String tag, String attribute, @Nullable Attributes atts);
 
     /**
      * For a given tag, return wether the content of this tag should be
@@ -129,7 +129,7 @@ public interface XMLDialect {
      *            The list of the tag attributes
      * @return <code>true</code> or <code>false</code>
      */
-    Boolean validateIntactTag(String tag, Attributes atts);
+    Boolean validateIntactTag(String tag, @Nullable Attributes atts);
 
     /**
      * For a given tag, return wether the content of this tag should be
@@ -142,7 +142,7 @@ public interface XMLDialect {
      *            The list of the tag attributes
      * @return <code>true</code> or <code>false</code>
      */
-    Boolean validateContentBasedTag(String tag, Attributes atts);
+    Boolean validateContentBasedTag(String tag, @Nullable Attributes atts);
 
     /**
      * For a given tag, return wether the content of this tag should be
@@ -156,7 +156,7 @@ public interface XMLDialect {
      *            The list of the tag attributes
      * @return <code>true</code> or <code>false</code>
      */
-    Boolean validateTranslatableTag(String tag, Attributes atts);
+    Boolean validateTranslatableTag(String tag, @Nullable Attributes atts);
 
     /**
      * For a given tag, return wether the content of this tag is a paragraph
@@ -186,7 +186,7 @@ public interface XMLDialect {
      *            The list of the tag attributes
      * @return <code>true</code> or <code>false</code>
      */
-    Boolean validatePreformatTag(String tag, Attributes atts);
+    Boolean validatePreformatTag(String tag, @Nullable Attributes atts);
 
     /**
      * Returns the set of translatable attributes (no matter what tag they

--- a/src/org/omegat/filters3/xml/typo3/Typo3Dialect.java
+++ b/src/org/omegat/filters3/xml/typo3/Typo3Dialect.java
@@ -28,6 +28,7 @@ package org.omegat.filters3.xml.typo3;
 
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.filters3.Attribute;
 import org.omegat.filters3.Attributes;
 import org.omegat.filters3.xml.DefaultXMLDialect;
@@ -67,7 +68,7 @@ public class Typo3Dialect extends DefaultXMLDialect {
      *         translated, <code>false</code> otherwise
      */
     @Override
-    public Boolean validateTranslatableTag(String tag, Attributes atts) {
+    public Boolean validateTranslatableTag(String tag, @Nullable Attributes atts) {
         if (atts != null) {
             for (int i = 0; i < atts.size(); i++) {
                 Attribute oneAttribute = atts.get(i);


### PR DESCRIPTION

## Pull request type

- Other (describe below)
refactor

## What does this PR change?

- Replaced `org.jetbrains.annotations.Nullable` with `org.jspecify.annotations.Nullable`.
- Updated method and field declarations to include JSpecify nullability annotations.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
