### PR TITLE
chore(dev-docs/ci): update variable names in publish workflows and developer manual to explain CI/CD configurations

### DIFF
--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -141,9 +141,8 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           echo "${{ secrets.OMEGAT_CI_RSA }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H "$SF_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          chmod 600 ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts ~/.ssh/id_rsa
 
       - name: Upload to SourceForge via lftp/SFTP
         env:

--- a/ci/azure-pipelines/publish_release.yml
+++ b/ci/azure-pipelines/publish_release.yml
@@ -59,4 +59,4 @@ steps:
     env:
       OMEGAT_VERSION: ${{ parameters.omegatVersion }}
       SF_HOST: frs.sourceforge.net
-      LFTP_PASSWORD: $(SOURCEFORGE_CI_PASSPHRASE)
+      LFTP_PASSWORD: $(SOURCEFORGE_KEY_PASS)

--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -51,4 +51,4 @@ steps:
     env:
       OMEGAT_VERSION: ${{ parameters.omegatVersion }}
       SF_HOST: frs.sourceforge.net
-      LFTP_PASSWORD: $(SOURCEFORGE_CI_PASSPHRASE)
+      LFTP_PASSWORD: $(SOURCEFORGE_KEY_PASS)

--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -30,7 +30,7 @@ steps:
         set -euo pipefail
         echo "=== Pre-flight check ==="
         # Catch missing variable immediately (-u flag alone won't give a nice message)
-        [[ -n "$LFTP_PASSWORD" ]] && echo "✅ LFTP_PASSWORD is set" || { echo "❌ LFTP_PASSWORD is empty — check SOURCEFORGE_CI_PASSPHRASE variable"; exit 1; }
+        [[ -n "$LFTP_PASSWORD" ]] && echo "✅ LFTP_PASSWORD is set" || { echo "❌ LFTP_PASSWORD is empty — check SOURCEFORGE_KEY_PASS variable"; exit 1; }
         # Verify key file exists and passphrase is correct in one shot
         ssh-keygen -y -f ~/.ssh/id_rsa -P "$LFTP_PASSWORD" > /dev/null && echo "✅ Key + passphrase OK" || { echo "❌ Key or passphrase wrong"; exit 1; }
         # Upload distributions

