### PR TITLE
feat(gui): add open-folder buttons to project properties dialog (SF-1535)

### DIFF
--- a/src/docs/manual/en/Dialogs_ProjectProperties.xml
+++ b/src/docs/manual/en/Dialogs_ProjectProperties.xml
@@ -347,6 +347,20 @@
                   		  instead of the default resource folder.</para>
             </listitem>
          </varlistentry>
+         <varlistentry xml:id="dialogs.project.properties.file.locations.open">
+            <term xml:id="dialogs.project.properties.file.locations.open.title">
+               <guibutton>Open</guibutton>
+            </term>
+            <listitem>
+               <para>The
+                  <guibutton>Open</guibutton> button next to each
+                  <guibutton>Browse</guibutton> button opens that resource folder in
+                  		  the system file manager. For the writable glossary, it opens the
+                  		  folder that contains the glossary file.</para>
+               <para>The button is only available while the folder entered in the
+                  		  corresponding field exists.</para>
+            </listitem>
+         </varlistentry>
          <varlistentry xml:id="dialogs.project.properties.file.locations.source.files">
             <term xml:id="dialogs.project.properties.file.locations.source.files.title">
                <option>Source files folder</option>

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -10,6 +10,7 @@
                2013 Aaron Madlon-Kay, Yu Tang
                2014-2015 Aaron Madlon-Kay
                2024 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -41,6 +42,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.io.File;
+import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Vector;
@@ -96,6 +98,7 @@ import org.omegat.util.gui.TokenizerComboBoxRenderer;
  * @author Didier Briel
  * @author Aaron Madlon-Kay
  * @author Yu Tang
