### PR TITLE
[6.0] chore(gradle): fix sourceDistZip task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -429,9 +429,13 @@ distributions {
         contents {
             from(rootDir) {
                 include 'config/**', 'docs/**', 'images/**', 'lib/**', 'release/**',
-                    'src/**', 'test/**', 'doc_src/**', 'docs_devel/**', 'scripts/**',
-                    'gradle/**', 'gradlew*', '*.gradle', 'README.md', '*.properties'
-                exclude '**/build/**', 'doc_src/**/pdf/**', 'local.properties'
+                    'src/**/*.java', 'test/**', 'doc_src/**', 'docs_devel/**', 'scripts/**',
+                    'gradle/**', 'gradlew*', '*.gradle', 'README.md', '*.properties',
+                    'test-integration/**', 'LICENSE', 'compose.yml'
+                exclude '**/build/**', 'doc_src/**/pdf/**', 'doc_src/**/xhtml5/**', 'local.properties', '**/out/**'
+            }
+            from(processResources) {
+                into('src')
             }
             into('lib/provided') {
                 from configurations.runtimeClasspath


### PR DESCRIPTION
Fix the resource duplication error for release preparation.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- Exclude resources from `from(rootDir)` directive
- Explicit include by `from(processResources)` as same as master branch
- other tweaks

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
