### PR TITLE
chore(greeting): remove toc from the greeting pane

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -115,6 +115,8 @@ manualLangsProvider.get().each { lang ->
         outputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/index.html"))
         contentFiles.set(fileTree(dir: layout.projectDirectory.dir("${documentRootDir}/manual/${lang}"), include: '*.xml'))
         css.set("css/omegat.css")
+        pageStyle.set("book")
+        enableToc.set("true")
         outputs.cacheIf { false }
         // debug.set("chunk-cleanup")
         dependsOn(copyImages, copyCss)
@@ -238,6 +240,8 @@ firstStepLangsProvider.get().each { lang ->
         outputFile.set(layout.buildDirectory.file("docs/greetings/${lang}/first_steps.html"))
         styleSheetFile.set(layout.projectDirectory.file("${styleRootDir}/db5-html.xsl"))
         css.set("greeting.css")
+        pageStyle.set("article")
+        enableToc.set("false")
         finalizedBy(firstStepsHtmlFinally)
     }
     firstSteps.dependsOn(firstStepsHtml)

--- a/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
@@ -2,9 +2,8 @@ package org.omegat.documentation
 
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -14,7 +13,7 @@ abstract class AbstractDocumentTask  extends DefaultTask {
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    final Provider<RegularFile> inputFile = project.objects.fileProperty()
+    final RegularFileProperty inputFile = project.objects.fileProperty()
 
      protected void configureLogging() {
         // Redirect spurious task output to INFO unless explicitly configured for debug

--- a/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
@@ -16,10 +16,22 @@ import org.gradle.api.tasks.Input
 class DocbookHtmlTask extends TransformationTask {
 
     private final Provider<String> css = project.objects.property(String)
+    private final Provider<String> pageStyle = project.objects.property(String)
+    private final Provider<String> enableToc = project.objects.property(String)
 
     @Input
     Provider<String> getCss() {
         return css
+    }
+
+    @Input
+    Provider<String> getPageStyle() {
+        return pageStyle
+    }
+
+    @Input
+    Provider<String> getEnableToc() {
+        return enableToc
     }
 
     @Override
@@ -38,21 +50,25 @@ class DocbookHtmlTask extends TransformationTask {
         def outputBaseDir = outputFile.get().asFile.parentFile.toURI().toString()
         transformer.setParameter(new QName("chunk-output-base-uri"), new XdmAtomicValue(outputBaseDir))
         transformer.setParameter(new QName("mediaobject-input-base-uri"), new XdmAtomicValue(inputBaseDir))
+        transformer.setParameter(new QName("chunk-section-depth"), new XdmAtomicValue(0))
+        // enable/disable table-of-contents--list of titles--and disable section numbering
+        transformer.setParameter(new QName("auto-toc"), new XdmAtomicValue(getEnableToc().get()))
         transformer.setParameter(new QName("persistent-toc"), new XdmAtomicValue(false))
         transformer.setParameter(new QName("persistent-toc-search"), new XdmAtomicValue(false))
-        transformer.setParameter(new QName("chunk-section-depth"), new XdmAtomicValue(0))
         transformer.setParameter(new QName("section-toc-depth"), new XdmAtomicValue(1))
+        transformer.setParameter(new QName("section-numbers"), new XdmAtomicValue("false"))
+        transformer.setParameter(new QName("pagetoc-dynamic"), new XdmAtomicValue(false))
+        // output file configurations
         transformer.setParameter(new QName("html-extension"), new XdmAtomicValue(".html"))
         transformer.setParameter(new QName("output-media"), new XdmAtomicValue("screen"))
-        transformer.setParameter(new QName("page-style"), new XdmAtomicValue("book"))
-        transformer.setParameter(new QName("pagetoc-dynamic"), new XdmAtomicValue(false))
-        transformer.setParameter(new QName("persistent-toc"), new XdmAtomicValue(false))
+        transformer.setParameter(new QName("page-style"), new XdmAtomicValue(pageStyle.get()))
         transformer.setParameter(new QName("use-id-as-filename"), new XdmAtomicValue("true"))
-        transformer.setParameter(new QName("use-docbook-css"), new XdmAtomicValue("false"))
         // html stylesheet link is constructed as "${resource-base-uri}${user-css-links}"
         // so "resource-base-uri" should be a plain file path that ends with "/"
         transformer.setParameter(new QName("resource-base-uri"), new XdmAtomicValue("./"))
         transformer.setParameter(new QName("user-css-links"), new XdmAtomicValue(css.get()))
+        transformer.setParameter(new QName("use-docbook-css"), new XdmAtomicValue("false"))
+        // suppress indexes
         transformer.setParameter(new QName("lists-of-examples"), new XdmAtomicValue("false"))
         transformer.setParameter(new QName("lists-of-figures"), new XdmAtomicValue("false"))
         transformer.setParameter(new QName("lists-of-tables"), new XdmAtomicValue("false"))

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -6,6 +6,7 @@ import net.sf.saxon.s9api.*
 import org.apache.xerces.jaxp.SAXParserFactoryImpl
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
@@ -36,10 +37,10 @@ class TransformationTask extends AbstractDocumentTask {
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    Provider<RegularFile> styleSheetFile = project.objects.fileProperty()
+    final RegularFileProperty styleSheetFile = project.objects.fileProperty()
 
     @OutputFile
-    Provider<RegularFile> outputFile = project.objects.fileProperty()
+    final RegularFileProperty outputFile = project.objects.fileProperty()
 
     @Input
     @Optional

--- a/firsttime-wizard/build.gradle
+++ b/firsttime-wizard/build.gradle
@@ -33,6 +33,8 @@ langs.each { lang ->
         outputFile.set(layout.buildDirectory.file("docs/greetings/${lang}/philosophy.html"))
         styleSheetFile.set(rootProject.layout.settingsDirectory.file("${documentRootDir}/xsl/db5-html.xsl"))
         css.set("../philosophy.css")
+        pageStyle.set("article")
+        enableToc.set("false")
         dependsOn copyCss
     }
     jar.dependsOn(philosophyHtml)

--- a/src_docs/style/greeting.css
+++ b/src_docs/style/greeting.css
@@ -12,11 +12,26 @@ hr {
     margin: 1em 0;
 }
 
-hr {
-    height: 1px;
-    border-style: none;
+.keycap {
+    font-family: monospace;
+    border: 1px solid;
+    border-radius: 4px;
+    margin: 0 .2rem;
+	padding-left: .3rem;
+	padding-right: .2rem;
 }
 
-blockquote {
-    margin: 2em 4em;
+.guibutton {
+    font-family: monospace;
+	font-size: 1.2em;
+    border: .1px solid;
+    border-radius:4px;
+    padding: 0 .3rem;
+    margin: 0 .2rem;
+}
+
+.guilabel,
+.guimenu {
+    font-family: monospace;
+	font-size: 1.2em;
 }

--- a/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
+++ b/test-acceptance/src/org/omegat/gui/editor/EditorUtilsGUITest.java
@@ -60,13 +60,21 @@ public final class EditorUtilsGUITest {
             //    OmegaT will create a folder set that contains your files. It
             //    will also create an empty translation memory that it will fill in the
             //    background, one segment at as time as you type your translation. Matches
-            // We test the last word in the first segment in the paragraph.
-            String target = "translation";
-            int begin = 469;
-            int offs = begin + target.length() / 2;
-            int end = begin + target.length();
+            String target = "memory";
+            String anchor = "create an empty translation ";
             assertNotNull(window);
             JTextComponent editPane = window.panel("First Steps").textBox("IntroPane").target();
+
+            String docText = editPane.getDocument().getText(0, editPane.getDocument().getLength());
+            int anchorIndex = docText.indexOf(anchor);
+            assertTrue("Anchor text not found: " + anchor, anchorIndex >= 0);
+
+            int begin = docText.indexOf(target, anchorIndex + anchor.length());
+            assertTrue("Target text not found after anchor: " + target, begin >= 0);
+
+            int offs = begin + target.length() / 2;
+            int end = begin + target.length();
+
             int posStart = EditorUtils.getWordStart(editPane, offs, Locale.ENGLISH);
             int posEnd = EditorUtils.getWordEnd(editPane, offs, Locale.ENGLISH);
             String word = editPane.getText(posStart, posEnd - posStart);


### PR DESCRIPTION
When opning OmegaT without specifying project, OmegaT shows a greeting text on the editor pane.

After integrating DocBook 5 manual project, it produces table of contents. We have CSS to unshow the ToC with `display: none`, it does not work on OmegaT editor pane.

It is because JTextPane supports only basic CSS.

This PR to improve stylesheet parameters and to allow document tasks to configure `page-style`, and `auto-toc`.

## Pull request type

- Documentation -> [documentation]
- Build and release changes -> [build/release]

## Which ticket is resolved?

## What does this PR change?

- Add task parameter `pageStyle` and `enableToc`
- Set `section-numbers` to be false
- Change file parameters to be `RegularFileProperty` from `Provider<RegularFile>`
- Update acceptance test case to use anchor test and target to be more robust.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
