### PR TITLE
chore(core): add null safety to `saveToSrx`

### DIFF
--- a/src/org/omegat/core/segmentation/SRX.java
+++ b/src/org/omegat/core/segmentation/SRX.java
@@ -77,7 +77,7 @@ public class SRX {
      *             if an I/O error occurs during saving
      */
     @Deprecated(forRemoval = true, since = "6.1.0")
-    public static void saveToSrx(SRX srx, File outDir) throws IOException {
+    public static void saveToSrx(@Nullable SRX srx, File outDir) throws IOException {
         SRXManager.saveToSrx(srx, outDir);
     }
 

--- a/src/org/omegat/core/segmentation/SRXManager.java
+++ b/src/org/omegat/core/segmentation/SRXManager.java
@@ -118,8 +118,14 @@ public final class SRXManager {
      *            where to put the file. The file name is forced to
      *            {@link #SRX_SENTSEG} and will be in standard SRX format.
      */
-    public static void saveToSrx(SRX srx, File outDir) throws IOException {
+    public static void saveToSrx(@Nullable SRX srx, File outDir) throws IOException {
         File outFile = new File(outDir, SRX_SENTSEG);
+
+        if (srx == null) {
+            Files.deleteIfExists(Paths.get(outFile.toURI()));
+            Files.deleteIfExists(Paths.get(new File(outDir, CONF_SENTSEG).toURI()));
+            return;
+        }
 
         ObjectFactory factory = new ObjectFactory();
         Srx jaxbObject = factory.createSrx();


### PR DESCRIPTION
Fix the NPE bug in the integration test.
It happened when SRXManager.saveToSrx called with srx argument NULL. When merging PR #1898, null handling logic is missing during refactoring of SRX class. 

## Pull request type

- Bug fix -> [bug]

## What does this PR change?

- Revert the null handling logic to remove SRX file when argument is null.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
