### PR TITLE
chore(build): add offline dependency support and integrate into source distribution build

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -24,6 +24,7 @@ gradlePlugin {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     // 'repository' for getting docbook xsd
     ivy {
@@ -64,4 +65,63 @@ dependencies {
     implementation 'tokyo.northside:whc:3.6.0'
     implementation 'xalan:xalan:2.7.3'
     implementation 'xalan:serializer:2.7.3'
+}
+
+// Extra deps only needed for the offline build (not on the compile/runtime classpath)
+def offlineOnlyDeps = [
+        'org.omegat:launch4j:3.55',
+        'org.omegat:launch4j:3.55:workdir-win32',
+        'org.omegat:launch4j:3.55:workdir-mac',
+        'org.omegat:launch4j:3.55:workdir-linux64',
+        'org.omegat:launch4j:3.55:workdir-linux',
+]
+
+// Declare the resolvable configuration at configuration time (not inside doLast)
+configurations.create('buildLogicDepsCopy') {
+    transitive = true
+    canBeConsumed = false
+    canBeResolved = true
+}
+// Populate it at configuration time
+configurations.implementation.dependencies.each { dep ->
+    dependencies.add('buildLogicDepsCopy', dep)
+}
+offlineOnlyDeps.each { coord ->
+    dependencies.add('buildLogicDepsCopy', coord)
+}
+
+def destDir = layout.buildDirectory.dir('libs/build-logic')
+tasks.register('downloadBuildLogicDependencies') {
+    description = 'Downloads build-logic dependencies for offline/enterprise builds'
+    group = 'build setup'
+
+    outputs.dir(destDir)
+
+    doLast {
+
+        configurations.buildLogicDepsCopy
+                .resolvedConfiguration
+                .resolvedArtifacts
+                .each { artifact ->
+                    def moduleVersion = artifact.moduleVersion.id
+                    // Reconstruct Maven layout: group/artifact/version/artifact-version[-classifier].ext
+                    def groupPath = moduleVersion.group.replace('.', '/')
+                    def artifactDir = new File(destDir.get().asFile,
+                            "${groupPath}/${moduleVersion.name}/${moduleVersion.version}")
+                    artifactDir.mkdirs()
+
+                    def classifier = artifact.classifier ? "-${artifact.classifier}" : ''
+                    def fileName = "${moduleVersion.name}-${moduleVersion.version}${classifier}.${artifact.extension}"
+                    copy { from artifact.file; into artifactDir; rename { fileName } }
+                    // Fetch POM separately
+                    def pomDep = "${moduleVersion.group}:${moduleVersion.name}:${moduleVersion.version}@pom"
+                    def pomConfig = configurations.detachedConfiguration(
+                            dependencies.create(pomDep)
+                    )
+                    pomConfig.resolvedConfiguration.resolvedArtifacts.each { pom ->
+                        def pomName = "${moduleVersion.name}-${moduleVersion.version}.pom"
+                        copy { from pom.file; into artifactDir; rename { pomName } }
+                    }
+                }
+    }
 }

--- a/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
@@ -20,6 +20,7 @@ ext {
     }
     providedCoreLibsPath = 'lib/provided/core'
     providedModuleLibsPath = 'lib/provided/module'
+    providedBuildLogicPath = 'lib/provided/build-logic'
     providedCoreLibsDir = layout.settingsDirectory.dir(providedCoreLibsPath).asFile
     providedModuleLibsDir = layout.settingsDirectory.dir(providedModuleLibsPath).asFile
 }

--- a/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
@@ -20,7 +20,6 @@ ext {
     }
     providedCoreLibsPath = 'lib/provided/core'
     providedModuleLibsPath = 'lib/provided/module'
-    providedBuildLogicPath = 'lib/provided/build-logic'
     providedCoreLibsDir = layout.settingsDirectory.dir(providedCoreLibsPath).asFile
     providedModuleLibsDir = layout.settingsDirectory.dir(providedModuleLibsPath).asFile
 }

--- a/build.gradle
+++ b/build.gradle
@@ -333,6 +333,7 @@ def moduleLibs = subprojects
         .flatten()
 
 def buildLogicLibsDir = layout.settingsDirectory.file('build-logic/build/libs/build-logic')
+def providedBuildLogicPath = 'lib/provided/build-logic'
 
 distributions {
     main {

--- a/build.gradle
+++ b/build.gradle
@@ -332,6 +332,8 @@ def moduleLibs = subprojects
         }
         .flatten()
 
+def buildLogicLibsDir = layout.settingsDirectory.file('build-logic/build/libs/build-logic')
+
 distributions {
     main {
         contents {
@@ -434,11 +436,18 @@ distributions {
             into(providedModuleLibsPath) {
                 from(configurations.moduleRuntimeLibs)
             }
+            into(providedBuildLogicPath) {
+                from buildLogicLibsDir
+            }
         }
         sourceDistZip.archiveFileName.set(
                 "${application.applicationName}_${project.version}${omtVersion.beta}_Source.zip")
     }
 }
+def buildLogicLibsTask = gradle.includedBuild('build-logic')
+        .task(':downloadBuildLogicDependencies')
+installSourceDist.dependsOn(buildLogicLibsTask)
+sourceDistZip.dependsOn(buildLogicLibsTask)
 
 tasks.register('mac') {
     description = 'Builds the Mac distributions.'


### PR DESCRIPTION
Implement a way to bundle build-logic dependencies into source package.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none
## What does this PR change?

- add new `build-logic` task to download dependencies
- configure source distribution bundles `build-logic` dependencies in mavenLocal format.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
