### PR TITLE
chore(build): add architecture detection for Linux packages (deb, rpm)

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.jpkg-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jpkg-conventions.gradle
@@ -126,9 +126,13 @@ tasks.register("linuxDistDeb", Exec) {
     dependsOn jpackageAppContent
     group = 'distribution'
     def debVersion = '3'
+    def debArch = 'amd64'
+    if (osdetector.classifier == 'linux-aarch_64') {
+        debArch = 'arm64'
+    }
     inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
     outputs.files file(layout.buildDirectory
-            .file("distributions/${application.applicationName}_${version}-${debVersion}_amd64.deb"))
+            .file("distributions/${application.applicationName}_${version}-${debVersion}_${debArch}.deb"))
     onlyIf { gradleOnJava17OrLater && exePresent('dpkg-deb') }
 
     commandLine(file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage")),
@@ -159,9 +163,13 @@ tasks.register("linuxDistRpm", Exec) {
     dependsOn jpackageAppContent
     group = 'distribution'
     def rpmVersion = '3'
+    def rpmArch = 'x86_64'
+    if (osdetector.classifier == 'linux-aarch_64') {
+        rpmArch = 'aarch64'
+    }
     inputs.files file(layout.buildDirectory.file("jpackage/app-image/${application.applicationName}"))
     outputs.files file(layout.buildDirectory
-            .file("distributions/${application.applicationName}-${version}-${rpmVersion}.x86_64.rpm"))
+            .file("distributions/${application.applicationName}-${version}-${rpmVersion}.${rpmArch}.rpm"))
     onlyIf { gradleOnJava17OrLater && exePresent('rpm') }
 
     commandLine(file(Paths.get(System.getProperty('java.home')).resolve("bin/jpackage")),


### PR DESCRIPTION
Improve jpackage task to detect architecture and handle output file path with architecture.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- Currently architecture name is hard-coded in output filename. This breaks cache control.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
