### PR TITLE
Apply orphan segment 6.0 patch to 6.1

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -720,7 +720,7 @@ CT_ERROR_ACCESS_GLOSSARY_DIR=Cannot access glossary folder!
 
 CT_ERROR_CREATING_TARGET_DIR=Cannot create folder for translated files:
 
-CT_ORPHAN_STRINGS=Orphan segments
+CT_ORPHAN_STRINGS=Orphan segment
 
 CT_START_EXTERNAL_CMD=Executing post-processing commands...
 

--- a/src_docs/manual/en/OmegaT_EditorsPanes.xml
+++ b/src_docs/manual/en/OmegaT_EditorsPanes.xml
@@ -748,8 +748,25 @@ Dossier de configuration
          parts in 
          <emphasis role="bold">green</emphasis> (when the adjacent part is a
          space, as above, the part is left uncolored).</para>
-      <para>The match also displays three matching percentages.</para>
-      <para>These percentages have the following meaning, in order:</para>
+      <para>The match also displays three matching percentages, the origin of the
+      match and how many times is the match repeated in the matching data.</para>
+    
+      <para>When a match comes from the project memory, its origin is only specified in
+      two cases:</para>
+    
+      <itemizedlist>
+         <listitem>
+            <para>If the matching segment is no longer present in the files located in the
+            source folder, it is labeled <emphasis role="bold">Orphan segment</emphasis>.</para>
+         </listitem>
+         <listitem>
+            <para>If the matching segment exists in the files located in the source folder,
+            as well as in other reference memories, it is labeled <emphasis role="bold">This
+            project</emphasis>.</para>
+         </listitem>
+      </itemizedlist>
+
+      <para>The matching percentages have the following meaning, in order:</para>
       <itemizedlist>
          <listitem>
             <para>Percentage calculated 

--- a/test/src/org/omegat/core/search/SearcherTest.java
+++ b/test/src/org/omegat/core/search/SearcherTest.java
@@ -349,7 +349,7 @@ public class SearcherTest {
         assertEquals("source.txt", results.get(0).getPreamble());
         assertEquals("OmegaT is great", results.get(0).getSrcText());
         assertEquals("OmegaT est génial", results.get(0).getTranslation());
-        assertEquals("Orphan segments", results.get(1).getPreamble());
+        assertEquals(OStrings.getString("CT_ORPHAN_STRINGS"), results.get(1).getPreamble());
         assertEquals("OmegaT is great", results.get(1).getSrcText());
     }
 


### PR DESCRIPTION
The patch was applied to 6.0 to add a short description of what orphan segments were and to clarify the UI wording (no plural to "orphan segment" in the match and search UI).