### PR TITLE
test: add coverage for space-delimited language handling

### DIFF
--- a/test/src/org/omegat/util/LanguageTest.java
+++ b/test/src/org/omegat/util/LanguageTest.java
@@ -116,6 +116,19 @@ public class LanguageTest {
         assertTrue(Language.verifySingleLangCode("ar-AE-x-dubai"));
     }
 
+    /**
+     * Test whether languages are treated as space-delimited correctly.
+     */
+    @Test
+    public void testIsSpaceDelimited() {
+        assertTrue(new Language("en").isSpaceDelimited());
+        assertTrue(new Language("fr").isSpaceDelimited());
+
+        assertFalse(new Language("zh").isSpaceDelimited());
+        assertFalse(new Language("ja").isSpaceDelimited());
+        assertFalse(new Language("bo").isSpaceDelimited());
+    }
+
     @Test
     public void testGetLowerCaseLanguageFromLocale_languageAndCountryLocale() {
         Locale.setDefault(LANGUAGE_AND_COUNTRY_LOCALE);


### PR DESCRIPTION
## Pull request type

- Other -> test

## Which ticket is resolved?

- None

## What does this PR change?

- Adds a unit test for `Language.isSpaceDelimited()`.
- Verifies that English and French are treated as space-delimited languages.
- Verifies that Chinese, Japanese, and Tibetan are treated as non-space-delimited languages.

## Other information

This test is useful because OmegaT supports many languages, and not all languages separate words using spaces. The test helps protect the expected behavior for languages such as Chinese, Japanese, and Tibetan, where normal space-based word separation should not be assumed.

Verification performed:

- `.\gradlew.bat :test --tests org.omegat.util.LanguageTest.testIsSpaceDelimited`