### PR TITLE
fix(matches): treat full-width digits as equivalent when substituting…

### DIFF
--- a/src/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/org/omegat/gui/matches/MatchesTextArea.java
@@ -301,20 +301,29 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         List<String> sourceNumbers = Stream.of(sourceTok.tokenizeVerbatimToStrings(source))
                 .filter(MatchesTextArea::isNumber).collect(Collectors.toList());
 
+        // Compare and map numbers on their width-normalized form so that
+        // full-width (ASCII) digits (U+FF10-U+FF19, common in Japanese) are
+        // treated as equivalent to their half-width counterparts. See feature
+        // request #1193.
+        List<String> normSourceMatchNumbers = normalizeDigitWidth(sourceMatchNumbers);
+        List<String> normTargetMatchNumbers = normalizeDigitWidth(targetMatchNumbers);
+
         if (sourceMatchNumbers.size() != sourceNumbers.size()
                 || sourceMatchNumbers.size() != targetMatchNumbers.size()
-                || !new HashSet<>(sourceMatchNumbers).equals(new HashSet<>(targetMatchNumbers))) {
+                || !new HashSet<>(normSourceMatchNumbers).equals(new HashSet<>(normTargetMatchNumbers))) {
             return targetMatch;
         }
 
-        Map<Integer, Integer> locationMap = mapIndices(sourceMatchNumbers, targetMatchNumbers);
+        Map<Integer, Integer> locationMap = mapIndices(normSourceMatchNumbers, normTargetMatchNumbers);
 
