### PR TITLE
chore(build): sign dependencies also for *.jnilib in modules and core

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
@@ -1,3 +1,4 @@
+import java.util.zip.ZipFile
 
 configurations {
     genMac
@@ -53,35 +54,69 @@ tasks.register('genMac') {
     }
 }
 
-ext.makeHunspellSignTask = {
-    def hunspellJar = configurations.runtimeClasspath.files.find {
-        it.name.startsWith('hunspell')
-    }
-    tasks.register('hunspellJarSignedContents', Sync) {
-        onlyIf {
-            // Set this in e.g. local.properties
-            conditions([project.hasProperty('macCodesignIdentity'), 'Code signing property not set'],
-                    [exePresent('codesign'), 'codesign command is not present in system.'])
+// Returns true if the given jar bundles at least one macOS native library.
+ext.jarContainsMacNativeLibs = { File jar ->
+    if (!jar.name.endsWith('.jar') || !jar.exists()) return false
+    def zf = new ZipFile(jar)
+    try {
+        return zf.entries().any {
+            !it.directory && (it.name.endsWith('.dylib') || it.name.endsWith('.jnilib'))
         }
-        from zipTree(hunspellJar)
+    } finally {
+        zf.close()
+    }
+}
 
-        destinationDir = file(layout.buildDirectory.file("hunspell"))
-        doLast {
-            def dylibs = fileTree(dir: destinationDir, include: '**/*.dylib').files
-            injected.execOps.exec {
-                commandLine('codesign', '--deep', '--force',
-                        '--sign', project.property('macCodesignIdentity'),
-                        '--timestamp',
-                        '--options', 'runtime',
-                        '--entitlements', file('release/mac-specific/java.entitlements'),
-                        *dylibs.toList())
+/*
+ * For every runtime dependency jar that bundles macOS native libraries
+ * (*.dylib / *.jnilib), register a pair of tasks that
+ *   1. extract the jar and codesign the native libraries inside it, then
+ *   2. repackage the signed contents into a jar with the original name.
+ *
+ * codesign --deep on the .app does not descend into jars, so native libraries
+ * shipped inside dependency jars (e.g. jna, jna-platform, lz4-java) must be
+ * signed here before the app is assembled and notarized.
+ *
+ * The repackaging (Jar) task providers are stored in ext.signedNativeLibJarTasks
+ * and the original jar names in ext.signedNativeLibJarNames, so the distribution
+ * can replace the unsigned originals with the signed jars.
+ */
+ext.makeNativeLibsSignTask = {
+    def nativeLibJars = configurations.runtimeClasspath.files.findAll { jarContainsMacNativeLibs(it) }
+    ext.signedNativeLibJarNames = nativeLibJars.collect { it.name }
+    ext.signedNativeLibJarTasks = nativeLibJars.collect { jar ->
+        def taskId = jar.name.replaceAll(/\.jar$/, '').replaceAll(/[^A-Za-z0-9]/, '_')
+        def contentsDir = layout.buildDirectory.dir("signedNativeLibs/${taskId}")
+
+        def contentsTask = tasks.register("signNativeLibContents_${taskId}", Sync) {
+            onlyIf {
+                // Set macCodesignIdentity in e.g. local.properties
+                conditions([project.hasProperty('macCodesignIdentity'), 'Code signing property not set'],
+                        [exePresent('codesign'), 'codesign command is not present in system.'])
+            }
+            from zipTree(jar)
+            destinationDir = contentsDir.get().asFile
+            doLast {
+                def dylibs = fileTree(dir: destinationDir, includes: ['**/*.dylib', '**/*.jnilib']).files
+                injected.execOps.exec {
+                    commandLine(['codesign', '--deep', '--force',
+                            '--sign', project.property('macCodesignIdentity'),
+                            '--timestamp',
+                            '--options', 'runtime',
+                            '--entitlements', file('release/mac-specific/java.entitlements')] + dylibs.toList())
+                }
             }
         }
-    }
 
-    tasks.register('hunspellSignedJar', Jar) {
-        from hunspellJarSignedContents.outputs
-        archiveFileName.set(hunspellJar.name)
+        tasks.register("signNativeLibJar_${taskId}", Jar) {
+            onlyIf {
+                conditions([project.hasProperty('macCodesignIdentity'), 'Code signing property not set'],
+                        [exePresent('codesign'), 'codesign command is not present in system.'])
+            }
+            from contentsTask
+            archiveFileName.set(jar.name)
+            destinationDirectory.set(layout.buildDirectory.dir('signedNativeLibJars'))
+        }
     }
 }
 
@@ -148,7 +183,14 @@ ext.makeMacTask = { args ->
                     [args.jrePath && !args.jrePath.empty, 'JRE not found'],
                     [exePresent('codesign'), 'codesign command is not present in system.'])
         }
-        from(installTask)
+        // Replace the unsigned native-library jars with versions whose *.dylib /
+        // *.jnilib have been codesigned (codesign --deep does not descend into jars).
+        from(installTask) {
+            exclude signedNativeLibJarNames.collect { "OmegaT.app/Contents/Java/lib/${it}" }
+        }
+        into('OmegaT.app/Contents/Java/lib') {
+            from(files(signedNativeLibJarTasks))
+        }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
         destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${versionPart}-${args.suffix}_Signed"))
         doFirst {
@@ -165,7 +207,6 @@ ext.makeMacTask = { args ->
             }
         }
         group = 'distribution'
-        dependsOn tasks.named('hunspellSignedJar')
     }
     parentTask.dependsOn installTask
 }

--- a/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
+++ b/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.process.ExecOperations
 
 import javax.inject.Inject
+import java.util.zip.ZipFile
 
 class OmegatModulePlugin implements Plugin<Project> {
 
@@ -74,7 +75,7 @@ class OmegatModulePlugin implements Plugin<Project> {
                         .resolve()
                         .collect { dep ->
                             if (dep.directory) return dep
-                            if (shouldSignDylibs(project) && containsDylibs(dep)) {
+                            if (shouldSignDylibs(project) && containsNativeLibs(dep)) {
                                 return project.fileTree(signAndExtractJar(project, dep))
                             }
                             return project.zipTree(dep)
@@ -228,11 +229,11 @@ class OmegatModulePlugin implements Plugin<Project> {
     /**
      * Returns true if the given jar file contains at least one *.dylib entry.
      */
-    private static boolean containsDylibs(File jar) {
+    private static boolean containsNativeLibs(File jar) {
         if (!jar.name.endsWith('.jar') || !jar.exists()) return false
-        def zipFile = new java.util.zip.ZipFile(jar)
+        def zipFile = new ZipFile(jar)
         try {
-            return zipFile.entries().any { !it.directory && it.name.endsWith('.dylib') }
+            return zipFile.entries().any { !it.directory && (it.name.endsWith('.dylib') || it.name.endsWith('.jnilib')) }
         } finally {
             zipFile.close()
         }
@@ -253,13 +254,13 @@ class OmegatModulePlugin implements Plugin<Project> {
             into stagingDir
         }
 
-        def dylibs = project.fileTree(dir: stagingDir, include: '**/*.dylib').files.toList()
+        def nativeLibs = project.fileTree(dir: stagingDir, includes: ['**/*.dylib', '**/*.jnilib']).files.toList()
         execOperations.exec {
             commandLine(['codesign', '--deep', '--force',
                     '--sign', project.property('macCodesignIdentity'),
                     '--timestamp',
                     '--options', 'runtime',
-                    '--entitlements', project.rootProject.file('release/mac-specific/java.entitlements')] + dylibs)
+                    '--entitlements', project.rootProject.file('release/mac-specific/java.entitlements')] + nativeLibs)
         }
 
         return stagingDir

--- a/build.gradle
+++ b/build.gradle
@@ -453,6 +453,9 @@ def buildLogicLibsTask = gradle.includedBuild('build-logic')
 installSourceDist.dependsOn(buildLogicLibsTask)
 sourceDistZip.dependsOn(buildLogicLibsTask)
 
+// Register the native-library signing task
+makeNativeLibsSignTask()
+
 tasks.register('mac') {
     description = 'Builds the Mac distributions.'
     group = 'distribution'


### PR DESCRIPTION
OmegaT dependecies libraries sometime uses JNI/JNA native library. It is important for mac build to sign the native libraries.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

none
## What does this PR change?

- SIgn `*.jnilib` in addition to `*.dylib` 
- Same mechanism for core dependencies
- 

## Other information

`.jnilib` was Apple's own file extension for JNI native libraries, used back when Apple shipped and maintained its own JVM (before Java 7, when Oracle took over the Mac JVM). 
