### PR TITLE
feat(editor): decouple segment sorting from filtering (#1094)

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -200,6 +200,35 @@ BUTTON_FILTER_REPLACE_NEXT=&Replace and Find Next
 BUTTON_FILTER_CANCEL=&Finish
 BUTTON_FILTER_REMOVE_FILTER=&Remove Filter
 
+# Segment sorting (editor display order)
+SORT_BAR_LABEL=Sort:
+SORT_BAR_WARNING=Segments are sorted; their numbers are no longer sequential.
+SORT_BAR_ADD=Add another sort criterion
+SORT_BAR_REMOVE_KEY=Remove this sort criterion
+SORT_ASCENDING=Ascending
+SORT_DESCENDING=Descending
+SORT_KEY_PRIMARY=Primary sort key:
+SORT_KEY_SECONDARY=Secondary sort key:
+SORT_KEY_TERTIARY=Tertiary sort key:
+SORT_KEY_NATURAL=File order (unsorted)
+SORT_KEY_SOURCE_ALPHA=Source alphabetical
+SORT_KEY_SOURCE_RHYME=Source reverse (rhyme)
+SORT_KEY_SOURCE_LENGTH=Source length
+SORT_KEY_TARGET_ALPHA=Target alphabetical
+SORT_KEY_TARGET_RHYME=Target reverse (rhyme)
+SORT_KEY_TARGET_LENGTH=Target length
+SORT_KEY_TRANS_STATUS=Translation status
+SORT_KEY_NOTE_ALPHA=Note alphabetical
+SORT_KEY_NOTE_RHYME=Note reverse (rhyme)
+SORT_KEY_NOTE_LENGTH=Note length
+SORT_KEY_COMMENT_ALPHA=Comment alphabetical
+SORT_KEY_COMMENT_RHYME=Comment reverse (rhyme)
+SORT_KEY_COMMENT_LENGTH=Comment length
+SORT_KEY_CHANGE_DATE=Change date
+SORT_KEY_CREATION_DATE=Creation date
+SORT_KEY_CHANGER=Modification author
+SORT_KEY_CREATOR=Creation author
+
 BUTTON_REMOVE=&Remove
 BUTTON_REMOVE_2=R&emove
 

--- a/src/org/omegat/Bundle_de.properties
+++ b/src/org/omegat/Bundle_de.properties
@@ -109,6 +109,35 @@ BUTTON_FILTER_REPLACE_NEXT=E&rsetzen und N\u00E4chstes finden
 BUTTON_FILTER_CANCEL=&Beenden
 BUTTON_FILTER_REMOVE_FILTER=Filte&r entfernen
 
+# Segmentsortierung (Anzeigereihenfolge im Editor)
+SORT_BAR_LABEL=Sortierung:
+SORT_BAR_WARNING=Segmente sind sortiert; ihre Nummern sind nicht mehr fortlaufend.
+SORT_ASCENDING=Aufsteigend
+SORT_DESCENDING=Absteigend
+SORT_BAR_ADD=Weiteres Sortierkriterium hinzuf\u00FCgen
+SORT_BAR_REMOVE_KEY=Dieses Sortierkriterium entfernen
+SORT_KEY_PRIMARY=Prim\u00E4rer Sortierschl\u00FCssel:
+SORT_KEY_SECONDARY=Sekund\u00E4rer Sortierschl\u00FCssel:
+SORT_KEY_TERTIARY=Terti\u00E4rer Sortierschl\u00FCssel:
+SORT_KEY_NATURAL=Dateireihenfolge (unsortiert)
+SORT_KEY_SOURCE_ALPHA=Quelle alphabetisch
+SORT_KEY_SOURCE_RHYME=Quelle r\u00FCckw\u00E4rts (Reim)
+SORT_KEY_SOURCE_LENGTH=Quelll\u00E4nge
+SORT_KEY_TARGET_ALPHA=Ziel alphabetisch
+SORT_KEY_TARGET_RHYME=Ziel r\u00FCckw\u00E4rts (Reim)
+SORT_KEY_TARGET_LENGTH=Ziell\u00E4nge
+SORT_KEY_TRANS_STATUS=\u00DCbersetzungsstatus
+SORT_KEY_NOTE_ALPHA=Notiz alphabetisch
+SORT_KEY_NOTE_RHYME=Notiz r\u00FCckw\u00E4rts (Reim)
+SORT_KEY_NOTE_LENGTH=Notizl\u00E4nge
+SORT_KEY_COMMENT_ALPHA=Kommentar alphabetisch
+SORT_KEY_COMMENT_RHYME=Kommentar r\u00FCckw\u00E4rts (Reim)
+SORT_KEY_COMMENT_LENGTH=Kommentarl\u00E4nge
+SORT_KEY_CHANGE_DATE=\u00C4nderungsdatum
+SORT_KEY_CREATION_DATE=Erstellungsdatum
+SORT_KEY_CHANGER=\u00C4nderungsautor
+SORT_KEY_CREATOR=Erstellungsautor
+
 BUTTON_REMOVE=&Entfernen
 BUTTON_REMOVE_2=Entfe&rnen
 

--- a/src/org/omegat/gui/editor/EditorController.java
+++ b/src/org/omegat/gui/editor/EditorController.java
@@ -68,7 +68,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import javax.swing.BoxLayout;
 import javax.swing.JComponent;
+import javax.swing.JPanel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
@@ -101,6 +103,7 @@ import org.omegat.core.events.IEntryEventListener;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.dialogs.ConflictDialogController;
 import org.omegat.gui.editor.autocompleter.IAutoCompleter;
+import org.omegat.gui.editor.sort.SortBar;
 import org.omegat.gui.editor.mark.CalcMarkersThread;
 import org.omegat.gui.editor.mark.ComesFromMTMarker;
 import org.omegat.gui.editor.mark.EntryMarks;
@@ -184,6 +187,10 @@ public class EditorController implements IEditor {
     /** Dockable pane for editor. */
     private DockablePanel pane;
     private JScrollPane scrollPane;
+    /** Container at the top of the editor stacking the sort and filter bars. */
+    private JPanel northBars;
+    /** Always-visible bar to choose the segment display order. */
+    private SortBar sortBar;
 
     private String title;
 
@@ -255,6 +262,8 @@ public class EditorController implements IEditor {
     volatile @Nullable IEditorFilter entriesFilter;
     private @Nullable Component entriesFilterControlComponent;
 
+    volatile @Nullable IEditorSorter entriesSorter;
+
     private final SegmentExportImport segmentExportImport;
 
     protected @Nullable String currentEntryOrigin;
@@ -299,6 +308,11 @@ public class EditorController implements IEditor {
                 m_docSegList = null;
                 history.clear();
                 removeFilter();
+                entriesSorter = null;
+                if (sortBar != null) {
+                    sortBar.reset();
+                    sortBar.setVisible(false);
+                }
                 markerController.removeAll();
                 showType = SHOW_TYPE.INTRO;
                 deactivateWithoutCommit();
@@ -413,6 +427,17 @@ public class EditorController implements IEditor {
         scrollPane.setName("EditorScrollPane");
         pane.setLayout(new BorderLayout());
         pane.add(scrollPane, BorderLayout.CENTER);
+
+        // The sort and filter bars are stacked in this north container (the sort
+        // bar is always visible on top; the filter bar appears below it when a
+        // filter is active). BorderLayout.NORTH itself holds only one component.
+        northBars = new JPanel();
+        northBars.setLayout(new BoxLayout(northBars, BoxLayout.Y_AXIS));
+        sortBar = new SortBar();
+        // Hidden until a project with more than one (post-filter) segment is shown.
+        sortBar.setVisible(false);
+        northBars.add(sortBar);
+        pane.add(northBars, BorderLayout.NORTH);
 
         mw.addDockable(pane);
 
@@ -718,6 +743,12 @@ public class EditorController implements IEditor {
                 tmpSegList.add(sb);
             }
         }
+        // Filtering is done; now apply the (optional) display sort. The default
+        // (no sorter) preserves natural file order because tmpSegList is already
+        // built in file order. List.sort is stable, so equal keys keep that order.
+        if (entriesSorter != null) {
+            tmpSegList.sort(entriesSorter.getComparator());
+        }
         m_docSegList = tmpSegList.toArray(new SegmentBuilder[0]);
 
         // Clamp displayedSegment to actually available entries.
@@ -775,6 +806,11 @@ public class EditorController implements IEditor {
         });
 
         markerController.process(m_docSegList);
+
+        // Only offer sorting when there is more than one segment to reorder.
+        if (sortBar != null) {
+            sortBar.setVisible(m_docSegList != null && m_docSegList.length > 1);
+        }
 
         editor.repaint();
     }
@@ -1668,13 +1704,10 @@ public class EditorController implements IEditor {
                         displayedFileIndex = i;
                         loadDocument();
                     }
-                    // find correct displayedEntryIndex
-                    for (int j = 0; j < m_docSegList.length; j++) {
-                        if (m_docSegList[j].segmentNumberInProject >= entryNum) { //
-                            displayedEntryIndex = j;
-                            break;
-                        }
-                    }
+                    // find correct displayedEntryIndex. The list may be in any
+                    // display order (a sorter can reorder it), so locate by exact
+                    // entry number, falling back to the nearest available entry.
+                    displayedEntryIndex = findDisplayIndexForEntry(entryNum);
                     break;
                 }
             }