-        // Substitute new numbers in the target match
+        // Substitute new numbers in the target match. The inserted number
+        // adopts the digit width of the target token it replaces, so the
+        // target match's digit convention is preserved.
         StringBuilder result = new StringBuilder();
         int i = 0;
         for (String tok : targetTokens) {
             if (isNumber(tok)) {
-                result.append(sourceNumbers.get(locationMap.get(i)));
+                result.append(toDigitWidthOf(sourceNumbers.get(locationMap.get(i)), tok));
                 i++;
             } else {
                 result.append(tok);
@@ -322,6 +331,45 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         }
 
         return result.toString();
+    }
+
+    /**
+     * Return a copy of the given number strings with every digit normalized to
+     * half-width, so that full-width and half-width digits compare equal.
+     * Feature request #1193.
+     */
+    private static List<String> normalizeDigitWidth(List<String> numbers) {
+        return numbers.stream().map(StringUtil::normalizeWidth).collect(Collectors.toList());
+    }
+
+    /**
+     * Render the given number with the digit width used by the template token:
+     * full-width when the template contains full-width digits, half-width
+     * otherwise. This makes a substituted number follow the target match's
+     * digit convention. Feature request #1193.
+     */
+    private static String toDigitWidthOf(String number, String template) {
+        return hasFullwidthDigit(template) ? toFullwidthDigits(number)
+                : StringUtil.normalizeWidth(number);
+    }
+
+    private static boolean hasFullwidthDigit(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c >= '０' && c <= '９') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String toFullwidthDigits(String number) {
+        StringBuilder sb = new StringBuilder(number.length());
+        for (int i = 0; i < number.length(); i++) {
+            char c = number.charAt(i);
+            sb.append(c >= '0' && c <= '9' ? (char) (c - '0' + 0xFF10) : c);
+        }
+        return sb.toString();
     }
 
     /**

--- a/test/src/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/test/src/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneJapaneseTokenizer;
 import org.omegat.util.TestPreferencesInitializer;
 
 public class MatchesTextAreaTest {
@@ -99,5 +100,115 @@ public class MatchesTextAreaTest {
         srcMatch = "foo 1 bar 2 baz 33";
         trgMatch = "bing 3 bang 2 bop 1";
         assertEquals("bing 3 bang 2 bop 1", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Full-width (ASCII) digits (U+FF10-U+FF19), common in Japanese text,
+     * must be treated as equivalent to their half-width counterparts when
+     * substituting numbers into a fuzzy match, and the inserted number must
+     * adopt the digit width used by the target match. Feature request #1193.
+     */
+    @Test
+    public void testReplaceNumbersFullwidth() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Reported case: full-width source number, half-width (Latin) target.
+        // The inserted number must be converted to half-width to match the target.
+        String source = "これは例文９です";
+        String srcMatch = "これは例文8です";
+        String trgMatch = "This is a sample sentence 8";
+        assertEquals("This is a sample sentence 9",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Equivalence: the match's own source uses a full-width digit while its
+        // target uses a half-width one. They must still be recognized as the
+        // same number so the substitution is applied.
+        source = "chapter ５";
+        srcMatch = "chapter ９";
+        trgMatch = "foo 9";
+        assertEquals("foo 5", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A full-width target keeps full-width digits: the half-width source
+        // number is converted to full-width to match the target convention.
+        source = "chapter 5";
+        srcMatch = "chapter 9";
+        trgMatch = "第９章";
+        assertEquals("第５章",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Full-width digits on both sides of a purely CJK segment.
+        source = "第５０章";
+        srcMatch = "第１２章";
+        trgMatch = "第１２章";
+        assertEquals("第５０章",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Regression guard: pure ASCII substitution is unaffected.
+        source = "chapter 5";
+        srcMatch = "chapter 1";
+        trgMatch = "foo 1";
+        assertEquals("foo 5", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Edge cases and documented scope limits of the full-width digit handling
+     * from feature request #1193.
+     */
+    @Test
+    public void testReplaceNumbersWidthEdgeCases() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Several numbers at once, full-width source into half-width target.
+        String source = "x ９ y ８";
+        String srcMatch = "x ３ y ４";
+        String trgMatch = "p 3 q 4";
+        assertEquals("p 9 q 8", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Each substituted number independently follows the width of the
+        // target token it replaces (mixed widths in one target).
+        source = "x ９ y ８";
+        srcMatch = "x ３ y ４";
+        // Target mixes a half-width and a full-width digit.
+        trgMatch = "p 3 q ４";
+        assertEquals("p 9 q ８",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Documented limit: full-width DECIMALS are not recognized as numbers
+        // (Double.parseDouble is ASCII-only), so no substitution happens. This
+        // pins the current scope; extending to full-width decimals is a
+        // possible follow-up.
+        source = "x ５．５";
+        srcMatch = "x １．１";
+        trgMatch = "foo 1.1";
+        assertEquals("foo 1.1", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Documented scope boundary: Arabic-Indic digits (U+0660-U+0669) and
+        // Extended Arabic-Indic digits (U+06F0-U+06F9) are recognized as
+        // numbers but are NOT width-normalized by #1193, so such a source
+        // number is inserted verbatim rather than converted. Cross
+        // numeral-system handling is intentionally out of scope here.
+        source = "x ٩";
+        srcMatch = "x 8";
+        trgMatch = "foo 8";
+        assertEquals("foo ٩",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * The reported #1193 scenario on the real Japanese production path: the
+     * source is tokenized with the Kuromoji-based Japanese tokenizer while the
+     * target uses a Latin tokenizer. The full-width (ASCII) source digit must still
+     * be recognized and inserted into the target as a half-width digit.
+     */
+    @Test
+    public void testReplaceNumbersJapaneseTokenizer() {
+        ITokenizer jaTok = new LuceneJapaneseTokenizer();
+        ITokenizer enTok = new DefaultTokenizer();
+
+        String source = "これは例文９です";
+        String srcMatch = "これは例文8です";
+        String trgMatch = "This is a sample sentence 8";
+        assertEquals("This is a sample sentence 9",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, jaTok, enTok));
     }
 }


### PR DESCRIPTION
… fuzzy-match numbers

Full-width Arabic numerals (U+FF10-U+FF19), common in Japanese source text, were not recognized as equivalent to their half-width counterparts when OmegaT substitutes numbers into an inserted fuzzy match. As a result the number-equivalence check could fail (blocking a valid substitution), and a substituted number was inserted with the source's width instead of the target's, producing for example "sentence ９" instead of "sentence 9".

Number comparison and index mapping in MatchesTextArea.substituteNumbers now operate on the width-normalized (StringUtil.normalizeWidth) form, and each substituted number adopts the digit width of the target token it replaces. Behaviour stays gated by the existing CONVERT_NUMBERS preference; no new option is introduced.

Adds tests for the reported case, the equivalence guard, both width directions, multiple and mixed-width numbers, and the real Japanese (Kuromoji) tokenizer path, and pins the scope limits (full-width decimals and non-full-width numeral systems such as Arabic-Indic are out of scope).

Addresses feature request #1193.
- Convert full-width Arabic numbers to half-width when inserting a fuzzy match
- https://sourceforge.net/p/omegat/feature-requests/1193/

written via LLM coding assistance
