### PR TITLE
chore(core): replace deprecated `setSerializationInclusion` with `setDefaultPropertyInclusion` in mappers

### DIFF
--- a/src/org/omegat/filters2/master/FilterMaster.java
+++ b/src/org/omegat/filters2/master/FilterMaster.java
@@ -129,7 +129,7 @@ public class FilterMaster {
                 .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
         MAPPER.registerModule(new JakartaXmlBindAnnotationModule());
         MAPPER.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY);
         MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/src/org/omegat/util/PreferencesXML.java
+++ b/src/org/omegat/util/PreferencesXML.java
@@ -79,7 +79,7 @@ public class PreferencesXML implements IPrefsPersistence {
         mapper = new XmlMapper();
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         this.firstRun = loadFile == null || !loadFile.exists();
         this.prefCreatedAt = null;
         this.prefUpdatedAt = null;

--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -100,7 +100,7 @@ public final class ProjectFileStorage {
                 .constructMapType(def.getOtherAttributes().getClass(), QName.class, String.class)));
         mapper.registerModule(module);
         mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 


### PR DESCRIPTION
Replace deprecated method with recommended one for jackson

## Pull request type
- Refactor

## Which ticket is resolved?
none

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
