### PR TITLE
docs(devel): add offline/enterprise build instructions and update ADR#2025001

### DIFF
--- a/src_docs/developer/08.HowToBuild.md
+++ b/src_docs/developer/08.HowToBuild.md
@@ -33,10 +33,6 @@ Some build tasks, such as signed installers, require additional configuration
 via a `local.properties` file placed at the root of the source tree. See
 `local.properties.example`.
 
-When specified a Gradle property `forceSkipDocumentBuild`, the build task 
-will skip build processes to generate greeting documents, `FirstStep.html`
-in languages, and bundled manuals. You can edit `local.properties` or
-
 ## Build Assets
 
 Some build tasks require the user to supply additional files not included in the
@@ -126,6 +122,13 @@ To build OmegaT from the source distribution:
 
 4. The build system automatically detects and uses the bundled dependencies in `lib/provided`
 
+> **Note for enterprise / offline builds:** The source distribution bundles all
+> runtime and module dependencies in `lib/provided/core` and `lib/provided/modules`,
+> but the **build-logic** Gradle plugins (e.g. SpotBugs, Spotless, ErrorProne) are
+> **not** included. Enterprise administrators must separately populate `lib/build-logic`
+> with the required JARs before running `./gradlew --offline`.
+> See [Offline Build](09.OfflineBuild.md) for step-by-step instructions.
+
 ### Testing and Validation
 
 The continuous integration workflow includes a dedicated test (`source-distribution-test.yml`) that verifies the source distribution's completeness:
@@ -168,10 +171,10 @@ Tasks runnable from root project 'OmegaT'
 
 Application tasks
 -----------------
-debug - Launchs app for debugging.
 run - Runs this project as a JVM application
-runOnJava17 - Launches app on Java 17
-runOnJava21 - Launches app on Java 21
+runDebugger - Runs application for debugging.
+runOnJava11 - Runs application on Java 11.
+runOnJava21 - Runs application on Java 21.
 
 Build tasks
 -----------
@@ -182,9 +185,9 @@ buildNeeded - Assembles and tests this project and all projects it depends on.
 classes - Assembles main classes.
 clean - Deletes the build directory.
 jar - Assembles a jar archive containing the classes of the 'main' feature.
-javaClasses - Assembles java classes.
 javadocJar - Assembles a jar archive containing the main javadoc.
 sourcesJar - Assembles a jar archive containing the main sources.
+testAcceptanceClasses - Assembles test acceptance classes.
 testClasses - Assembles test classes.
 testFixturesClasses - Assembles test fixtures classes.
 testFixturesJar - Assembles a jar archive containing the classes of the 'testFixtures' feature.
@@ -193,7 +196,14 @@ testIntegrationClasses - Assembles test integration classes.
 Build Setup tasks
 -----------------
 init - Initializes a new Gradle build.
+spotlessInstallGitPrePushHook - Installs Spotless Git pre-push hook.
+updateDaemonJvm - Generates or updates the Gradle Daemon JVM criteria.
 wrapper - Generates Gradle wrapper files.
+
+Develocity tasks
+----------------
+buildScanPublishPrevious - Publishes the data captured by the last build.
+provisionDevelocityAccessKey - Provisions a new access key for this build environment.
 
 Distribution tasks
 ------------------
@@ -202,43 +212,46 @@ assembleSourceDist - Assembles the source distributions
 distTar - Bundles the project as a distribution.
 distZip - Bundles the project as a distribution.
 installDist - Installs the project as a distribution as-is.
-installLinux64Dist - Creates a Linux installDist for linux64. 
-installLinuxArm64Dist - Creates a Linux installDist for linuxArm64. 
+installLinux64Dist - Creates a linux installDist for linux64.
+installLinuxArm64Dist - Creates a linux installDist for linuxArm64.
+installMacArmDist - Builds the macOS distribution.
+installMacArmSignedDist - Builds the signed macOS distribution. Requires an Apple Developer Account.
+installMacX64Dist - Builds the macOS distribution.
+installMacX64SignedDist - Builds the signed macOS distribution. Requires an Apple Developer Account.
 installSourceDist - Installs the project as a distribution as-is.
-linuxDebDist
-linuxRpmDist
-macArmInstallDist - Builds a Mac distribution.
-macArmInstallSignedDist - Builds a signed Mac distribution. Requires an Apple Developer Account.
-macX64InstallDist - Builds a Mac distribution.
-macX64InstallSignedDist - Builds a signed Mac distribution. Requires an Apple Developer Account.
+linux - Builds the Linux distributions.
+linux64DistTarBz - Creates a Linux distribution for linux64.
+linuxArm64DistTarBz - Creates a Linux distribution for linuxArm64.
+linuxDistDeb
+linuxDistRpm
+mac - Builds the Mac distributions.
 sourceDistTar - Bundles the project as a distribution.
 sourceDistZip - Bundles the project as a distribution.
