### PR TITLE
chore(ci): update source distribution workflow to use `installSourceDist` and standardize paths

### DIFF
--- a/.github/workflows/source-distribution-test.yml
+++ b/.github/workflows/source-distribution-test.yml
@@ -28,16 +28,13 @@ jobs:
       name: Setup Gradle
     - name: Build source distribution
       run: |
-        ./gradlew sourceDistZip
-        cd build/distributions
-        unzip -q OmegaT_*_Source.zip
+        ./gradlew installSourceDist
     - name: Test source distribution compilation
       run: |
-        cd build/distributions/OmegaT_*_Source
+        cd build/install/OmegaT-source
         chmod +x ./gradlew
         ./gradlew -PenvIsCi=true -Pheadless=true distZip
     - name: check source distribution dependencies duplication
       run: |
         chmod +x ./ci/check_duplicate_dependencies.sh
-        ./ci/check_duplicate_dependencies.sh build/distributions/OmegaT_*_Source
-        
+        ./ci/check_duplicate_dependencies.sh build/install/OmegaT-source


### PR DESCRIPTION
Simplify and speed-up source distribution test workflow

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?

none

## What does this PR change?

- Replace sourceDistZip task with installSourceDist
- This avoid zipping and unzipping

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