@@ -1682,6 +1715,30 @@ public class EditorController implements IEditor {
         activateEntry(pos);
         editor.setCursor(oldCursor);
         updateTitleCurrentFile();
+    }
+
+    /**
+     * Find the index in {@link #m_docSegList} of the segment with the given
+     * project entry number. The list may be in any display order (a sorter can
+     * reorder it), so we cannot assume ascending order. If the exact entry is not
+     * present (e.g. filtered out), return the index of the segment whose entry
+     * number is closest to {@code entryNum}, or 0 if the list is empty.
+     */
+    private int findDisplayIndexForEntry(int entryNum) {
+        int fallback = 0;
+        int bestDelta = Integer.MAX_VALUE;
+        for (int j = 0; j < m_docSegList.length; j++) {
+            int num = m_docSegList[j].segmentNumberInProject;
+            if (num == entryNum) {
+                return j;
+            }
+            int delta = Math.abs(num - entryNum);
+            if (delta < bestDelta) {
+                bestDelta = delta;
+                fallback = j;
+            }
+        }
+        return fallback;
     }
 
     @Override
@@ -2153,12 +2210,13 @@ public class EditorController implements IEditor {
         UIThreadsUtil.mustBeSwingThread();
 
         if (entriesFilterControlComponent != null) {
-            pane.remove(entriesFilterControlComponent);
+            northBars.remove(entriesFilterControlComponent);
         }
 
         entriesFilter = filter;
         entriesFilterControlComponent = filter.getControlComponent();
-        pane.add(entriesFilterControlComponent, BorderLayout.NORTH);
+        // Append below the always-present sort bar.
+        northBars.add(entriesFilterControlComponent);
         pane.revalidate();
 
         SourceTextEntry curEntry = getCurrentEntry();
@@ -2171,16 +2229,30 @@ public class EditorController implements IEditor {
             if (entriesFilter == null || entriesFilter.allowed(curEntry)) {
                 gotoEntry(curEntry.entryNum());
             } else {
-                // Go to next (available) segment. But first, we need to reset
-                // the displayedEntryIndex to the number where the current but
-                // filtered entry could have been if it was not filtered.
+                // The current entry was filtered out. Go to the visible segment
+                // closest after it in entry-number space (or the closest before it
+                // if none follows). The list may be in any display order, so search
+                // by entry number rather than by position.
+                int best = -1;
+                int bestNum = Integer.MAX_VALUE;
+                int prev = -1;
+                int prevNum = Integer.MIN_VALUE;
                 for (int j = 0; j < m_docSegList.length; j++) {
-                    if (m_docSegList[j].segmentNumberInProject >= curEntryNum) { //
-                        displayedEntryIndex = j - 1;
-                        break;
+                    int num = m_docSegList[j].segmentNumberInProject;
+                    if (num >= curEntryNum && num < bestNum) {
+                        bestNum = num;
+                        best = j;
+                    }
+                    if (num < curEntryNum && num > prevNum) {
+                        prevNum = num;
+                        prev = j;
                     }
                 }
-                nextEntry();
+                int target = (best >= 0) ? best : prev;
+                if (target >= 0) {
+                    displayedEntryIndex = target;
+                    activateEntry();
+                }
             }
         }
     }
@@ -2199,7 +2271,7 @@ public class EditorController implements IEditor {
 
         entriesFilter = null;
         if (entriesFilterControlComponent != null) {
-            pane.remove(entriesFilterControlComponent);
+            northBars.remove(entriesFilterControlComponent);
             pane.revalidate();
             entriesFilterControlComponent = null;
         }
@@ -2212,6 +2284,63 @@ public class EditorController implements IEditor {
         if (doc != null && project != null && project.isProjectLoaded()) {
             List<FileInfo> files = project.getProjectFiles();
             if (files != null && !files.isEmpty()) {
+                loadDocument();
+                gotoEntry(curEntryNum);
+            }
+        }
+    }
+
+    @Override
+    public @Nullable IEditorSorter getSort() {
+        return entriesSorter;
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded to immediately apply the new display
+     * order, keeping the current entry active. The sort bar itself is always
+     * visible and managed by the editor, so no control component is added here.
+     */
+    @Override
+    public void setSort(IEditorSorter sorter) {
+        UIThreadsUtil.mustBeSwingThread();
+
+        entriesSorter = sorter;
+
+        SourceTextEntry curEntry = getCurrentEntry();
+        Document3 doc = editor.getOmDocument();
+        IProject project = Core.getProject();
+        // Prevent NullPointerErrors in loadDocument. Only load if there is a document.
+        if (doc != null && project.getProjectFiles() != null && curEntry != null) {
+            commitAndDeactivate();
+            loadDocument(); // rebuild + re-sort entrylist
+            // The current entry is never removed by sorting, only repositioned.
+            gotoEntry(curEntry.entryNum());
+        }
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded if appropriate to revert to natural file
+     * order.
+     */
+    @Override
+    public void removeSort() {
+        UIThreadsUtil.mustBeSwingThread();
+
+        if (entriesSorter == null) {
+            return;
+        }
+
+        entriesSorter = null;
+
+        int curEntryNum = getCurrentEntryNumber();
+        Document3 doc = editor.getOmDocument();
+        IProject project = Core.getProject();
+        // `if` check is to prevent NullPointerErrors in loadDocument.
+        // Only load if there is a document and the project is loaded.
+        if (doc != null && project != null && project.isProjectLoaded()) {
+            List<FileInfo> files = project.getProjectFiles();
+            if (files != null && !files.isEmpty()) {
+                commitAndDeactivate();
                 loadDocument();
                 gotoEntry(curEntryNum);
             }

--- a/src/org/omegat/gui/editor/IEditor.java
+++ b/src/org/omegat/gui/editor/IEditor.java
@@ -478,6 +478,28 @@ public interface IEditor {
     void removeFilter();
 
     /**
+     * Gets the sorter for this editor, or null if no custom sort is applied (i.e.
+     * segments are shown in natural file order).
+     */
+    @Nullable
+    IEditorSorter getSort();
+
+    /**
+     * Sets a sorter for this editor. The sorter changes the order in which the
+     * (filtered) segments are displayed, without changing which segments are
+     * shown. The document is reloaded so the new order takes effect immediately.
+     *
+     * @param sorter
+     *            Sorter instance
+     */
+    void setSort(IEditorSorter sorter);
+
+    /**
+     * Removes the current sorter, reverting to natural file order.
+     */
+    void removeSort();
+
+    /**
      * Returns current translation or null.
      */
     String getCurrentTranslation();

--- a/src/org/omegat/gui/editor/IEditorSorter.java
+++ b/src/org/omegat/gui/editor/IEditorSorter.java
@@ -1,0 +1,49 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 zollsoft
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import java.util.Comparator;
+
+/**
+ * Interface for the editor's display sort. While {@link IEditorFilter} decides
+ * <em>which</em> segments are shown, an {@code IEditorSorter} decides in
+ * <em>which order</em> the (already filtered) segments are displayed.
+ * <p>
+ * Filtering and sorting are intentionally decoupled so the display order can be
+ * changed live without affecting the set of visible segments.
+ *
+ * @author zollsoft
+ */
+public interface IEditorSorter {
+
+    /**
+     * The comparator used to order the (already filtered) list of segments. It
+     * must define a stable, total order; implementations should fall back to the
+     * natural project order (by {@code entryNum}) for otherwise-equal segments so
+     * that the result is fully deterministic.
+     */
+    Comparator<SegmentBuilder> getComparator();
+}

--- a/src/org/omegat/gui/editor/sort/MultiKeySorter.java
+++ b/src/org/omegat/gui/editor/sort/MultiKeySorter.java
@@ -1,0 +1,142 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 zollsoft
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.sort;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import org.jspecify.annotations.Nullable;
+import org.omegat.gui.editor.IEditorSorter;
+import org.omegat.gui.editor.SegmentBuilder;
+
+/**
+ * An {@link IEditorSorter} that orders segments by a combinable list of
+ * {@link SortKey}s (primary, secondary, tertiary, ...), each ascending or
+ * descending. Text keys collate using a {@link Collator} built for the source
+ * language so that accents and language-specific ordering are respected.
+ *
+ * @author zollsoft
+ */
+public class MultiKeySorter implements IEditorSorter {
+
+    /** One (key, direction) pair of the sort chain. */
+    public static final class KeySpec {
+        public final SortKey key;
+        public final boolean ascending;
+
+        public KeySpec(SortKey key, boolean ascending) {
+            this.key = key;
+            this.ascending = ascending;
+        }
+    }
+
+    private final List<KeySpec> keys;
+    private final Collator collator;
+
+    /**
+     * @param keys
+     *            ordered list of sort keys (primary first); may be empty
+     * @param sourceLocale
+     *            locale used for text collation
+     */
+    public MultiKeySorter(List<KeySpec> keys, Locale sourceLocale) {
+        this.keys = new ArrayList<>(keys);
+        this.collator = Collator.getInstance(sourceLocale);
+    }
+
+    @Override
+    public Comparator<SegmentBuilder> getComparator() {
+        Comparator<SegmentBuilder> cmp = null;
+        for (KeySpec ks : keys) {
+            Comparator<SegmentBuilder> next = ks.key.comparator(collator, ks.ascending);
+            cmp = (cmp == null) ? next : cmp.thenComparing(next);
+        }
+        // Stable tiebreaker: equal keys keep natural project order. This also keeps
+        // gotoEntry()'s exact-match relocation deterministic.
+        Comparator<SegmentBuilder> natural = Comparator
+                .comparingInt(sb -> sb.getSourceTextEntry().entryNum());
+        return (cmp == null) ? natural : cmp.thenComparing(natural);
+    }
+
+    /** The configured sort keys, in priority order. */
+    public List<KeySpec> getKeys() {
+        return Collections.unmodifiableList(keys);
+    }
+
+    /** True if no effective sort key is configured (i.e. natural order). */
+    public boolean isEmpty() {
+        return keys.isEmpty();
+    }
+
+    /**
+     * Serializes the sort chain to a compact, preference-friendly string such as
+     * {@code "SOURCE_ALPHA:asc;SOURCE_LENGTH:desc"}.
+     */
+    public String toPreferenceString() {
+        return toPreferenceString(keys);
+    }
+
+    /** Serializes a sort chain to its preference string form. */
+    public static String toPreferenceString(List<KeySpec> keys) {
+        StringBuilder sb = new StringBuilder();
+        for (KeySpec ks : keys) {
+            if (sb.length() > 0) {
+                sb.append(';');
+            }
+            sb.append(ks.key.name()).append(':').append(ks.ascending ? "asc" : "desc");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Parses a preference string produced by {@link #toPreferenceString()} back
+     * into a list of {@link KeySpec}. Unknown or malformed entries are skipped.
+     */
+    public static List<KeySpec> fromPreferenceString(@Nullable String s) {
+        List<KeySpec> result = new ArrayList<>();
+        if (s == null || s.trim().isEmpty()) {
+            return result;
+        }
+        for (String part : s.split(";")) {
+            String[] kv = part.split(":");
+            if (kv.length != 2) {
+                continue;
+            }
+            try {
+                SortKey key = SortKey.valueOf(kv[0].trim());
+                boolean asc = !"desc".equalsIgnoreCase(kv[1].trim());
+                result.add(new KeySpec(key, asc));
+            } catch (IllegalArgumentException ex) {
+                // unknown key name - skip
+            }
+        }
+        return result;
+    }
+}

--- a/src/org/omegat/gui/editor/sort/README.md
+++ b/src/org/omegat/gui/editor/sort/README.md
@@ -1,0 +1,130 @@
+# Segment Sorting — Design & Development Log
+
+This package implements **decoupled filtering and sorting of editor segments** for
+OmegaT, addressing SourceForge feature request
+[#1094 "Sorting segments"](https://sourceforge.net/p/omegat/feature-requests/1094/).
+
+Until now the editor's displayed segment list (`m_docSegList` in
+`EditorController`) was built in `loadDocument()` by iterating `file.entries` in
+natural file order, optionally applying an `IEditorFilter`, and emitting the
+segments in exactly that order. Filtering and ordering were coupled and the order
+was always the file order. This feature separates the two concerns so the display
+order can be changed live, without affecting which segments are visible.
+
+## Architecture
+
+- **`IEditorFilter`** (unchanged) decides *which* segments are shown.
+- **`IEditorSorter`** (new) decides *in which order* the already-filtered segments
+  are shown. It exposes a single `Comparator<SegmentBuilder> getComparator()`.
+- **`SortKey`** (new enum) is one sort criterion. Each constant defines an
+  *ascending* comparator; descending is derived centrally via
+  `comparator(Collator, boolean)`. Adding a criterion = adding one enum constant.
+  Text keys collate with a `java.text.Collator` built for the **source language**,
+  so accents and language-specific ordering are respected.
+- **`MultiKeySorter`** (new) implements `IEditorSorter` by chaining a list of
+  `KeySpec` (key + direction) via `thenComparing`, with a stable natural-order
+  (`entryNum`) tiebreaker so the result is fully deterministic. It also offers
+  `toPreferenceString` / `fromPreferenceString` serialization helpers.
+- **`SortBar`** (new Swing component) is the always-available control bar.
+- **`EditorController`** wiring:
+  - `loadDocument()` applies the sorter **after** filtering (`tmpSegList.sort(...)`).
+    With no sorter the order is byte-identical to before (no regression).
+  - `setSort` / `getSort` / `removeSort` were added to `IEditor`, mirroring the
+    filter API; the document is reloaded live and the current entry is preserved.
+  - The sort and filter bars are stacked in a north container (`northBars`); the
+    sort bar sits **above** the filter bar.
+  - The sort bar is shown only when a project is open and there is **more than one**
+    segment after filtering (sorting a single segment is pointless).
+
+### Order-independence fix (important)
+
+`gotoEntry(int)` and the `setFilter` fallback previously assumed `m_docSegList`
+was sorted ascending by `segmentNumberInProject` (a `>= entryNum` linear search).
+Once the list can be reordered, that assumption breaks. Both were changed to
+locate segments by **exact `entryNum`** (with a nearest-entry fallback), making
+them order-independent. Index-based navigation (`iterateToEntry` next/prev) is
+intentionally left as-is so it now follows the visible sort order.
+
+## Sort criteria
+
+`File order (unsorted)` (default) · Source alphabetical / reverse "rhyme" / length ·
+Target alphabetical / reverse / length · Translation status · Note alphabetical /
+reverse / length · Comment alphabetical / reverse / length · Change date ·
+Creation date · Modification author · Creation author. Each (except file order)
+can be ascending or descending.
+
+Note the distinction:
+- **Comment** = read-only comment from the source document
+  (`SourceTextEntry.getComment()`).
+- **Note** = the translator's own note on the segment (`TMXEntry.getNote()`).
+
+## UI behaviour
+
+- Always-visible bar above the editor (no menu needed), centered in its row.
+- One criterion by default. A **`+`** button adds a secondary, then a tertiary
+  criterion (max 3); the third row has no `+`. Rows 2 and 3 have a **`−`** button
+  to remove that criterion. The first row has no `−`.
+- With more than one criterion the rows are labelled *Primary / Secondary /
+  Tertiary sort key*.
+- The `+` is disabled while the primary key is "file order (unsorted)", since a
+  secondary criterion is meaningless without a primary sort.
+- When a sort is active, a notice that the segment numbers are no longer
+  sequential appears on its own line above the controls.
+
+## Contributing this feature
+
+OmegaT tracks **tickets on SourceForge** but hosts **code and pull requests on
+GitHub** (`omegat-org/omegat`). So:
+
+1. Assign / comment on SourceForge ticket #1094 to claim it.
+2. Push the `feature/1094-segment-sorting` branch to your GitHub fork and open a
+   pull request against `omegat-org/omegat`, referencing the SourceForge ticket in
+   the description.
+
+## Development log
+
+The feature was built iteratively. The rounds below summarize the discussion that
+shaped it (timestamps removed).
+
+**Initial request.** Separate filtering and sorting of segments so the display
+order can be changed dynamically/live.
+
+**Research.** A check of the SourceForge feature-request tracker found the open
+ticket #1094 "Sorting segments", which matches this work almost exactly: multiple
+combinable criteria, ascending/descending, a remove control mirroring the filter,
+and the explicit requirement that sorting must cooperate with (not replace)
+filtering.
+
+**Round 1 — criteria & multi-key.** Requested combinable primary/secondary/
+tertiary sorting and criteria: file order (default), source alphabetical (asc/desc),
+reverse-string "rhyming dictionary" (asc/desc), length, translation status. A
+multi-disciplinary review (developers, localizers, UX) was requested to decide what
+else makes sense.
+
+**Round 2 — target & comment.** Added sorting by target text and by comment in
+addition to source.
+
+**Round 3 — UX streamlining.** The sort bar should always be visible (no menu);
+the default option should read "File order (unsorted)" and the empty "—" entry was
+dropped; the secondary/tertiary UI was temporarily removed; the bar was centered
+and moved above the filter bar; added comment reverse ("rhyme") and comment length.
+
+**Round 4 — dynamic multi-key & more criteria.** The bar must be hidden when no
+project is open or when one or fewer segments remain after filtering. "Has note"
+was dropped. Added change date, creation date, modification author, creation author
+(all asc/desc) and note alphabetical / reverse / length. The renumbering notice was
+moved to its own line above the controls. A `+` button adds another criterion (up
+to three; primary/secondary/tertiary labels); the first row has no `−`, rows 2 and
+3 do. During this round the earlier mislabeling of "comment" (which had been mapped
+to the note) was corrected: comment now comes from the source document and note
+from the translator's note.
+
+**Round 5 — team-feedback follow-up.** The agreed UX refinement was implemented:
+the `+` button is disabled while the primary key is "file order (unsorted)".
+
+## Tests
+
+`MultiKeySorterTest` covers the comparator chaining (single key asc/desc, multi-key
+with a secondary breaking primary ties, the stable natural tiebreaker), the
+source-based criteria, and the preference-string round-trip including empty/unknown
+handling.

--- a/src/org/omegat/gui/editor/sort/SortBar.java
+++ b/src/org/omegat/gui/editor/sort/SortBar.java
@@ -1,0 +1,268 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 zollsoft
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.sort;
+
+import java.awt.Component;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+
+import org.omegat.core.Core;
+import org.omegat.gui.editor.sort.MultiKeySorter.KeySpec;
+import org.omegat.util.OStrings;
+
+/**
+ * Always-available control bar for the editor's segment sort, shown above the
+ * filter bar. It supports up to three combinable criteria (primary, secondary,
+ * tertiary), each a {@link SortKey} with an ascending/descending direction.
+ * Criteria are added/removed with the {@code +}/{@code −} buttons. The default
+ * is a single {@link SortKey#NATURAL} criterion ("file order / unsorted").
+ * Changes are applied live through {@link org.omegat.gui.editor.IEditor#setSort}
+ * / {@link org.omegat.gui.editor.IEditor#removeSort}.
+ * <p>
+ * Whether the bar is shown at all (project open and more than one segment after
+ * filtering) is decided by the editor controller, not here.
+ *
+ * @author zollsoft
+ */
+@SuppressWarnings("serial")
+public class SortBar extends JPanel {
+
+    private static final int MAX_KEYS = 3;
+    private static final String[] ROW_LABEL_KEYS = { "SORT_KEY_PRIMARY", "SORT_KEY_SECONDARY",
+            "SORT_KEY_TERTIARY" };
+
+    private final List<CriterionRow> rows = new ArrayList<>();
+    private final JLabel warning = new JLabel(OStrings.getString("SORT_BAR_WARNING"));
+    /** The "add criterion" button of the current last row, or null if none is shown. */
+    private JButton plusButton;
+
+    public SortBar() {
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        Border border = UIManager.getBorder("OmegaTEditorFilter.border");
+        if (border != null) {
+            setBorder(border);
+        }
+        rows.add(new CriterionRow());
+        rebuild();
+    }
+
+    /** Reset to the default single, unsorted criterion. */
+    public void reset() {
+        rows.clear();
+        rows.add(new CriterionRow());
+        rebuild();
+    }
+
+    /** Rebuild the row layout (after adding/removing a criterion). */
+    private void rebuild() {
+        removeAll();
+
+        // Notice that the segment numbers are no longer sequential, on its own
+        // line above the controls; only relevant while a sort is active.
+        JPanel warnRow = new JPanel();
+        warnRow.setLayout(new BoxLayout(warnRow, BoxLayout.LINE_AXIS));
+        warnRow.add(Box.createHorizontalGlue());
+        warnRow.add(warning);
+        warnRow.add(Box.createHorizontalGlue());
+        add(warnRow);
+
+        plusButton = null;
+        boolean multi = rows.size() > 1;
+        for (int i = 0; i < rows.size(); i++) {
+            CriterionRow row = rows.get(i);
+            JPanel rp = new JPanel();
+            rp.setLayout(new BoxLayout(rp, BoxLayout.LINE_AXIS));
+            rp.add(Box.createHorizontalGlue());
+            rp.add(new JLabel(rowLabel(i, multi)));
+            rp.add(Box.createHorizontalStrut(4));
+            rp.add(row.keyCombo);
+            rp.add(Box.createHorizontalStrut(4));
+            rp.add(row.dirCombo);
+            if (i > 0) {
+                rp.add(Box.createHorizontalStrut(4));
+                rp.add(minusButton(i));
+            }
+            if (i == rows.size() - 1 && rows.size() < MAX_KEYS) {
+                rp.add(Box.createHorizontalStrut(4));
+                plusButton = createPlusButton();
+                rp.add(plusButton);
+            }
+            rp.add(Box.createHorizontalGlue());
+            add(rp);
+        }
+
+        warning.setVisible(isSortActive());
+        refreshPlusEnabled();
+        revalidate();
+        repaint();
+    }
+
+    /**
+     * Adding a secondary/tertiary criterion only makes sense once the primary
+     * criterion actually sorts, so the "+" is disabled while it is "file order".
+     */
+    private void refreshPlusEnabled() {
+        if (plusButton != null) {
+            plusButton.setEnabled(isSortActive());
+        }
+    }
+
+    private String rowLabel(int index, boolean multi) {
+        if (!multi) {
+            return OStrings.getString("SORT_BAR_LABEL");
+        }
+        return OStrings.getString(ROW_LABEL_KEYS[index]);
+    }
+
+    private JButton createPlusButton() {
+        JButton plus = new JButton("+");
+        plus.setMargin(new Insets(0, 6, 0, 6));
+        plus.setToolTipText(OStrings.getString("SORT_BAR_ADD"));
+        plus.addActionListener(e -> addRow());
+        return plus;
+    }
+
+    private JButton minusButton(int index) {
+        JButton minus = new JButton("−");
+        minus.setMargin(new Insets(0, 6, 0, 6));
+        minus.setToolTipText(OStrings.getString("SORT_BAR_REMOVE_KEY"));
+        minus.addActionListener(e -> removeRow(index));
+        return minus;
+    }
+
+    private void addRow() {
+        if (rows.size() >= MAX_KEYS) {
+            return;
+        }
+        rows.add(new CriterionRow());
+        rebuild();
+        apply();
+    }
+
+    private void removeRow(int index) {
+        if (index <= 0 || index >= rows.size()) {
+            return;
+        }
+        rows.remove(index);
+        rebuild();
+        apply();
+    }
+
+    /** True if the primary criterion actually reorders (i.e. is not file order). */
+    private boolean isSortActive() {
+        return !rows.isEmpty() && rows.get(0).key() != SortKey.NATURAL;
+    }
+
+    private void apply() {
+        if (!Core.getProject().isProjectLoaded()) {
+            return;
+        }
+        Core.getEditor().commitAndDeactivate();
+        if (!isSortActive()) {
+            warning.setVisible(false);
+            Core.getEditor().removeSort();
+            return;
+        }
+        List<KeySpec> keys = new ArrayList<>();
+        for (CriterionRow r : rows) {
+            keys.add(r.spec());
+        }
+        Locale loc = Core.getProject().getProjectProperties().getSourceLanguage().getLocale();
+        Core.getEditor().setSort(new MultiKeySorter(keys, loc));
+        warning.setVisible(true);
+    }
+
+    /** A single criterion: a sort key plus a direction. */
+    private final class CriterionRow {
+        final JComboBox<SortKey> keyCombo = new JComboBox<>();
+        final JComboBox<Boolean> dirCombo = new JComboBox<>(new Boolean[] { Boolean.TRUE, Boolean.FALSE });
+
+        CriterionRow() {
+            for (SortKey k : SortKey.values()) {
+                keyCombo.addItem(k);
+            }
+            keyCombo.setSelectedItem(SortKey.NATURAL);
+            keyCombo.setRenderer(new KeyRenderer());
+            dirCombo.setRenderer(new DirectionRenderer());
+            keyCombo.setMaximumSize(keyCombo.getPreferredSize());
+            dirCombo.setMaximumSize(dirCombo.getPreferredSize());
+            updateDirEnabled();
+            keyCombo.addActionListener(e -> {
+                updateDirEnabled();
+                refreshPlusEnabled();
+                apply();
+            });
+            dirCombo.addActionListener(e -> apply());
+        }
+
+        /** Direction is meaningless for the unsorted "file order" option. */
+        void updateDirEnabled() {
+            dirCombo.setEnabled(key() != SortKey.NATURAL);
+        }
+
+        SortKey key() {
+            return (SortKey) keyCombo.getSelectedItem();
+        }
+
+        KeySpec spec() {
+            return new KeySpec(key(), Boolean.TRUE.equals(dirCombo.getSelectedItem()));
+        }
+    }
+
+    /** Renders a {@link SortKey} with its localized name. */
+    private static class KeyRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                boolean isSelected, boolean cellHasFocus) {
+            String text = (value == null) ? "" : ((SortKey) value).getLocalizedName();
+            return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus);
+        }
+    }
+
+    /** Renders the ascending/descending direction flag. */
+    private static class DirectionRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                boolean isSelected, boolean cellHasFocus) {
+            String text = Boolean.TRUE.equals(value) ? OStrings.getString("SORT_ASCENDING")
+                    : OStrings.getString("SORT_DESCENDING");
+            return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus);
+        }
+    }
+}

--- a/src/org/omegat/gui/editor/sort/SortKey.java
+++ b/src/org/omegat/gui/editor/sort/SortKey.java
@@ -1,0 +1,250 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 zollsoft
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.sort;
+
+import java.text.Collator;
+import java.util.Comparator;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.gui.editor.SegmentBuilder;
+import org.omegat.util.OStrings;
+
+/**
+ * A single sort criterion for ordering editor segments. Each key defines an
+ * <em>ascending</em> comparator; descending order is obtained centrally via
+ * {@link #comparator(Collator, boolean)}, so adding a new criterion only
+ * requires defining one comparator here.
+ *
+ * @author zollsoft
+ */
+public enum SortKey {
+
+    /** Natural project/file order (by {@code entryNum}). The default. */
+    NATURAL("SORT_KEY_NATURAL") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> sb.getSourceTextEntry().entryNum());
+        }
+    },
+
+    /** Alphabetical by source text, using locale-aware collation. */
+    SOURCE_ALPHA("SORT_KEY_SOURCE_ALPHA") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> sb.getSourceTextEntry().getSrcText(), collator);
+        }
+    },
+
+    /**
+     * Reverse-string ("rhyming dictionary") order: the source text is reversed
+     * character-wise before collation, grouping segments by their endings.
+     */
+    SOURCE_RHYME("SORT_KEY_SOURCE_RHYME") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(
+                    sb -> new StringBuilder(sb.getSourceTextEntry().getSrcText()).reverse().toString(),
+                    collator);
+        }
+    },
+
+    /** Source length in characters. */
+    SOURCE_LENGTH("SORT_KEY_SOURCE_LENGTH") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> sb.getSourceTextEntry().getSrcText().length());
+        }
+    },
+
+    /** Alphabetical by target (translation) text, using locale-aware collation. */
+    TARGET_ALPHA("SORT_KEY_TARGET_ALPHA") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(SortKey::targetText, collator);
+        }
+    },
+
+    /** Reverse-string ("rhyming") order of the target text. */
+    TARGET_RHYME("SORT_KEY_TARGET_RHYME") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> new StringBuilder(targetText(sb)).reverse().toString(),
+                    collator);
+        }
+    },
+
+    /** Target length in characters. */
+    TARGET_LENGTH("SORT_KEY_TARGET_LENGTH") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> targetText(sb).length());
+        }
+    },
+
+    /** Translation status: untranslated segments first, translated last. */
+    TRANSLATION_STATUS("SORT_KEY_TRANS_STATUS") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> {
+                TMXEntry e = Core.getProject().getTranslationInfo(sb.getSourceTextEntry());
+                return e.isTranslated() ? 1 : 0;
+            });
+        }
+    },
+
+    /** Alphabetical by user note text, using locale-aware collation. */
+    NOTE_ALPHA("SORT_KEY_NOTE_ALPHA") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(SortKey::noteText, collator);
+        }
+    },
+
+    /** Reverse-string ("rhyming") order of the user note text. */
+    NOTE_RHYME("SORT_KEY_NOTE_RHYME") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> new StringBuilder(noteText(sb)).reverse().toString(),
+                    collator);
+        }
+    },
+
+    /** User note length in characters. */
+    NOTE_LENGTH("SORT_KEY_NOTE_LENGTH") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> noteText(sb).length());
+        }
+    },
+
+    /** Alphabetical by source-document comment, using locale-aware collation. */
+    COMMENT_ALPHA("SORT_KEY_COMMENT_ALPHA") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(SortKey::commentText, collator);
+        }
+    },
+
+    /** Reverse-string ("rhyming") order of the source-document comment. */
+    COMMENT_RHYME("SORT_KEY_COMMENT_RHYME") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> new StringBuilder(commentText(sb)).reverse().toString(),
+                    collator);
+        }
+    },
+
+    /** Source-document comment length in characters. */
+    COMMENT_LENGTH("SORT_KEY_COMMENT_LENGTH") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingInt(sb -> commentText(sb).length());
+        }
+    },
+
+    /** Translation change date (oldest first). */
+    CHANGE_DATE("SORT_KEY_CHANGE_DATE") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingLong(
+                    sb -> Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getChangeDate());
+        }
+    },
+
+    /** Translation creation date (oldest first). */
+    CREATION_DATE("SORT_KEY_CREATION_DATE") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparingLong(
+                    sb -> Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getCreationDate());
+        }
+    },
+
+    /** Alphabetical by the author who last changed the translation. */
+    CHANGER("SORT_KEY_CHANGER") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> nullToEmpty(
+                    Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getChanger()), collator);
+        }
+    },
+
+    /** Alphabetical by the author who created the translation. */
+    CREATOR("SORT_KEY_CREATOR") {
+        @Override
+        Comparator<SegmentBuilder> ascending(Collator collator) {
+            return Comparator.comparing(sb -> nullToEmpty(
+                    Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getCreator()), collator);
+        }
+    };
+
+    private final String bundleKey;
+
+    SortKey(String bundleKey) {
+        this.bundleKey = bundleKey;
+    }
+
+    /** Localized display name for UI components. */
+    public String getLocalizedName() {
+        return OStrings.getString(bundleKey);
+    }
+
+    /** The ascending comparator for this key. {@code collator} may be unused for non-text keys. */
+    abstract Comparator<SegmentBuilder> ascending(Collator collator);
+
+    /**
+     * Comparator for this key in the requested direction.
+     *
+     * @param collator
+     *            locale-aware collator for text keys
+     * @param asc
+     *            ascending if true, descending otherwise
+     */
+    public Comparator<SegmentBuilder> comparator(Collator collator, boolean asc) {
+        Comparator<SegmentBuilder> c = ascending(collator);
+        return asc ? c : c.reversed();
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /** Null-safe target/translation text of a segment. */
+    private static String targetText(SegmentBuilder sb) {
+        return nullToEmpty(Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getTranslationText());
+    }
+
+    /** Null-safe user note text of a segment. */
+    private static String noteText(SegmentBuilder sb) {
+        return nullToEmpty(Core.getProject().getTranslationInfo(sb.getSourceTextEntry()).getNote());
+    }
+
+    /** Null-safe source-document comment of a segment. */
+    private static String commentText(SegmentBuilder sb) {
+        return nullToEmpty(sb.getSourceTextEntry().getComment());
+    }
+}

