### PR TITLE
feat: sign macOS dylibs in jar dependencies for improved compatibility

### DIFF
--- a/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
+++ b/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
@@ -10,12 +10,25 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.plugins.quality.PmdExtension
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
 
 class OmegatModulePlugin implements Plugin<Project> {
+
+    private final ExecOperations execOperations
+    private final FileSystemOperations fileSystemOperations
+
+    @Inject
+    OmegatModulePlugin(ExecOperations execOperations, FileSystemOperations fileSystemOperations) {
+        this.execOperations = execOperations
+        this.fileSystemOperations = fileSystemOperations
+    }
 
     @Override
     void apply(Project project) {
@@ -59,7 +72,13 @@ class OmegatModulePlugin implements Plugin<Project> {
             from({
                 project.configurations.getByName("runtimeClasspath")
                         .resolve()
-                        .collect { it.directory ? it : project.zipTree(it) }
+                        .collect { dep ->
+                            if (dep.directory) return dep
+                            if (shouldSignDylibs(project) && containsDylibs(dep)) {
+                                return project.fileTree(signAndExtractJar(project, dep))
+                            }
+                            return project.zipTree(dep)
+                        }
             })
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             exclude "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA"
@@ -188,6 +207,62 @@ class OmegatModulePlugin implements Plugin<Project> {
     private static String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
         return project.hasProperty(propertyName) ?
                 project.property(propertyName).toString() : defaultValue
+    }
+
+    /**
+     * Returns true if the macCodesignIdentity property is set and the codesign tool is present on PATH.
+     */
+    private static boolean shouldSignDylibs(Project project) {
+        if (!project.hasProperty('macCodesignIdentity')) return false
+        return ['which codesign', 'where codesign'].any {
+            try {
+                def proc = it.execute()
+                proc.waitForProcessOutput()
+                return proc.exitValue() == 0
+            } catch (ignored) {
+                return false
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given jar file contains at least one *.dylib entry.
+     */
+    private static boolean containsDylibs(File jar) {
+        if (!jar.name.endsWith('.jar') || !jar.exists()) return false
+        def zipFile = new java.util.zip.ZipFile(jar)
+        try {
+            return zipFile.entries().any { !it.directory && it.name.endsWith('.dylib') }
+        } finally {
+            zipFile.close()
+        }
+    }
+
+    /**
+     * Extracts the given dependency jar to a per-jar staging directory, signs all *.dylib files
+     * inside it with the Apple developer identity from the macCodesignIdentity project property,
+     * and returns the staging directory.  The caller should include this directory in the fat-jar
+     * instead of the original zipTree so that the signed native libraries end up in the module jar.
+     */
+    private File signAndExtractJar(Project project, File jar) {
+        def jarBaseName = jar.name.replaceAll(/\.jar$/, '')
+        def stagingDir = project.layout.buildDirectory.dir("signedJarContents/${jarBaseName}").get().asFile
+
+        fileSystemOperations.copy {
+            from project.zipTree(jar)
+            into stagingDir
+        }
+
+        def dylibs = project.fileTree(dir: stagingDir, include: '**/*.dylib').files.toList()
+        execOperations.exec {
+            commandLine(['codesign', '--deep', '--force',
+                    '--sign', project.property('macCodesignIdentity'),
+                    '--timestamp',
+                    '--options', 'runtime',
+                    '--entitlements', project.rootProject.file('release/mac-specific/java.entitlements')] + dylibs)
+        }
+
+        return stagingDir
     }
 
     /**


### PR DESCRIPTION
We have many dependencies in our subprojects/modules.
There are several dependnecies includes native libraries for its feature such as

- `FlatLaf LookAndFeel library` in `theme` subproject
- `Dumont Hunspell` in `spellchecker/hunspell`  subproject

These native libraries should be singned for notarization of apple macOS platform to run on.
This adds a logic to sign the nativef libraries which has `.dylib` extension in jar files in subproject/module dependencies when creating FarJar jar files.
 
## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]


## Which ticket is resolved?

none

## What does this PR change?
- Add logic to detect and sign *.dylib files in jar dependencies using Apple developer identity
- Update fat-jar process to include signed dylibs instead of original zipTree
- Inject `ExecOperations` and `FileSystemOperations` for file manipulation and command execution


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
