### PR TITLE
Update Authoring information

### DIFF
--- a/aligner/src/main/resources/org/omegat/gui/align/Bundle.properties
+++ b/aligner/src/main/resources/org/omegat/gui/align/Bundle.properties
@@ -3,7 +3,8 @@
 #           with fuzzy matching, translation memory, keyword search,
 #           glossaries, and translation leveraging into updated projects.
 #
-#  Copyright (C) 2023 Hiroshi Miura
+#  Copyright (C) 2016 Aaron Madlon-Kay
+#                2023 Hiroshi Miura
 #                Home page: https://www.omegat.org/
 #                Support center: https://omegat.org/support
 #

--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -17,7 +17,7 @@
 #               2015 Yu Tang, Aaron Madlon-Kay, Didier Briel, Hiroshi Miura
 #               2016 Alex Buloichik, Aaron Madlon-Kay, Didier Briel, Briac Pilpre
 #               2017 Didier Briel
-#               2020-2024 Hiroshi Miura
+#               2020-2026 Jean-Christophe Helary, Hiroshi Miura, Philippe Tourigny
 #               Home page: https://www.omegat.org/
 #               Support centre: https://omegat.org/support
 #
@@ -39,23 +39,27 @@
 #
 #  Resources file for OmegaT
 #
-#  @author Keith Godfrey
-#  @author Maxym Mykhalchuk
-#  @author Henry Pijffers
+#  @author Zoltan Bartko
 #  @author Didier Briel
-#  @author Jean-Christophe Helary
-#  @author Zoltan Bartko - bartkozoltan@bartkozoltan.com
-#  @author Martin Fleurke
-#  @author Andrzej Sawula
 #  @author Alex Buloichik
+#  @author Martin Fleurke
 #  @author Wildrich Fourie
-#  @author Antonio Vilei
-#  @author Briac Pilpre
-#  @author Aaron Madlon-Kay
+#  @author Keith Godfrey
+#  @author Jean-Christophe Helary
 #  @author Piotr Kulik
-#  @author Briac Pilpre
+#  @author Guido Leenders
+#  @author Aaron Madlon-Kay
+#  @author Hiroshi Miura
+#  @author Maxym Mykhalchuk
+#  @author Arno Peters
+#  @author Henry Pijffers
+#  @author Briac Pilpré
+#  @author Andrzej Sawula
+#  @author Yu Tang
+#  @author Philippe Tourigny
+#  @author Antonio Vilei
 #
-#  @version 4.1
+#  @version 6.1
 #
 
 application-name=OmegaT


### PR DESCRIPTION
The new bundles that have been created (in 2023?) also need proper authoring attribution.