--- a/src/org/omegat/gui/scripting/ConsoleBindings.java
+++ b/src/org/omegat/gui/scripting/ConsoleBindings.java
@@ -31,6 +31,7 @@ import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.editor.IEditorFilter;
+import org.omegat.gui.editor.IEditorSorter;
 import org.omegat.gui.editor.IEditorSettings;
 import org.omegat.gui.editor.IPopupMenuConstructor;
 import org.omegat.gui.editor.autocompleter.IAutoCompleter;
@@ -290,6 +291,21 @@ public class ConsoleBindings implements IGlossaries, IEditor, IScriptLogger {
 
     @Override
     public void removeFilter() {
+
+    }
+
+    @Override
+    public final IEditorSorter getSort() {
+        return null;
+    }
+
+    @Override
+    public void setSort(IEditorSorter sorter) {
+
+    }
+
+    @Override
+    public void removeSort() {
 
     }
 

--- a/test/fixtures/org/omegat/gui/editor/EditorStub.java
+++ b/test/fixtures/org/omegat/gui/editor/EditorStub.java
@@ -261,6 +261,21 @@ public class EditorStub implements IEditor {
     }
 
     @Override
+    public IEditorSorter getSort() {
+        return null;
+    }
+
+    @Override
+    public void setSort(IEditorSorter sorter) {
+        // do nothing
+    }
+
+    @Override
+    public void removeSort() {
+        // do nothing
+    }
+
+    @Override
     public String getCurrentTranslation() {
         return "";
     }

--- a/test/src/org/omegat/gui/editor/sort/MultiKeySorterTest.java
+++ b/test/src/org/omegat/gui/editor/sort/MultiKeySorterTest.java
@@ -1,0 +1,163 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 zollsoft
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.sort;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Test;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.editor.SegmentBuilder;
+import org.omegat.gui.editor.sort.MultiKeySorter.KeySpec;
+
+/**
+ * Unit tests for the sort comparator chaining and preference serialization.
+ * Covers the source-based keys (which only need {@link SegmentBuilder} /
+ * {@link SourceTextEntry}); target/note/status keys depend on the live project
+ * and are exercised through the GUI integration tests instead.
+ */
+public class MultiKeySorterTest {
+
+    /** Build a mock segment with the given project entry number and source text. */
+    private static SegmentBuilder seg(int entryNum, String src) {
+        SourceTextEntry ste = mock(SourceTextEntry.class);
+        when(ste.getSrcText()).thenReturn(src);
+        when(ste.entryNum()).thenReturn(entryNum);
+        SegmentBuilder sb = mock(SegmentBuilder.class);
+        when(sb.getSourceTextEntry()).thenReturn(ste);
+        return sb;
+    }
+
+    private static MultiKeySorter sorter(KeySpec... keys) {
+        return new MultiKeySorter(Arrays.asList(keys), Locale.ENGLISH);
+    }
+
+    /** Sort a copy and return the resulting entry-number order. */
+    private static List<Integer> order(List<SegmentBuilder> segs, MultiKeySorter sorter) {
+        List<SegmentBuilder> copy = new ArrayList<>(segs);
+        copy.sort(sorter.getComparator());
+        List<Integer> result = new ArrayList<>();
+        for (SegmentBuilder sb : copy) {
+            result.add(sb.getSourceTextEntry().entryNum());
+        }
+        return result;
+    }
+
+    @Test
+    public void emptySorterKeepsNaturalOrder() {
+        List<SegmentBuilder> segs = Arrays.asList(seg(3, "c"), seg(1, "a"), seg(2, "b"));
+        assertTrue(sorter().isEmpty());
+        assertEquals(Arrays.asList(1, 2, 3), order(segs, sorter()));
+    }
+
+    @Test
+    public void sourceAlphaAscendingAndDescending() {
+        List<SegmentBuilder> segs = Arrays.asList(seg(1, "banana"), seg(2, "apple"), seg(3, "cherry"));
+        assertEquals(Arrays.asList(2, 1, 3),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_ALPHA, true))));
+        assertEquals(Arrays.asList(3, 1, 2),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_ALPHA, false))));
+    }
+
+    @Test
+    public void sourceLengthAscending() {
+        List<SegmentBuilder> segs = Arrays.asList(seg(1, "aa"), seg(2, "b"), seg(3, "ccc"));
+        assertEquals(Arrays.asList(2, 1, 3),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_LENGTH, true))));
+    }
+
+    @Test
+    public void sourceRhymeSortsByReversedString() {
+        // reversed: "ba"->"ab"(1), "ca"->"ac"(2), "ab"->"ba"(3)
+        List<SegmentBuilder> segs = Arrays.asList(seg(1, "ba"), seg(2, "ca"), seg(3, "ab"));
+        assertEquals(Arrays.asList(1, 2, 3),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_RHYME, true))));
+        // distinct from plain alphabetical, which would yield "ab"(3),"ba"(1),"ca"(2)
+        assertEquals(Arrays.asList(3, 1, 2),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_ALPHA, true))));
+    }
+
+    @Test
+    public void naturalTiebreakerKeepsEqualKeysInEntryOrder() {
+        // equal length: ties must fall back to natural entry-number order
+        List<SegmentBuilder> segs = Arrays.asList(seg(5, "xx"), seg(2, "yy"), seg(9, "z"));
+        assertEquals(Arrays.asList(9, 2, 5),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_LENGTH, true))));
+    }
+
+    @Test
+    public void secondaryKeyBreaksPrimaryTies() {
+        // primary length asc, secondary source alpha desc
+        List<SegmentBuilder> segs = Arrays.asList(seg(1, "bb"), seg(2, "aa"), seg(3, "c"));
+        assertEquals(Arrays.asList(3, 1, 2),
+                order(segs, sorter(new KeySpec(SortKey.SOURCE_LENGTH, true),
+                        new KeySpec(SortKey.SOURCE_ALPHA, false))));
+    }
+
+    @Test
+    public void preferenceStringRoundTrip() {
+        List<KeySpec> keys = Arrays.asList(new KeySpec(SortKey.SOURCE_ALPHA, true),
+                new KeySpec(SortKey.SOURCE_LENGTH, false));
+        String s = MultiKeySorter.toPreferenceString(keys);
+        assertEquals("SOURCE_ALPHA:asc;SOURCE_LENGTH:desc", s);
+
+        List<KeySpec> parsed = MultiKeySorter.fromPreferenceString(s);
+        assertEquals(2, parsed.size());
+        assertEquals(SortKey.SOURCE_ALPHA, parsed.get(0).key);
+        assertTrue(parsed.get(0).ascending);
+        assertEquals(SortKey.SOURCE_LENGTH, parsed.get(1).key);
+        assertFalse(parsed.get(1).ascending);
+    }
+
+    @Test
+    public void fromPreferenceStringHandlesEmptyAndNull() {
+        assertTrue(MultiKeySorter.fromPreferenceString(null).isEmpty());
+        assertTrue(MultiKeySorter.fromPreferenceString("").isEmpty());
+        assertTrue(MultiKeySorter.fromPreferenceString("   ").isEmpty());
+    }
+
+    @Test
+    public void fromPreferenceStringSkipsUnknownKeys() {
+        List<KeySpec> parsed = MultiKeySorter.fromPreferenceString("FOO:asc;SOURCE_ALPHA:desc");
+        assertEquals(1, parsed.size());
+        assertEquals(SortKey.SOURCE_ALPHA, parsed.get(0).key);
+        assertFalse(parsed.get(0).ascending);
+    }
+
+    @Test
+    public void emptyKeyListSerializesToEmptyString() {
+        assertEquals("", MultiKeySorter.toPreferenceString(Collections.emptyList()));
+    }
+}

