### PR TITLE
chore(build-logic): remove unused macOS distribution tasks

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
@@ -83,62 +83,8 @@ ext.makeHunspellSignTask = {
 ext.makeMacTask = { args ->
     String installTaskName = 'install' + args.name.capitalize()  + "Dist"
     String signedInstallTaskName = 'install' + args.name.capitalize() + "SignedDist"
-    String distZipTaskName = args.name + "DistZip"
-    String signedZipTaskName = args.name + "Signed"
-    String notarizeTaskName = args.name + "Notarize"
-    String stapledNotarizedDistZipTaskName = args.name + "StapledNotarized"
     def parentTask = tasks.getByName(args.parentTaskName)
     def versionPart = project.ext.omtVersion.version + project.ext.omtVersion.beta
-
-    def distZipTask = tasks.register(distZipTaskName, Zip) {
-        description = "Creates a macOS distribution for ${args.name}."
-        // mac specific contents
-        from(genMac.outputs) {
-            exclude '**/MacOS/OmegaT', '**/Info.plist', '**/java.entitlements'
-        }
-        from(genMac.outputs) {
-            include '**/MacOS/OmegaT'
-            filePermissions {
-                unix(0755)
-            }
-        }
-        from(genMac.outputs) {
-            include '**/Info.plist'
-            expand(version: project.version,
-                    jvmRequired: '11+',
-                    // when bundled JRE, path 'jre.bundle', otherwise 'default'
-                    jreRuntime: args.jrePath ? 'jre.bundle' : 'default',
-                    // $APP_ROOT is expanded at runtime by the launcher binary
-                    configfile: '$APP_ROOT/Contents/Resources/Configuration.properties')
-        }
-        into('OmegaT.app/Contents/Java') {
-            with distributions.main.contents
-            exclude '*.sh', '*.kaptn', 'OmegaT', 'OmegaT.bat', 'omegat.desktop', '*.exe'
-        }
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        archiveFileName.set("${application.applicationName}_${versionPart}_${args.suffix}.zip")
-        if (args.jrePath && !args.jrePath.empty) {
-            from(tarTree(args.jrePath.singleFile)) {
-                into 'OmegaT.app/Contents/PlugIns'
-                includeEmptyDirs = false
-                eachFile {
-                    replaceRelativePathSegment(it, /jdk.*-jre/, 'jre.bundle')
-                }
-            }
-        }
-        outputs.upToDateWhen {
-            // detect up-to-date when OmegaT.jar exists and newer than libs/OmegaT.jar
-            def f1 = base.distsDirectory.file(archiveFileName).get().asFile
-            def f2 = base.libsDirectory.file('OmegaT.jar').get().asFile
-            f1.exists() && f2.exists() && f1.lastModified() > f2.lastModified()
-        }
-        onlyIf {
-            condition(!args.jrePath || !args.jrePath.empty, 'JRE not found')
-        }
-        group = 'omegat distribution'
-    }
-    assemble.dependsOn distZipTask
-    parentTask.dependsOn distZipTask
 
     def installTask = tasks.register(installTaskName, Sync) {
         description = 'Builds the macOS distribution.'
@@ -176,7 +122,7 @@ ext.makeMacTask = { args ->
             }
         }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${args.suffix}"))
+        destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${versionPart}-${args.suffix}"))
         outputs.upToDateWhen {
             // detect up-to-date when OmegaT.jar exists and newer than libs/OmegaT.jar
             def f1 = file("$destinationDir/OmegaT.app/Contents/Java/OmegaT.jar")
@@ -203,7 +149,7 @@ ext.makeMacTask = { args ->
             into 'OmegaT.app/Contents/Java/lib'
         }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${args.suffix}_Signed"))
+        destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${versionPart}-${args.suffix}_Signed"))
         doFirst {
             delete "$destinationDir/OmegaT.app/Contents/PlugIns/jre.bundle"
         }
@@ -220,55 +166,5 @@ ext.makeMacTask = { args ->
         group = 'distribution'
         dependsOn hunspellSignedJar
     }
-
-    def signedZipTask = tasks.register(signedZipTaskName, Zip) {
-        def zipRoot = "${application.applicationName}_${versionPart}_${args.suffix}_Signed"
-        from signedInstallTask
-        into zipRoot
-        archiveFileName.set("${zipRoot}.zip")
-        group = 'omegat distribution'
-        dependsOn signedInstallTaskName
-    }
-
-    tasks.register(notarizeTaskName, Exec) {
-        onlyIf {
-            conditions([project.hasProperty('macNotarizationUsername'), 'Username for notarization not set'],
-                    [exePresent('xcrun'), 'XCode is not present in system.'])
-        }
-        inputs.files signedZipTask.get().archiveFile
-        doLast {
-            injected.execOps.exec {
-                // Assuming setup per instructions at
-                // https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow#3087734
-                commandLine 'xcrun', 'altool', '--notarize-app',
-                        '--primary-bundle-id', "org.omegat.$version",
-                        '--username', project.property('macNotarizationUsername'),
-                        '--password', '@keychain:AC_PASSWORD',
-                        '--file', signedZipTask.get().archiveFile
-            }
-        }
-        dependsOn signedZipTask
-    }
-
-    tasks.register(stapledNotarizedDistZipTaskName, Zip) {
-        def zipRoot = "${application.applicationName}_${versionPart}_${args.suffix}_Notarized"
-        from signedInstallTask
-        into zipRoot
-        onlyIf {
-            condition(exePresent('xcrun'), 'XCode is not present in system.')
-        }
-        doFirst {
-            if (args.name.equals("mac")) {
-                injected.execOps.exec {
-                    commandLine 'xcrun', 'stapler', 'staple', "${macInstallSignedDist.destinationDir}/OmegaT.app"
-                }
-            } else {
-                injected.execOps.exec {
-                    commandLine 'xcrun', 'stapler', 'staple', "${armMacInstallSignedDist.destinationDir}/OmegaT.app"
-                }
-            }
-        }
-        archiveFileName.set("${zipRoot}.zip")
-        dependsOn signedInstallTask
-    }
+    parentTask.dependsOn installTask
 }


### PR DESCRIPTION
Based on dev list discussion, we decided to drop Zip arcvhie creation from build system and remove it from (weekly) release.

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Drop Zip archive tasks for macOS
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