+win - Builds the Windows distributions.
+winArm64JRE - Creates a Windows installer for winArm64JRE distro. Requires Inno Setup (http://www.jrsoftware.org/isinfo.php).
+winJRE64 - Creates a Windows installer for winJRE64 distro. Requires Inno Setup (http://www.jrsoftware.org/isinfo.php).
+winNoJRE - Creates a Windows installer for winNoJRE distro. Requires Inno Setup (http://www.jrsoftware.org/isinfo.php).
 
 Documentation tasks
 -------------------
-firstSteps - Builds the First Steps HTML pages for all languages at docs/greetings/. Requires Docker.
-genDocIndex - Generates the docs index file
+firstSteps - Builds the introductory page for all languages at src/docs/greetings/.
 javadoc - Generates Javadoc API documentation for the 'main' feature.
-manualHtmls - Builds HTML manuals and zip for all languages. Requires container runtime.
-manualPdfs - Builds PDF manuals for all languages. Requires container runtime.
-manualZips - Builds ZIP manuals to bundle into the application. Requires container runtime.
+manualCa - Builds the whc contents.
+manualEn - Builds the whc contents.
+manualFr - Builds the whc contents.
+manualHtmls - Builds and zips the HTML manuals for all languages.
+manualIt - Builds the whc contents.
+manualJa - Builds the whc contents.
+manualNl - Builds the whc contents.
 testFixturesJavadoc - Generates Javadoc API documentation for the 'testFixtures' feature.
-updateManuals - Updates Instant Start guides and HTML manuals.
--> we don't have the Instant Start anymore. What does this do?
-webManual - Syncs the HTML manual files
--> syncs from where to where?
-
-Gradle Enterprise tasks
------------------------
-buildScanPublishPrevious - Publishes the data captured by the last build.
-provisionGradleEnterpriseAccessKey - Provisions a new access key for this build environment.
+tipsHtmls - Copy tips html/css contents into build folder
 
 Help tasks
 ----------
-buildEnvironment - Displays all the build scripts dependencies declared in root project 'OmegaT'.
-dependencies - Displays all the dependencies declared in root project 'OmegaT'.
+artifactTransforms - Displays the Artifact Transforms that can be executed in root project 'OmegaT'.
+buildEnvironment - Displays all buildscript dependencies declared in root project 'OmegaT'.
+dependencies - Displays all dependencies declared in root project 'OmegaT'.
 dependencyInsight - Displays the insight into a specific dependency in root project 'OmegaT'.
-dependencyUpdates - Displays the dependency updates for the project.
 help - Displays a help message.
 javaToolchains - Displays the detected java toolchains.
 outgoingVariants - Displays the outgoing variants of root project 'OmegaT'.
@@ -252,60 +265,79 @@ IDE tasks
 cleanEclipse - Cleans all Eclipse files.
 eclipse - Generates all Eclipse files.
 
+Jaxb tasks
+----------
+genFilters
+genJAXB - Generate classes for loading and manipulating XML formats
+genProject
+genSegmentation
+genTbx
+
 Launch4j tasks
 --------------
 createAllExecutables - Runs all tasks that implement DefaultLaunch4jTask
 createExe - Runs the launch4j jar to generate an .exe file
 
-Omegat distribution tasks
--------------------------
-Linux - Builds the Linux distributions.
-linux64DistTarBz - Creates a Linux distribution for linux64. 
-linuxArm64DistTarBz - Creates a Linux distribution for linuxArm64. 
-mac - Builds the Mac distributions.
-macArmDistZip - Creates a Mac distribution for macArm
-macArmSignedDistZip
-macX64DistZip - Creates a Mac distribution for macX64
-macX64SignedDistZip
-win - Builds the Windows distributions.
-winJRE64Signed
-winJRESigned
-winNoJRESigned
-
-Omegat release tasks
---------------------
-publishJavadoc - Copies javadoc to SourceForge web.
-publishManual - Copies manual to SourceForge web.
-publishVersion - Updates the version considered current by the version check.
-
-Omegat workflow tasks
----------------------
-spotlessChangedApply - Applies code formatting to files that have been changed on the current branch.
-testIntegration - Runs integration tests. Pass repo URL as -Domegat.test.repo=<repo>
-
 Publishing tasks
 ----------------
+closeAndReleaseSonatypeStagingRepository - Closes and releases open staging repository in 'sonatype' Nexus instance.
+closeAndReleaseStagingRepositories - Closes and releases open staging repositories in the following Nexus instance: 'sonatype'
+closeSonatypeStagingRepository - Closes open staging repository in 'sonatype' Nexus instance.
+closeStagingRepositories - Closes open staging repositories in the following Nexus instance: 'sonatype'
+findSonatypeStagingRepository - Finds the staging repository for sonatype
+generateMetadataFileForManualCaPublication - Generates the Gradle metadata file for publication 'manualCa'.
+generateMetadataFileForManualEnPublication - Generates the Gradle metadata file for publication 'manualEn'.
+generateMetadataFileForManualFrPublication - Generates the Gradle metadata file for publication 'manualFr'.
+generateMetadataFileForManualItPublication - Generates the Gradle metadata file for publication 'manualIt'.
+generateMetadataFileForManualJaPublication - Generates the Gradle metadata file for publication 'manualJa'.
+generateMetadataFileForManualNlPublication - Generates the Gradle metadata file for publication 'manualNl'.
 generateMetadataFileForMavenJavaPublication - Generates the Gradle metadata file for publication 'mavenJava'.
+generatePomFileForManualCaPublication - Generates the Maven POM file for publication 'manualCa'.
+generatePomFileForManualEnPublication - Generates the Maven POM file for publication 'manualEn'.
+generatePomFileForManualFrPublication - Generates the Maven POM file for publication 'manualFr'.
+generatePomFileForManualItPublication - Generates the Maven POM file for publication 'manualIt'.
+generatePomFileForManualJaPublication - Generates the Maven POM file for publication 'manualJa'.
+generatePomFileForManualNlPublication - Generates the Maven POM file for publication 'manualNl'.
 generatePomFileForMavenJavaPublication - Generates the Maven POM file for publication 'mavenJava'.
+initializeSonatypeStagingRepository - Initializes the staging repository in 'sonatype' Nexus instance.
 publish - Publishes all publications produced by this project.
-publishAllPublicationsToMavenRepository - Publishes all Maven publications produced by this project to the maven repository.
+publishAllPublicationsToSonatypeRepository - Publishes all Maven publications produced by this project to the sonatype repository.
+publishManualCaPublicationToMavenLocal - Publishes Maven publication 'manualCa' to the local Maven repository.
+publishManualCaPublicationToSonatypeRepository - Publishes Maven publication 'manualCa' to Maven repository 'sonatype'.
+publishManualEnPublicationToMavenLocal - Publishes Maven publication 'manualEn' to the local Maven repository.
+publishManualEnPublicationToSonatypeRepository - Publishes Maven publication 'manualEn' to Maven repository 'sonatype'.
+publishManualFrPublicationToMavenLocal - Publishes Maven publication 'manualFr' to the local Maven repository.
+publishManualFrPublicationToSonatypeRepository - Publishes Maven publication 'manualFr' to Maven repository 'sonatype'.
+publishManualItPublicationToMavenLocal - Publishes Maven publication 'manualIt' to the local Maven repository.
+publishManualItPublicationToSonatypeRepository - Publishes Maven publication 'manualIt' to Maven repository 'sonatype'.
+publishManualJaPublicationToMavenLocal - Publishes Maven publication 'manualJa' to the local Maven repository.
+publishManualJaPublicationToSonatypeRepository - Publishes Maven publication 'manualJa' to Maven repository 'sonatype'.
+publishManualNlPublicationToMavenLocal - Publishes Maven publication 'manualNl' to the local Maven repository.
+publishManualNlPublicationToSonatypeRepository - Publishes Maven publication 'manualNl' to Maven repository 'sonatype'.
 publishMavenJavaPublicationToMavenLocal - Publishes Maven publication 'mavenJava' to the local Maven repository.
-publishMavenJavaPublicationToMavenRepository - Publishes Maven publication 'mavenJava' to Maven repository 'maven'.
+publishMavenJavaPublicationToSonatypeRepository - Publishes Maven publication 'mavenJava' to Maven repository 'sonatype'.
 publishToMavenLocal - Publishes all Maven publications produced by this project to the local Maven cache.
+publishToSonatype - Publishes all Maven/Ivy publications produced by this project to the 'sonatype' Nexus repository.
+publishVersion - Updates the version considered current by the version check.
+releaseSonatypeStagingRepository - Releases closed staging repository in 'sonatype' Nexus instance.
+releaseStagingRepositories - Releases open staging repositories in the following Nexus instance: 'sonatype'
+retrieveSonatypeStagingProfile - Gets and displays a staging profile id for a given repository and package group. This is a diagnostic task to get the value and put it into the NexusRepository configuration closure as stagingProfileId.                                                                                                                                                                                                                       
 
 Verification tasks
 ------------------
 check - Runs all checks.
+jacocoAcceptanceReport
+jacocoIntegrationReport
 jacocoTestCoverageVerification - Verifies code coverage metrics based on specified rules for the test task.
 jacocoTestReport - Generates code coverage report for the test task.
-spotbugsJava - Runs SpotBugs analysis for the source set 'java'
-spotbugsMain - Runs SpotBugs analysis for the source set 'main'
-spotbugsMainReport
-spotbugsTest - Runs SpotBugs analysis for the source set 'test'
-spotbugsTestFixtures - Runs SpotBugs analysis for the source set 'testFixtures'
-spotbugsTestIntegration - Runs SpotBugs analysis for the source set 'testIntegration'
-spotbugsTestReport
+spotbugsMain - Run SpotBugs analysis for the source set 'main'
+spotbugsReport
+spotbugsTest - Run SpotBugs analysis for the source set 'test'
+spotbugsTestAcceptance - Run SpotBugs analysis for the source set 'testAcceptance'
+spotbugsTestFixtures - Run SpotBugs analysis for the source set 'testFixtures'
+spotbugsTestIntegration - Run SpotBugs analysis for the source set 'testIntegration'
 spotlessApply - Applies code formatting steps to sourcecode in-place.
+spotlessChangedApply - Applies code formatting to files that have been changed on the current branch.
 spotlessCheck - Checks that sourcecode satisfies formatting steps.
 spotlessDiagnose
 spotlessJava
@@ -313,12 +345,10 @@ spotlessJavaApply
 spotlessJavaCheck
 spotlessJavaDiagnose
 test - Runs the test suite.
-testOnJava17 - Runs the test cases on Java 17
-testOnJava21 - Runs the test cases on Java 21
-
-Other tasks
------------
-jpackage
+testAcceptance - Runs acceptance GUI test.
+testCodeCoverageReport - Generates aggregated code coverage report.
+testIntegration - Runs integration tests. Pass repo URL as -Domegat.test.repo=<repo>.
+validateModuleMetadata - Validate OmegaT module metadata (e.g., org.omegat.module.category).
 
 Rules
 -----
@@ -379,16 +409,6 @@ When you want to build html manuals in all supported languages, use `manualHtlms
 ## Quick OmegaT project building
 
 We provide several ways and technics to speed up the build-and-try cycles.
-
-### Skip containerized manual build
-
-If you don't need to build the HTML manuals, you have 2 options:
-
-1. If the container support software is not installed, the document building is always skipped.
-2. You can use the `-PforceSkipDocumentBuild` property in Gradle command line to skip the documentation building.
--> we need a third option where the container software is not running.
-   
-The task execution log will record the reason why the manuals building was skipped with the "SKIPPED" label.
 
 ### Smart task execution
 

--- a/src_docs/developer/09.OfflineBuild.md
+++ b/src_docs/developer/09.OfflineBuild.md
@@ -2,6 +2,7 @@
 
 This page describes how to build OmegaT without internet access,
 which is typically required in enterprise environments with restricted networks.
+It is also useful when building old OmegaT from source distribution to reproduce some issues even if the dependencies are removed from the remote repository.
 
 ## Overview
 
@@ -11,131 +12,32 @@ for **application** dependencies: all runtime and module JARs are bundled under
 
 However, the **build-logic** layer — the Gradle convention plugins that provide tasks
 such as SpotBugs, Spotless, ErrorProne, and documentation tools — depends on additional
-Gradle plugins and libraries that are **not** included in the source distribution.
-
-To build fully offline, an enterprise administrator must pre-populate the maven local directory from
-`lib/provided/build-logic` with the required JARs.
-
-## Directory Layout
-```
-
-<project-root>/
-├── lib/
-│   └── provided/
-│       ├── core/         ← bundled in source dist; application runtime deps
-│       ├── modules/      ← bundled in source dist; module plugin deps
-│       └── build-logic/  ← NOT bundled; must be populated by admin for offline builds
-└── build-logic/
-└── build.gradle      ← detects lib/provided/build-logic; reads from lib/build-logic
-```
-### Provide build dependencies
+Gradle plugins and libraries that are included in the source distribution.
 
 `build-logic/build.gradle` depends on `mavenLocal()`, `mavenCentral()`, `gradlePlugins()` and `DocBook.org repository`.
 
-An admin can copy `lib/provided/build-logic` into `~/.m2/repositories` to construct the maven local reposiotry.
+To build fully offline, an enterprise administrator must pre-populate the maven local directory from `lib/provided/build-logic` with the required JARs.
+An admin can copy the folder tree `lib/provided/build-logic/*` into `~/.m2/repositories` to construct the maven local reposiotry.
 
 So the workflow for an admin is:
 
-1. Construct maven local repsoitory by `cp -r lib/provided/build-logic/* ~/.m2/repositories/` with all required JARs.
+1. Construct the maven local repsoitory by `cp -r lib/provided/build-logic/* ~/.m2/repositories/` with all required JARs.
 2. Developers then run `./gradlew --offline` normally.
 
-## Required JARs for `lib/build-logic`
+## Directory Layout
 
-### Gradle Plugins
-
-| File                                        | Coordinates                                              |
-|---------------------------------------------|----------------------------------------------------------|
-| `gradle-versions-plugin-0.52.0.jar`         | `com.github.ben-manes:gradle-versions-plugin:0.52.0`     |
-| `spotbugs-gradle-plugin-6.1.5.jar`          | `com.github.spotbugs.snom:spotbugs-gradle-plugin:6.1.5`  |
-| `spotless-plugin-gradle-8.6.0.jar`          | `com.diffplug.spotless:spotless-plugin-gradle:8.6.0`     |
-| `launch4j-4.0.0.jar`                        | `edu.sc.seis.launch4j:launch4j:4.0.0`                    |
-| `gradle-errorprone-plugin-4.2.0.jar`        | `net.ltgt.gradle:gradle-errorprone-plugin:4.2.0`         |
-| `gradle-nullaway-plugin-2.2.0.jar`          | `net.ltgt.gradle:gradle-nullaway-plugin:2.2.0`           |
-| `org.hidetake.ssh.gradle.plugin-2.11.2.jar` | `org.hidetake.ssh:org.hidetake.ssh.gradle.plugin:2.11.2` |
-
-### Documentation & Build Tools
-
-| File                       | Coordinates                          |
-|----------------------------|--------------------------------------|
-| `Saxon-HE-12.9.jar`        | `net.sf.saxon:Saxon-HE:12.9`         |
-| `docbook-xslTNG-2.7.6.jar` | `org.docbook:docbook-xslTNG:2.7.6`   |
-| `sinclude-5.2.4.jar`       | `com.nwalsh:sinclude:5.2.4`          |
-| `whc-3.6.0.jar`            | `tokyo.northside:whc:3.6.0`          |
-| `xalan-2.7.3.jar`          | `xalan:xalan:2.7.3`                  |
-| `serializer-2.7.3.jar`     | `xalan:serializer:2.7.3`             |
-| `xercesImpl-2.12.2.jar`    | `xerces:xercesImpl:2.12.2`           |
-| `xml-resolver-1.2.jar`     | `xml-resolver:xml-resolver:1.2`      |
-| `xmlresolver-6.0.23.jar`   | `org.xmlresolver:xmlresolver:6.0.23` |
-
-### Utilities the plugins use
-
-| File                          | Coordinates                                |
-|-------------------------------|--------------------------------------------|
-| `launch4j-3.55.jar`           | `org.omegat:launch4j:3.55`                 |
-| `launch4j-3.55-win32.jar`     | `org.omegat:launch4j:3.55:workdir-win32`   |
-| `launch4j-3.55-mac.jar`       | `org.omegat:launch4j:3.55:workdir-mac`     |
-| `launch4j-3.55-linux64.jar`   | `org.omegat:launch4j:3.55:workdir-linux64` |
-| `launch4j-3.55-linux.jar`     | `org.omegat:launch4j:3.55:workdir-linux`   |
-
-> **Tip:** Each JAR may also require its transitive dependencies. Use the download
-> script below on a machine with internet access to capture all transitive dependencies.
-
-## How to Populate `lib/build-logic`
-
-### Option A: Download on a Connected Machine (Recommended)
-
-On a machine that has internet access and the OmegaT source tree:
-
-Uncomment repository settings in `build-logic/src/main/groovy/org.omegat.java-conventions.gradle`
+Required dependencies are bundled in the source distribution.
 
 ```
-repositories {
-    mavenCentral()
-    // required by offline build
-    // mavenLocal()
-    // gradlePluginPortal()
-}
+<project-root>/
+├── lib/
+│   └── provided/
+│       ├── core/         ← application runtime deps
+│       ├── modules/      ← module plugin deps
+│       └── build-logic/  ← copy to maven local repo by admin for offline builds
+└── build-logic/
+    └── build.gradle      ← use mavenLocal() in addtion of mavenCentral() and gradlePlugins()
 ```
-
-and then execute the special task
-
-```shell script
-./gradlew downloadBuildLogicDependencies
-```
-
-This task (when available) downloads all required JARs into `lib/build-logic/`.
-Then transfer the directory to the air-gapped machine.
-
-### Option B: Manual Download via Maven Coordinates
-
-Use any tool that can resolve Maven artifacts to download the JARs listed in the table above,
-including all transitive dependencies, into `lib/build-logic/`.
-
-### Option C: Use an Internal Maven Repository
-
-If your organisation runs an internal Maven mirror (Nexus, Artifactory, etc.):
-
-1. Ensure the mirror proxies or has the artifacts listed above.
-2. Leave `lib/build-logic` absent.
-3. Edit `build-logic/build.gradle` to point the `flatDir` or `maven` repository
-   entries at your internal server — or configure it via `settings.gradle`
-   `pluginManagement.repositories`.
-
-## Running the Offline Build
-
-Once `lib/build-logic/` is populated and `lib/provided/build-logic/` exists:
-
-```shell script
-./gradlew --offline distZip
-```
-
-## Troubleshooting
-
-| Symptom                                               | Likely Cause                                                                       |
-|-------------------------------------------------------|------------------------------------------------------------------------------------|
-| `Could not resolve …` during build-logic compilation  | A JAR (or its transitive dep) is missing from `lib/build-logic/`                   |
-| Flat-dir repository not activated                     | `lib/build-logic/` directory does not exist                                        |
-| `Network access disabled` errors for application deps | `lib/provided/core/` is missing; ensure you extracted the full source distribution |
 
 ## See Also
 

--- a/src_docs/developer/09.OfflineBuild.md
+++ b/src_docs/developer/09.OfflineBuild.md
@@ -1,0 +1,150 @@
+# Offline / Enterprise Build
+
+This page describes how to build OmegaT without internet access,
+which is typically required in enterprise environments with restricted networks.
+
+## Overview
+
+OmegaT's source distribution (`OmegaT_*_Source.zip`) is designed to be self-contained
+for **application** dependencies: all runtime and module JARs are bundled under
+`lib/provided/core` and `lib/provided/modules`.
+
+However, the **build-logic** layer — the Gradle convention plugins that provide tasks
+such as SpotBugs, Spotless, ErrorProne, and documentation tools — depends on additional
+Gradle plugins and libraries that are **not** included in the source distribution.
+
+To build fully offline, an enterprise administrator must pre-populate the directory
+`lib/build-logic` with the required JARs.
+
+## Directory Layout
+```
+
+<project-root>/
+├── lib/
+│   ├── provided/
+│   │   ├── core/         ← bundled in source dist; application runtime deps
+│   │   └── modules/      ← bundled in source dist; module plugin deps
+│   └── build-logic/      ← NOT bundled; must be populated by admin for offline builds
+└── build-logic/
+└── build.gradle      ← detects lib/provided/build-logic; reads from lib/build-logic
+```
+### Detection Mechanism
+
+`build-logic/build.gradle` activates the flat-directory repository when the marker
+directory `lib/provided/build-logic` **exists**:
+
+```groovy
+if (file('../lib/provided/build-logic').exists()) {
+    flatDir { dirs '../lib/build-logic' }
+}
+```
+
+So the workflow for an admin is:
+
+1. Populate `lib/build-logic/` with all required JARs.
+2. Create the marker directory `lib/provided/build-logic/` (may be empty).
+3. Developers then run `./gradlew --offline` normally.
+
+## Required JARs for `lib/build-logic`
+
+### Gradle Plugins
+
+| File                                        | Coordinates                                              |
+|---------------------------------------------|----------------------------------------------------------|
+| `gradle-versions-plugin-0.52.0.jar`         | `com.github.ben-manes:gradle-versions-plugin:0.52.0`     |
+| `spotbugs-gradle-plugin-6.1.5.jar`          | `com.github.spotbugs.snom:spotbugs-gradle-plugin:6.1.5`  |
+| `spotless-plugin-gradle-8.6.0.jar`          | `com.diffplug.spotless:spotless-plugin-gradle:8.6.0`     |
+| `launch4j-4.0.0.jar`                        | `edu.sc.seis.launch4j:launch4j:4.0.0`                    |
+| `gradle-errorprone-plugin-4.2.0.jar`        | `net.ltgt.gradle:gradle-errorprone-plugin:4.2.0`         |
+| `gradle-nullaway-plugin-2.2.0.jar`          | `net.ltgt.gradle:gradle-nullaway-plugin:2.2.0`           |
+| `org.hidetake.ssh.gradle.plugin-2.11.2.jar` | `org.hidetake.ssh:org.hidetake.ssh.gradle.plugin:2.11.2` |
+
+### Documentation & Build Tools
+
+| File                       | Coordinates                          |
+|----------------------------|--------------------------------------|
+| `Saxon-HE-12.9.jar`        | `net.sf.saxon:Saxon-HE:12.9`         |
+| `docbook-xslTNG-2.7.6.jar` | `org.docbook:docbook-xslTNG:2.7.6`   |
+| `sinclude-5.2.4.jar`       | `com.nwalsh:sinclude:5.2.4`          |
+| `whc-3.6.0.jar`            | `tokyo.northside:whc:3.6.0`          |
+| `xalan-2.7.3.jar`          | `xalan:xalan:2.7.3`                  |
+| `serializer-2.7.3.jar`     | `xalan:serializer:2.7.3`             |
+| `xercesImpl-2.12.2.jar`    | `xerces:xercesImpl:2.12.2`           |
+| `xml-resolver-1.2.jar`     | `xml-resolver:xml-resolver:1.2`      |
+| `xmlresolver-6.0.23.jar`   | `org.xmlresolver:xmlresolver:6.0.23` |
+
+### Utilities the plugins use
+
+| File                          | Coordinates                                |
+|-------------------------------|--------------------------------------------|
+| `launch4j-3.55.jar`           | `org.omegat:launch4j:3.55`                 |
+| `launch4j-3.55-win32.jar`     | `org.omegat:launch4j:3.55:workdir-win32`   |
+| `launch4j-3.55-mac.jar`       | `org.omegat:launch4j:3.55:workdir-mac`     |
+| `launch4j-3.55-linux64.jar`   | `org.omegat:launch4j:3.55:workdir-linux64` |
+| `launch4j-3.55-linux.jar`     | `org.omegat:launch4j:3.55:workdir-linux`   |
+
+> **Tip:** Each JAR may also require its transitive dependencies. Use the download
+> script below on a machine with internet access to capture all transitive dependencies.
+
+## How to Populate `lib/build-logic`
+
+### Option A: Download on a Connected Machine (Recommended)
+
+On a machine that has internet access and the OmegaT source tree:
+
+Uncomment repository settings in `build-logic/src/main/groovy/org.omegat.java-conventions.gradle`
+
+```
+repositories {
+    mavenCentral()
+    // required by offline build
+    // mavenLocal()
+    // gradlePluginPortal()
+}
+```
+
+and then execute the special task
+
+```shell script
+./gradlew downloadBuildLogicDependencies
+```
+
+This task (when available) downloads all required JARs into `lib/build-logic/`.
+Then transfer the directory to the air-gapped machine.
+
+### Option B: Manual Download via Maven Coordinates
+
+Use any tool that can resolve Maven artifacts to download the JARs listed in the table above,
+including all transitive dependencies, into `lib/build-logic/`.
+
+### Option C: Use an Internal Maven Repository
+
+If your organisation runs an internal Maven mirror (Nexus, Artifactory, etc.):
+
+1. Ensure the mirror proxies or has the artifacts listed above.
+2. Leave `lib/build-logic` absent.
+3. Edit `build-logic/build.gradle` to point the `flatDir` or `maven` repository
+   entries at your internal server — or configure it via `settings.gradle`
+   `pluginManagement.repositories`.
+
+## Running the Offline Build
+
+Once `lib/build-logic/` is populated and `lib/provided/build-logic/` exists:
+
+```shell script
+./gradlew --offline distZip
+```
+
+## Troubleshooting
+
+| Symptom                                               | Likely Cause                                                                       |
+|-------------------------------------------------------|------------------------------------------------------------------------------------|
+| `Could not resolve …` during build-logic compilation  | A JAR (or its transitive dep) is missing from `lib/build-logic/`                   |
+| Flat-dir repository not activated                     | `lib/build-logic/` directory does not exist                                        |
+| `Network access disabled` errors for application deps | `lib/provided/core/` is missing; ensure you extracted the full source distribution |
+
+## See Also
+
+- [How to build OmegaT](08.HowToBuild.md) — general build instructions
+- [Source tree](36.SourceTree.md) — layout of the source distribution
+- [Build and dependency security](37.BuildAndDependencySecurity.md)

--- a/src_docs/developer/09.OfflineBuild.md
+++ b/src_docs/developer/09.OfflineBuild.md
@@ -13,8 +13,8 @@ However, the **build-logic** layer — the Gradle convention plugins that provid
 such as SpotBugs, Spotless, ErrorProne, and documentation tools — depends on additional
 Gradle plugins and libraries that are **not** included in the source distribution.
 
-To build fully offline, an enterprise administrator must pre-populate the directory
-`lib/build-logic` with the required JARs.
+To build fully offline, an enterprise administrator must pre-populate the maven local directory from
+`lib/provided/build-logic` with the required JARs.
 
 ## Directory Layout
 ```

--- a/src_docs/developer/09.OfflineBuild.md
+++ b/src_docs/developer/09.OfflineBuild.md
@@ -21,29 +21,23 @@ To build fully offline, an enterprise administrator must pre-populate the direct
 
 <project-root>/
 ├── lib/
-│   ├── provided/
-│   │   ├── core/         ← bundled in source dist; application runtime deps
-│   │   └── modules/      ← bundled in source dist; module plugin deps
-│   └── build-logic/      ← NOT bundled; must be populated by admin for offline builds
+│   └── provided/
+│       ├── core/         ← bundled in source dist; application runtime deps
+│       ├── modules/      ← bundled in source dist; module plugin deps
+│       └── build-logic/  ← NOT bundled; must be populated by admin for offline builds
 └── build-logic/
 └── build.gradle      ← detects lib/provided/build-logic; reads from lib/build-logic
 ```
-### Detection Mechanism
+### Provide build dependencies
 
-`build-logic/build.gradle` activates the flat-directory repository when the marker
-directory `lib/provided/build-logic` **exists**:
+`build-logic/build.gradle` depends on `mavenLocal()`, `mavenCentral()`, `gradlePlugins()` and `DocBook.org repository`.
 
-```groovy
-if (file('../lib/provided/build-logic').exists()) {
-    flatDir { dirs '../lib/build-logic' }
-}
-```
+An admin can copy `lib/provided/build-logic` into `~/.m2/repositories` to construct the maven local reposiotry.
 
 So the workflow for an admin is:
 
-1. Populate `lib/build-logic/` with all required JARs.
-2. Create the marker directory `lib/provided/build-logic/` (may be empty).
-3. Developers then run `./gradlew --offline` normally.
+1. Construct maven local repsoitory by `cp -r lib/provided/build-logic/* ~/.m2/repositories/` with all required JARs.
+2. Developers then run `./gradlew --offline` normally.
 
 ## Required JARs for `lib/build-logic`
 

--- a/src_docs/developer/adr/2025001.BuildSystem.md
+++ b/src_docs/developer/adr/2025001.BuildSystem.md
@@ -2,6 +2,7 @@
 
 ## Status
 **Accepted** – Fully Implemented
+**Updated** - 2026-05-31
 
 ## Context
 
@@ -16,21 +17,28 @@ Given OmegaT's structure of 42 module subprojects, there was a need for a cleane
 
 The development team decided to refactor the build system by modularizing the configurations through centralized, reusable Gradle convention plugins.
 
+### Updates
+
+- **2026-05-31**: Update description against [Migrated to real `OmegatModulePlugin` from conventions plugin](https://github.com/omegat-org/omegat/pull/1630), and [Update manual/greetings to docbook 5](https://github.com/omegat-org/omegat/pull/1861).
+
 ### Key Architectural Changes
 
 #### Modularization of Build Configurations
-- **New `build-logic/` directory**: A directory for Groovy-based convention plugins such as:
-    - `org.omegat.java-conventions`
-    - `org.omegat.module-conventions`
-    - `org.omegat.version-conventions`
-    - `org.omegat.windows-conventions`
+- **`build-logic/` directory**: A directory for Groovy-based convention plugins such as:
+    - `org.omegat.java-conventions.gradle`
+    - `org.omegat.version-conventions.gradle`
+    - `org.omegat.windows-conventions.gradle`
+- **Gradle plugin implementations with Groovy** such as:
+    - `org.omegat.module.OmegatModulePlugin.groovy`
+    - `org.omegat.documentation.DocumentationPlugin.groovy`
 - Each plugin centralizes repetitive build logic (e.g., manifest setup, task definitions) and applies standardized configurations across module projects.
+- Gradle plugin implementations support complex builds without Docker container execution or complex convention hacks.
 
 #### Plugin-Based Approach
 - Modules now apply the shared conventions using Gradle's `plugins` block:
   ```groovy
   plugins {
-      id 'org.omegat.module-conventions'
+      id 'org.omegat.module'
   }
   ```
 - Centralized configuration leads to consistency across module subprojects.
@@ -93,9 +101,7 @@ The development team decided to refactor the build system by modularizing the co
 
 ## Testing and Verification
 
-- The refactored build system was tested across multiple environments:
-    - Clean builds with and without the `-PforceSkipDocumentBuild` parameter.
-    - Verification of FatJar and normal JAR artifacts.
+- The refactored build system was tested across multiple environments.
 - The new structure successfully allows OmegaT to integrate module-subproject conventions while maintaining backward compatibility.
 
 ## Migration Strategy
@@ -109,12 +115,16 @@ The development team decided to refactor the build system by modularizing the co
     - Gradual enhancement of build logic.
 
 ## References
-- Pull Request: [#1237](https://github.com/omegat-org/omegat/pull/1237)
+- Pull Requests:
+    - [Bump Gradle@8.12, structured build configuration with conventions plugin, and fix deprecated methods](https://github.com/omegat-org/omegat/pull/1237)
+    - [Migrate to real OmegatModulePlugin from conventions plugin](https://github.com/omegat-org/omegat/pull/1630)
+    - [Update manual/greetings to docbook 5](https://github.com/omegat-org/omegat/pull/1861)
 - Relevant Mail Thread: [OmegaT Development - proposal: structural buld configuration of gradle](https://sourceforge.net/p/omegat/mailman/omegat-development/thread/b5eeb88d-70dc-4965-8569-3c9838b86aa4%40northside.tokyo/#msg59112760)
 - Gradle Documentation: [Conventions Plugin](https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:convention_plugins)
 
 ---
 
 **Date**: 2025-01-17
+**Update**: 2026-05-31
 **Author**: Hiroshi Miura
 **Reviewers**: OmegaT Development Team

--- a/src_docs/developer/index.md
+++ b/src_docs/developer/index.md
@@ -82,6 +82,7 @@
 
 ## Other information
 
+* [Offline Build](09.OfflineBuild.md)
 * [Release procedure](90.ReleaseProcedure.md)
 * [Code Signing How-to](92.CodeSigning.md)
 * [Building installer](93.BuildingInstallerPackage.md)


### PR DESCRIPTION
We recently add CI test to check source distribution consistency.
We have unique policy in source.zip distribution that should have all dependency library jars to allow future developers to reproduce old version of the OmegaT even if the dependency project had removed.

This PR add an explanation of the offline build and source distribution policy, and amend explanation and PR links to ADR#2025001.

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?
none
## What does this PR change?

- Update ADR#2025001
- Add 09.OfflineBuild.md
- Update links in index.md and 08.HowToBuild.md

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
