### PR TITLE
fix(filelist): release the closed project's file list

### DIFF
--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -155,9 +155,9 @@ public class ProjectFilesListController implements IProjectFilesList {
     private static final int MIN_PROGRESS_WIDTH = 3;
 
     private ProjectFilesList list;
-    private FileInfoModel modelFiles;
+    private @Nullable FileInfoModel modelFiles;
     private AbstractTableModel modelTotal;
-    private Sorter currentSorter;
+    private @Nullable Sorter currentSorter;
     private @Nullable TableColumn filesProgressColumn;
     private @Nullable TableColumn totalsProgressColumn;
 
@@ -247,6 +247,14 @@ public class ProjectFilesListController implements IProjectFilesList {
         CoreEvents.registerProjectChangeListener(eventType -> {
             switch (eventType) {
             case CLOSE:
+                // Drop every reference to the closed project's file list: the
+                // sorter, the model and the progress column each hold the
+                // FileInfo list and with it the project's whole segment
+                // graph, which otherwise stays in memory until the next load.
+                list.tableFiles.setRowSorter(null);
+                currentSorter = null;
+                modelFiles = null;
+                filesProgressColumn = null;
                 list.tableFiles.setModel(new DefaultTableModel());
                 list.tableFiles.repaint();
                 modelTotal.fireTableDataChanged();
@@ -278,8 +286,9 @@ public class ProjectFilesListController implements IProjectFilesList {
                 list.tableFiles.repaint();
                 list.tableTotal.repaint();
                 modelTotal.fireTableDataChanged();
-                if (shouldRefreshProjectFilesProgress()) {
-                    modelFiles.fireTableDataChanged();
+                FileInfoModel model = modelFiles;
+                if (model != null && shouldRefreshProjectFilesProgress()) {
+                    model.fireTableDataChanged();
                 }
             }
 
@@ -291,8 +300,9 @@ public class ProjectFilesListController implements IProjectFilesList {
             public void onEntryActivated(SourceTextEntry newEntry) {
                 UIThreadsUtil.mustBeSwingThread();
                 modelTotal.fireTableDataChanged();
-                if (shouldRefreshProjectFilesProgress()) {
-                    modelFiles.fireTableDataChanged();
+                FileInfoModel model = modelFiles;
+                if (model != null && shouldRefreshProjectFilesProgress()) {
+                    model.fireTableDataChanged();
                 }
             }
         });
@@ -387,9 +397,14 @@ public class ProjectFilesListController implements IProjectFilesList {
     }
 
     private void updateTitle() {
-        int numFiles = currentSorter.getModelRowCount();
+        Sorter sorter = currentSorter;
+        if (sorter == null) {
+            // No project is shown (the sorter is dropped on close).
+            return;
+        }
+        int numFiles = sorter.getModelRowCount();
         if (isFiltering()) {
-            int showingFiles = currentSorter.getViewRowCount();
+            int showingFiles = sorter.getViewRowCount();
             list.setTitle(StringUtil.format(OStrings.getString("PF_WINDOW_TITLE_FILTERED"), showingFiles,
                     numFiles));
         } else {
@@ -405,7 +420,12 @@ public class ProjectFilesListController implements IProjectFilesList {
         list.btnUp.setEnabled(enabled);
     }
 
-    private JPopupMenu createContextMenuForRow(int row) {
+    private @Nullable JPopupMenu createContextMenuForRow(int row) {
+        FileInfoModel model = modelFiles;
+        if (model == null || list.tableFiles.getRowSorter() == null) {
+            // No project is shown (model and sorter are dropped on close).
+            return null;
+        }
         int[] rows;
         if (IntStream.of(list.tableFiles.getSelectedRows()).anyMatch(r -> r == row)) {
             // If clicked on selection, use selection
@@ -415,7 +435,7 @@ public class ProjectFilesListController implements IProjectFilesList {
             rows = new int[] { row };
         }
         List<FileInfo> infos = IntStream.of(rows).map(list.tableFiles.getRowSorter()::convertRowIndexToModel)
-                .mapToObj(modelFiles::getDataAtRow).collect(Collectors.toList());
+                .mapToObj(model::getDataAtRow).collect(Collectors.toList());
         if (infos.isEmpty() || infos.stream().anyMatch(Objects::isNull)) {
             return null;
         }
@@ -575,7 +595,12 @@ public class ProjectFilesListController implements IProjectFilesList {
         Pattern findPattern = Pattern.compile(quoted, Pattern.CASE_INSENSITIVE);
         FilesTableColumn.FILE_NAME.setHighlightPattern(findPattern);
         Pattern matchPattern = Pattern.compile(".*" + quoted + ".*", Pattern.CASE_INSENSITIVE);
-        currentSorter.setFilter(matchPattern);
+        Sorter sorter = currentSorter;
+        if (sorter != null) {
+            // The filter panel only exists while a project is shown, but the
+            // project may go away underneath it on close.
+            sorter.setFilter(matchPattern);
+        }
         selectRow(0);
     }
 
@@ -590,7 +615,11 @@ public class ProjectFilesListController implements IProjectFilesList {
         list.btnFirst.setEnabled(true);
         list.btnLast.setEnabled(true);
         filterPanel = null;
-        currentSorter.setFilter(null);
+        Sorter sorter = currentSorter;
+        if (sorter != null) {
+            // See applyFilter: the project may have been closed meanwhile.
+            sorter.setFilter(null);
+        }
         list.tableFiles.requestFocus();
         int currentRow = list.tableFiles.getSelectedRow();
         list.tableFiles.scrollRectToVisible(list.tableFiles.getCellRect(currentRow, 0, true));
@@ -599,6 +628,12 @@ public class ProjectFilesListController implements IProjectFilesList {
     }
 
     ActionListener moveAction = e -> {
+        Sorter sorter = currentSorter;
+        if (sorter == null) {
+            // No project is shown (the move buttons are disabled then, this
+            // guards against stray events anyway).
+            return;
+        }
         int[] selected = list.tableFiles.getSelectedRows();
         if (selected.length == 0) {
             return;
@@ -618,7 +653,7 @@ public class ProjectFilesListController implements IProjectFilesList {
         } else {
             return;
         }
-        pos = currentSorter.moveTo(selected, newPos);
+        pos = sorter.moveTo(selected, newPos);
         list.tableFiles.getSelectionModel().setSelectionInterval(pos, pos + selected.length - 1);
     };
 
@@ -1454,7 +1489,9 @@ public class ProjectFilesListController implements IProjectFilesList {
         }
 
         @Override
-        public FileInfoModel getModel() {
+        public @Nullable FileInfoModel getModel() {
+            // Null only after the project was closed; the sorter is dropped
+            // together with the model then.
             return modelFiles;
         }
 

--- a/src/main/java/org/omegat/util/DirectoryMonitor.java
+++ b/src/main/java/org/omegat/util/DirectoryMonitor.java
@@ -46,7 +46,7 @@ public class DirectoryMonitor extends Thread {
     /** Local logger. */
     private static final Logger LOGGER = Logger.getLogger(DirectoryMonitor.class.getName());
 
-    private boolean stopped = false;
+    private volatile boolean stopped = false;
     protected final File dir;
     protected final Callback callback;
     protected final DirectoryCallback directoryCallback;
@@ -87,6 +87,9 @@ public class DirectoryMonitor extends Thread {
      */
     public void fin() {
         stopped = true;
+        // Wake the polling sleep so the thread (whose callback references the
+        // project being closed) ends now instead of up to a second later.
+        interrupt();
     }
 
     @Override

--- a/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
@@ -1,0 +1,133 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.omegat.core.Core;
+import org.omegat.core.TestCore;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
+import org.omegat.util.Language;
+
+/**
+ * Reproduction guard for the memory exhaustion seen after repeatedly opening
+ * and closing large projects: every open/close cycle must leave the previous
+ * {@link RealProject} unreachable, or the retained heaps of large projects add
+ * up until the VM dies. The cycle here is the core data-engine path (load,
+ * publish via {@link Core#setProject}, close, replace); if an instance
+ * survives garbage collection, something static or long-lived still points at
+ * the closed project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectReloadLeakTest extends TestCore {
+
+    private static final int CYCLES = 3;
+
+    private File projectRoot;
+
+    @Before
+    public final void setUpProject() throws Exception {
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        FilterMaster.setFilterClasses(Arrays.asList(TextFilter.class));
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+
+        projectRoot = Files.createTempDirectory("omegat-leak").toFile();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            sb.append("Segment number ").append(i).append(" with some text payload.\n\n");
+        }
+        ProjectProperties props = makeProps();
+        props.autocreateDirectories();
+        Files.write(new File(props.getSourceRoot(), "source.txt").toPath(),
+                sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ProjectProperties makeProps() throws Exception {
+        ProjectProperties props = new ProjectProperties(projectRoot);
+        props.setSourceLanguage(new Language("en"));
+        props.setTargetLanguage(new Language("de"));
+        props.setSentenceSegmentingEnabled(true);
+        props.setSupportDefaultTranslations(true);
+        // Project-level filter config: loadProject re-reads filters from the
+        // preferences, which know nothing about the test's filter classes.
+        props.setProjectFilters(FilterMaster.createDefaultFiltersConfig());
+        return props;
+    }
+
+    @Test
+    public void closedProjectsMustBecomeUnreachable() throws Exception {
+        List<WeakReference<RealProject>> closed = new ArrayList<>();
+
+        for (int i = 0; i < CYCLES; i++) {
+            // The same sequence the UI uses to open and close a project.
+            ProjectFactory.loadProject(makeProps(), false);
+            assertTrue("fixture project must load", Core.getProject().isProjectLoaded());
+            closed.add(new WeakReference<>((RealProject) Core.getProject()));
+
+            Core.getProject().closeProject();
+            Core.setProject(new NotLoadedProject());
+        }
+
+        for (int i = 0; i < closed.size(); i++) {
+            WeakReference<RealProject> ref = closed.get(i);
+            if (!becomesUnreachable(ref)) {
+                fail("closed project of cycle " + i + " is still strongly reachable "
+                        + "- a listener, cache, or singleton keeps the project alive after close");
+            }
+        }
+    }
+
+    private boolean becomesUnreachable(WeakReference<?> ref) throws InterruptedException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            System.gc();
+            if (ref.get() == null) {
+                return true;
+            }
+            // Brief backoff: releasing can lag behind close by a few
+            // milliseconds (monitor threads finish, EDT drains).
+            byte[][] pressure = new byte[64][];
+            for (int i = 0; i < pressure.length; i++) {
+                pressure[i] = new byte[1024 * 1024];
+            }
+            Thread.sleep(10);
+        }
+        return ref.get() == null;
+    }
+}

--- a/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
@@ -1,0 +1,208 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.TestCore;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectFactory;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.RealProject;
+import org.omegat.core.events.IProjectEventListener;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
+import org.omegat.gui.main.IMainWindow;
+import org.omegat.util.Language;
+
+/**
+ * GUI-side companion of
+ * {@link org.omegat.core.data.ProjectReloadLeakTest}: with a real
+ * {@link EditorController} attached, every open/close cycle must still leave
+ * the closed {@link RealProject} unreachable. The editor is the biggest
+ * per-project consumer (its document and segment builders reference all
+ * entries of the displayed file), so anything in the editor or its helpers
+ * that survives the close event shows up here.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class EditorProjectReloadLeakTest extends TestCore {
+
+    private static final int CYCLES = 3;
+
+    private EditorController editorController;
+    private File projectRoot;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        org.junit.Assume.assumeFalse("Skipping test: headless environment",
+                GraphicsEnvironment.isHeadless());
+    }
+
+    @Before
+    public final void setUpProject() throws Exception {
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        FilterMaster.setFilterClasses(Arrays.asList(TextFilter.class));
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+
+        projectRoot = Files.createTempDirectory("omegat-leak").toFile();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            sb.append("Segment number ").append(i).append(" with some text payload.\n\n");
+        }
+        ProjectProperties props = makeProps();
+        props.autocreateDirectories();
+        Files.write(new File(props.getSourceRoot(), "source.txt").toPath(),
+                sb.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ProjectProperties makeProps() throws Exception {
+        ProjectProperties props = new ProjectProperties(projectRoot);
+        props.setSourceLanguage(new Language("en"));
+        props.setTargetLanguage(new Language("de"));
+        props.setSentenceSegmentingEnabled(true);
+        props.setSupportDefaultTranslations(true);
+        // Project-level filter config: loadProject re-reads filters from the
+        // preferences, which know nothing about the test's filter classes.
+        props.setProjectFilters(FilterMaster.createDefaultFiltersConfig());
+        return props;
+    }
+
+    @Test
+    public void closedProjectsMustBecomeUnreachableWithEditorAttached() throws Exception {
+        List<WeakReference<RealProject>> closed = new ArrayList<>();
+        // The project object being collectable is not enough: the editor held
+        // the closed project's whole entry graph (via the old document) even
+        // after the RealProject itself was gone. So track an entry too.
+        List<WeakReference<org.omegat.core.data.SourceTextEntry>> closedEntries = new ArrayList<>();
+
+        for (int i = 0; i < CYCLES; i++) {
+            ProjectFactory.loadProject(makeProps(), false);
+            assertTrue("fixture project must load", Core.getProject().isProjectLoaded());
+            closed.add(new WeakReference<>((RealProject) Core.getProject()));
+            closedEntries.add(new WeakReference<>(Core.getProject().getAllEntries().get(0)));
+
+            fireProjectEventAndWait(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+            waitForDocument();
+
+            Core.getProject().closeProject();
+            fireProjectEventAndWait(IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE);
+            Core.setProject(new NotLoadedProject());
+        }
+
+        for (int i = 0; i < closed.size(); i++) {
+            if (!becomesUnreachable(closed.get(i))) {
+                fail("closed project of cycle " + i + " is still strongly reachable with the editor"
+                        + " attached - some editor/GUI state keeps the project alive after close");
+            }
+            if (!becomesUnreachable(closedEntries.get(i))) {
+                fail("the entries of closed project " + i + " are still strongly reachable - the"
+                        + " editor (document, undo history) keeps the closed project's segment"
+                        + " graph alive after close");
+            }
+        }
+    }
+
+    /**
+     * The editor builds its document via a nested invokeLater after the LOAD
+     * event; without the document (and its segment builders) the leak this
+     * test guards against cannot occur, so wait until it is really there.
+     */
+    private void waitForDocument() throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (editorController.editor.getOmDocument() == null
+                && System.currentTimeMillis() < deadline) {
+            CountDownLatch latch = new CountDownLatch(1);
+            javax.swing.SwingUtilities.invokeLater(latch::countDown);
+            latch.await(1, TimeUnit.SECONDS);
+            Thread.sleep(20);
+        }
+        assertTrue("editor document must be built after project load",
+                editorController.editor.getOmDocument() != null);
+    }
+
+    private void fireProjectEventAndWait(IProjectEventListener.PROJECT_CHANGE_TYPE type)
+            throws InterruptedException {
+        CoreEvents.fireProjectChange(type);
+        // Project events are dispatched on the EDT; an empty EDT task after
+        // them means the editor finished (un)loading the document.
+        CountDownLatch latch = new CountDownLatch(1);
+        javax.swing.SwingUtilities.invokeLater(latch::countDown);
+        assertTrue("EDT must drain", latch.await(15, TimeUnit.SECONDS));
+    }
+
+    private boolean becomesUnreachable(WeakReference<?> ref) throws InterruptedException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            System.gc();
+            if (ref.get() == null) {
+                return true;
+            }
+            // Brief backoff: releasing can lag behind close by a few
+            // milliseconds (monitor threads finish, EDT drains).
+            byte[][] pressure = new byte[64][];
+            for (int i = 0; i < pressure.length; i++) {
+                pressure[i] = new byte[1024 * 1024];
+            }
+            Thread.sleep(10);
+        }
+        return ref.get() == null;
+    }
+
+    /**
+     * The project-files window is part of every real session and holds the
+     * file/entry lists of the shown project; create it like the GUI bootstrap
+     * does so its close handling is under test as well.
+     */
+    @Before
+    public final void setUpProjectFilesWindow() {
+        new org.omegat.gui.filelist.ProjectFilesListController();
+    }
+
+    @Override
+    protected void initEditor(IMainWindow mainWindow) {
+        editorController = new EditorController(mainWindow);
+        TestCoreInitializer.initEditor(editorController);
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- No tracker ticket. The leak was found while testing repeated project reloads: after a few open/close cycles of large projects, OmegaT exhausts the default heap and shuts down with an out-of-memory error.

## What does this PR change?

- Closing a project only replaced the files table model of the Project Files window; the row sorter, the model field and the progress column's renderer kept referencing the `FileInfo` list — and through it the whole segment graph of the closed project. On reopening, the old and the new project were in memory at the same time.
- The close handler now drops the sorter, the model and the progress column, and the row context menu guards against the cleared state.
- `DirectoryMonitor.fin()` additionally interrupts the polling sleep (and the stop flag is now volatile), so the monitor threads — whose callbacks also reference the closing project — end immediately instead of up to a second later.
- Two `WeakReference`-based regression tests pin that closed projects become unreachable after close: one for the core data-engine cycle (`ProjectReloadLeakTest`), one for the GUI cycle with the editor and the Project Files window attached (`EditorProjectReloadLeakTest`).

## Other information

Review feedback: `modelFiles` and `currentSorter` are now annotated `@Nullable` and every reference site either guards against null or documents why it is safe; the getter that can return null is annotated as well.