--- a/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -261,6 +261,19 @@ public class MatchesVarExpansionTest {
         }
 
         @Override
+        public org.omegat.gui.editor.IEditorSorter getSort() {
+            return null;
+        }
+
+        @Override
+        public void setSort(org.omegat.gui.editor.IEditorSorter sorter) {
+        }
+
+        @Override
+        public void removeSort() {
+        }
+
+        @Override
         public void setAlternateTranslationForCurrentEntry(boolean alternate) {
         }
 


### PR DESCRIPTION
Filtering decides which segments show; a new IEditorSorter now decides their order, applied in loadDocument() after filtering. No sorter set -> order is byte-identical to before.

- IEditorSorter + SortKey enum + MultiKeySorter (locale-aware Collator, stable entryNum tiebreaker)
- setSort/getSort/removeSort on IEditor, mirroring the filter API
- always-visible SortBar above the filter bar: primary/secondary/tertiary keys, asc/desc, +/- to add/remove; shown only with a project and >1 filtered segment
- criteria: source/target/note/comment (alpha·rhyme·length), translation status, change/creation date, changer/creator
- fix gotoEntry + setFilter fallback to locate entries by exact entryNum, so navigation survives reordering

Co-Authored-By: Claude Opus 4.8 (1M context)
Session
 Total cost:            $29.43
 Total duration (API):  48m 40s
 Total duration (wall): 2h 22m 44s
 Total code changes:    1632 lines added, 251 lines removed
 Usage by model:      claude-haiku-4-5:  15.3k input, 13.2k output, 2.1m cache read, 81.2k cache write ($0.3950)
        claude-opus-4-8:  18.7k input, 189.5k output, 34.5m cache read, 1.1m cache write ($29.04)