### PR TITLE
Feature/empty translation issue

### DIFF
--- a/src/org/omegat/gui/issues/EmptyTranslationIssueProvider.java
+++ b/src/org/omegat/gui/issues/EmptyTranslationIssueProvider.java
@@ -1,0 +1,61 @@
+package org.omegat.gui.issues;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+
+public class EmptyTranslationIssueProvider implements IIssueProvider {
+
+    @Override
+    public String getName() {
+        return "Empty Translation Checker";
+    }
+
+    @Override
+    public String getId() {
+        return getClass().getCanonicalName();
+    }
+
+    @Override
+    public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
+        if (sourceEntry == null || tmxEntry == null) {
+            return Collections.emptyList();
+        }
+
+        String source = sourceEntry.getSrcText();
+        String translation = tmxEntry.translation;
+
+        if (source != null
+                && !source.trim().isEmpty()
+                && (translation == null || translation.trim().isEmpty())) {
+            return Arrays.asList(new EmptyTranslationIssue(sourceEntry, tmxEntry));
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static class EmptyTranslationIssue extends SimpleIssue {
+
+        EmptyTranslationIssue(SourceTextEntry sourceEntry, TMXEntry targetEntry) {
+            super(sourceEntry, targetEntry);
+        }
+
+        @Override
+        protected String getColor() {
+            return "#FFA500";
+        }
+
+        @Override
+        public String getTypeName() {
+            return "Empty Translation";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Translation is empty for a non-empty source segment.";
+        }
+    }
+}

--- a/src/org/omegat/gui/issues/IssueProviders.java
+++ b/src/org/omegat/gui/issues/IssueProviders.java
@@ -100,9 +100,10 @@ public final class IssueProviders {
         reg.removeIf(p -> SpellingIssueProvider.class.getCanonicalName().equals(p.getId())
                 || TerminologyIssueProvider.class.getCanonicalName().equals(p.getId()));
 
-        // Add defaults at the front in a stable order: Spelling, then Terminology
+        // Add defaults at the front in a stable order: Empty translation, Spelling, then Terminology
         reg.add(0, new TerminologyIssueProvider());
         reg.add(0, new SpellingIssueProvider());
+        reg.add(0, new EmptyTranslationIssueProvider());
     }
 
     public static void setProviderEnabled(String id, boolean enabled) {


### PR DESCRIPTION
## Summary

Adds a new issue provider that detects segments where the source text is not empty but the translation is empty.

## Changes

- Added EmptyTranslationIssueProvider
- Registered the provider in IssueProviders
- Added detection logic for empty translations