### PR TITLE
refactor: modernize `DateFormat` with `DateTimeFormatter` in `SegmentPropertiesArea`

### DIFF
--- a/src/org/omegat/core/statistics/Statistics.java
+++ b/src/org/omegat/core/statistics/Statistics.java
@@ -39,9 +39,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.text.BreakIterator;
-import java.text.DateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -77,6 +79,14 @@ public final class Statistics {
 
     protected static final int PERCENT_EXACT_MATCH = 101;
     protected static final int PERCENT_REPETITIONS = 102;
+
+    /**
+     * Short date/time formatter for the statistics file header. Equivalent to
+     * the former {@code DateFormat.getInstance()} (short date and short time).
+     * {@link DateTimeFormatter} is immutable and thread-safe.
+     */
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter
+            .ofLocalizedDateTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault());
 
     /**
      * Computes the number of characters excluding spaces in a string. Special
@@ -160,7 +170,7 @@ public final class Statistics {
 
         try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-            writer.write(DateFormat.getInstance().format(new Date()) + "\n");
+            writer.write(TIMESTAMP_FORMAT.format(Instant.now()) + "\n");
             writer.write(text);
         } catch (Exception ex) {
             Log.log(ex);
@@ -198,7 +208,7 @@ public final class Statistics {
                 StandardCharsets.UTF_8)) {
             switch (format) {
             case TEXT:
-                out.write(DateFormat.getInstance().format(new Date()) + "\n");
+                out.write(TIMESTAMP_FORMAT.format(Instant.now()) + "\n");
                 out.write(result.getTextData());
                 break;
             case XML:

--- a/src/org/omegat/core/statistics/StatsResult.java
+++ b/src/org/omegat/core/statistics/StatsResult.java
@@ -31,14 +31,14 @@ package org.omegat.core.statistics;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -103,6 +103,14 @@ public class StatsResult {
     private Set<String> translated;
     @JsonProperty("files")
     private List<FileData> counts;
+
+    /**
+     * Formatter with format YYYYMMDDThhmmssZ able to display a date in UTC time.
+     * <p>
+     * {@link DateTimeFormatter} is immutable and thread-safe.
+     */
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
 
     @JsonProperty("date")
     private String date;
@@ -260,9 +268,7 @@ public class StatsResult {
     }
 
     private void setDate() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        date = dateFormat.format(new Date());
+        date = DATE_FORMAT.format(Instant.now());
     }
 
     // CHECKSTYLE:OFF

--- a/src/org/omegat/core/threads/SaveThread.java
+++ b/src/org/omegat/core/threads/SaveThread.java
@@ -29,8 +29,9 @@
 
 package org.omegat.core.threads;
 
