### PR TITLE
chore(docker): upgrade Java to 21 and Gradle to 9.6.0 in compose and Dockerfile

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,9 +15,9 @@ services:
     build:
       context: test-integration/docker/client
       args:
-        JAVA: 17
-        JDKVER: jdk_17.0.14.0.0+7-1
-        GRADLE: 8.13
+        JAVA: 21
+        JDKVER: jdk_25.0.3.0.0+9-1
+        GRADLE: 9.6.0
     depends_on:
       server:
         condition: service_started

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -29,7 +29,7 @@ ARG TARGETARCH
 ARG CAVER=1.0.3-1
 ARG JAVA=25
 ARG JDKVER=jdk_25.0.3.0.0+9-1
-ARG GRADLE=9.4.1
+ARG GRADLE=9.6.0
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git inotify-tools curl subversion unzip rsync  \
  java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit locales
 RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh


### PR DESCRIPTION
Fix docker compose configuration for integration test.

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?
none

## What does this PR change?

- synchronize JDK and Gradle versions in Docker configuration
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
