### PR TITLE
fix(issues): skip glossary entries with empty target in terminology c…

### DIFF
--- a/src/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -78,11 +78,21 @@ class TerminologyIssueProvider implements IIssueProvider {
         if (glossaryEntries.isEmpty()) {
             return Collections.emptyList();
         }
-        return glossaryEntries.stream().map(glossaryEntry -> {
-            List<String> trgTerms = Core.getGlossaryManager().searchTargetMatches(tmxEntry.translation,
-                    sourceEntry.getProtectedParts(), glossaryEntry);
-            return trgTerms.isEmpty() ? new TerminologyIssue(sourceEntry, tmxEntry, glossaryEntry) : null;
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+        return glossaryEntries.stream()
+                .filter(glossaryEntry -> {
+                    // Bug #1315: skip monolingual glossary entries where all target
+                    // terms are empty. An empty target term is not a real term to
+                    // check against, so raising a warning for it is a false positive.
+                    String[] locTerms = glossaryEntry.getLocTerms(false);
+                    return Arrays.stream(locTerms).anyMatch(t -> !t.isEmpty());
+                })
+                .map(glossaryEntry -> {
+                    List<String> trgTerms = Core.getGlossaryManager().searchTargetMatches(tmxEntry.translation,
+                            sourceEntry.getProtectedParts(), glossaryEntry);
+                    return trgTerms.isEmpty() ? new TerminologyIssue(sourceEntry, tmxEntry, glossaryEntry) : null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -79,13 +79,7 @@ class TerminologyIssueProvider implements IIssueProvider {
             return Collections.emptyList();
         }
         return glossaryEntries.stream()
-                .filter(glossaryEntry -> {
-                    // Bug #1315: skip monolingual glossary entries where all target
-                    // terms are empty. An empty target term is not a real term to
-                    // check against, so raising a warning for it is a false positive.
-                    String[] locTerms = glossaryEntry.getLocTerms(false);
-                    return Arrays.stream(locTerms).anyMatch(t -> !t.isEmpty());
-                })
+                .filter(TerminologyIssueProvider::hasNonEmptyTargetTerms)
                 .map(glossaryEntry -> {
                     List<String> trgTerms = Core.getGlossaryManager().searchTargetMatches(tmxEntry.translation,
                             sourceEntry.getProtectedParts(), glossaryEntry);
@@ -93,6 +87,10 @@ class TerminologyIssueProvider implements IIssueProvider {
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
+    }
+
+    private static boolean hasNonEmptyTargetTerms(GlossaryEntry entry) {
+        return Arrays.stream(entry.getLocTerms(false)).anyMatch(t -> !t.isEmpty());
     }
 
     /**

--- a/src_docs/manual/en/App_Glossaries.xml
+++ b/src_docs/manual/en/App_Glossaries.xml
@@ -105,13 +105,6 @@
          three-column lists, with the source term in the first column, an optional
          target term in the second column, and an optional comment in the third
          column.</para>
-      <note>
-         <para>Entries where the target term is empty (for example,
-            <code>source term\t\tcomment</code>) are treated as monolingual entries.
-            They will appear in the Glossary pane but will not be checked by the
-            <guilabel>Terminology Issues</guilabel> checker, so they will not raise
-            false-positive warnings.</para>
-      </note>
       <para>Glossaries can be “tab-separated values” (TSV) or “comma-separated
          values” (CSV) files or can also use the TermBase eXchange (TBX 2)
          format.</para>

--- a/src_docs/manual/en/App_Glossaries.xml
+++ b/src_docs/manual/en/App_Glossaries.xml
@@ -105,6 +105,13 @@
          three-column lists, with the source term in the first column, an optional
          target term in the second column, and an optional comment in the third
          column.</para>
+      <note>
+         <para>Entries where the target term is empty (for example,
+            <code>source term\t\tcomment</code>) are treated as monolingual entries.
+            They will appear in the Glossary pane but will not be checked by the
+            <guilabel>Terminology Issues</guilabel> checker, so they will not raise
+            false-positive warnings.</para>
+      </note>
       <para>Glossaries can be “tab-separated values” (TSV) or “comma-separated
          values” (CSV) files or can also use the TermBase eXchange (TBX 2)
          format.</para>

--- a/src_docs/manual/en/Menus_Tools.xml
+++ b/src_docs/manual/en/Menus_Tools.xml
@@ -77,9 +77,7 @@
                      details.</para>
                   <note>
                      <para>Glossary entries with an empty target term are excluded
-                        from terminology checks. Such entries — for example, those in
-                        monolingual glossaries or entries that contain only a source term
-                        and a comment — will not produce false-positive warnings.</para>
+                        from terminology checks.</para>
                   </note>
                </listitem>
                <listitem>

--- a/src_docs/manual/en/Menus_Tools.xml
+++ b/src_docs/manual/en/Menus_Tools.xml
@@ -72,9 +72,15 @@
                   <para>
                      <guilabel>Terminology Issues</guilabel> (optional): detects
                      all the glossary items that are not properly translated. See the
-                     
+
                      <link linkend="dialogs.preferences.glossary" endterm="dialogs.preferences.glossary.title"></link> preferences for
                      details.</para>
+                  <note>
+                     <para>Glossary entries with an empty target term are excluded
+                        from terminology checks. Such entries — for example, those in
+                        monolingual glossaries or entries that contain only a source term
+                        and a comment — will not produce false-positive warnings.</para>
+                  </note>
                </listitem>
                <listitem>
                   <para>

--- a/test/src/org/omegat/gui/issues/TerminologyIssueProviderTest.java
+++ b/test/src/org/omegat/gui/issues/TerminologyIssueProviderTest.java
@@ -1,0 +1,103 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 fung911
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.issues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+import org.omegat.gui.glossary.GlossaryEntry;
+
+/**
+ * Tests for TerminologyIssueProvider.
+ *
+ * Verifies that glossary entries with an empty target term are correctly
+ * identified and excluded from the terminology check (bug #1315).
+ */
+public class TerminologyIssueProviderTest {
+
+    /**
+     * Helper: invoke the private static hasNonEmptyTargetTerms() via reflection.
+     */
+    private boolean hasNonEmptyTargetTerms(GlossaryEntry entry) throws Exception {
+        Method m = TerminologyIssueProvider.class
+                .getDeclaredMethod("hasNonEmptyTargetTerms", GlossaryEntry.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(null, entry);
+    }
+
+    /**
+     * A glossary entry whose target term is empty (e.g. "source\t\tcomment" in
+     * a TSV file) must return false — it should be excluded from the check.
+     */
+    @Test
+    public void testEmptyTargetTermReturnsFalse() throws Exception {
+        GlossaryEntry entry = new GlossaryEntry("backend", "", "comment", false, "glossary.txt");
+        assertFalse(hasNonEmptyTargetTerms(entry));
+    }
+
+    /**
+     * A glossary entry with a real target term must return true — it should be
+     * included in the terminology check.
+     */
+    @Test
+    public void testNonEmptyTargetTermReturnsTrue() throws Exception {
+        GlossaryEntry entry = new GlossaryEntry("server", "serveur", "", true, "glossary.txt");
+        assertTrue(hasNonEmptyTargetTerms(entry));
+    }
+
+    /**
+     * A glossary entry where every target term is an empty string (multi-target
+     * case) must return false.
+     */
+    @Test
+    public void testAllTargetTermsEmptyReturnsFalse() throws Exception {
+        GlossaryEntry entry = new GlossaryEntry(
+                "source",
+                new String[]{"", ""},
+                new String[]{"comment1", "comment2"},
+                new boolean[]{false, false},
+                new String[]{"glossary.txt", "glossary.txt"});
+        assertFalse(hasNonEmptyTargetTerms(entry));
+    }
+
+    /**
+     * A glossary entry where at least one target term is non-empty must return
+     * true, even if other target terms are empty.
+     */
+    @Test
+    public void testPartiallyEmptyTargetTermsReturnsTrue() throws Exception {
+        GlossaryEntry entry = new GlossaryEntry(
+                "source",
+                new String[]{"", "serveur"},
+                new String[]{"", ""},
+                new boolean[]{false, false},
+                new String[]{"glossary.txt", "glossary.txt"});
+        assertTrue(hasNonEmptyTargetTerms(entry));
+    }
+}


### PR DESCRIPTION


Fixes BUGS#1315: When a glossary entry has an empty target term (e.g. monolingual glossaries or entries with only a comment column), the terminology checker incorrectly raises a warning expecting an empty string in the translation.

Fix: filter out entries where all target terms are empty before running the target match check in TerminologyIssueProvider.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

- Bug fix -> [bug]


## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Title: Terminology issue raised when there's no target term in glossary
  * URL: https://sourceforge.net/p/omegat/bugs/1315/
<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- In TerminologyIssueProvider.getIssues(), add a filter step that skips
  glossary entries where all target terms are empty strings.
- Prevents false-positive terminology warnings for entries where the target column is empty but a comment column
  is present (e.g. "source\t\tcomment" format).

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
