### PR TITLE
chore(spellchecker): improve test cases and checking supported platform

### DIFF
--- a/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/HunSpellChecker.java
+++ b/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/HunSpellChecker.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 
 import dumonts.hunspell.Hunspell;
+import org.omegat.util.Platform;
 import tokyo.northside.logging.ILogger;
 import tokyo.northside.logging.LoggerFactory;
 
@@ -74,7 +75,13 @@ public class HunSpellChecker extends AbstractSpellChecker implements ISpellCheck
      * Register plugins into OmegaT.
      */
     public static void loadPlugins() {
-        Core.registerSpellCheckClass(HunSpellChecker.class);
+        // dumont hunspell only supports limited platform
+        boolean isSupportedPlatform = Platform.isMacOSX()
+                || (Platform.isWindows && Platform.isX86_64)
+                || (Platform.isLinux() && Platform.isX86_64);
+        if (isSupportedPlatform) {
+            Core.registerSpellCheckClass(HunSpellChecker.class);
+        }
     }
 
     public static void unloadPlugins() {

--- a/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
+++ b/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
@@ -94,7 +94,7 @@ public class HunspellSpellcheckerTest {
     }
 
     @Test
-    public void testReadHunspellDictionary() throws Exception {
+    public void testReadHunspellDictionary() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("es_MX"));
         setupProject(props, false);
@@ -106,7 +106,7 @@ public class HunspellSpellcheckerTest {
     }
 
     @Test
-    public void testReadHunspellLTDictionary() throws Exception {
+    public void testReadHunspellLTDictionary() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("de_DE"));
         setupProject(props, false);
@@ -119,7 +119,7 @@ public class HunspellSpellcheckerTest {
     }
 
     @Test
-    public void testBundledDictionaryFR() throws Exception {
+    public void testBundledDictionaryFR() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("fr_FR"));
         setupProject(props, false);
@@ -151,7 +151,7 @@ public class HunspellSpellcheckerTest {
     @Test
     public void testSaveWordListsWhenProjectStatusChanged() throws Exception {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
-        tmpDir.resolve("omegat").toFile().mkdir();
+        Files.createDirectory(tmpDir.resolve("omegat"));
         props.setTargetLanguage(new Language("fr_FR"));
         verifyWordListsSave(props, false);
         verifyWordListsSave(props, true);

--- a/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
+++ b/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
@@ -28,6 +28,7 @@ package org.omegat.spellchecker.hunspell;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -56,6 +58,7 @@ import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.util.Language;
 import org.omegat.util.OConsts;
+import org.omegat.util.Platform;
 import org.omegat.util.TestPreferencesInitializer;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -76,6 +79,13 @@ public class HunspellSpellcheckerTest {
         Files.createDirectory(configDir.resolve("spelling"));
         copyFile("es_MX.aff");
         copyFile("es_MX.dic");
+    }
+
+    @Before
+    public void assumeSupportedPlatform() {
+        assumeTrue("Tests only run on supported platforms (Mac, Windows x64, or Linux x64)", Platform.isMacOSX()
+                || (Platform.isWindows && Platform.isX86_64)
+                || (Platform.isLinux() && Platform.isX86_64));
     }
 
     @AfterClass

--- a/spellchecker/lucene/build.gradle
+++ b/spellchecker/lucene/build.gradle
@@ -15,4 +15,10 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))
     testImplementation(libs.commons.io)
+    testImplementation(libs.languagetool.de)
+}
+
+test {
+    dependsOn project(':language-modules:de').tasks.withType(Jar)
+    dependsOn project(':language-modules:fr').tasks.withType(Jar)
 }

