### PR TITLE
chore: migrate from `javax.xml.bind` to `jakarta.xml.bind` package

### DIFF
--- a/src/org/omegat/core/statistics/StatCount.java
+++ b/src/org/omegat/core/statistics/StatCount.java
@@ -25,7 +25,7 @@
 
 package org.omegat.core.statistics;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/org/omegat/core/statistics/StatProjectProperties.java
+++ b/src/org/omegat/core/statistics/StatProjectProperties.java
@@ -25,7 +25,7 @@
 
 package org.omegat.core.statistics;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/org/omegat/util/StringUtil.java
+++ b/src/org/omegat/util/StringUtil.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 /**
  * Utilities for string processing.

--- a/test/src/org/omegat/filters2/master/PluginUtilsTest.java
+++ b/test/src/org/omegat/filters2/master/PluginUtilsTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.junit.Test;
 import org.omegat.util.FileUtil;


### PR DESCRIPTION
There are several classes that are incomplete for the migration to JAXB4.
This update import path to up-to-date JAXB4 package.

## Pull request type

- Bug fix -> [bug]

## What does this PR change?

- The imcomplete import path still works because the dependency loomchild's segment depends on JAXB2

## Other information

