### PR TITLE
refactor(preferences): install the preferences store through a testable seam

### DIFF
--- a/src/org/omegat/util/Preferences.java
+++ b/src/org/omegat/util/Preferences.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.SRXManager;
 import org.omegat.filters2.master.FilterMaster;
@@ -796,11 +797,28 @@ public final class Preferences {
         if (didInit) {
             return;
         }
-        didInit = true;
-
         File loadFile = getPreferencesFile();
         File saveFile = new File(StaticUtils.getConfigDir(), Preferences.FILE_PREFERENCES);
-        preferences = new PreferencesImpl(new PreferencesXML(loadFile, saveFile));
+        setPreferences(new PreferencesImpl(new PreferencesXML(loadFile, saveFile)));
+    }
+
+    /**
+     * Install the preferences store to be used by the static facade.
+     * <p>
+     * This is the single point that assigns the backing {@link IPreferences}
+     * instance, mirroring the {@code setInstance} approach used by
+     * {@link org.omegat.core.data.CoreState} and
+     * {@link org.omegat.core.data.RuntimePreferenceStore}. Production code
+     * reaches it once through {@link #init()}. Tests inject an isolated store
+     * (see {@code org.omegat.util.TestPreferences}) so preference state cannot
+     * leak between tests; installing a store marks the system initialized, so a
+     * later {@link #init()} call keeps the injected store rather than replacing
+     * it with the user's on-disk preferences.
+     */
+    @VisibleForTesting
+    static synchronized void setPreferences(IPreferences preferences) {
+        Preferences.preferences = preferences;
+        didInit = true;
     }
 
     public static synchronized void initFilters() {

--- a/src_docs/developer/adr/2026002.PreferencesArchitecture.md
+++ b/src_docs/developer/adr/2026002.PreferencesArchitecture.md
@@ -1,0 +1,54 @@
+# ADR: Preferences Architecture and Testable Store Injection
+
+## Status
+**Proposed** (Date: 2026-07-12)
+- Pull Request: [#2110](https://github.com/omegat-org/omegat/pull/2110)
+
+## Context
+`org.omegat.util.Preferences` is a static facade over one mutable store, built
+lazily once per JVM behind a `didInit` guard. That is correct for a launch, but
+in tests it means the first test to touch preferences fixes the store for every
+test that follows, so mutated values leak and cause order-dependent failures.
+The concrete symptom was `EditorControllerTest` asserting offsets that depend on
+`MARK_PARA_DELIMITATIONS`, which the console tests leave as `false` (fragile
+assertions from [#1326](https://github.com/omegat-org/omegat/pull/1326)). There
+was no ADR or specification for the mechanism, and the first fix was an ad hoc
+`resetPreferencesForTest()` back door into private state.
+
+## Decision
+Give `Preferences` one explicit installation point for its store and let tests
+inject an isolated store, mirroring `org.omegat.core.data.CoreState`
+([ADR 2025002](2025002.CoreStateSingleton.md)) and `RuntimePreferenceStore`.
+
+Specification: static accessors delegate to an installed `IPreferences`.
+`PreferencesImpl` holds values in memory over an `IPrefsPersistence` backing
+(`PreferencesXML` on disk in production). `init()` builds the production store
+against the config dir and is idempotent via `didInit`.
+
+Implementation:
+- `@VisibleForTesting static synchronized setPreferences(IPreferences)` becomes
+  the sole assignment point; `init()` routes through it. Installing sets
+  `didInit`, so a later `init()` keeps the injected store.
+- `TestPreferences` is an empty, never-persisted in-memory store;
+  `TestPreferencesInitializer` installs a fresh one per test.
+- The `resetPreferencesForTest()` back door is removed.
+
+Production behavior is unchanged.
+
+## Consequences
+Tests become isolated and order-independent, and the full suite passes.
+Preferences follow the same testable-singleton seam as `CoreState`. Tests that
+need on-disk persistence still construct `PreferencesImpl`/`PreferencesXML`
+directly. `Preferences` stays a static facade; full dependency injection is out
+of scope.
+
+## Alternatives Considered
+- **Pin the one preference in the failing test** — patches one case, leaves the leak.
+- **`resetPreferencesForTest()` back door** — fixes the leak but is a bespoke
+  private-state mutator, off-pattern.
+- **Full dependency injection** — cleanest long-term, but a large cross-cutting change.
+
+## References
+- [ADR 2025002 — Refactor Core Class Static State Management](2025002.CoreStateSingleton.md)
+- `org.omegat.core.data.CoreState`, `org.omegat.core.data.RuntimePreferenceStore`
+- Origin of the fragile offset assertions: [#1326](https://github.com/omegat-org/omegat/pull/1326)

--- a/src_docs/developer/adr/index.md
+++ b/src_docs/developer/adr/index.md
@@ -10,6 +10,7 @@
 - 2025007 [CLI Plugin API Implementation](2025007.CLIPluginAPI.md)
 - 2025008 [Adoption of JSpecify for Null-Safety](2025008.AdoptionJSpecifyForNullSafety.md)
 - 2025012 [Plugin Security Architecture and ClassLoader Isolation](2025012.PluginSecurityArchitecture.md)
+- 2026002 [Preferences Architecture and Testable Store Injection](2026002.PreferencesArchitecture.md)
 
 ## Core features
 

--- a/test/fixtures/org/omegat/util/TestPreferences.java
+++ b/test/fixtures/org/omegat/util/TestPreferences.java
@@ -1,0 +1,73 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import java.util.List;
+
+import org.omegat.util.PreferencesImpl.IPrefsPersistence;
+
+/**
+ * An isolated preferences store for tests.
+ * <p>
+ * It is a {@link PreferencesImpl} backed by an in-memory persistence that
+ * starts empty and is never written to disk, so each test can install a fresh,
+ * independent instance through {@link Preferences#setPreferences(Preferences.IPreferences)}
+ * without preference state leaking between tests. This mirrors the
+ * {@code TestCoreState} and {@code TestRuntimePreferenceStore} fixtures.
+ */
+public class TestPreferences extends PreferencesImpl {
+
+    public TestPreferences() {
+        super(new InMemoryPersistence());
+    }
+
+    private static final class InMemoryPersistence implements IPrefsPersistence {
+        @Override
+        public void load(List<String> keys, List<String> values) {
+            // Tests start from an empty store: nothing to load.
+        }
+
+        @Override
+        public void save(List<String> keys, List<String> values) {
+            // Tests never persist preferences to disk.
+        }
+
+        @Override
+        public boolean isFirstRun() {
+            return true;
+        }
+
+        @Override
+        public String getCreatedAt() {
+            return null;
+        }
+
+        @Override
+        public String getUpdatedAt() {
+            return null;
+        }
+    }
+}

--- a/test/fixtures/org/omegat/util/TestPreferencesInitializer.java
+++ b/test/fixtures/org/omegat/util/TestPreferencesInitializer.java
@@ -66,7 +66,12 @@ public final class TestPreferencesInitializer {
     public static synchronized void init(String configDir) {
         TestRuntimePreferenceStore.reset();
         TestRuntimePreferenceStore.getInstance().setConfigDir(configDir);
-        Preferences.init();
+        // Install a fresh, isolated preferences store for this test. Preferences
+        // builds its store only once per JVM, so without this every test after
+        // the first would share (and inherit the mutations of) whatever store the
+        // first test created. Injecting a TestPreferences gives each test a clean
+        // store and prevents preference state from leaking across the suite.
+        Preferences.setPreferences(new TestPreferences());
         Preferences.initFilters();
         Preferences.initSegmentation();
     }


### PR DESCRIPTION

Preferences is a static facade over a single store built once per JVM behind a
didInit guard. In the test suite that let the first test to touch preferences
fix the shared store for every later test, so mutated values leaked and produced
order-dependent failures - most visibly EditorControllerTest, whose offset
assertions depend on MARK_PARA_DELIMITATIONS (left false by the console tests;
the fragile assertions came from #1326).

Instead of a bespoke test-only reset of private state, add a single explicit
installation point setPreferences(IPreferences), annotated @VisibleForTesting,
mirroring the CoreState and RuntimePreferenceStore seams. init() now routes
through it and stays idempotent. Tests install a fresh, in-memory TestPreferences
per test (via TestPreferencesInitializer), so no preference state leaks across
the suite; the resetPreferencesForTest hook is removed.

Production behavior is unchanged: setPreferences is package-private and reached
only through init() outside tests.

The mechanism and this decision are documented in ADR 2026002.

Addresses the order-dependent failures caused by the assertions introduced in
898c07f666de89db3e8f8e6c7d1a0a2c78349c01 (#1326).

written via LLM coding assistance

