### PR TITLE
chore(docs/devel): migrate docs builder from MkDocs to Sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,8 @@ build:
   tools:
     python: "3.14"
 
-mkdocs:
-  configuration: src_docs/mkdocs.yml
+sphinx:
+  configuration: src_docs/developer/conf.py
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/src_docs/developer/conf.py
+++ b/src_docs/developer/conf.py
@@ -1,0 +1,78 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'OmegaT'
+copyright = '2024-2026, OmegaT development team'
+author = 'OmegaT development team'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'myst_parser',
+    'sphinx_copybutton',
+    'sphinx_design',
+    'sphinxcontrib.mermaid',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx_last_updated_by_git',
+]
+
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'furo'
+html_static_path = ['assets']
+
+# -- Options for MyST parser -------------------------------------------------
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
+
+# Set the root document to index
+root_doc = 'index'
+
+html_theme_options = {
+    "source_repository": "https://github.com/omegat-org/omegat/",
+    "source_branch": "master",
+    "source_directory": "src_docs/developer/",
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/omegat-org/omegat",
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+                    0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
+                    -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66
+                    .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
+                    -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27
+                    .68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12
+                    .51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48
+                    0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+            """,
+            "class": "",
+        },
+    ],
+}

--- a/src_docs/requirements.txt
+++ b/src_docs/requirements.txt
@@ -4,3 +4,13 @@ jinja2
 mkdocs-material
 pymdown-extensions
 mkdocs-git-revision-date-localized-plugin
+sphinx
+myst-parser
+furo
+linkify-it-py
+sphinx-copybutton
+sphinx-design
+sphinxcontrib-mermaid
+sphinx-last-updated-by-git
+sphinx-copybutton
+sphinx-design


### PR DESCRIPTION
Migrate developer manual document builder from MkDocs to Sphinx.
It is because MkDocs Material theme moves to a commercial model and MkDocs processes not well for complex lists.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Add sphinx configuration conf.py
- Update requirements.txt to have sphinx and related packages
- Change readthedocs configuration to use sphinx

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
