### PR TITLE
chore(jpackage): improve error handling for desktop menu commands

### DIFF
--- a/release/jpackage-specific/linux/postinst
+++ b/release/jpackage-specific/linux/postinst
@@ -46,7 +46,13 @@ package_type=deb
 
 case "$1" in
     configure)
+    set +e
 DESKTOP_COMMANDS_INSTALL
+    desktop_commands_status=$?
+    set -e
+    if [ "$desktop_commands_status" -ne 0]; then
+      echo "Warning: desktop menu registration failed with status $desktop_commands_status; continuing installation." >&2
+    fi
     ln -s -b /opt/omegat-org/omegat/bin/OmegaT /usr/bin/omegat
     ;;
 

--- a/release/jpackage-specific/linux/prerm
+++ b/release/jpackage-specific/linux/prerm
@@ -49,7 +49,13 @@ case "$1" in
     if [ -e /usr/bin/omegat ]; then
       rm -f /usr/bin/omegat
     fi
+    set +e
 DESKTOP_COMMANDS_UNINSTALL
+    desktop_commands_status=$?
+    set -e
+    if [ "$desktop_commands_status" -ne 0 ]; then
+        echo "Warning: desktop menu unregistration failed with status $desktop_commands_status; continuing removal." >&2
+    fi
     ;;
 
     failed-upgrade)


### PR DESCRIPTION
When installing deb package into WSL2, it can be failed because we treat desktop menu command status as mandatory. On WSL2 or headless system, the error is not harmless, so we change the error as warning.

It is useful if user uses OmegaT in the CI/CD environment.

## Pull request type
 Build and release changes -> [build/release]

## What does this PR change?

- add "set +e" on postinst/prerm script of deb package
- Show warning if xdg-desktop-menu failed.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