--- a/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
+++ b/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
@@ -34,8 +34,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -57,7 +56,7 @@ public class LuceneHunspellSpellcheckerTest {
     private static Path configDir;
 
     @BeforeClass
-    public static final void setUpClass() throws Exception {
+    public static void setUpClass() throws Exception {
         tmpDir = Files.createTempDirectory("omegat");
         assertThat(tmpDir.toFile()).isDirectory();
         configDir = Files.createDirectory(tmpDir.resolve(".omegat"));
@@ -68,16 +67,16 @@ public class LuceneHunspellSpellcheckerTest {
         copyFile("en.dic");
     }
 
-    @After
-    public final void tearDown() throws Exception {
+    @AfterClass
+    public static void tearDown() throws Exception {
         FileUtils.forceDeleteOnExit(tmpDir.toFile());
     }
 
     @Test
-    public void testReadHunspellDictionary() throws Exception {
+    public void testReadHunspellDictionary() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("en"));
-        setupProject(props, false);
+        setupProject(props);
         ISpellChecker checker = new LuceneHunSpellChecker();
         assertThat(checker.initialize()).as("Success initialize").isTrue();
         assertThat(checker.isCorrect("Hello")).isTrue();
@@ -86,10 +85,10 @@ public class LuceneHunspellSpellcheckerTest {
     }
 
     @Test
-    public void testReadHunspellLTDictionary() throws Exception {
+    public void testReadHunspellLTDictionary() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("de_DE"));
-        setupProject(props, false);
+        setupProject(props);
         ISpellChecker checker = new LuceneHunSpellChecker();
         assertThat(checker.initialize()).as("Success initialize").isTrue();
         assertThat(checker.isCorrect("Hallo")).as("Spell check for correct word").isTrue();
@@ -99,10 +98,10 @@ public class LuceneHunspellSpellcheckerTest {
     }
 
     @Test
-    public void testBundledDictionaryFR() throws Exception {
+    public void testBundledDictionaryFR() {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("fr_FR"));
-        setupProject(props, false);
+        setupProject(props);
         ISpellChecker checker = new LuceneHunSpellChecker();
         assertThat(checker.initialize()).as("Success initialize").isTrue();
         assertThat(checker.isCorrect("Bonjour")).as("Spell check for correct word").isTrue();
@@ -110,16 +109,11 @@ public class LuceneHunspellSpellcheckerTest {
         assertThat(checker.suggest("Erruer")).as("Get suggestion").contains("erreur", "errer");
     }
 
-    private void setupProject(ProjectProperties props, boolean isProjectLoaded) {
+    private void setupProject(ProjectProperties props) {
         Core.setProject(new NotLoadedProject() {
             @Override
             public ProjectProperties getProjectProperties() {
                 return props;
-            }
-
-            @Override
-            public boolean isProjectLoaded() {
-                return isProjectLoaded;
             }
         });
     }

--- a/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
+++ b/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
@@ -31,10 +31,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -43,6 +45,7 @@ import org.omegat.core.Core;
 import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.spellchecker.ISpellChecker;
+import org.omegat.filters2.master.PluginUtils;
 import org.omegat.util.Language;
 import org.omegat.util.TestPreferencesInitializer;
 
@@ -50,15 +53,16 @@ import org.omegat.util.TestPreferencesInitializer;
 public class LuceneHunspellSpellcheckerTest {
     private static final String DICTIONARY_PATH = "/org/omegat/spellchecker/lucene/";
 
-    private Path tmpDir;
-    private Path configDir;
+    private static Path tmpDir;
+    private static Path configDir;
 
-    @Before
-    public final void setUp() throws Exception {
+    @BeforeClass
+    public static final void setUpClass() throws Exception {
         tmpDir = Files.createTempDirectory("omegat");
         assertThat(tmpDir.toFile()).isDirectory();
         configDir = Files.createDirectory(tmpDir.resolve(".omegat"));
         TestPreferencesInitializer.init(configDir.toString());
+        PluginUtils.loadPlugins(Collections.emptyMap());
         Files.createDirectory(configDir.resolve("spelling"));
         copyFile("en.aff");
         copyFile("en.dic");
@@ -73,12 +77,7 @@ public class LuceneHunspellSpellcheckerTest {
     public void testReadHunspellDictionary() throws Exception {
         ProjectProperties props = new ProjectProperties(tmpDir.toFile());
         props.setTargetLanguage(new Language("en"));
-        Core.setProject(new NotLoadedProject() {
-            @Override
-            public ProjectProperties getProjectProperties() {
-                return props;
-            }
-        });
+        setupProject(props, false);
         ISpellChecker checker = new LuceneHunSpellChecker();
         assertThat(checker.initialize()).as("Success initialize").isTrue();
         assertThat(checker.isCorrect("Hello")).isTrue();
@@ -86,7 +85,46 @@ public class LuceneHunspellSpellcheckerTest {
         assertThat(checker.suggest("incorrecti")).contains("incorrect");
     }
 
-    private void copyFile(String target) throws IOException {
+    @Test
+    public void testReadHunspellLTDictionary() throws Exception {
+        ProjectProperties props = new ProjectProperties(tmpDir.toFile());
+        props.setTargetLanguage(new Language("de_DE"));
+        setupProject(props, false);
+        ISpellChecker checker = new LuceneHunSpellChecker();
+        assertThat(checker.initialize()).as("Success initialize").isTrue();
+        assertThat(checker.isCorrect("Hallo")).as("Spell check for correct word").isTrue();
+        assertThat(checker.isCorrect("Hello")).as("Spell check for wrong word").isFalse();
+        assertThat(checker.suggest("Hello")).as("Get suggestion").hasSize(8).contains("holle", "hella",
+                "cello", "hell", "helle", "hallo", "hellt", "helot");
+    }
+
+    @Test
+    public void testBundledDictionaryFR() throws Exception {
+        ProjectProperties props = new ProjectProperties(tmpDir.toFile());
+        props.setTargetLanguage(new Language("fr_FR"));
+        setupProject(props, false);
+        ISpellChecker checker = new LuceneHunSpellChecker();
+        assertThat(checker.initialize()).as("Success initialize").isTrue();
+        assertThat(checker.isCorrect("Bonjour")).as("Spell check for correct word").isTrue();
+        assertThat(checker.isCorrect("Erruer")).as("Spell check for wrong word").isFalse();
+        assertThat(checker.suggest("Erruer")).as("Get suggestion").contains("erreur", "errer");
+    }
+
+    private void setupProject(ProjectProperties props, boolean isProjectLoaded) {
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return props;
+            }
+
+            @Override
+            public boolean isProjectLoaded() {
+                return isProjectLoaded;
+            }
+        });
+    }
+
+    private static void copyFile(String target) throws IOException {
         try (InputStream is = LuceneHunspellSpellcheckerTest.class.getResourceAsStream(DICTIONARY_PATH + target)) {
             if (is == null) {
                 throw new IOException("Target resource not found");


### PR DESCRIPTION
A Lucene Hunspell spell checker is pure java implementation. 
Because a Hunspell checker uses Dumont Hunspell library which is bridge to native hunspell library that supports only mac(intel, arm), Windows(amd) and Linux(amd), it failed when testing on windows arm and linux arm.

## Pull request type

- Other (describe below)
Enhance test quality

## What does this PR change?

- Avoid error messages when using on Windows/Linux aarch64

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
