### PR TITLE
[6.0] chore(ci): update JRE download URLs and build tasks in Azure Pipelines

### DIFF
--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -7,11 +7,9 @@ steps:
         mkdir -p $(System.ArtifactsDirectory)/asset
         cd $(System.ArtifactsDirectory)/asset || exit 1
         jres=(
-          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.29_7.tar.gz
-          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_arm_linux_hotspot_11.0.29_7.tar.gz
-          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.29_7.tar.gz
-          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x64_mac_hotspot_11.0.29_7.tar.gz
-          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x64_windows_hotspot_11.0.29_7.zip
+          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_arm_linux_hotspot_11.0.31_11.tar.gz
+          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_linux_hotspot_11.0.31_11.tar.gz
+          https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.31_11.zip
           https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.29_7.zip
         )
         for url in "${jres[@]}"; do
@@ -31,7 +29,7 @@ steps:
     displayName: 'Preparation for build'
   - task: Gradle@3
     inputs:
-      tasks: 'clean sourceDistZip distZip mac linux win'
+      tasks: 'clean sourceDistZip distZip linux win'
       options: '--build-cache -PenvIsCi -PassetDir=$(System.ArtifactsDirectory)/asset'
       jdkVersionOption: '1.11'
     displayName: 'Build distribution packages and docs'


### PR DESCRIPTION


## Pull request type
- Build and release changes -> [build/release]


## What does this PR change?

- Update bundle JRE to up-to-date 11.0.31
- Supress mac-zip distribution from release
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
