### PR TITLE
refactor: replace ctor of Locale with Locale.of and simplify Arrays.asList

### DIFF
--- a/src/org/omegat/core/data/CommandVarExpansion.java
+++ b/src/org/omegat/core/data/CommandVarExpansion.java
@@ -27,8 +27,6 @@ package org.omegat.core.data;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -63,7 +61,7 @@ public class CommandVarExpansion extends VarExpansion<ProjectProperties> {
     private static final String[] COMMAND_VARIABLES;
 
     public static List<String> getCommandVariables() {
-        return Collections.unmodifiableList(Arrays.asList(COMMAND_VARIABLES));
+        return List.of(COMMAND_VARIABLES);
     }
 
     public CommandVarExpansion(String template) {

--- a/src/org/omegat/core/data/ProjectProperties.java
+++ b/src/org/omegat/core/data/ProjectProperties.java
@@ -36,8 +36,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.omegat.core.segmentation.SRX;
@@ -75,7 +73,7 @@ public class ProjectProperties {
     };
 
     public static List<String> getDefaultExcludes() {
-        return Collections.unmodifiableList(Arrays.asList(DEFAULT_EXCLUDES));
+        return List.of(DEFAULT_EXCLUDES);
     }
 
     /**
@@ -92,7 +90,7 @@ public class ProjectProperties {
         projectRootDir = projectDir;
         projectName = projectDir.getName();
         setSourceRoot(getProjectRoot() + OConsts.DEFAULT_SOURCE + File.separator);
-        sourceRootExcludes.addAll(Arrays.asList(DEFAULT_EXCLUDES));
+        sourceRootExcludes.addAll(List.of(DEFAULT_EXCLUDES));
         setTargetRoot(getProjectRoot() + OConsts.DEFAULT_TARGET + File.separator);
         setGlossaryRoot(getProjectRoot() + OConsts.DEFAULT_GLOSSARY + File.separator);
         setWriteableGlossary(

--- a/src/org/omegat/core/matching/NearString.java
+++ b/src/org/omegat/core/matching/NearString.java
@@ -108,8 +108,11 @@ public class NearString {
      * @param fuzzyMark
      *            fuzzy or not
      * @param nearScore
+     *            similarity score
      * @param nearScoreNoStem
+     *            similarity score for match without non-word tokens
      * @param adjustedScore
+     *            adjusted similarity score for match including all tokens
      * @param nearData
      *            similarity data.
      * @param projName
@@ -177,24 +180,22 @@ public class NearString {
     public static NearString merge(NearString ns, EntryKey key, ITMXEntry entry, MATCH_SOURCE comesFrom,
             boolean fuzzyMark, Scores scores, byte[] nearData, String projName) {
 
-        List<String> projs = new ArrayList<>();
-        List<Scores> mergedScores = new ArrayList<>();
-        projs.addAll(Arrays.asList(ns.projs));
-        mergedScores.addAll(Arrays.asList(ns.scores));
+        List<String> projs = new ArrayList<>(List.of(ns.projs));
+        List<Scores> mergedScores = new ArrayList<>(List.of(ns.scores));
 
         NearString merged;
         if (scores.score > ns.scores[0].score) {
             merged = new NearString(key, entry, comesFrom, fuzzyMark, scores, nearData, null);
-            projs.add(0, projName);
-            mergedScores.add(0, merged.scores[0]);
+            projs.addFirst(projName);
+            mergedScores.addFirst(merged.scores[0]);
         } else {
             merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark, scores,
                     ns.attr, null, ns.creator, ns.creationDate, ns.changer, ns.changedDate, ns.props);
             projs.add(projName);
             mergedScores.add(merged.scores[0]);
         }
-        merged.projs = projs.toArray(new String[projs.size()]);
-        merged.scores = mergedScores.toArray(new Scores[mergedScores.size()]);
+        merged.projs = projs.toArray(new String[0]);
+        merged.scores = mergedScores.toArray(new Scores[0]);
         return merged;
     }
 
@@ -205,18 +206,16 @@ public class NearString {
             final String creator, final long creationDate, final String changer, final long changedDate,
             final List<TMXProp> props) {
 
-        List<String> projs = new ArrayList<>();
-        List<Scores> mergedScores = new ArrayList<>();
-        projs.addAll(Arrays.asList(ns.projs));
-        mergedScores.addAll(Arrays.asList(ns.scores));
+        List<String> projs = Arrays.asList(ns.projs);
+        List<Scores> mergedScores = Arrays.asList(ns.scores);
 
         NearString merged;
         if (nearScore > ns.scores[0].score) {
             merged = new NearString(key, source, translation, comesFrom, fuzzyMark, nearScore,
                     nearScoreNoStem, adjustedScore, nearData, null, creator, creationDate, changer,
                     changedDate, props);
-            projs.add(0, projName);
-            mergedScores.add(0, merged.scores[0]);
+            projs.addFirst(projName);
+            mergedScores.addFirst(merged.scores[0]);
         } else {
             merged = new NearString(ns.key, ns.source, ns.translation, ns.comesFrom, ns.fuzzyMark, nearScore,
                     nearScoreNoStem, adjustedScore, ns.attr, null, ns.creator, ns.creationDate, ns.changer,
@@ -224,8 +223,8 @@ public class NearString {
             projs.add(projName);
             mergedScores.add(merged.scores[0]);
         }
-        merged.projs = projs.toArray(new String[projs.size()]);
-        merged.scores = mergedScores.toArray(new Scores[mergedScores.size()]);
+        merged.projs = projs.toArray(new String[0]);
+        merged.scores = mergedScores.toArray(new Scores[0]);
         return merged;
     }
 
@@ -274,15 +273,7 @@ public class NearString {
         }
 
         public String toString() {
-            StringBuilder b = new StringBuilder();
-            b.append("(");
-            b.append(score);
-            b.append("/");
-            b.append(scoreNoStem);
-            b.append("/");
-            b.append(adjustedScore);
-            b.append("%)");
-            return b.toString();
+            return "(" + score + "/" + scoreNoStem + "/" + adjustedScore + "%)";
         }
     }
 

--- a/src/org/omegat/core/spellchecker/DictionaryManager.java
+++ b/src/org/omegat/core/spellchecker/DictionaryManager.java
@@ -28,10 +28,12 @@ package org.omegat.core.spellchecker;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 import org.apache.commons.io.FilenameUtils;
@@ -144,8 +146,8 @@ public class DictionaryManager {
                 }
 
                 if (match) {
-                    result.add(new SpellingDictionaryEntry(affixName, SpellCheckDictionaryType.HUNSPELL,
-                                    true));
+                    result.add(
+                            new SpellingDictionaryEntry(affixName, SpellCheckDictionaryType.HUNSPELL, true));
                 }
             }
         }
@@ -158,10 +160,10 @@ public class DictionaryManager {
             }
         }
 
-        for (String language: SpellCheckerManager.getHunspellDictionaryLanguages()) {
+        for (String language : SpellCheckerManager.getHunspellDictionaryLanguages()) {
             result.add(new SpellingDictionaryEntry(language, SpellCheckDictionaryType.HUNSPELL, false));
         }
-        for (String language: SpellCheckerManager.getMorfologikDictionaryLanguages()) {
+        for (String language : SpellCheckerManager.getMorfologikDictionaryLanguages()) {
             result.add(new SpellingDictionaryEntry(language, SpellCheckDictionaryType.MORFOLOGIK, false));
         }
 
@@ -180,7 +182,8 @@ public class DictionaryManager {
         if (lang == null || lang.isEmpty()) {
             return false;
         }
-        var target = getLocalDictionaryEntries().stream().filter(it -> it.languageCode.equals(lang)).findFirst();
+        Optional<SpellingDictionaryEntry> target = getLocalDictionaryEntries().stream().filter(
+                it -> it.languageCode.equals(lang)).findFirst();
         if (target.isPresent()) {
             String base = getDirectory() + File.separator + lang;
             if (target.get().type.equals(SpellCheckDictionaryType.HUNSPELL)) {
@@ -233,8 +236,11 @@ public class DictionaryManager {
         List<String> result = new ArrayList<>();
 
         // download the file
-        URL url = new URL(Preferences.getPreference(Preferences.SPELLCHECKER_DICTIONARY_URL));
-        String htmlfile = HttpConnectionUtils.getURL(url);
+        String dictionary = Preferences.getPreference(Preferences.SPELLCHECKER_DICTIONARY_URL);
+        if (dictionary == null || dictionary.isEmpty()) {
+            return result;
+        }
+        String htmlfile = HttpConnectionUtils.getURL(URI.create(dictionary).toURL());
 
         // build a list of available language codes
         Matcher matcher = PatternConsts.DICTIONARY_ZIP.matcher(htmlfile);
@@ -260,7 +266,8 @@ public class DictionaryManager {
      */
     @Deprecated
     public void installRemoteDictionary(String langCode) throws IOException {
-        String from = Preferences.getPreference(Preferences.SPELLCHECKER_DICTIONARY_URL) + "/" + langCode + ".zip";
+        String dictionary = Preferences.getPreference(Preferences.SPELLCHECKER_DICTIONARY_URL);
+        String from = dictionary + "/" + langCode + ".zip";
 
         // Dirty hack for the French dictionary. Since it is named
         // fr_FR_1-3-2.zip, we remove the "_1-3-2" portion
@@ -271,7 +278,7 @@ public class DictionaryManager {
         }
         List<String> expectedFiles = List.of(langCode + OConsts.SC_AFFIX_EXTENSION,
                 langCode + OConsts.SC_DICTIONARY_EXTENSION);
-        HttpConnectionUtils.downloadZipFileAndExtract(new URL(from), dir, expectedFiles);
+        HttpConnectionUtils.downloadZipFileAndExtract(URI.create(from).toURL(), dir, expectedFiles);
     }
 
     public static class SpellingDictionaryEntry {

--- a/src/org/omegat/core/spellchecker/DictionaryManager.java
+++ b/src/org/omegat/core/spellchecker/DictionaryManager.java
@@ -29,7 +29,6 @@ package org.omegat.core.spellchecker;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -205,6 +204,7 @@ public class DictionaryManager {
      * return a list of names of installable dictionaries (e.g. en_US - english
      * (USA))
      */
+    @Deprecated
     public List<String> getInstallableDictionaryNameList() throws IOException {
         return getDictionaryNameList(getInstallableDictionaryCodeList());
     }
@@ -272,7 +272,7 @@ public class DictionaryManager {
         // Dirty hack for the French dictionary. Since it is named
         // fr_FR_1-3-2.zip, we remove the "_1-3-2" portion
         // [ 2138846 ] French dictionary cannot be downloaded and installed
-        int pos = langCode.indexOf("_1-3-2", 0);
+        int pos = langCode.indexOf("_1-3-2");
         if (pos != -1) {
             langCode = langCode.substring(0, pos);
         }

--- a/src/org/omegat/core/spellchecker/DictionaryManager.java
+++ b/src/org/omegat/core/spellchecker/DictionaryManager.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -81,9 +80,9 @@ public class DictionaryManager {
             String[] parts = dic.split("_");
             Locale locale;
             if (parts.length == 1) {
-                locale = new Locale(parts[0]);
+                locale = Locale.of(parts[0]);
             } else {
-                locale = new Locale(parts[0], parts[1]);
+                locale = Locale.of(parts[0], parts[1]);
             }
             result.add(dic + " - " + locale.getDisplayName());
         }
@@ -270,7 +269,7 @@ public class DictionaryManager {
         if (pos != -1) {
             langCode = langCode.substring(0, pos);
         }
-        List<String> expectedFiles = Arrays.asList(langCode + OConsts.SC_AFFIX_EXTENSION,
+        List<String> expectedFiles = List.of(langCode + OConsts.SC_AFFIX_EXTENSION,
                 langCode + OConsts.SC_DICTIONARY_EXTENSION);
         HttpConnectionUtils.downloadZipFileAndExtract(new URL(from), dir, expectedFiles);
     }

--- a/src/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -177,7 +176,7 @@ public class RemoteRepositoryProvider {
             throw new IllegalArgumentException("There is no mapping for file '" + path + "'");
         }
 
-        return mappings.get(0);
+        return mappings.getFirst();
     }
 
     /**
@@ -228,7 +227,7 @@ public class RemoteRepositoryProvider {
         }
 
         if (!errors.isEmpty()) {
-            throw errors.get(0);
+            throw errors.getFirst();
         }
     }
 
@@ -464,7 +463,7 @@ public class RemoteRepositoryProvider {
         }
 
         private void addRawExcludes(String... excludes) {
-            this.forceExcludes.addAll(Arrays.asList(excludes));
+            this.forceExcludes.addAll(List.of(excludes));
         }
 
         private void addTruncatedExcludes(String prefix, String... excludes) {

--- a/src/org/omegat/core/team2/impl/SVNRemoteRepository2.java
+++ b/src/org/omegat/core/team2/impl/SVNRemoteRepository2.java
@@ -29,7 +29,7 @@ package org.omegat.core.team2.impl;
 import java.io.File;
 import java.net.SocketException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
@@ -217,7 +217,7 @@ public class SVNRemoteRepository2 implements IRemoteRepository2 {
                     // to get the list of files changed/deleted
                     1000000, new ISVNLogEntryHandler() {
                         @Override
-                        public void handleLogEntry(final SVNLogEntry en) throws SVNException {
+                        public void handleLogEntry(final SVNLogEntry en) {
                             if (en.getRevision() == sinceRevision.getNumber()) {
                                 return;
                             }
@@ -285,7 +285,7 @@ public class SVNRemoteRepository2 implements IRemoteRepository2 {
             LOGGER.atDebug().log(SVN_FINISH_MSG, "commit");
             return Long.toString(info.getNewRevision());
         } catch (SVNException ex) {
-            if (Arrays.asList(SVNErrorCode.FS_TXN_OUT_OF_DATE, SVNErrorCode.WC_NOT_UP_TO_DATE,
+            if (List.of(SVNErrorCode.FS_TXN_OUT_OF_DATE, SVNErrorCode.WC_NOT_UP_TO_DATE,
                     SVNErrorCode.FS_CONFLICT).contains(ex.getErrorMessage().getErrorCode())) {
                 // Somebody else committed changes - it's normal. Will upload on
                 // next save.
@@ -314,7 +314,7 @@ public class SVNRemoteRepository2 implements IRemoteRepository2 {
                 throw new NetworkException(se);
             }
 
-            if (Arrays.asList(SVNErrorCode.RA_SVN_IO_ERROR, SVNErrorCode.RA_SVN_CONNECTION_CLOSED)
+            if (List.of(SVNErrorCode.RA_SVN_IO_ERROR, SVNErrorCode.RA_SVN_CONNECTION_CLOSED)
                     .contains(se.getErrorMessage().getErrorCode())) {
                 throw new NetworkException(se);
             }

--- a/src/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/org/omegat/filters2/html2/FilterVisitor.java
@@ -397,8 +397,8 @@ public class FilterVisitor extends NodeVisitor {
         String[] parentElementTags = { "HEAD", "HTML" };
 
         return (tagname.equals("BR") && options.getParagraphOnBr())
-                || Arrays.asList(parentElementTags).contains(tagname)
-                || Arrays.asList(blockElementTags).contains(tagname);
+                || List.of(parentElementTags).contains(tagname)
+                || List.of(blockElementTags).contains(tagname);
     }
 
     /** Should the content of this tag be kept intact? */

--- a/src/org/omegat/gui/editor/AlphabeticalMarkers.java
+++ b/src/org/omegat/gui/editor/AlphabeticalMarkers.java
@@ -259,9 +259,11 @@ public abstract class AlphabeticalMarkers extends JPanel {
     protected abstract Map<Integer, Point> getViewableSegmentLocations();
 
     /**
-     * Translate a marker title letter to a segment number. If the letter
-     * found, it will be converted to actual segment number string.
-     * @param inputValue as marker title letter
+     * Translate a marker title letter to a segment number. If the letter found,
+     * it will be converted to actual segment number string.
+     * 
+     * @param inputValue
+     *            as marker title letter
      * @return if the letter found translated string, otherwise inputValue.
      */
     public String translateSegmentNumber(String inputValue) {
@@ -273,9 +275,11 @@ public abstract class AlphabeticalMarkers extends JPanel {
         }
     }
 
-     /**
+    /**
      * Returns <tt>true</tt> if this list contains the specified title.
-     * @param title as segment shortcut letter
+     * 
+     * @param title
+     *            as segment shortcut letter
      * @return <tt>true</tt> if this list contains the specified title
      */
     public boolean containsTitle(int title) {
@@ -310,7 +314,8 @@ public abstract class AlphabeticalMarkers extends JPanel {
 
     private static class Marker {
         int segmentNumber = 0;
-        @Nullable Point location = null;
+        @Nullable
+        Point location = null;
         int title = 0;
 
         @Override

--- a/src/org/omegat/gui/editor/AlphabeticalMarkers.java
+++ b/src/org/omegat/gui/editor/AlphabeticalMarkers.java
@@ -36,7 +36,6 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.font.TextLayout;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -200,7 +199,7 @@ public abstract class AlphabeticalMarkers extends JPanel {
     }
 
     private static Font getTitleFont() {
-        boolean fontAvailable = Arrays.asList(StaticUtils.getFontNames())
+        boolean fontAvailable = List.of(StaticUtils.getFontNames())
                 .contains(DEFAULT_MARKER_FONT_NAME);
         String fontName = fontAvailable ? DEFAULT_MARKER_FONT_NAME : Font.SERIF;
         int fontSize = Preferences.getPreferenceDefault(

--- a/src/org/omegat/gui/editor/ModificationInfoManager.java
+++ b/src/org/omegat/gui/editor/ModificationInfoManager.java
@@ -30,8 +30,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -88,7 +86,7 @@ public final class ModificationInfoManager {
     };
 
     public static List<String> getModInfoVariables() {
-        return Collections.unmodifiableList(Arrays.asList(MOD_INFO_VARIABLES));
+        return List.of(MOD_INFO_VARIABLES);
     }
 
     private static final String[] MOD_INFO_VARIABLES_NO_DATE = {
@@ -96,7 +94,7 @@ public final class ModificationInfoManager {
     };
 
     public static List<String> getModInfoVariablesNoDate() {
-        return Collections.unmodifiableList(Arrays.asList(MOD_INFO_VARIABLES_NO_DATE));
+        return List.of(MOD_INFO_VARIABLES_NO_DATE);
     }
 
     public static final String DEFAULT_TEMPLATE =

--- a/src/org/omegat/gui/glossary/GlossaryManager.java
+++ b/src/org/omegat/gui/glossary/GlossaryManager.java
@@ -133,9 +133,9 @@ public class GlossaryManager implements DirectoryMonitor.Callback {
     }
 
     public void addGlossaryProvider(IGlossary provider) {
-        List<IGlossary> providers = new ArrayList<>(Arrays.asList(externalGlossaries));
+        List<IGlossary> providers = Arrays.asList(externalGlossaries);
         providers.add(provider);
-        externalGlossaries = providers.toArray(new IGlossary[providers.size()]);
+        externalGlossaries = providers.toArray(new IGlossary[0]);
     }
 
     public void start() {

--- a/src/org/omegat/gui/glossary/GlossaryManager.java
+++ b/src/org/omegat/gui/glossary/GlossaryManager.java
@@ -221,7 +221,8 @@ public class GlossaryManager implements DirectoryMonitor.Callback {
      * Get glossary entries.
      *
      * @return all entries
-     * @param src keyword of the glossary to seek.
+     * @param src
+     *            keyword of the glossary to seek.
      */
     public List<GlossaryEntry> getGlossaryEntries(String src) {
         List<GlossaryEntry> result = new ArrayList<>();

--- a/src/org/omegat/gui/issues/SpellingIssueProvider.java
+++ b/src/org/omegat/gui/issues/SpellingIssueProvider.java
@@ -28,7 +28,6 @@ package org.omegat.gui.issues;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,7 +70,7 @@ class SpellingIssueProvider implements IIssueProvider {
     public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
         List<Token> misspelled = Core.getSpellChecker().getMisspelledTokens(tmxEntry.translation);
         return misspelled.isEmpty() ? Collections.emptyList()
-                : Arrays.asList(new SpellingIssue(sourceEntry, tmxEntry, misspelled));
+                : List.of(new SpellingIssue(sourceEntry, tmxEntry, misspelled));
     }
 
     /**

--- a/src/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -156,7 +156,7 @@ class TerminologyIssueProvider implements IIssueProvider {
             String[] uniqueTerms = glossaryEntry.getLocTerms(true);
             // Multiple origins, but just one term
             if (uniqueTerms.length == 1) {
-                String origin = String.join(oDelim, FileUtil.getUniqueNames(Arrays.asList(uniqueOrigins)));
+                String origin = String.join(oDelim, FileUtil.getUniqueNames(List.of(uniqueOrigins)));
                 return OStrings.getString("ISSUES_TERMINOLOGY_DESCRIPTION", origin, glossaryEntry.getSrcText(),
                         uniqueTerms[0]);
             }

--- a/src/org/omegat/gui/matches/MatchesVarExpansion.java
+++ b/src/org/omegat/gui/matches/MatchesVarExpansion.java
@@ -28,8 +28,6 @@
 package org.omegat.gui.matches;
 
 import java.text.DateFormat;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -99,7 +97,7 @@ public class MatchesVarExpansion extends VarExpansion<NearString> {
             VAR_MATCH_SOURCE };
 
     public static List<String> getMatchesVariables() {
-        return Collections.unmodifiableList(Arrays.asList(MATCHES_VARIABLES));
+        return List.of(MATCHES_VARIABLES);
     }
 
     public static final String DEFAULT_TEMPLATE = VAR_ID + ". " + VAR_FUZZY_FLAG + VAR_SOURCE_TEXT + "\n"

--- a/src/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -34,7 +34,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -233,7 +232,7 @@ public class SegmentPropertiesArea implements IPaneMenu {
                     Preferences.SEGPROPS_NOTIFY_DEFAULT_PROPS);
         }
         String rawProps = Preferences.getPreference(Preferences.SEGPROPS_NOTIFY_PROPS);
-        return Arrays.asList(SPLIT_COMMAS.split(rawProps));
+        return List.of(SPLIT_COMMAS.split(rawProps));
     }
 
     private void setKeyToNotify(String key, boolean enabled) {

--- a/src/org/omegat/util/Language.java
+++ b/src/org/omegat/util/Language.java
@@ -31,8 +31,6 @@
 
 package org.omegat.util;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -63,7 +61,7 @@ import java.util.regex.Matcher;
  * @author Briac Pilpre
  */
 public class Language implements Comparable<Object> {
-    private static final Locale EMPTY_LOCALE = new Locale("");
+    private static final Locale EMPTY_LOCALE = Locale.of("");
     private final Locale locale;
 
     /** Creates a new instance of Language, based on Locale */
@@ -99,7 +97,7 @@ public class Language implements Comparable<Object> {
                     String languageCode = m.group(1);
                     String countryCode = m.group(2) == null ? "" : m.group(2);
 
-                    locale = new Locale(languageCode.toLowerCase(Locale.ENGLISH),
+                    locale = Locale.of(languageCode.toLowerCase(Locale.ENGLISH),
                             countryCode.toUpperCase(Locale.ENGLISH));
 
                 } else {
@@ -644,7 +642,7 @@ public class Language implements Comparable<Object> {
      * @return Unmodifiable list of languages
      */
     public static List<Language> getLanguages() {
-        return Collections.unmodifiableList(Arrays.asList(LANGUAGES));
+        return List.of(LANGUAGES);
     }
 
     /**

--- a/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
@@ -86,7 +86,7 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     /**
      * Close the project.
      * <p>
-     *     block until the close action finished.
+     * block until the close action finished.
      */
     protected void closeProject() throws Exception {
         if (!Core.getProject().isProjectLoaded()) {
@@ -116,7 +116,8 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Open project from the specified path and wait until the dictionary is loaded.
+     * Open project from the specified path and wait until the dictionary is
+     * loaded.
      */
     protected void openSampleProjectWaitDictionary(Path projectPath) throws Exception {
         DictionariesTextArea dictionariesTextArea = (DictionariesTextArea) Core.getDictionaries();
@@ -127,9 +128,13 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Open project from the specified path and wait until the glossary is loaded.
-     * @param projectPath project root path.
-     * @throws Exception when error occurred.
+     * Open project from the specified path and wait until the glossary is
+     * loaded.
+     * 
+     * @param projectPath
+     *            project root path.
+     * @throws Exception
+     *             when error occurred.
      */
     protected void openSampleProjectWaitGlossary(Path projectPath) throws Exception {
         GlossaryTextArea glossaryTextArea = (GlossaryTextArea) Core.getGlossary();
@@ -145,7 +150,8 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Open project from the specified path and wait until the active match is set.
+     * Open project from the specified path and wait until the active match is
+     * set.
      */
     protected void openSampleProjectWaitMatches(Path projectPath) throws Exception {
         MatchesTextArea matchesTextArea = (MatchesTextArea) Core.getMatcher();
@@ -162,8 +168,10 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     /**
      * Opens a sample project from the specified path for testing purposes.
      *
-     * @param projectPath the path to the sample project to be opened
-     * @throws Exception if an error occurs while opening the project
+     * @param projectPath
+     *            the path to the sample project to be opened
+     * @throws Exception
+     *             if an error occurs while opening the project
      */
     protected void openSampleProject(Path projectPath) throws Exception {
         // 0. Prepare project folder
@@ -235,8 +243,8 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Reset state and initialize GUI components for each individual test.
-     * This ensures test isolation while reusing the core system setup.
+     * Reset state and initialize GUI components for each individual test. This
+     * ensures test isolation while reusing the core system setup.
      */
     @Override
     protected void onSetUp() throws Exception {
@@ -246,8 +254,8 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Initialize GUI components on the Event Dispatch Thread.
-     * This ensures all Swing operations happen on the correct thread.
+     * Initialize GUI components on the Event Dispatch Thread. This ensures all
+     * Swing operations happen on the correct thread.
      */
     protected void initializeGUIComponents() throws Exception {
         // Create main window on EDT and wait for completion
@@ -296,6 +304,7 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
         @Override
         public void enable() {
         }
+
         @Override
         public void disable() {
         }
@@ -326,11 +335,14 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
      * Captures a screenshot of the current desktop and saves it as a PNG file
      * in a directory structure based on the provided class name.
      *
-     * @param className the name of the class used to determine the directory structure
-     *                  where the screenshot will be saved
-     * @param name      the name of the screenshot file
-     * @throws IOException if an I/O error occurs during directory creation,
-     *                     file deletion, or saving the screenshot
+     * @param className
+     *            the name of the class used to determine the directory
+     *            structure where the screenshot will be saved
+     * @param name
+     *            the name of the screenshot file
+     * @throws IOException
+     *             if an I/O error occurs during directory creation, file
+     *             deletion, or saving the screenshot
      */
     protected void takeScreenshot(String className, String name) throws IOException {
         Path imageDir = Paths.get(IMAGE_PARENT).resolve(className);
@@ -344,9 +356,11 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Initialize OmegaT Core components once per test class.
-     * This should be called only once for the entire test class.
-     * @throws Exception when the error occurred.
+     * Initialize OmegaT Core components once per test class. This should be
+     * called only once for the entire test class.
+     * 
+     * @throws Exception
+     *             when the error occurred.
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
@@ -361,8 +375,8 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     }
 
     /**
-     * Initialize the core OmegaT system components.
-     * Called once per test class to set up the basic infrastructure.
+     * Initialize the core OmegaT system components. Called once per test class
+     * to set up the basic infrastructure.
      */
     private static void initializeOmegaTCore() throws Exception {
         // Set up temporary config directory for the test class

--- a/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
+++ b/test-acceptance/src/org/omegat/gui/main/TestCoreGUI.java
@@ -351,7 +351,7 @@ public abstract class TestCoreGUI extends AssertJSwingJUnitTestCase {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         // Apply locale for the test class
-        LocaleRule.applyLocaleForClass(new Locale("en"));
+        LocaleRule.applyLocaleForClass(Locale.of("en"));
 
         // Initialize core system components that should persist across tests
         initializeOmegaTCore();

--- a/test/src/org/omegat/core/KnownExceptionTest.java
+++ b/test/src/org/omegat/core/KnownExceptionTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 
 public class KnownExceptionTest {
     @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+    public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
     @Test
     public void testExceptions() {

--- a/test/src/org/omegat/core/search/SearcherTest.java
+++ b/test/src/org/omegat/core/search/SearcherTest.java
@@ -65,7 +65,7 @@ public class SearcherTest {
     private IProject.FileInfo fi;
 
     @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+    public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
     @Before
     public void preUp() throws Exception {

--- a/test/src/org/omegat/core/segmentation/SRXTest.java
+++ b/test/src/org/omegat/core/segmentation/SRXTest.java
@@ -113,7 +113,7 @@ public final class SRXTest {
     public static class SRXMigrateTest {
 
         @org.junit.Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+        public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
         @org.junit.Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
@@ -129,7 +129,7 @@ public final class SRXTest {
     public static class SRXMigrateJaTest {
 
         @org.junit.Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("ja"));
+        public final LocaleRule localeRule = new LocaleRule(Locale.of("ja"));
 
         @org.junit.Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
@@ -145,7 +145,7 @@ public final class SRXTest {
     public static class SRXMigrateOldDeTest {
 
         @org.junit.Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("de"));
+        public final LocaleRule localeRule = new LocaleRule(Locale.of("de"));
 
         @org.junit.Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
@@ -165,7 +165,7 @@ public final class SRXTest {
     public static class SRXMigrateExtDeTest {
 
         @org.junit.Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("de"));
+        public final LocaleRule localeRule = new LocaleRule(Locale.of("de"));
 
         @org.junit.Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();
@@ -219,7 +219,7 @@ public final class SRXTest {
     public static class SRXSecurityTest {
 
         @org.junit.Rule
-        public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+        public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
         @org.junit.Rule
         public final TemporaryFolder folder = TemporaryFolder.builder().assureDeletion().build();

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -49,7 +49,7 @@ import org.omegat.util.StringUtil;
 public class POFilterTest extends TestFilterBase {
 
     @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+    public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
     @Test
     public void testParse() throws Exception {

--- a/test/src/org/omegat/filters/POFilterTest.java
+++ b/test/src/org/omegat/filters/POFilterTest.java
@@ -205,14 +205,14 @@ public class POFilterTest extends TestFilterBase {
         checkMulti("Multiline\nmessage ID with linefeed character.", null, "", null, null,
                 "References:\nmultiple_lines\n" + "\n");
         checkMulti("Long context in only one line.", null,
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
-                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " +
-                        "Excepteur sint occaecat cupidatat non proident",
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+                        + "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+                        + "Excepteur sint occaecat cupidatat non proident",
                 null, null, "References:\none_line_only_with_ctx\n" + "\n");
         checkMulti("Long context in several lines.", null,
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\\n" +
-                        "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\\n" +
-                        "Excepteur sint occaecat cupidatat non proident",
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\\n"
+                        + "Reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\\n"
+                        + "Excepteur sint occaecat cupidatat non proident",
                 null, null, "References:\nmultiple_lines_with_ctx\n" + "\n");
         checkMultiEnd();
     }

--- a/test/src/org/omegat/gui/editor/EditorUtilsTest.java
+++ b/test/src/org/omegat/gui/editor/EditorUtilsTest.java
@@ -34,13 +34,13 @@ public class EditorUtilsTest {
     @Test
     public void testGetBoundarySimple() {
         final String lineString = "Hello world of toys!";
-        assertEquals(lineString.indexOf('w'), EditorUtils.getWordBoundary(new Locale("en"), lineString, 8,
+        assertEquals(lineString.indexOf('w'), EditorUtils.getWordBoundary(Locale.of("en"), lineString, 8,
                 false));
-        assertEquals(lineString.indexOf('d') + 1, EditorUtils.getWordBoundary(new Locale("en"), lineString, 8,
+        assertEquals(lineString.indexOf('d') + 1, EditorUtils.getWordBoundary(Locale.of("en"), lineString, 8,
                 true));
-        assertEquals(lineString.indexOf('!'), EditorUtils.getWordBoundary(new Locale("en"), lineString, 15,
+        assertEquals(lineString.indexOf('!'), EditorUtils.getWordBoundary(Locale.of("en"), lineString, 15,
                 true));
-        assertEquals(lineString.indexOf('!') + 1, EditorUtils.getWordBoundary(new Locale("en"), lineString,
+        assertEquals(lineString.indexOf('!') + 1, EditorUtils.getWordBoundary(Locale.of("en"), lineString,
                 lineString.length() + 2, true));
     }
 
@@ -48,13 +48,13 @@ public class EditorUtilsTest {
     public void testGetWordBoundaryJa() {
         final String lineString = "太平寺の中心的なペン塔";
         //太平寺-の-中心-的-な-ペン-塔
-        assertEquals(lineString.indexOf('太'), EditorUtils.getWordBoundary(new Locale("ja"), lineString, 2,
+        assertEquals(lineString.indexOf('太'), EditorUtils.getWordBoundary(Locale.of("ja"), lineString, 2,
                 false));
-        assertEquals(lineString.indexOf('寺') + 1, EditorUtils.getWordBoundary(new Locale("ja"), lineString, 2,
+        assertEquals(lineString.indexOf('寺') + 1, EditorUtils.getWordBoundary(Locale.of("ja"), lineString, 2,
                 true));
-        assertEquals(lineString.indexOf('中'), EditorUtils.getWordBoundary(new Locale("ja"), lineString, 5,
+        assertEquals(lineString.indexOf('中'), EditorUtils.getWordBoundary(Locale.of("ja"), lineString, 5,
                 false));
-        assertEquals(lineString.indexOf('心') + 1, EditorUtils.getWordBoundary(new Locale("ja"), lineString, 5,
+        assertEquals(lineString.indexOf('心') + 1, EditorUtils.getWordBoundary(Locale.of("ja"), lineString, 5,
                 true));
     }
 
@@ -62,13 +62,13 @@ public class EditorUtilsTest {
     public void testGetWordBoundaryCn() {
         final String lineString = "太平寺中的文笔塔";
         // 太平寺-中的-文笔-塔
-        assertEquals(lineString.indexOf('太'), EditorUtils.getWordBoundary(new Locale("zh_CN"), lineString, 2,
+        assertEquals(lineString.indexOf('太'), EditorUtils.getWordBoundary(Locale.of("zh_CN"), lineString, 2,
                 false));
-        assertEquals(lineString.indexOf('寺') + 1, EditorUtils.getWordBoundary(new Locale("zh_CN"), lineString, 2,
+        assertEquals(lineString.indexOf('寺') + 1, EditorUtils.getWordBoundary(Locale.of("zh_CN"), lineString, 2,
                 true));
-        assertEquals(lineString.indexOf('中'), EditorUtils.getWordBoundary(new Locale("zh_CN"), lineString, 4,
+        assertEquals(lineString.indexOf('中'), EditorUtils.getWordBoundary(Locale.of("zh_CN"), lineString, 4,
                 false));
-        assertEquals(lineString.indexOf('的') + 1, EditorUtils.getWordBoundary(new Locale("zh_CN"), lineString, 4,
+        assertEquals(lineString.indexOf('的') + 1, EditorUtils.getWordBoundary(Locale.of("zh_CN"), lineString, 4,
                 true));
     }
 }

--- a/test/src/org/omegat/gui/issues/IssuesTypeListModelTest.java
+++ b/test/src/org/omegat/gui/issues/IssuesTypeListModelTest.java
@@ -47,7 +47,7 @@ public class IssuesTypeListModelTest {
      */
 
     @Rule
-    public final LocaleRule localeRule = new LocaleRule(new Locale("en"));
+    public final LocaleRule localeRule = new LocaleRule(Locale.of("en"));
 
     @Test
     public void testCalculateData_NoIssues() {

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -94,7 +94,7 @@ public class LanguageToolTest {
 
     @Test
     public void testFrench() throws Exception {
-        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForLocale(new Locale("fr")));
+        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForLocale(Locale.of("fr")));
 
         // example from
         // https://github.com/languagetool-org/languagetool/issues/2852
@@ -105,7 +105,7 @@ public class LanguageToolTest {
 
     @Test
     public void testEnglish() throws Exception {
-        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForLocale(new Locale("en", "US")));
+        JLanguageTool lt = new JLanguageTool(Languages.getLanguageForLocale(Locale.of("en", "US")));
 
         List<RuleMatch> matches = lt.check("Check test");
         assertEquals(0, matches.size());
@@ -187,9 +187,9 @@ public class LanguageToolTest {
     public void testLanguageMapping() {
         org.languagetool.Language lang;
         lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-US"));
-        assertEquals(Languages.getLanguageForLocale(new Locale("en", "US")).getClass(), lang.getClass());
+        assertEquals(Languages.getLanguageForLocale(Locale.of("en", "US")).getClass(), lang.getClass());
         lang = LanguageToolNativeBridge.getLTLanguage(new Language("en-CA"));
-        assertEquals(Languages.getLanguageForLocale(new Locale("en", "CA")).getClass(), lang.getClass());
+        assertEquals(Languages.getLanguageForLocale(Locale.of("en", "CA")).getClass(), lang.getClass());
         lang = LanguageToolNativeBridge.getLTLanguage(new Language("en"));
         assertEquals(Languages.getLanguageForShortCode("en").getClass(), lang.getClass());
         // Unknown region--fall back to generic class

--- a/test/src/org/omegat/languagetools/LanguageToolTest.java
+++ b/test/src/org/omegat/languagetools/LanguageToolTest.java
@@ -111,7 +111,7 @@ public class LanguageToolTest {
         assertEquals(0, matches.size());
     }
 
-    private static final int[] FREE_PORT_RANGE = {8081, 10080, 10081, 10082, 10083, 10084, 10085, 10086};
+    private static final int[] FREE_PORT_RANGE = { 8081, 10080, 10081, 10082, 10083, 10084, 10085, 10086 };
 
     private int getFreePort() {
         for (int p : FREE_PORT_RANGE) {

--- a/test/src/org/omegat/util/StringUtilTest.java
+++ b/test/src/org/omegat/util/StringUtilTest.java
@@ -234,7 +234,7 @@ public class StringUtilTest {
         assertEquals("\u01CB", StringUtil.toTitleCase("\u01CC", locale));
         // LATIN SMALL LETTER I (U+0069) -> LATIN CAPITAL LETTER I WITH DOT
         // ABOVE (U+0130) in Turkish
-        assertEquals("\u0130jk", StringUtil.toTitleCase("ijk", new Locale("tr")));
+        assertEquals("\u0130jk", StringUtil.toTitleCase("ijk", Locale.of("tr")));
         // Non-letters in front
         assertEquals("'Good day, sir.'", StringUtil.toTitleCase("'GOOD DAY, SIR.'", locale));
         // No letters at all
@@ -279,7 +279,7 @@ public class StringUtilTest {
         assertEquals("\u01CB", StringUtil.capitalizeFirst("\u01CC", locale));
         // LATIN SMALL LETTER I (U+0069) -> LATIN CAPITAL LETTER I WITH DOT
         // ABOVE (U+0130) in Turkish
-        assertEquals("\u0130jk", StringUtil.capitalizeFirst("ijk", new Locale("tr")));
+        assertEquals("\u0130jk", StringUtil.capitalizeFirst("ijk", Locale.of("tr")));
         // Empty string -> empty string (like toLowerCase, toUpperCase)
         assertEquals("", StringUtil.capitalizeFirst("", locale));
     }
@@ -451,7 +451,7 @@ public class StringUtilTest {
         // Test that behavior changes for Turkish
         assertEquals("Istanbul", StringUtil.replaceCase("\\uistanbul", Locale.ENGLISH)); // English
                                                                                          // version
-        assertEquals("\u0130stanbul", StringUtil.replaceCase("\\uistanbul", new Locale("tr"))); // Turkish
+        assertEquals("\u0130stanbul", StringUtil.replaceCase("\\uistanbul", Locale.of("tr"))); // Turkish
                                                                                                 // version
     }
 

--- a/test/src/org/omegat/util/StringUtilTest.java
+++ b/test/src/org/omegat/util/StringUtilTest.java
@@ -452,7 +452,7 @@ public class StringUtilTest {
         assertEquals("Istanbul", StringUtil.replaceCase("\\uistanbul", Locale.ENGLISH)); // English
                                                                                          // version
         assertEquals("\u0130stanbul", StringUtil.replaceCase("\\uistanbul", Locale.of("tr"))); // Turkish
-                                                                                                // version
+                                                                                               // version
     }
 
     @Test


### PR DESCRIPTION
When we need to have constant list of values, `Array.asList` has uncenesarry overhead because it is equivalent with `new ArrayList<>(List.of(val1, val2,..))`.  `List.of()` is immutable and `Array.asList` is mutable.
So when we use immutable list, `List.of()` is good.

In recent Java versions, `new Locale()` is not recommended and it is better to use `Locale.of()` 

## Pull request type

- Other (describe below)
refactor
## Which ticket is resolved?
none
## What does this PR change?

- Replace `Array.asList` by `List.of`
- Replace `new Locale` by `Locale.of`
- Apply spotless code formatter

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
