### PR TITLE
Add tests for Chinese language module registration

### DIFF
--- a/language-modules/zh/src/test/java/org/omegat/languages/zh/ChinesePluginTest.java
+++ b/language-modules/zh/src/test/java/org/omegat/languages/zh/ChinesePluginTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+  OmegaT - Computer Assisted Translation (CAT) tool
+           with fuzzy matching, translation memory, keyword search,
+           glossaries, and translation leveraging into updated projects.
+
+  Copyright (C) 2026 burgger
+                Home page: https://www.omegat.org/
+                Support center: https://omegat.org/support
+
+  This file is part of OmegaT.
+
+  OmegaT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OmegaT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package org.omegat.languages.zh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+
+import org.omegat.languagetools.LanguageDataBroker;
+import org.omegat.languagetools.LanguageManager;
+import org.omegat.util.Language;
+
+public class ChinesePluginTest {
+
+    private static final String CHINESE_LT_CLASS = "org.languagetool.language.Chinese";
+
+    @BeforeClass
+    public static void setUpClass() {
+        JLanguageTool.setDataBroker(new LanguageDataBroker());
+        ChinesePlugin.loadPlugins();
+    }
+
+    @Test
+    public void testExactChineseLanguageCode() {
+        assertChineseLanguage(new Language("zh-CH"));
+    }
+
+    @Test
+    public void testUnderscoreChineseLanguageCode() {
+        assertChineseLanguage(new Language("zh_CH"));
+    }
+
+    @Test
+    public void testChineseLanguageCodeWithDifferentRegion() {
+        assertChineseLanguage(new Language("zh-CN"));
+    }
+
+    private static void assertChineseLanguage(Language language) {
+        assertThat(LanguageManager.getLTLanguage(language))
+                .isNotNull()
+                .extracting(lang -> lang.getClass().getName())
+                .isEqualTo(CHINESE_LT_CLASS);
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Add test cases


## What does this PR change?

Add tests for the Chinese language module registration.

The new tests verify that the Chinese LanguageTool mapping works for:
- the exact registered code `zh-CH`
- underscore-form language code `zh_CH`
- another Chinese regional code `zh-CN`

Verification:
- `./gradlew :language-modules:zh:test`
- `./gradlew :language-modules:zh:check`