--- a/src_docs/developer/90.ReleaseProcedure.md
+++ b/src_docs/developer/90.ReleaseProcedure.md
@@ -71,7 +71,7 @@ def windowsJRE = fileTree(dir: assetDir, include: 'OpenJDK17U-jre_x64_windows_*.
 ```
 
 If you want to bundle the Java 21 Long Term Support JRE, you need to change
-`OpenJDK11U` to `OpenJDK21U`.
+`OpenJDK17U` to `OpenJDK21U`.
 
 ## 3. Check manual versions
 
@@ -136,6 +136,9 @@ tag on GitHub.
 ```sh
 git push origin vX.Y.Z
 ```
+
+The CI/CD scripts configure to build binary packaages for Linux and Windows installers, manuals and javadoc,
+and then upload the files onto sourceforge file distribution server.
 
 ## 8. Add signature to Windows distribution files locally, and publish.
 
@@ -203,24 +206,24 @@ which can be checked in the system tool certmg.msc
 
 A file is updated with signature. You should keep an original file for backup.
 
-## 9. Build a notarized macOS distribution file locally, and publish
+## 9. Build a notarized macOS distribution file locally and publish
 
-First, make sure the local JRE is up-to-date.
+Only Apple certified developer can perform this step only on a macOS device.
+First, make sure the local JRE is up to date, and you have `codesign` command on your platform.
+You can build and install the package image using:
 
-Sign and submit binary to Apple:
-
-```sh
-./gradlew macNotarize
+```bash
+./gradlew installMacArmDist installMacX64Dist
 ```
 
-When the confirmation email arrives, do:
+When you have already configured `macCodesignIdentity` project property,
 
-```sh
-./gradlew macStapledNotarizedDistZip
+```bash
+./gradlew installMacArmSignedDist installMacX64SignedDist
 ```
 
-Publish to SourceForge Files.
-
+This command will build and sign the files for both ARM and x64 architectures.
+After you check all required files are properly processed, create the dmg package and submit it to Apple for notarization.
 
 ## 10. Set default downloads
 
@@ -232,14 +235,7 @@ Publish to SourceForge Files.
 5. Click Save
 
 
-## 11. Publish the manual and Javadoc
-
-```sh
-./gradlew publishManual publishJavadoc
-```
-
-
-## 14. Publish to Maven Central
+## 11. Publish to Maven Central
 
 ```sh
 ./gradlew publish

--- a/src_docs/developer/90.ReleaseProcedure.md
+++ b/src_docs/developer/90.ReleaseProcedure.md
@@ -223,7 +223,7 @@ When you have already configured `macCodesignIdentity` project property,
 ```
 
 This command will build and sign the files for both ARM and x64 architectures.
-After you check all required files are properly processed, create the dmg package and submit it to Apple for notarization.
+After you check all required files are properly processed,  submit the contents to Apple for notarization.
 
 ## 10. Set default downloads
 

--- a/src_docs/developer/93.BuildingInstallerPackage.md
+++ b/src_docs/developer/93.BuildingInstallerPackage.md
@@ -57,96 +57,35 @@ Gradle tasks automatically check for the existence of the `iscc` command, or a c
 
 ### Gradle tasks
 
-There are 6 tasks defined to assemble a Windows installer.
-Launching the `win` task will launch all 6 tasks.
+There are 3 tasks defined to assemble a Windows installer.
+Launching the `win` task will launch all 3 tasks.
 
-- winJRE
+- winArm64JRE
 - winJRE64
 - winNoJRE
-- winJRESigned
-- winJRE64Signed
-- winNoJRESigned
 
 To build a signed executable binary installer, you need to have a signing tool and a certification
-in your smartcard (HSM). You should configure your key id and passphrase in `$HOME/.gradle/gradle.properties`.
-You also need to install a smartcard reader driver in your system.
-
-A typical configuration looks like:
-
-```
-properties
-#pkcs11engine=/usr/lib/x86_64-linux-gnu/engine-3/libpkcs11.so
-pkcs11module=/usr/lib/libcrypto3PKCS.so
-pkcs11cert=pkcs11:type=cert
-winCodesignPassword=passphraseHere
-winCodesignTimestampUrl=http://time.certum.pl/
-```
-
-The OmegaT gradle build script is configured to run the build process on Linux or Windows, and considers that the `osslsigncode` utility is installed on your system.
+in your smartcard (HSM). You also need to install a smartcard reader driver in your system.
 
 Because of recent changes of operation policy by certification authority consortiums, 
 certification is now provided as a form of hardware security module (HSM) such as a smartcard,
-which makes it difficult to sign code in container environments.
-
-If anyone knows of a way to certify our code in such environments, please let us know.
-
+which makes it difficult to sign code in CI/CD or container.
 
 ## Building macOS installer
 
-OmegaT project provides zip-packages which have a macOS framework folder structure with an
-application launcher binary. We use `AppBundler` that Sun Microsystems (currently Oracle)
+The build system produces a macOS framework folder structure with an application launcher binary. We use `AppBundler` that Sun Microsystems (currently Oracle)
 released for java applications on macOS. 
 
-We also use a `gradle-appbundler-plugin` configured to produce both an Intel-compatible launcher and
-an M1/M2 compatible launcher. The `genMac` task is used to configure the launcher generation.
-
-**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
-
-See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
-
-### build distribution
-
-There are several tasks defined to assemble distributions for macOS.
-
-#### basic distribution without signing
-
-The `armMacDistZip` and `macDistZip` tasks are used to build the standard distribution packages.
-If you launch the `mac` task, you will get these 2 package files.
-
-**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
-
-See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
-
-**Warning** The `mac` tasks does not fail even though the task `armMacDisZip` fails with
-`Task 'armMacDistZip' not found in root project 'OmegaT' and its subprojects.`
-
-
-#### signed package
-
-The OmegaT project prepares tasks to sign packages for macOS.
-
-- macSignedDistZip
-- armMacSignedDistZip
-- macStapledNotarizedDistZip
-- armMacStapledNotarizedDistZip
-
-**Warning** The zip-packages are only useable as non-notarized packages and thus not useable for distribution targetting macOS 15 and above.
-
-See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
-
-#### Debug mac packages
-
-Use one of the following tasks to prepare the package directory
-structure in a `build/install/` folder:
+Use one of the following tasks to prepare the package directory structure in a `build/install/` folder:
 
 - installMacArmDist
 - InstallMacX64Dist
 
-**Warning** The `installArmMacDist` task errors with this message:
-`Task 'installArmMacDist' not found in root project 'OmegaT' and its subprojects.`
+We use a `gradle-appbundler-plugin` configured to produce both an Intel-compatible launcher and
+an M1/M2 compatible launcher. The `genMac` task is used to configure the launcher generation.
 
-**Warning** The `InstallMacDist` task errors with this message:
-`Task 'installMacDist' is ambiguous in root project 'OmegaT' and its subprojects. Candidates are: 'installMacArmDist', 'installMacArmSignedDist'.`
+See the [Notes regarding the notarization of the macOS package](https://github.com/omegat-org/omegat/blob/topic/jc/macos/notarization/notarization.md#notes-regarding-the-notarization-of-the-macos-package).
+
 
 ## Building the distribution with a Linux Java runtime
 
@@ -163,7 +102,7 @@ You need to put a Java Runtime package in the directory specified by the `assetD
 
 The following packages are recognized as windows JREs:
 
-- OpenJDK17U-jre_x86-32_windows_hotspot_17.0.8.1_1.zip
+- OpenJDK17U-jre_aarch64_windows_hotspot_17.0.8.1_1.zip
 - OpenJDK17U-jre_x64_windows_hotspot_17.0.8.1_1.zip
 
 The following packages are recognized as macOS JREs:

--- a/src_docs/developer/96.ContinuousIntegration.md
+++ b/src_docs/developer/96.ContinuousIntegration.md
@@ -1,0 +1,167 @@
+# Continuous Integration and Continuous Delivery
+
+OmegaT uses two CI/CD platforms:
+
+- **Azure Pipelines** — the primary platform, handling build, test, and publishing of Windows packages and documentation.
+- **GitHub Actions** — handles Linux package builds, daily quality checks, and supplementary publishing.
+
+The pipeline configuration files are located under `ci/azure-pipelines/` and `.github/workflows/`.
+
+---
+
+## Azure Pipelines
+
+The main pipeline definition is `azure-pipelines.yml` at the project root.
+It is triggered on pushes and pull requests targeting `master` and `releases/*` branches,
+as well as on a weekly schedule (every Saturday at 12:00 UTC).
+
+The pipeline is structured into three **stages**:
+
+### Stage 1: TestAndDocCI
+
+Runs on every push and pull request (but not on scheduled or manual runs, and not on release tags).
+
+A `CheckChanges` job first inspects which files have changed since the previous commit (or since
+`master` for pull requests). Based on the result, downstream jobs are conditionally executed:
+
+- **BuildDocument** — runs only when documentation files under `src_docs/` or tip-of-the-day files have changed.
+- **testOnLinux / testOnWindows / testOnMac** — run only when non-documentation source files have changed.
+
+### Stage 2: Weekly
+
+Runs on a scheduled Saturday build or on a manual trigger.
+
+This stage runs the following jobs **in parallel** before publishing:
+
+- **CheckForWeekly** — runs `check_steps.yml`, which executes the Gradle `check` task. This is a comprehensive quality gate that includes unit tests, style checks, and other verifications.
+- **IntegrationTestForWeekly** — runs `integ_test_steps.yml`, which launches Docker Compose-based integration tests (GIT type, with a 600 second duration limit).
+- **WeeklyBuild** — builds Windows and macOS distribution packages and documentation. Uses `build_steps.yml` and `build_doc_steps.yml` (see below).
+
+**WeeklyPublish** depends on all three jobs above succeeding, then downloads the pipeline
+artifacts and uploads them to the SourceForge file release server via `publish_weekly.yml`.
+
+### Stage 3: Release
+
+Triggered only when a version tag (matching `refs/tags/v*`) is pushed.
+
+- **CheckForRelease** — same as `CheckForWeekly`: runs the full Gradle `check` task.
+- **ReleaseBuild** — depends on `CheckForRelease` passing. Builds all distribution packages and documentation using `build_steps.yml` and `build_doc_steps.yml`.
+- **ReleasePublish** — downloads the built artifacts and uploads them to the SourceForge release directory via `publish_release.yml`.
+
+---
+
+## Azure Pipeline Sub-tasks
+
+The reusable step templates live under `ci/azure-pipelines/`:
+
+| File                    | Purpose                                                                                                                                          |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `build_steps.yml`       | Downloads bundled JREs, builds Windows and macOS packages (`win`, `mac`), source distribution (`sourceDistZip`, `distZip`), and Javadoc.         |
+| `build_doc_steps.yml`   | Builds the HTML manuals using the Gradle `manualHtmls` task with JDK 17.                                                                         |
+| `check_steps.yml`       | Runs the Gradle `check` task and publishes test results as a pipeline report.                                                                    |
+| `integ_test_steps.yml`  | Runs and tears down Docker Compose-based integration tests. Accepts `testType` and `duration` parameters.                                        |
+| `publish_weekly.yml`    | Uploads distribution packages to `SourceForge/Weekly` and HTML manuals to the SourceForge project web snapshot directory, using SFTP via `lftp`. |
+| `publish_release.yml`   | Uploads distribution packages, HTML manuals, and Javadoc to versioned release directories on SourceForge, using SFTP via `lftp`.                 |
+| `test_java17_steps.yml` | Runs the standard test suite on a given platform (Linux, Windows, macOS) using JDK 17.                                                           |
+
+---
+
+## GitHub Actions
+
+### Linux Package Build and Publish (`publish-linux.yml`)
+
+This workflow builds Linux distribution packages and publishes them to SourceForge.
+
+It is triggered by:
+- A version tag push (`v*`) — publishes as a release.
+- A weekly schedule (every Saturday at 13:18 UTC) — publishes as a weekly snapshot.
+- A manual `workflow_dispatch` — lets you choose `release` or `weekly` explicitly.
+
+The **build** job uses a matrix strategy to build on two architectures in parallel:
+
+| Architecture | Runner | Gradle tasks |
+|---|---|---|
+| `amd64` | `ubuntu-latest` | `linuxDistDeb linuxDistRpm linux64DistTarBz` |
+| `aarch64` | `ubuntu-24.04-arm` | `linuxDistDeb linuxDistRpm linuxArm64DistTarBz` |
+
+Each build step:
+1. Downloads the appropriate Temurin JRE 17 for its architecture into a local `asset/` directory.
+2. Runs the Gradle tasks using `jpackage`-based tasks defined in `org.omegat.linux-conventions.gradle` and `org.omegat.jpkg-conventions.gradle`.
+3. Uploads the distribution files as GitHub Actions artifacts.
+
+The **publish** job then:
+1. Downloads the artifacts from both architectures.
+2. Determines whether to publish to the `Weekly` folder or to a versioned release folder on SourceForge, based on the trigger event.
+3. Uploads via `lftp` over SFTP using an SSH key stored as a GitHub Actions secret.
+
+> **Note:** Both architectures must succeed (`fail-fast: false` is set, but `publish` requires both build jobs).
+
+---
+
+## Daily Quality Checks on GitHub Actions
+
+The following workflows run on every push to `master` / `releases/*` and on every pull request,
+providing continuous quality feedback. Most workflows skip `ci/`, `src_docs/`, and `*.md` changes
+to avoid unnecessary runs on non-code changes.
+
+| Workflow file                  | Name                     | What it checks                                                                                                                                                                                      |
+|--------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `acceptance-master.yml`        | Acceptance Tests         | Runs the UI acceptance test suite under a virtual framebuffer (`Xvfb`).                                                                                                                             |
+| `checkstyle-annotate.yml`      | Run checkstyle           | Runs `checkstyleMain` and `checkstyleTest` Gradle tasks and annotates violations inline.                                                                                                            |
+| `gradle-check-master.yml`      | Quality checks           | Runs the full Gradle `check` task and verifies the Git working tree is clean after the build.                                                                                                       |
+| `manuals-builds-master.yml`    | Check manuals build      | Builds the HTML manuals with `manualHtmls`; triggered only when manual source files change.                                                                                                         |
+| `pmd-annotate.yml`             | Run PMD                  | Runs `pmdMain` and `pmdTest` Gradle tasks and annotates findings inline.                                                                                                                            |
+| `qodana-code-quality.yml`      | Qodana                   | Runs a nightly JetBrains Qodana static analysis scan and uploads results to the Qodana cloud.                                                                                                       |
+| `semgrep.yml`                  | Run Semgrep              | Runs Semgrep SAST analysis on every pull request and on pushes to `master`.                                                                                                                         |
+| `source-distribution-test.yml` | Source Distribution Test | Builds the source distribution with `installSourceDist`, then compiles it from scratch and checks for duplicate dependencies — this catches any missing or incorrectly declared build dependencies. |
+| `spotbugs-annotate.yml`        | Run SpotBugs             | Runs `spotbugsMain` and `spotbugsTest` Gradle tasks and annotates findings inline.                                                                                                                  |
+
+### Notes on specific checks
+
+- **Acceptance Tests** require a display server; the workflow installs `xvfb` and related X11 libraries before running.
+- **Qodana** runs nightly on a schedule (daily at 21:03 UTC) rather than on every push, due to its longer execution time. It uses a baseline file (`qodana.sarif.json`) to suppress known issues.
+- **Source Distribution Test** is particularly important for catching missing dependency declarations: it installs the source distribution to a clean directory and attempts to build it independently, failing fast if any transitive dependency is absent from the declared dependency list.
+- **Semgrep** skips pull requests from `dependabot[bot]` to avoid permission issues with the Semgrep token.
+
+---
+
+## Secrets and Credentials
+
+The publish pipelines require the following secrets to be configured:
+
+| Secret                                                                | Platform       | Purpose                                           |
+|-----------------------------------------------------------------------|----------------|---------------------------------------------------|
+| `SOURCEFORGE_CI_USER`                                                 | Azure / GitHub | SourceForge SFTP username                         |
+| `SOURCEFORGE_KEY_PASS`                                                | Azure / GitHub | Passphrase for the SSH private key                |
+| `omegat-ci-rsa` (Azure Secure File) / `OMEGAT_CI_RSA` (GitHub Secret) | Azure / GitHub | SSH private key for SourceForge SFTP access       |
+| `QODANA_TOKEN`                                                        | GitHub         | Authentication token for uploading Qodana results |
+| `SEMGREP_APP_TOKEN`                                                   | GitHub         | Authentication token for the Semgrep cloud app    |
+
+---
+
+## CI File Locations Summary
+
+```
+azure-pipelines.yml                        # Root pipeline definition (Azure)
+ci/
+  azure-pipelines/
+    build_steps.yml                        # Windows/macOS/source distribution build
+    build_doc_steps.yml                    # Manual HTML build
+    check_steps.yml                        # Gradle check + test result publishing
+    integ_test_steps.yml                   # Docker Compose integration tests
+    publish_weekly.yml                     # Upload to SourceForge Weekly
+    publish_release.yml                    # Upload to SourceForge release folder
+    test_java17_steps.yml                  # Cross-platform unit test run
+.github/
+  workflows/
+    acceptance-master.yml                  # UI acceptance tests
+    checkstyle-annotate.yml                # Checkstyle
+    gradle-check-master.yml                # Gradle check + clean tree verification
+    manuals-builds-master.yml              # Manuals HTML build check
+    pmd-annotate.yml                       # PMD static analysis
+    publish-linux.yml                      # Linux package build + SourceForge publish
+    qodana-code-quality.yml                # Nightly Qodana scan
+    semgrep.yml                            # Semgrep SAST
+    source-distribution-test.yml           # Source distribution build + dependency check
+    spotbugs-annotate.yml                  # SpotBugs static analysis
+```

--- a/src_docs/developer/index.md
+++ b/src_docs/developer/index.md
@@ -44,6 +44,7 @@
 * [Integration test](34.IntegrationTest.md)
 * [Build and dependency security](37.BuildAndDependencySecurity.md)
 * [Test a specific feature](35.SpecificFeatureTests.md)
+* [Continuous Integration and Continuous Delivery](96.ContinuousIntegration.md)
 
 ## Documentation
 


### PR DESCRIPTION
Add CI/CD developer manual section.
Use secret name SOURCEFORGE_KEY_PASS as same as github


## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
None
## What does this PR change?

- Use consolidated secret variable name
- Add CI/CD developer manual section.
- Update developer manuals to synchronizes current build configuration

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
