### PR TITLE
chore(gradle): remove unused `runOnJava*` tasks from build scripts

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -103,46 +103,6 @@ tasks.register('runDebugger', JavaExec) {
     dependsOn subprojects.collect {it.tasks.withType(Jar)}
 }
 
-tasks.register('runOnJava11', JavaExec) {
-    description = 'Runs application on Java 11.'
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-    mainClass.set application.mainClass
-    classpath = sourceSets.main.runtimeClasspath
-    if (System.getProperty("os.name").toLowerCase().contains("linux") ||
-            System.getProperty("os.name").toLowerCase().contains("bsd")) {
-        jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
-    }
-    group = 'application'
-    // Allow setting the max heap size for the run task from the command line, e.g.
-    // `gradle -PrunMaxHeapSize=1024M run`
-    maxHeapSize = findProperty('runMaxHeapSize')
-    // Ask modules to be up-to-date before run task executed
-    dependsOn subprojects.collect {it.tasks.withType(Jar)}
-}
-
-tasks.register('runOnJava21', JavaExec) {
-    description = 'Runs application on Java 21.'
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(21)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-    mainClass.set application.mainClass
-    classpath = sourceSets.main.runtimeClasspath
-    if (System.getProperty("os.name").toLowerCase().contains("linux") ||
-            System.getProperty("os.name").toLowerCase().contains("bsd")) {
-        jvmArgs(["--add-opens", "java.desktop/sun.awt.X11=ALL-UNNAMED"])
-    }
-    group = 'application'
-    // Allow setting the max heap size for the run task from the command line, e.g.
-    // `gradle -PrunMaxHeapSize=1024M run`
-    maxHeapSize = findProperty('runMaxHeapSize')
-    // Ask modules to be up-to-date before run task executed
-    dependsOn subprojects.collect {it.tasks.withType(Jar)}
-}
-
 tasks.register('testIntegration', JavaExec) {
     description = 'Runs integration tests. Pass repo URL as -Domegat.test.repo=<repo>.'
     javaLauncher = javaToolchains.launcherFor {


### PR DESCRIPTION
Clean up unused tasks.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none
## What does this PR change?

- remove runOnJava11 and runOnJava21 because we use JDK21 to build

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