+ * @author stephan.pakebusch at zollsoft.de
  */
 @SuppressWarnings("serial")
 public class ProjectPropertiesDialog extends JDialog {
@@ -470,6 +473,9 @@ public class ProjectPropertiesDialog extends JDialog {
         bSrc.add(Box.createRigidArea(new Dimension(5, 0)));
         bSrc.add(srcBrowse);
         Mnemonics.setLocalizedText(srcBrowse, OStrings.getString("PP_BUTTON_BROWSE_SRC"));
+        configureOpenButton(srcOpen, SRC_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_SRC_ROOT");
+        bSrc.add(Box.createRigidArea(new Dimension(5, 0)));
+        bSrc.add(srcOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bSrcRootLabel);
         dirsBox.add(bSrc);
@@ -486,6 +492,9 @@ public class ProjectPropertiesDialog extends JDialog {
         tmBrowse.setName(TM_BROWSE_BUTTON_NAME);
         bTM.add(Box.createRigidArea(new Dimension(5, 0)));
         bTM.add(tmBrowse);
+        configureOpenButton(tmOpen, TM_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_TM_ROOT");
+        bTM.add(Box.createRigidArea(new Dimension(5, 0)));
+        bTM.add(tmOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bTmRootLabel);
         dirsBox.add(bTM);
@@ -502,6 +511,9 @@ public class ProjectPropertiesDialog extends JDialog {
         glosBrowse.setName(GLOSSARY_BROWSE_BUTTON_NAME);
         bGlos.add(Box.createRigidArea(new Dimension(5, 0)));
         bGlos.add(glosBrowse);
+        configureOpenButton(glosOpen, GLOSSARY_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_GLOS_ROOT");
+        bGlos.add(Box.createRigidArea(new Dimension(5, 0)));
+        bGlos.add(glosOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bGlosRootLabel);
         dirsBox.add(bGlos);
@@ -518,6 +530,9 @@ public class ProjectPropertiesDialog extends JDialog {
         wGlosBrowse.setName(WRITABLE_GLOSSARY_BROWSE_BUTTON_NAME);
         bwGlos.add(Box.createRigidArea(new Dimension(5, 0)));
         bwGlos.add(wGlosBrowse);
+        configureOpenButton(wGlosOpen, WRITABLE_GLOSSARY_OPEN_BUTTON_NAME, "PP_OPEN_W_GLOS_FOLDER_TOOLTIP", "PP_WRITEABLE_GLOS");
+        bwGlos.add(Box.createRigidArea(new Dimension(5, 0)));
+        bwGlos.add(wGlosOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bWriteableGlosLabel);
         dirsBox.add(bwGlos);
@@ -534,6 +549,9 @@ public class ProjectPropertiesDialog extends JDialog {
         dictBrowse.setName(DICTIONARY_BROWSE_BUTTON_NAME);
         bDict.add(Box.createRigidArea(new Dimension(5, 0)));
         bDict.add(dictBrowse);
+        configureOpenButton(dictOpen, DICTIONARY_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_DICT_ROOT");
+        bDict.add(Box.createRigidArea(new Dimension(5, 0)));
+        bDict.add(dictOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bLocDictLabel);
         dirsBox.add(bDict);
@@ -550,10 +568,19 @@ public class ProjectPropertiesDialog extends JDialog {
         locBrowse.setName(LOC_BROWSE_BUTTON_NAME);
         bLoc.add(Box.createRigidArea(new Dimension(5, 0)));
         bLoc.add(locBrowse);
+        configureOpenButton(locOpen, LOC_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_LOC_ROOT");
+        bLoc.add(Box.createRigidArea(new Dimension(5, 0)));
+        bLoc.add(locOpen);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(bLocRootLabel);
         dirsBox.add(bLoc);
 
+        addExportTMSection(dirsBox, emptyBorder);
+
+        return dirsBox;
+    }
+
+    private void addExportTMSection(Box dirsBox, Border emptyBorder) {
         JLabel exportTMRootLabel = new JLabel();
         Mnemonics.setLocalizedText(exportTMRootLabel, OStrings.getString("PP_EXPORT_TM_ROOT"));
         Box bExportTMRootLabel = Box.createHorizontalBox();
@@ -566,6 +593,9 @@ public class ProjectPropertiesDialog extends JDialog {
         exportTMBrowse.setName(EXPORT_TM_BROWSE_BUTTON_NAME);
         bExpTM.add(Box.createRigidArea(new Dimension(5, 0)));
         bExpTM.add(exportTMBrowse);
+        configureOpenButton(exportTMOpen, EXPORT_TM_OPEN_BUTTON_NAME, "PP_OPEN_FOLDER_TOOLTIP", "PP_EXPORT_TM_ROOT");
+        bExpTM.add(Box.createRigidArea(new Dimension(5, 0)));
+        bExpTM.add(exportTMOpen);
         // Supply check boxes to choose which TM formats to export
         exportTMOmegaTCheckBox = new JCheckBox(OStrings.getString("PP_EXPORT_TM_OMEGAT"));
         exportTMLevel1CheckBox = new JCheckBox(OStrings.getString("PP_EXPORT_TM_LEVEL1"));
@@ -587,8 +617,36 @@ public class ProjectPropertiesDialog extends JDialog {
         exportTMPanel.add(exportTMLevel2CheckBox);
         dirsBox.add(Box.createRigidArea(new Dimension(0, 5)));
         dirsBox.add(exportTMPanel);
+    }
 
-        return dirsBox;
+    /**
+     * Configures one of the small buttons that open a folder of the file
+     * locations section in the system file manager. The buttons keep a short
+     * caption and carry an explanatory tooltip instead, so that the layout
+     * stays compact. Because all these buttons share the same caption, each
+     * gets an accessible name naming its resource row, so that screen reader
+     * users can tell them apart.
+     *
+     * @param button
+     *            button to configure
+     * @param name
+     *            component name used by UI tests
+     * @param tooltipKey
+     *            resource bundle key of the tooltip text
+     * @param rowLabelKey
+     *            resource bundle key of the label of the resource row the
+     *            button belongs to
+     */
+    private void configureOpenButton(JButton button, String name, String tooltipKey, String rowLabelKey) {
+        button.setText(OStrings.getString("PP_BUTTON_OPEN_FOLDER"));
+        button.setToolTipText(OStrings.getString(tooltipKey));
+        button.setName(name);
+        String rowLabel = OStrings.getString(rowLabelKey).replace("&", "");
+        if (rowLabel.endsWith(":")) {
+            rowLabel = rowLabel.substring(0, rowLabel.length() - 1);
+        }
+        button.getAccessibleContext().setAccessibleName(
+                MessageFormat.format(OStrings.getString("PP_OPEN_FOLDER_ACCESSIBLE_NAME"), rowLabel));
     }
 
     private void setResolveDirsDefaults() {
@@ -747,6 +805,15 @@ public class ProjectPropertiesDialog extends JDialog {
     JButton glosBrowse = new JButton();
     JButton dictBrowse = new JButton();
 
+    // buttons to open the file location folders in the system file manager
+    JButton srcOpen = new JButton();
+    JButton locOpen = new JButton();
+    JButton glosOpen = new JButton();
+    JButton wGlosOpen = new JButton();
+    JButton tmOpen = new JButton();
+    JButton exportTMOpen = new JButton();
+    JButton dictOpen = new JButton();
+
     // extern command
     JLabel variablesLabel = new javax.swing.JLabel();
     JComboBox<String> variablesList;
@@ -777,6 +844,14 @@ public class ProjectPropertiesDialog extends JDialog {
             "project_properties_writable_glossary_browse_button";
     public static final String LOC_BROWSE_BUTTON_NAME = "project_properties_loc_browse_button";
     public static final String DICTIONARY_BROWSE_BUTTON_NAME = "project_properties_dictionary_browse_button";
+    public static final String SRC_OPEN_BUTTON_NAME = "project_properties_src_open_button";
+    public static final String LOC_OPEN_BUTTON_NAME = "project_properties_loc_open_button";
+    public static final String GLOSSARY_OPEN_BUTTON_NAME = "project_properties_glossary_open_button";
+    public static final String WRITABLE_GLOSSARY_OPEN_BUTTON_NAME =
+            "project_properties_writable_glossary_open_button";
+    public static final String TM_OPEN_BUTTON_NAME = "project_properties_tm_open_button";
+    public static final String EXPORT_TM_OPEN_BUTTON_NAME = "project_properties_export_tm_open_button";
+    public static final String DICTIONARY_OPEN_BUTTON_NAME = "project_properties_dictionary_open_button";
     public static final String SOURCE_TOKENIZER_FIELD_NAME = "project_properties_source_tokenizer_field";
     public static final String TARGET_TOKENIZER_FIELD_NAME = "project_properties_target_tokenizer_field";
     public static final String SOURCE_LOCALE_CB_NAME = "project_properties_source_locale_cb";

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -10,6 +10,7 @@
                2013 Aaron Madlon-Kay, Yu Tang
                2014-2015 Aaron Madlon-Kay
                2024 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -39,9 +40,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.AbstractAction;
+import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.segmentation.SRX;
@@ -51,6 +55,7 @@ import org.omegat.externalfinder.item.ExternalFinderConfiguration;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.master.PluginUtils;
 import org.omegat.gui.filters2.FiltersCustomizer;
+import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.segmentation.SegmentationCustomizer;
 import org.omegat.util.Language;
 import org.omegat.util.OConsts;
@@ -224,6 +229,74 @@ public class ProjectPropertiesDialogController {
                 filters = dlg.getResult(); // saving config
             }
         });
+        initializeOpenButtons();
+    }
+
+    /**
+     * Wires the buttons that open the folders of the file locations section in
+     * the system file manager. For the writable glossary the containing
+     * folder is opened, because the field points to a file. Each button is
+     * only enabled while the folder taken from the corresponding text field
+     * exists.
+     */
+    private void initializeOpenButtons() {
+        setupOpenButton(dialog.srcOpen, dialog.srcRootField, false);
+        setupOpenButton(dialog.locOpen, dialog.locRootField, false);
+        setupOpenButton(dialog.glosOpen, dialog.glosRootField, false);
+        setupOpenButton(dialog.wGlosOpen, dialog.writeableGlosField, true);
+        setupOpenButton(dialog.tmOpen, dialog.tmRootField, false);
+        setupOpenButton(dialog.exportTMOpen, dialog.exportTMRootField, false);
+        setupOpenButton(dialog.dictOpen, dialog.dictRootField, false);
+    }
+
+    private void setupOpenButton(JButton button, JTextField field, boolean openParent) {
+        button.addActionListener(e -> {
+            File folder = getOpenButtonTarget(field, openParent);
+            if (folder != null) {
+                ProjectUICommands.openFile(folder);
+            }
+        });
+        field.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateOpenButtonState(button, field, openParent);
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateOpenButtonState(button, field, openParent);
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateOpenButtonState(button, field, openParent);
+            }
+        });
+        updateOpenButtonState(button, field, openParent);
+    }
+
+    private static void updateOpenButtonState(JButton button, JTextField field, boolean openParent) {
+        File folder = getOpenButtonTarget(field, openParent);
+        button.setEnabled(folder != null && folder.isDirectory());
+    }
+
+    /**
+     * Returns the folder a given open button should open, or null when the
+     * field is empty or no folder can be derived from it.
+     *
+     * @param field
+     *            text field holding the path
+     * @param openParent
+     *            true when the field holds a file path whose containing folder
+     *            should be opened instead
+     */
+    private static File getOpenButtonTarget(JTextField field, boolean openParent) {
+        String path = field.getText();
+        if (StringUtil.isEmpty(path)) {
+            return null;
+        }
+        File target = new File(path);
+        return openParent ? target.getParentFile() : target;
     }
 
     /**

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -805,6 +805,15 @@ PP_BUTTON_BROWSE_EXP_TM=Browse...
 
 PP_BUTTON_BROWSE_DICT=Brows&e...
 
+PP_BUTTON_OPEN_FOLDER=Open
+
+PP_OPEN_FOLDER_TOOLTIP=Open this folder in the system file manager
+
+# {0} - label of a resource row of the file locations section, e.g. "Source files folder"
+PP_OPEN_FOLDER_ACCESSIBLE_NAME=Open: {0}
+
+PP_OPEN_W_GLOS_FOLDER_TOOLTIP=Open the folder containing the writable glossary file in the system file manager
+
 PP_BROWSE_TITLE_SOURCE=Source Files Folder
 
 PP_BROWSE_TITLE_TARGET=Translated Files Folder

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -771,6 +771,15 @@ PP_BUTTON_BROWSE_EXP_TM=Durchsuchen...
 
 PP_BUTTON_BROWSE_DICT=Du&rchsuchen...
 
+PP_BUTTON_OPEN_FOLDER=\u00D6ffnen
+
+PP_OPEN_FOLDER_TOOLTIP=Diesen Ordner im Dateimanager des Systems \u00F6ffnen
+
+# {0} - Beschriftung einer Ressourcen-Zeile im Speicherorte-Abschnitt, z. B. "Ordner f\u00FCr Quelldateien"
+PP_OPEN_FOLDER_ACCESSIBLE_NAME=\u00D6ffnen: {0}
+
+PP_OPEN_W_GLOS_FOLDER_TOOLTIP=Den Ordner, der das schreibbare Glossar enth\u00E4lt, im Dateimanager des Systems \u00F6ffnen
+
 PP_BROWSE_TITLE_SOURCE=Ordner f\u00FCr Quelldateien
 
 PP_BROWSE_TITLE_TARGET=Ordner f\u00FCr Zieldateien


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Add "open folder/file" button for paths in the "File locations" part of the "Edit Project" window
  * https://sourceforge.net/p/omegat/feature-requests/1535/

## What does this PR change?

- Adds an Open button next to each of the seven resource fields in the Edit Project dialog (source, target, translation memory, glossary, writable glossary, dictionaries, exported TM); it shows the folder in the system file manager via the existing `ProjectUICommands.openFile` mechanism. For the writable glossary, which is a file path, the containing folder is opened.
- The buttons track the entered path live through a `DocumentListener` and are disabled while the field does not point to an existing directory.
- Because all seven buttons share the same short caption, each carries an explanatory tooltip and a distinguishable accessible name (built from the row label), so screen reader users can tell them apart.
- New bundle keys are provided in English and German; other languages fall back to English.
- The English user manual (project properties dialog chapter) documents the new buttons.

### Screenshots

before, without the change:
<img width="689" height="560" alt="unchanged-noOpen" src="https://github.com/user-attachments/assets/90e26c3b-2fbc-469d-8545-3eccc13f40c7" />

after, including the change:
<img width="696" height="839" alt="withChange-withOpen" src="https://github.com/user-attachments/assets/fd11bd21-c2ae-4424-bf73-b64d3c2365ff" />

