### PR TITLE
chore(gradle): use distribution task group for all packaging tasks

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.linux-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.linux-conventions.gradle
@@ -44,7 +44,7 @@ ext.makeLinuxTask = { args ->
         }
         compression = Compression.BZIP2
         archiveExtension = 'tar.bz2'
-        group = 'omegat distribution'
+        group = 'distribution'
     }
     assemble.dependsOn tarTaskName
     parentTask.dependsOn tarTaskName

--- a/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.publish-conventions.gradle
@@ -50,7 +50,7 @@ signing {
 
 tasks.register('publishVersion') {
     description = 'Updates the version considered current by the version check.'
-    group = 'omegat release'
+    group = 'publishing'
     doLast {
         ssh.run {
             session(remotes.sourceforgeWeb) {

--- a/build-logic/src/main/groovy/org.omegat.spotless-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.spotless-conventions.gradle
@@ -39,7 +39,7 @@ tasks.register('changedOnBranch') {
 
 tasks.register('spotlessChangedApply') {
     description = 'Applies code formatting to files that have been changed on the current branch.'
-    group = 'omegat workflow'
+    group = 'verification'
     finalizedBy 'spotlessApply'
     dependsOn changedOnBranch
     doFirst {

--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -144,7 +144,7 @@ tasks.register('testIntegration', JavaExec) {
         languageVersion = JavaLanguageVersion.of(17)
         vendor = JvmVendorSpec.ADOPTIUM
     }
-    group = 'omegat workflow'
+    group = 'verification'
     mainClass = 'org.omegat.core.data.TestTeamIntegration'
     classpath = sourceSets.testIntegration.runtimeClasspath
     if (System.hasProperty('java.util.logging.config.file')) {
@@ -260,6 +260,7 @@ tasks.register('spotbugsReport') {
             }
         }
     }
+    group = 'verification'
     doLast {
         printReport(rootProject)
         subprojects.each { p ->

--- a/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
@@ -83,7 +83,7 @@ def windowsJRE = fileTree(dir: assetDir, include: 'OpenJDK17U-jre_x64_windows_*.
 def windowsArm64JRE = fileTree(dir: assetDir, include: 'OpenJDK21U-jre_aarch64_windows_*.zip')
 tasks.register('win') {
     description = 'Builds the Windows distributions.'
-    group = 'omegat distribution'
+    group = 'distribution'
 }
 ext.makeWinTask = { args ->
     def installerBasename = "OmegaT_${fullVersion}_${args.suffix}"
@@ -162,7 +162,7 @@ ext.makeWinTask = { args ->
         into base.distsDirectory
         outputs.file installerWinExe
         dependsOn genDistsTaskName
-        group = 'omegat distribution'
+        group = 'distribution'
     }
     assemble.dependsOn distsTaskName
     tasks.win.dependsOn distsTaskName

--- a/build.gradle
+++ b/build.gradle
@@ -419,14 +419,14 @@ distributions {
 
 tasks.register('mac') {
     description = 'Builds the Mac distributions.'
-    group = 'omegat distribution'
+    group = 'distribution'
 }
 makeMacTask(name: 'macX64', suffix: 'Mac_x64', jrePath: macJRE, parentTaskName: 'mac')
 makeMacTask(name: 'macArm', suffix: 'Mac_arm', jrePath: armMacJRE, parentTaskName: 'mac')
 
 tasks.register('linux') {
     description = 'Builds the Linux distributions.'
-    group = 'omegat distribution'
+    group = 'distribution'
     dependsOn linuxDistDeb
     dependsOn linuxDistRpm
 }


### PR DESCRIPTION
Simplify Gradle task group to help contributor to find task name.


## Pull request type
- Build and release changes -> [build/release]


## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
