### PR TITLE
chore(filters): deprecate MozillaLang filter

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -1452,7 +1452,7 @@ MOZFTL_FILTER_REMOVE_STRINGS_UNTRANSLATED=&Remove untranslated strings in the ta
 MOZFTL_FILTER_EXCEPTION=The Mozilla FTL filter encountered an error:
 
 # MozillaLangFilter.java
-MOZLANG_FILTER_NAME=Mozilla Lang
+MOZLANG_FILTER_NAME=Mozilla Lang(Deprecated)
 LANGFILTER_LOCALIZATION_NOTE=---- Localization Notes ----
 
 # RESXFilter.java

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -259,4 +259,13 @@ public class MozillaLangFilter extends AbstractFilter {
     public boolean isBilingual() {
         return true;
     }
+
+    /**
+     * Deprecated in 6.1.0 and will be removed in 6.2.0.
+     * @return false
+     */
+    @Override
+    public boolean isEnabledInDefault() {
+        return false;
+    }
 }

--- a/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -260,10 +260,6 @@ public class MozillaLangFilter extends AbstractFilter {
         return true;
     }
 
-    /**
-     * Deprecated in 6.1.0 and will be removed in 6.2.0.
-     * @return false
-     */
     @Override
     public boolean isEnabledInDefault() {
         return false;


### PR DESCRIPTION
.lang is no longer part of modern Mozilla localization workflows
it was never widely adopted outside Mozilla-specific tooling
the remaining use cases seem limited to legacy or frozen projects
keeping support for an almost-unused format adds maintenance cost without much practical benefit

## Pull request type

- Other (describe below)
release management

## What does this PR change?

- Update filter name in `Bundle.properties` to indicate deprecation.
- Disabled in default.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