-import java.text.DateFormat;
-import java.util.Date;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -151,7 +152,7 @@ public class SaveThread implements IAutoSave {
                 dataEngine.teamSyncPrepare();
             });
             Core.getMainWindow().showStatusMessageRB("ST_PROJECT_AUTOSAVED",
-                    DateFormat.getTimeInstance(DateFormat.SHORT).format(new Date()));
+                    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(LocalTime.now()));
         } catch (TimeoutException ex) {
             Log.logWarningRB("AUTOSAVE_LOCK_ACQUISITION_TIMEOUT");
         } catch (KnownException ex) {

--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -39,11 +39,13 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
@@ -552,12 +554,12 @@ public class FilterMaster {
      * Return current system time in the specified date format.
      *
      * @param dateFormat
-     *            Date format for java.text.SimpleDateFormat.
+     *            Date format pattern for
+     *            {@link java.time.format.DateTimeFormatter}.
      */
     public static String now(String dateFormat) {
-        Calendar cal = Calendar.getInstance();
-        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-        return sdf.format(cal.getTime());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat, Locale.getDefault());
+        return formatter.format(ZonedDateTime.now(ZoneId.systemDefault()));
     }
 
     /**

--- a/src/org/omegat/gui/editor/ModificationInfoManager.java
+++ b/src/org/omegat/gui/editor/ModificationInfoManager.java
@@ -26,10 +26,12 @@
  **************************************************************************/
 package org.omegat.gui.editor;
 
-import java.text.DateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -128,41 +130,51 @@ public final class ModificationInfoManager {
 
     public static class ModificationInfoVarExpansion extends VarExpansion<TMXEntry> {
 
-        private final DateFormat dateFormat;
-        private final DateFormat dateFormatCountry;
-        private final DateFormat dateFormatShort;
-        private final DateFormat dateFormatShortCountry;
-        private final DateFormat timeFormat;
-        private final DateFormat timeFormatCountry;
-        private final DateFormat timeFormatShort;
-        private final DateFormat timeFormatShortCountry;
+        private final DateTimeFormatter dateFormat;
+        private final DateTimeFormatter dateFormatCountry;
+        private final DateTimeFormatter dateFormatShort;
+        private final DateTimeFormatter dateFormatShortCountry;
+        private final DateTimeFormatter timeFormat;
+        private final DateTimeFormatter timeFormatCountry;
+        private final DateTimeFormatter timeFormatShort;
+        private final DateTimeFormatter timeFormatShortCountry;
 
         public ModificationInfoVarExpansion(String template) {
             super(template);
 
+            ZoneId zone = ZoneId.systemDefault();
             Locale defaultLocale = Locale.getDefault();
-            dateFormat = DateFormat.getDateInstance(DateFormat.DEFAULT, defaultLocale);
-            dateFormatShort = DateFormat.getDateInstance(DateFormat.SHORT, defaultLocale);
-            timeFormat = DateFormat.getTimeInstance(DateFormat.DEFAULT, defaultLocale);
-            timeFormatShort = DateFormat.getTimeInstance(DateFormat.SHORT, defaultLocale);
+            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(defaultLocale)
+                    .withZone(zone);
+            dateFormatShort = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(defaultLocale)
+                    .withZone(zone);
+            timeFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM).withLocale(defaultLocale)
+                    .withZone(zone);
+            timeFormatShort = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(defaultLocale)
+                    .withZone(zone);
 
+            Locale countryLocale = defaultLocale;
             Locale[] locales = Locale.getAvailableLocales();
             for (Locale l : locales) {
                 if (l.getCountry().equals(defaultLocale.getCountry())) {
-                    defaultLocale = l;
+                    countryLocale = l;
                     break;
                 }
             }
-            dateFormatCountry = DateFormat.getDateInstance(DateFormat.DEFAULT, defaultLocale);
-            dateFormatShortCountry = DateFormat.getDateInstance(DateFormat.SHORT, defaultLocale);
-            timeFormatCountry = DateFormat.getTimeInstance(DateFormat.DEFAULT, defaultLocale);
-            timeFormatShortCountry = DateFormat.getTimeInstance(DateFormat.SHORT, defaultLocale);
+            dateFormatCountry = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(countryLocale)
+                    .withZone(zone);
+            dateFormatShortCountry = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+                    .withLocale(countryLocale).withZone(zone);
+            timeFormatCountry = DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM).withLocale(countryLocale)
+                    .withZone(zone);
+            timeFormatShortCountry = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+                    .withLocale(countryLocale).withZone(zone);
         }
 
         @Override
         public String expandVariables(TMXEntry trans) {
-            Date creationDate = new Date(trans.creationDate);
-            Date changeDate = new Date(trans.changeDate);
+            Instant creationDate = Instant.ofEpochMilli(trans.creationDate);
+            Instant changeDate = Instant.ofEpochMilli(trans.changeDate);
 
             // do not modify template directly, so that we can reuse for another change
             String localTemplate = this.template;

--- a/src/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/org/omegat/gui/editor/SegmentBuilder.java
@@ -30,9 +30,12 @@
 
 package org.omegat.gui.editor;
 
-import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -574,9 +577,13 @@ public class SegmentBuilder {
             String template;
             if (trans.changeDate != 0) {
                 template = OStrings.getString("TF_CUR_SEGMENT_AUTHOR_DATE");
-                Date changeDate = new Date(trans.changeDate);
-                String changeDateString = DateFormat.getDateInstance().format(changeDate);
-                String changeTimeString = DateFormat.getTimeInstance().format(changeDate);
+                Instant changeDate = Instant.ofEpochMilli(trans.changeDate);
+                Locale locale = Locale.getDefault();
+                ZoneId zone = ZoneId.systemDefault();
+                String changeDateString = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                        .withLocale(locale).withZone(zone).format(changeDate);
+                String changeTimeString = DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM)
+                        .withLocale(locale).withZone(zone).format(changeDate);
                 Object[] args = { author, changeDateString, changeTimeString };
                 text = StringUtil.format(template, args);
             } else {

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -30,11 +30,12 @@ import java.awt.Point;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.lang.reflect.Constructor;
-import java.text.DateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
@@ -72,8 +73,8 @@ public class SegmentPropertiesArea implements IPaneMenu {
 
     private static final Pattern SPLIT_COMMAS = Pattern.compile("\\s*,\\s*");
 
-    private final DateFormat dateFormat = DateFormat.getDateInstance();
-    private final DateFormat timeFormat = DateFormat.getTimeInstance();
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy h:mm:ss a",
+            Locale.getDefault()).withZone(ZoneId.systemDefault());
 
     private static final String KEY_ISDUP = "isDup";
     private static final String KEY_FILE = "file";
@@ -349,13 +350,11 @@ public class SegmentPropertiesArea implements IPaneMenu {
             return;
         }
         if (entry.changeDate != 0) {
-            setProperty(KEY_CHANGED, dateFormat.format(new Date(entry.changeDate)) + " "
-                    + timeFormat.format(new Date(entry.changeDate)));
+            setProperty(KEY_CHANGED, dateTimeFormatter.format(Instant.ofEpochMilli(entry.changeDate)));
         }
         setProperty(KEY_CHANGER, entry.changer);
         if (entry.creationDate != 0) {
-            setProperty(KEY_CREATED, dateFormat.format(new Date(entry.creationDate)) + " "
-                    + timeFormat.format(new Date(entry.creationDate)));
+            setProperty(KEY_CREATED, dateTimeFormatter.format(Instant.ofEpochMilli(entry.creationDate)));
         }
         setProperty(KEY_CREATOR, entry.creator);
         if (!entry.defaultTranslation) {

--- a/src/org/omegat/gui/search/SearchWindowController.java
+++ b/src/org/omegat/gui/search/SearchWindowController.java
@@ -45,8 +45,10 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.File;
 import java.text.MessageFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
@@ -133,7 +135,7 @@ public class SearchWindowController {
         if (Platform.isMacOSX()) {
             OSXIntegration.enableFullScreen(form);
         }
-        dateFormat = new SimpleDateFormat(SAVED_DATE_FORMAT);
+        dateFormat = DateTimeFormatter.ofPattern(SAVED_DATE_FORMAT).withZone(ZoneId.systemDefault());
 
         form.m_searchField.setModel(new DefaultComboBoxModel<>(HistoryManager.getSearchItems()));
         if (form.m_searchField.getModel().getSize() > 0) {
@@ -657,10 +659,10 @@ public class SearchWindowController {
         Preferences.setPreference(Preferences.SEARCHWINDOW_AUTHOR_NAME, form.m_authorField.getText());
         Preferences.setPreference(Preferences.SEARCHWINDOW_DATE_FROM, form.m_dateFromCB.isSelected());
         Preferences.setPreference(Preferences.SEARCHWINDOW_DATE_FROM_VALUE,
-                dateFormat.format(dateFromModel.getDate()));
+                dateFormat.format(dateFromModel.getDate().toInstant()));
         Preferences.setPreference(Preferences.SEARCHWINDOW_DATE_TO, form.m_dateToCB.isSelected());
         Preferences.setPreference(Preferences.SEARCHWINDOW_DATE_TO_VALUE,
-                dateFormat.format(dateToModel.getDate()));
+                dateFormat.format(dateToModel.getDate().toInstant()));
         Preferences.setPreference(Preferences.SEARCHWINDOW_NUMBER_OF_RESULTS,
                 form.m_numberOfResults.getValue());
         Preferences.setPreference(Preferences.SEARCHWINDOW_EXCLUDE_ORPHANS,
@@ -1196,15 +1198,15 @@ public class SearchWindowController {
             form.m_dateFromCB.setSelected(Preferences.isPreference(Preferences.SEARCHWINDOW_DATE_FROM));
             String dateFromValue = Preferences.getPreference(Preferences.SEARCHWINDOW_DATE_FROM_VALUE);
             if (!StringUtil.isEmpty(dateFromValue)) {
-                dateFromModel.setValue(dateFormat.parse(dateFromValue));
+                dateFromModel.setValue(Date.from(Instant.from(dateFormat.parse(dateFromValue))));
             }
             // to date
             form.m_dateToCB.setSelected(Preferences.isPreference(Preferences.SEARCHWINDOW_DATE_TO));
             String dateToValue = Preferences.getPreference(Preferences.SEARCHWINDOW_DATE_TO_VALUE);
             if (!StringUtil.isEmpty(dateToValue)) {
-                dateToModel.setValue(dateFormat.parse(dateToValue));
+                dateToModel.setValue(Date.from(Instant.from(dateFormat.parse(dateToValue))));
             }
-        } catch (ParseException e) {
+        } catch (DateTimeException e) {
             // use safe settings in case of parsing error
             form.m_dateFromCB.setSelected(false);
             form.m_dateToCB.setSelected(false);
@@ -1288,7 +1290,7 @@ public class SearchWindowController {
         });
     }
 
-    private final SimpleDateFormat dateFormat;
+    private final DateTimeFormatter dateFormat;
     private final SpinnerDateModel dateFromModel;
     private final SpinnerDateModel dateToModel;
 

--- a/src/org/omegat/util/TMXReader2.java
+++ b/src/org/omegat/util/TMXReader2.java
@@ -56,15 +56,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.TimeZone;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipInputStream;
 
@@ -83,8 +84,11 @@ import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
 public class TMXReader2 {
 
     private final XMLInputFactory inputFactory;
-    private final SimpleDateFormat dateFormat1;
-    private final SimpleDateFormat dateFormat2;
+
+    private static final DateTimeFormatter DATE_FORMAT1 = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter DATE_FORMAT2 = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
 
     /** Segment Type attribute value: "paragraph" */
     public static final String SEG_PARAGRAPH = "paragraph";
@@ -136,10 +140,6 @@ public class TMXReader2 {
             warningsCount++;
         });
         inputFactory.setXMLResolver(TMX_DTD_RESOLVER_2);
-        dateFormat1 = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH);
-        dateFormat1.setTimeZone(TimeZone.getTimeZone("UTC"));
-        dateFormat2 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH);
-        dateFormat2.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     public boolean isParagraphSegtype() {
@@ -743,12 +743,12 @@ public class TMXReader2 {
             return 0;
         }
         try {
-            return dateFormat1.parse(str).getTime();
-        } catch (ParseException ignored) {
+            return Instant.from(DATE_FORMAT1.parse(str)).toEpochMilli();
+        } catch (DateTimeException ignored) {
         }
         try {
-            return dateFormat2.parse(str).getTime();
-        } catch (ParseException ignored) {
+            return Instant.from(DATE_FORMAT2.parse(str)).toEpochMilli();
+        } catch (DateTimeException ignored) {
         }
 
         return 0;

--- a/src/org/omegat/util/TMXWriter2.java
+++ b/src/org/omegat/util/TMXWriter2.java
@@ -38,13 +38,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -81,12 +81,12 @@ public class TMXWriter2 implements AutoCloseable {
     private final boolean forceValidTMX;
 
     /**
-     * DateFormat with format YYYYMMDDThhmmssZ able to display a date in UTC
-     * time.
-     *
-     * SimpleDateFormat IS NOT THREAD SAFE !!!
+     * Formatter with format YYYYMMDDThhmmssZ able to display a date in UTC time.
+     * <p>
+     * {@link DateTimeFormatter} is immutable and thread-safe.
      */
-    private final SimpleDateFormat tmxDateFormat;
+    private static final DateTimeFormatter TMX_DATE_FORMAT = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH).withZone(ZoneOffset.UTC);
 
     /**
      *
@@ -140,9 +140,6 @@ public class TMXWriter2 implements AutoCloseable {
 
         langSrc = sourceLanguage.toString();
         langTar = targetLanguage.toString();
-
-        tmxDateFormat = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.ENGLISH);
-        tmxDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     public void close() throws XMLStreamException, IOException {
@@ -311,13 +308,13 @@ public class TMXWriter2 implements AutoCloseable {
                 xml.writeAttribute("changeid", changer);
             }
             if (changeDate > 0) {
-                xml.writeAttribute("changedate", tmxDateFormat.format(new Date(changeDate)));
+                xml.writeAttribute("changedate", TMX_DATE_FORMAT.format(Instant.ofEpochMilli(changeDate)));
             }
             if (!StringUtil.isEmpty(creator)) {
                 xml.writeAttribute("creationid", creator);
             }
             if (creationDate > 0) {
-                xml.writeAttribute("creationdate", tmxDateFormat.format(new Date(creationDate)));
+                xml.writeAttribute("creationdate", TMX_DATE_FORMAT.format(Instant.ofEpochMilli(creationDate)));
             }
             xml.writeCharacters(lineSeparator);
 

--- a/src/org/omegat/util/logging/OmegaTLogFormatter.java
+++ b/src/org/omegat/util/logging/OmegaTLogFormatter.java
@@ -29,8 +29,9 @@ package org.omegat.util.logging;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -60,18 +61,15 @@ public class OmegaTLogFormatter extends Formatter {
     private final boolean isMaskContainsLoggerName;
     private final boolean isMaskContainsTime;
 
-    private String defaultTimeFormat = "HH:mm:ss";
+    private static final String DEFAULT_TIME_FORMAT = "HH:mm:ss";
 
     /**
-     * We have to use ThreadLocal for formatting time because DateFormat is not
-     * thread safe.
+     * Formatter for the log timestamp. {@link DateTimeFormatter} is immutable
+     * and thread-safe, so a single shared instance can be reused across threads
+     * without the per-thread allocation and lookup overhead of a
+     * {@link ThreadLocal}.
      */
-    private final ThreadLocal<SimpleDateFormat> timeFormatter = new ThreadLocal<SimpleDateFormat>() {
-        @Override
-        protected SimpleDateFormat initialValue() {
-            return new SimpleDateFormat(defaultTimeFormat);
-        }
-    };
+    private final DateTimeFormatter timeFormatter;
 
     /**
      * Initialize formatter.
@@ -88,9 +86,10 @@ public class OmegaTLogFormatter extends Formatter {
         }
 
         String timeFormat = manager.getProperty(cname + ".timeFormat");
-        if (timeFormat != null) {
-            defaultTimeFormat = timeFormat;
+        if (timeFormat == null) {
+            timeFormat = DEFAULT_TIME_FORMAT;
         }
+        timeFormatter = DateTimeFormatter.ofPattern(timeFormat).withZone(ZoneId.systemDefault());
 
         isMaskContainsKey = logMask.contains("$key");
         isMaskContainsLevel = logMask.contains("$level");
@@ -156,7 +155,7 @@ public class OmegaTLogFormatter extends Formatter {
             res = res.replace("$mark", LINE_MARK);
         }
         if (isMaskContainsTime) {
-            res = res.replace("$time", timeFormatter.get().format(new Date()));
+            res = res.replace("$time", timeFormatter.format(Instant.now()));
         }
         if (isMaskContainsLoggerName) {
             res = res.replace("$loggerName", record.getLoggerName());

--- a/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
+++ b/test-acceptance/src/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
@@ -77,7 +77,7 @@ public class SegmentPropertiesAreaTest extends TestCoreGUI {
         ZonedDateTime utcDateTime = ZonedDateTime.parse("20241127T035216Z", customFormatter);
         ZonedDateTime expectedDateTime = utcDateTime.withZoneSameInstant(java.time.ZoneId.systemDefault());
         final String expected = expectedDateTime
-                .format(DateTimeFormatter.ofPattern("MMM dd, yyyy h:m:s a", Locale.getDefault()));
+                .format(DateTimeFormatter.ofPattern("MMM dd, yyyy h:mm:ss a", Locale.getDefault()));
         final String translator = "Hiroshi Miura";
         //
         final Map<String, String> expectation = new HashMap<>();


### PR DESCRIPTION
Java community changes Date/Time handling of Java language from Java 8 as standard JSR-310.
OmegaT uses legacy datetime API before Java 6 which changes behavior after Java 21.

This modernaize the datetime formatter with newer modern recommened way.

## Pull request type

- Other (describe below)
Refactor

## Which ticket is resolved?

None
## What does this PR change?



- Migrate to modern `java.time` API for date and time formatting
- Update relevant test for `DateTimeFormatter` pattern consistency
- Ready for Java 21 and later


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
