### PR TITLE
feat(filters:latex): add verbatim environment support

### DIFF
--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -336,6 +336,8 @@ public class LatexFilter extends AbstractFilter {
     private final List<String> oneArgInlineText = new LinkedList<>();
     private final List<String> oneArgParText = new LinkedList<>();
     private final List<String> parBreakCommand = new LinkedList<>();
+    private int verbatimLevel = 0;
+    private List<String> verbatimEnvironments;
 
     private void init() {
         oneArgNoText.add("\\begin");

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -171,6 +171,43 @@ public class LatexFilter extends AbstractFilter {
              */
             String state;
             while ((s = lpin.readLine()) != null) {
+                // Enter verbatim mode on \begin{verbatim} etc.
+                if (verbatimLevel == 0) {
+                    String trimmed = s.trim();
+                    if (trimmed.startsWith("\\begin{")) {
+                        int openBrace = trimmed.indexOf("{");
+                        int closeBrace = trimmed.indexOf('}', openBrace);
+                        if (closeBrace > openBrace) {
+                            String envName = trimmed.substring(openBrace + 1, closeBrace).trim();
+                            if (verbatimEnvironments.contains(envName)) {
+                                verbatimLevel++;
+                                out.write(s);
+                                out.write(lpin.getLinebreak());
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // Skip verbatim blocks as-is (copy through to \end{...})
+                if (verbatimLevel > 0) {
+                    out.write(s);
+                    out.write(lpin.getLinebreak());
+                    // Check for matching \end{verbatim} to leave verbatim mode
+                    String trimmed = s.trim();
+                    if (trimmed.startsWith("\\end{")) {
+                        int openBrace = trimmed.indexOf("{");
+                        int closeBrace = trimmed.indexOf('}', openBrace);
+                        if (closeBrace > openBrace) {
+                            String envName = trimmed.substring(openBrace + 1, closeBrace).trim();
+                            if (verbatimEnvironments.contains(envName)) {
+                                verbatimLevel--;
+                            }
+                        }
+                    }
+                    continue;
+                }
+                
                 lineBreak = lpin.getLinebreak();
                 // String[] c = s.split(""); In Java 8, that line gave a first
                 // empty element, so it was replaced with the
@@ -303,6 +340,13 @@ public class LatexFilter extends AbstractFilter {
     private void init() {
         oneArgNoText.add("\\begin");
         oneArgNoText.add("\\end");
+
+        verbatimEnvironments = java.util.Arrays.asList(
+            "verbatim", "verbatim*",
+            "comment", "verbatimimport",
+            "lstlisting", "lstlisting*",
+            "minted", "listing", "listing*"
+        );
         oneArgNoText.add("\\cite");
         oneArgNoText.add("\\label");
         oneArgNoText.add("\\ref");

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -11,6 +11,7 @@
                2014 Adiel Mittmann
                2017 Didier Briel
                2023 Hiroshi Miura
+               2026 pierreldff
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -43,6 +44,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.Instance;
@@ -157,7 +159,7 @@ public class LatexFilter extends AbstractFilter {
      * @param out
      *            Target document
      */
-    private void processLatexFile(BufferedReader in, Writer out) throws IOException {
+    void processLatexFile(BufferedReader in, Writer out) throws IOException {
         try (LinebreakPreservingReader lpin = new LinebreakPreservingReader(in)) {
             StringBuilder par = new StringBuilder();
             String s;
@@ -324,7 +326,8 @@ public class LatexFilter extends AbstractFilter {
      * @param prefix the command prefix to look for (e.g., "\\begin{")
      * @return the content inside braces, or null if not found
      */
-    private String parseBracedCommand(String line, String prefix) {
+    @VisibleForTesting
+    String parseBracedCommand(String line, String prefix) {
         if (!line.startsWith(prefix)) {
             return null;
         }

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -173,19 +173,12 @@ public class LatexFilter extends AbstractFilter {
             while ((s = lpin.readLine()) != null) {
                 // Enter verbatim mode on \begin{verbatim} etc.
                 if (verbatimLevel == 0) {
-                    String trimmed = s.trim();
-                    if (trimmed.startsWith("\\begin{")) {
-                        int openBrace = trimmed.indexOf("{");
-                        int closeBrace = trimmed.indexOf('}', openBrace);
-                        if (closeBrace > openBrace) {
-                            String envName = trimmed.substring(openBrace + 1, closeBrace).trim();
-                            if (verbatimEnvironments.contains(envName)) {
-                                verbatimLevel++;
-                                out.write(s);
-                                out.write(lpin.getLinebreak());
-                                continue;
-                            }
-                        }
+                    String envName = parseBracedCommand(s.trim(), "\\begin{");
+                    if (envName != null && verbatimEnvironments.contains(envName)) {
+                        verbatimLevel++;
+                        out.write(s);
+                        out.write(lpin.getLinebreak());
+                        continue;
                     }
                 }
 
@@ -193,21 +186,13 @@ public class LatexFilter extends AbstractFilter {
                 if (verbatimLevel > 0) {
                     out.write(s);
                     out.write(lpin.getLinebreak());
-                    // Check for matching \end{verbatim} to leave verbatim mode
-                    String trimmed = s.trim();
-                    if (trimmed.startsWith("\\end{")) {
-                        int openBrace = trimmed.indexOf("{");
-                        int closeBrace = trimmed.indexOf('}', openBrace);
-                        if (closeBrace > openBrace) {
-                            String envName = trimmed.substring(openBrace + 1, closeBrace).trim();
-                            if (verbatimEnvironments.contains(envName)) {
-                                verbatimLevel--;
-                            }
-                        }
+                    String envName = parseBracedCommand(s.trim(), "\\end{");
+                    if (envName != null && verbatimEnvironments.contains(envName)) {
+                        verbatimLevel--;
                     }
                     continue;
                 }
-                
+
                 lineBreak = lpin.getLinebreak();
                 // String[] c = s.split(""); In Java 8, that line gave a first
                 // empty element, so it was replaced with the
@@ -330,6 +315,25 @@ public class LatexFilter extends AbstractFilter {
         par = par.replaceAll("%", "\\\\%");
         par = par.replaceAll("<br0>", "\\\\\\\\");
         return par;
+    }
+
+    /**
+     * Extracts the argument from a braced command like \command{arg}.
+     *
+     * @param line the line to parse
+     * @param prefix the command prefix to look for (e.g., "\\begin{")
+     * @return the content inside braces, or null if not found
+     */
+    private String parseBracedCommand(String line, String prefix) {
+        if (!line.startsWith(prefix)) {
+            return null;
+        }
+        int openBrace = line.indexOf("{");
+        int closeBrace = line.indexOf('}', openBrace);
+        if (closeBrace > openBrace) {
+            return line.substring(openBrace + 1, closeBrace).trim();
+        }
+        return null;
     }
 
     private final List<String> oneArgNoText = new LinkedList<>();

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.Instance;
@@ -331,6 +332,7 @@ public class LatexFilter extends AbstractFilter {
      * @return the content inside braces, or null if not found
      */
     @VisibleForTesting
+    @Nullable
     String parseBracedCommand(String line, String prefix) {
         if (!line.startsWith(prefix)) {
             return null;

--- a/src/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/org/omegat/filters2/latex/LatexFilter.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.NullMarked;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.Instance;
@@ -64,6 +65,7 @@ import org.omegat.util.OStrings;
  * @author Adiel Mittmann
  * @author Hiroshi Miura
  */
+@NullMarked
 public class LatexFilter extends AbstractFilter {
 
     /**
@@ -322,8 +324,10 @@ public class LatexFilter extends AbstractFilter {
     /**
      * Extracts the argument from a braced command like \command{arg}.
      *
-     * @param line the line to parse
-     * @param prefix the command prefix to look for (e.g., "\\begin{")
+     * @param line
+     *            the line to parse
+     * @param prefix
+     *            the command prefix to look for (e.g., "\\begin{")
      * @return the content inside braces, or null if not found
      */
     @VisibleForTesting
@@ -344,18 +348,12 @@ public class LatexFilter extends AbstractFilter {
     private final List<String> oneArgParText = new LinkedList<>();
     private final List<String> parBreakCommand = new LinkedList<>();
     private int verbatimLevel = 0;
-    private List<String> verbatimEnvironments;
+    private final List<String> verbatimEnvironments = List.of("verbatim", "verbatim*", "comment",
+            "verbatimimport", "lstlisting", "lstlisting*", "minted", "listing", "listing*");
 
     private void init() {
         oneArgNoText.add("\\begin");
         oneArgNoText.add("\\end");
-
-        verbatimEnvironments = java.util.Arrays.asList(
-            "verbatim", "verbatim*",
-            "comment", "verbatimimport",
-            "lstlisting", "lstlisting*",
-            "minted", "listing", "listing*"
-        );
         oneArgNoText.add("\\cite");
         oneArgNoText.add("\\label");
         oneArgNoText.add("\\ref");

--- a/test/data/filters/Latex/latexverbatim.tex
+++ b/test/data/filters/Latex/latexverbatim.tex
@@ -1,0 +1,29 @@
+% Verbatim test file for OmegaT LaTeX filter
+\documentclass{article}
+\begin{document}
+\section{Hello World}
+This is normal text that should be translated.
+
+\begin{verbatim}
+#include <stdio.h>
+int main() {
+    printf("Hello, World!\n");  // This line has special chars: $ % & { }
+    return 0;
+}
+\end{verbatim}
+
+More text after verbatim that should be translated too.
+
+\begin{verbatim*}
+Nested \begin and \end should NOT be interpreted.
+Special characters: $, %, &, #, {, }, ^, _, ~
+\end{verbatim*}
+
+\begin{minted}{java}
+public class Test {
+    // Code inside minted should be preserved too
+    String s = "test$pecial";
+}
+\end{minted}
+
+\end{document}

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class LatexFilterTest extends TestFilterBase {
 
@@ -100,5 +101,34 @@ public class LatexFilterTest extends TestFilterBase {
         String target = entries.get(0);
         assertTrue("ends with unwanted string: " + target.substring(target.length() - 10),
                 target.matches("We <u\\d> it, and <u\\d> is compressed. Then we <u\\d>. "));
+    }
+    /**
+     * Verifies that verbatim environments (verbatim, minted, lstlisting, etc.)
+     * are preserved as-is and their content is NOT extracted as translatable segments.
+     */
+    @Test
+    public void testVerbatimPreserved() throws Exception {
+        String f = "test/data/filters/Latex/latexverbatim.tex";
+        List<String> segments = parse(new LatexFilter(), f);
+
+        // Normal text should be extracted as segments
+        assertTrue("Normal text before verbatim should be a segment",
+                segments.stream().anyMatch(s -> s.contains("Hello World")));
+        assertTrue("Normal text after verbatim should be a segment",
+                segments.stream().anyMatch(s -> s.contains("More text after verbatim")));
+
+        // Verbatim content must NOT appear as separate segments
+        assertFalse("C include directive should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("#include")));
+        assertFalse("C main function should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("int main")));
+        assertFalse("printf call should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("printf")));
+        assertFalse("Special chars should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("return 0")));
+        assertFalse("minted content should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("public class Test")));
+        assertFalse("minted code should NOT be a segment",
+                segments.stream().anyMatch(s -> s.contains("test$pecial")));
     }
 }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -106,7 +106,8 @@ public class LatexFilterTest extends TestFilterBase {
 
     /**
      * Verifies that verbatim environments (verbatim, minted, lstlisting, etc.)
-     * are preserved as-is and their content is NOT extracted as translatable segments.
+     * are preserved as-is and their content is NOT extracted as translatable
+     * segments.
      */
     @Test
     public void testVerbatimPreserved() throws Exception {

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -30,10 +30,13 @@ import org.junit.Test;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.latex.LatexFilter;
 
+import java.lang.reflect.Method;
+
 import java.io.File;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -130,5 +133,29 @@ public class LatexFilterTest extends TestFilterBase {
                 segments.stream().anyMatch(s -> s.contains("public class Test")));
         assertFalse("minted code should NOT be a segment",
                 segments.stream().anyMatch(s -> s.contains("test$pecial")));
+    }
+
+    @Test
+    public void testParseBracedCommand() throws Exception {
+        LatexFilter filter = new LatexFilter();
+        Method m = LatexFilter.class.getDeclaredMethod("parseBracedCommand", String.class, String.class);
+        m.setAccessible(true);
+
+        // Valid \begin{env}
+        assertEquals("verbatim", m.invoke(filter, "\\begin{verbatim}", "\\begin{"));
+        assertEquals("verbatim*", m.invoke(filter, "\\begin{verbatim*}", "\\begin{"));
+
+        // Valid \end{env}
+        assertEquals("verbatim", m.invoke(filter, "\\end{verbatim}", "\\end{"));
+
+        // No brace pair -> null
+        assertNull(m.invoke(filter, "\\begin{verbatim", "\\begin{"));
+        assertNull(m.invoke(filter, "\\begin", "\\begin{"));
+
+        // Wrong prefix -> null
+        assertNull(m.invoke(filter, "\\end{verbatim}", "\\begin{"));
+
+        // No match at start
+        assertNull(m.invoke(filter, "hello \\begin{verbatim}", "\\begin{"));
     }
 }

--- a/test/src/org/omegat/filters/LatexFilterTest.java
+++ b/test/src/org/omegat/filters/LatexFilterTest.java
@@ -5,6 +5,7 @@
 
  Copyright (C) 2011 Alex Buloichik
                2023 Hiroshi Miura
+               2026 pierreldff
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -30,15 +31,12 @@ import org.junit.Test;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.latex.LatexFilter;
 
-import java.lang.reflect.Method;
-
 import java.io.File;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LatexFilterTest extends TestFilterBase {
 
@@ -105,6 +103,7 @@ public class LatexFilterTest extends TestFilterBase {
         assertTrue("ends with unwanted string: " + target.substring(target.length() - 10),
                 target.matches("We <u\\d> it, and <u\\d> is compressed. Then we <u\\d>. "));
     }
+
     /**
      * Verifies that verbatim environments (verbatim, minted, lstlisting, etc.)
      * are preserved as-is and their content is NOT extracted as translatable segments.
@@ -133,29 +132,5 @@ public class LatexFilterTest extends TestFilterBase {
                 segments.stream().anyMatch(s -> s.contains("public class Test")));
         assertFalse("minted code should NOT be a segment",
                 segments.stream().anyMatch(s -> s.contains("test$pecial")));
-    }
-
-    @Test
-    public void testParseBracedCommand() throws Exception {
-        LatexFilter filter = new LatexFilter();
-        Method m = LatexFilter.class.getDeclaredMethod("parseBracedCommand", String.class, String.class);
-        m.setAccessible(true);
-
-        // Valid \begin{env}
-        assertEquals("verbatim", m.invoke(filter, "\\begin{verbatim}", "\\begin{"));
-        assertEquals("verbatim*", m.invoke(filter, "\\begin{verbatim*}", "\\begin{"));
-
-        // Valid \end{env}
-        assertEquals("verbatim", m.invoke(filter, "\\end{verbatim}", "\\end{"));
-
-        // No brace pair -> null
-        assertNull(m.invoke(filter, "\\begin{verbatim", "\\begin{"));
-        assertNull(m.invoke(filter, "\\begin", "\\begin{"));
-
-        // Wrong prefix -> null
-        assertNull(m.invoke(filter, "\\end{verbatim}", "\\begin{"));
-
-        // No match at start
-        assertNull(m.invoke(filter, "hello \\begin{verbatim}", "\\begin{"));
     }
 }

--- a/test/src/org/omegat/filters2/latex/LatexFilterUnitTest.java
+++ b/test/src/org/omegat/filters2/latex/LatexFilterUnitTest.java
@@ -1,0 +1,57 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 pierreldff
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.filters2.latex;
+
+import org.junit.Test;
+import org.omegat.filters.TestFilterBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class LatexFilterUnitTest extends TestFilterBase {
+
+    @Test
+    public void testParseBracedCommand() throws Exception {
+        LatexFilter filter = new LatexFilter();
+
+        // Valid \begin{env}
+        assertEquals("verbatim", filter.parseBracedCommand("\\begin{verbatim}", "\\begin{"));
+        assertEquals("verbatim*", filter.parseBracedCommand("\\begin{verbatim*}", "\\begin{"));
+
+        // Valid \end{env}
+        assertEquals("verbatim", filter.parseBracedCommand("\\end{verbatim}", "\\end{"));
+
+        // No brace pair -> null
+        assertNull(filter.parseBracedCommand("\\begin{verbatim", "\\begin{"));
+        assertNull(filter.parseBracedCommand("\\begin", "\\begin{"));
+
+        // Wrong prefix -> null
+        assertNull(filter.parseBracedCommand("\\end{verbatim}", "\\begin{"));
+
+        // No match at start
+        assertNull(filter.parseBracedCommand("hello \\begin{verbatim}", "\\begin{"));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## What does this PR change?

- Detect and preserve LaTeX verbatim environments (`verbatim`, `minted`, `lstlisting`, etc.) without extracting their content as translatable segments.
- Prevents source code or untranslatable blocks within LaTeX files from being exposed to the translator, improving the segmentation workflow.
- Added corresponding unit tests to validate the LaTeX filter behavior.

## Other information

* **AI-assisted:** The initial implementation logic was drafted/assisted by AI.

### Checklist
- [x] Automated tests pass locally
- [x] No regressions introduced in other LaTeX environments