### PR TITLE
chore(ci, build-logic): update JRE versions for Windows builds and pipelines

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.windows-conventions.gradle
@@ -79,7 +79,7 @@ launch4j {
 }
 
 def assetDir = findProperty('assetDir') ?: '../'
-def windowsJRE = fileTree(dir: assetDir, include: 'OpenJDK17U-jre_x64_windows_*.zip')
+def windowsJRE = fileTree(dir: assetDir, include: 'OpenJDK25U-jre_x64_windows_*.zip')
 def windowsArm64JRE = fileTree(dir: assetDir, include: 'OpenJDK21U-jre_aarch64_windows_*.zip')
 tasks.register('win') {
     description = 'Builds the Windows distributions.'

--- a/ci/azure-pipelines/build_steps.yml
+++ b/ci/azure-pipelines/build_steps.yml
@@ -7,11 +7,8 @@ steps:
         mkdir -p $(System.ArtifactsDirectory)/asset
         cd $(System.ArtifactsDirectory)/asset || exit 1
         jres=(
-          https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_mac_hotspot_25.0.3_9.tar.gz
-          https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_windows_hotspot_25.0.3_9.zip
-          https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_mac_hotspot_25.0.3_9.tar.gz
+          https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK25U-jre_aarch64_windows_hotspot_21.0.9_10.zip
           https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_windows_hotspot_25.0.3_9.zip
-          https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x86-32_windows_hotspot_25.0.3_9.zip 
         )
         for url in "${jres[@]}"; do
           curl -L -O "$url"


### PR DESCRIPTION
Eclipse project focus on x64 architecture in Java 25 on Windows. We need to keep Java 21 for Windows on Arm64.
 
## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]


## Which ticket is resolved?

none
## What does this PR change?

- Update JRE file name match in windows-conventions
- azure-pipelines: update download JRE urls
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
