### PR TITLE
feat(editor): mark narrow no-break space and figure space (SF-1684)

### DIFF
--- a/src/docs/manual/en/Menus_View.xml
+++ b/src/docs/manual/en/Menus_View.xml
@@ -80,7 +80,10 @@
          </term>
          <listitem>
             <para>If checked, non-breakable spaces are displayed with a gray
-               background.</para>
+               background. This covers the no-break space (U+00A0), the narrow
+               no-break space (U+202F) used before tall punctuation in French
+               typography, and the figure space (U+2007) used to group digits in
+               numbers.</para>
          </listitem>
       </varlistentry>
       <varlistentry xml:id="menus.view.mark.white.space">

--- a/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2012 Martin Fleurke
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,20 +26,29 @@
 
 package org.omegat.gui.editor.mark;
 
+import java.util.regex.Pattern;
+
 import org.omegat.core.Core;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.Styles;
 
 /**
- * Marker for Non-breakable space
+ * Marker for no-break spaces.
+ *
+ * Marks the regular NO-BREAK SPACE (U+00A0), the NARROW NO-BREAK SPACE
+ * (U+202F), which is the recommended space before tall punctuation in
+ * French typography and therefore common in translated text, and the
+ * FIGURE SPACE (U+2007), a non-breaking space as wide as a digit that is
+ * used to group digits in numbers.
  *
  * @author Martin Fleurke
+ * @author stephan.pakebusch at zollsoft.de
  */
 public class NBSPMarker extends AbstractMarker {
     public NBSPMarker() throws Exception {
         painter = new TransparentHighlightPainter(Styles.EditorColor.COLOR_NBSP.getColor(), 0.5F);
         toolTip = OStrings.getString("MARKER_NBSP");
-        patternChar = '\u00a0';
+        pattern = Pattern.compile("[\u00a0\u202f\u2007]");
     }
     protected boolean isEnabled() {
         return Core.getEditor().getSettings().isMarkNBSP();

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2306,7 +2306,7 @@ EXTERNAL_COMMAND_DESCRIPTION=
 ALLOW_PROJECT_EXTERN_CMD=&Allow local post-processing commands
 
 #Marker tooltips
-MARKER_NBSP=Non-breakable space
+MARKER_NBSP=No-break space
 MARKER_TAB=Tab
 MARKER_TAG=Tag
 MARKER_REMOVETAG=Text to remove

--- a/src/test/java/org/omegat/gui/editor/mark/NBSPMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/NBSPMarkerTest.java
@@ -4,6 +4,7 @@
  *           glossaries, and translation leveraging into updated projects.
  *
  *  Copyright (C) 2024 Hiroshi Miura.
+ *                2026 Stephan Pakebusch
  *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
@@ -75,6 +76,56 @@ public class NBSPMarkerTest extends MarkerTestBase {
         assertEquals(1, result.size());
         assertEquals(16, result.get(0).startOffset);
         assertEquals(17, result.get(0).endOffset);
+    }
+
+    @Test
+    public void testMarkerNarrowNBSP() throws Exception {
+        IMarker marker = new NBSPMarker();
+        Core.getEditor().getSettings().setMarkNBSP(true);
+        String sourceText = "narrow space before\u202f!";
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
+        List<Mark> result = marker.getMarksForEntry(ste, sourceText, null, true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(19, result.get(0).startOffset);
+        assertEquals(20, result.get(0).endOffset);
+    }
+
+    @Test
+    public void testMarkerFigureSpace() throws Exception {
+        IMarker marker = new NBSPMarker();
+        Core.getEditor().getSettings().setMarkNBSP(true);
+        String sourceText = "1\u2007000 units";
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
+        List<Mark> result = marker.getMarksForEntry(ste, sourceText, null, true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).startOffset);
+        assertEquals(2, result.get(0).endOffset);
+    }
+
+    @Test
+    public void testMarkerBothNoBreakSpaces() throws Exception {
+        IMarker marker = new NBSPMarker();
+        Core.getEditor().getSettings().setMarkNBSP(true);
+        String sourceText = "a\u00a0b\u202fc";
+        String translationText = "x\u202fy";
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
+        List<Mark> result = marker.getMarksForEntry(ste, sourceText, translationText, true);
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals(Mark.ENTRY_PART.SOURCE, result.get(0).entryPart);
+        assertEquals(1, result.get(0).startOffset);
+        assertEquals(2, result.get(0).endOffset);
+        assertEquals(Mark.ENTRY_PART.SOURCE, result.get(1).entryPart);
+        assertEquals(3, result.get(1).startOffset);
+        assertEquals(4, result.get(1).endOffset);
+        assertEquals(Mark.ENTRY_PART.TRANSLATION, result.get(2).entryPart);
+        assertEquals(1, result.get(2).startOffset);
+        assertEquals(2, result.get(2).endOffset);
     }
 
 }


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Make "Mark Non-breaking spaces" show also narrow no-break spaces
  * https://sourceforge.net/p/omegat/feature-requests/1684/

## What does this PR change?

- The editor's "Mark non-breaking spaces" highlight now also covers the NARROW NO-BREAK SPACE (U+202F), the recommended space before tall punctuation in French typography.
- It additionally covers the FIGURE SPACE (U+2007), a digit-wide non-breaking space used to group digits in numbers.
- Three new test cases in `NBSPMarkerTest` verify the new characters with exact mark offsets, in source and translation parts.

## Other information

Zero-width invisible characters (ZWSP, BOM, word joiner, soft hyphen) are deliberately out of scope: background highlighting requires glyph width, so those need symbol-based rendering and their own view option.

Note for macOS reviewers: the default editor font (Lucida Grande via Dialog) renders U+202F with a zero-width glyph, which makes the highlight invisible; with e.g. Menlo or Monospaced the mark shows as expected. This is a JDK font quirk independent of this change.

### Screenshots

unchanged as before with font Dialog:
<img width="715" height="532" alt="unchanged-font_Dialog" src="https://github.com/user-attachments/assets/a8e5da6e-d4ec-4f17-b725-f566c26ed14e" />

unchanged as before with font Menlo:
<img width="659" height="557" alt="unchanged-font_Menlo" src="https://github.com/user-attachments/assets/df4b2362-7c73-436b-8251-db974802e064" />

including the change with font Dialog:
<img width="671" height="516" alt="withChange-font_Dialog" src="https://github.com/user-attachments/assets/b49fc7a1-02d0-494b-acfa-cd102fd0dce3" />

including the change with font Menlo:
<img width="680" height="530" alt="withChange-font_Menlo" src="https://github.com/user-attachments/assets/ae9fe98b-08fa-4982-b264-7890f8012a46" />
