### PR TITLE
ci: add repository and event checks to Linux publish workflow

### DIFF
--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'omegat-org/omegat' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +81,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    if: github.repository == 'omegat-org/omegat'
     concurrency:
       group: sourceforge-upload
       cancel-in-progress: false


### PR DESCRIPTION
This is safegurd for the fork project.

## Pull request type

- Build and release changes -> [build/release]


## What does this PR change?

- add `if` condition to allow publish only on `omegat-org/omegat` repository.
- still allow fork to test build script

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
