### PR TITLE
fix(core): fix project TMX initialization and segmenter usage

### DIFF
--- a/src/org/omegat/core/data/RealProject.java
+++ b/src/org/omegat/core/data/RealProject.java
@@ -233,9 +233,7 @@ public class RealProject implements IProject {
             remoteRepositoryProvider = new RemoteRepositoryProvider(config.getProjectRootDir(), null, config);
         }
 
-        projectTMX = new ProjectTMX(config.getSourceLanguage(), config.getTargetLanguage(),
-                config.isSentenceSegmentingEnabled(), config.getProjectRootDir(), checkOrphanedCallback,
-                Core.getSegmenter());
+        projectTMX = new ProjectTMX(checkOrphanedCallback);
         sourceTokenizer = createTokenizer(RuntimePreferenceStore.getInstance().getTokenizerSource(),
                 props.getSourceTokenizer());
         Log.logInfoRB("SOURCE_TOKENIZER", sourceTokenizer.getClass().getName());
@@ -1652,9 +1650,6 @@ public class RealProject implements IProject {
     }
 
     public void iterateByDefaultTranslations(DefaultTranslationsIterator it) {
-        if (projectTMX == null) {
-            return;
-        }
         Map.Entry<String, TMXEntry>[] entries;
         synchronized (projectTMX) {
             entries = entrySetToArray(projectTMX.defaults.entrySet());

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -52,6 +52,8 @@ import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.events.IProjectEventListener;
+import org.omegat.core.segmentation.SRXManager;
+import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.threads.IAutoSave;
 import org.omegat.filters2.master.PluginUtils;
@@ -129,6 +131,7 @@ public final class TestTeamIntegrationChild {
             }
             TestPreferencesInitializer.init();
             Preferences.setPreference(Preferences.TEAM_AUTHOR, source);
+            TestCoreState.getInstance().setSegmenter(new Segmenter(SRXManager.getDefault()));
 
             // Init UI stubs. In a CI environment, errors can occur when
             // initializing the RemoteRepositoryProvider, so we need to make


### PR DESCRIPTION
There is a potential bug in the chage of #1564 that will cause unwanted project load when creating `ProjectTMX` object in the ctor of `RealProject`. When the refactoring #1898 merged, the potential bug lead an error of the integration test.

## Pull request type

- Bug fix -> [bug]

## What does this PR change?

- Update the creation of `ProjectTMX` without the side effect using the other constructor. 
- Enforce to set the segmenter in the TestIntegrationChild main 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
