### PR TITLE
chore(core): use try-with-resources in StatsResult for SequenceWriter

### DIFF
--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -238,9 +238,9 @@ public class StatsResult {
         setDate();
         StringWriter result = new StringWriter();
         ObjectMapper mapper = new ObjectMapper();
-        SequenceWriter writer = mapper.writer().writeValues(result);
-        writer.write(this);
-        writer.close();
+        try (SequenceWriter writer = mapper.writer().writeValues(result)) {
+            writer.write(this);
+        }
         return result.toString();
     }
 


### PR DESCRIPTION
It guarantees to close the resource even when abort in `write` operation.

## Pull request type

- Other (describe below)
refactor

## What does this PR change?

- use try-with-resource in `StatsResult` class

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
