### PR TITLE
refactor(build-logic): improve build configuration

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -45,7 +45,6 @@ genDocIndex.finalizedBy(copyDocIndex)
 
 tasks.register('manualZips') {
     description = 'Builds the zipped manuals to bundle into the application.'
-    group = 'other'
 }
 
 tasks.register('manualHtmls') {

--- a/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
@@ -16,9 +16,6 @@ def genjaxb = tasks.register('genJAXB') {
     description = 'Generate classes for loading and manipulating XML formats'
     outputs.dir layout.buildDirectory.dir('generated/sources/jaxb/main/java')
     group = 'jaxb'
-    doFirst {
-        mkdir layout.buildDirectory.dir('generated/sources/jaxb/main/java').get().asFile
-    }
 }
 compileJava.dependsOn(genjaxb)
 

--- a/build-logic/src/main/groovy/org.omegat.jpkg-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jpkg-conventions.gradle
@@ -90,7 +90,6 @@ tasks.register('jpackageAppContent') {
 tasks.register('jpackage', Exec) {
     dependsOn cleanJpkgWorkdir
     dependsOn jars
-    group = 'other'
 
     inputs.files file(layout.buildDirectory.file('jars'))
     outputs.files file(layout.buildDirectory.file("jpackage/app-image"))

--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -318,13 +318,18 @@ tasks.register('jacocoIntegrationReport', JacocoReport) {
 }
 
 tasks.register('spotbugsReport') {
+    // Capture at configuration time
+    def rootProjectDir = rootProject.projectDir
+    def rootProjectPath = rootProject.path
+    def subprojectDirs = subprojects.collect { [dir: it.projectDir, path: it.path] }
+
     // Reusable function to check and print the report for a given project
     def printReport = { project ->
         ["main", "test"].each { target ->
-            def reportFile = project.file("build/reports/spotbugs/${target}.txt")
+            def reportFile = new File(projectDir, "build/reports/spotbugs/${target}.txt")
             if (reportFile.exists()) {
                 def sep = "-".repeat(40)
-                def ppath = project.path
+                def ppath = projectPath == ":" ? "OmegaT root project" : projectPath
                 if (ppath.equals(":")) {
                     ppath = "OmegaT root project"
                 }
@@ -338,8 +343,6 @@ tasks.register('spotbugsReport') {
     group = 'verification'
     doLast {
         printReport(rootProject)
-        subprojects.each { p ->
-            printReport(p)
-        }
+        subprojectDirs.each { p -> printReport(p.dir, p.path) }
     }
 }

--- a/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/AbstractDocumentTask.groovy
@@ -4,20 +4,30 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
+import javax.inject.Inject
+
 @CompileStatic
 abstract class AbstractDocumentTask  extends DefaultTask {
 
+    @Internal
+    final LogLevel logLevel = project.gradle.startParameter.logLevel
+
+    @Inject
+    abstract ObjectFactory getObjects()
+
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    final RegularFileProperty inputFile = project.objects.fileProperty()
+    final RegularFileProperty inputFile = objects.fileProperty()
 
-     protected void configureLogging() {
+    protected void configureLogging() {
         // Redirect spurious task output to INFO unless explicitly configured for debug
-        switch (project.gradle.startParameter.logLevel) {
+        switch (logLevel) {
             case LogLevel.DEBUG:
                 break
             default:

--- a/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.Input
 
 @CompileStatic
 @CacheableTask
-class DocbookHtmlTask extends TransformationTask {
+abstract class DocbookHtmlTask extends TransformationTask {
 
     private final Provider<String> css = project.objects.property(String)
     private final Provider<String> pageStyle = project.objects.property(String)

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -11,9 +11,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.xml.sax.InputSource
 import org.xml.sax.XMLReader
-import org.xmlresolver.Resolver
-import org.xmlresolver.ResolverConfiguration
 import org.xmlresolver.ResolverFeature
+import org.xmlresolver.XMLResolver
 import org.xmlresolver.XMLResolverConfiguration
 
 import javax.xml.parsers.SAXParserFactory
@@ -127,10 +126,10 @@ abstract class TransformationTask extends AbstractDocumentTask {
 
     private static ResourceResolverWrappingURIResolver initializeResourceResolver() {
         // Use the Catalog Resolver for URI resolution
-        ResolverConfiguration resolverConfig = new XMLResolverConfiguration()
+        XMLResolverConfiguration resolverConfig = new XMLResolverConfiguration()
         resolverConfig.addCatalog(CATALOG)
         resolverConfig.setFeature(ResolverFeature.CLASSPATH_CATALOGS, true)
-        def resolver = new Resolver(resolverConfig)
-        return new ResourceResolverWrappingURIResolver(resolver)
+        XMLResolver xmlResolver = new XMLResolver(resolverConfig)
+        return new ResourceResolverWrappingURIResolver(xmlResolver.getURIResolver())
     }
 }

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -5,7 +5,6 @@ import net.sf.saxon.lib.ResourceResolverWrappingURIResolver
 import net.sf.saxon.s9api.*
 import org.apache.xerces.jaxp.SAXParserFactoryImpl
 import org.gradle.api.file.FileTree
-import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -23,7 +22,7 @@ import javax.xml.transform.stream.StreamSource
 
 @CompileStatic
 @CacheableTask
-class TransformationTask extends AbstractDocumentTask {
+abstract class TransformationTask extends AbstractDocumentTask {
 
     private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities"
     private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities"

--- a/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 
 @CompileStatic
-class WhcTask extends AbstractDocumentTask {
+abstract class WhcTask extends AbstractDocumentTask {
 
     @InputFiles
     final Provider<FileTree> contentFiles = project.objects.property(FileTree)


### PR DESCRIPTION
We have the `build-logic` extended build configuration with groovy language and gradle convention mechanism.

There are several refactoring and improvement points in the build system.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none
## What does this PR change?

- `AbstractDocumentTask.groovy` should be `abstract` and `@Inject abstract ObjectFactory getObjects()` to avoid referencing `project` in the logging configuration that is used in execution phase.
- The inherited classes also become `abstract`
- `TransformationTask` class uses deprecated class `Resolver`. This replace it with newer `XMLResolver`
- We should not use `other` group in the configuration; whenb no group is specified, it goes to other
- We don't need to create output directory when we specify `outputs` parameter; it is automatically created
- Improve `spotbugsReport` task to deefine paths out of the execution task to support configuration cache.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
