### PR TITLE
feat(aligner): remember window, parameters, languages and directories

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -81,9 +81,84 @@ public class AlignFilePickerController {
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
 
     public AlignFilePickerController() {
+        // Preselect the languages of the previous aligner session (feature
+        // request #1456). Callers overwrite them through the setters when a
+        // project is open.
         List<Language> allLangs = Language.getLanguages();
-        sourceLanguage = allLangs.get(0);
-        targetLanguage = allLangs.get(allLangs.size() - 1);
+        sourceLanguage = restorePersistedLanguage(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, allLangs.get(0));
+        targetLanguage = restorePersistedLanguage(AlignerPrefs.ALIGNER_TARGET_LANGUAGE,
+                allLangs.get(allLangs.size() - 1));
+        sourceDefaultDir = restorePersistedDir(AlignerPrefs.ALIGNER_LAST_SOURCE_DIR);
+        targetDefaultDir = restorePersistedDir(AlignerPrefs.ALIGNER_LAST_TARGET_DIR);
+    }
+
+    /**
+     * Read a directory stored in the given preference.
+     *
+     * @param prefKey
+     *            preference key holding a directory path
+     * @return the stored directory, or null when nothing is stored
+     */
+    static @Nullable String restorePersistedDir(String prefKey) {
+        String dir = Preferences.getPreferenceDefault(prefKey, "");
+        return StringUtil.isEmpty(dir) ? null : dir;
+    }
+
+    /**
+     * Read a language stored in the given preference, falling back when
+     * nothing valid is stored.
+     *
+     * @param prefKey
+     *            preference key holding a language code
+     * @param fallback
+     *            language to use when the preference is empty or invalid
+     * @return the stored language, or the fallback
+     */
+    static Language restorePersistedLanguage(String prefKey, Language fallback) {
+        String code = Preferences.getPreferenceDefault(prefKey, "");
+        if (StringUtil.isEmpty(code) || !Language.verifySingleLangCode(code)) {
+            return fallback;
+        }
+        return new Language(code);
+    }
+
+    /**
+     * Store the chosen languages for the next aligner session (feature
+     * request #1456).
+     *
+     * @param source
+     *            source language to store, skipped when null
+     * @param target
+     *            target language to store, skipped when null
+     */
+    static void persistLanguages(@Nullable Language source, @Nullable Language target) {
+        if (source != null) {
+            Preferences.setPreference(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, source.getLanguage());
+        }
+        if (target != null) {
+            Preferences.setPreference(AlignerPrefs.ALIGNER_TARGET_LANGUAGE, target.getLanguage());
+        }
+    }
+
+    /**
+     * Store the directory of the given file for the next aligner session
+     * (feature request #1456). Covers files that arrived by typing or drag and
+     * drop, which never pass through the file chooser.
+     *
+     * @param prefKey
+     *            preference key to store the directory under
+     * @param file
+     *            file whose parent directory is stored, skipped when null or
+     *            without a parent
+     */
+    static void persistInputDir(String prefKey, @Nullable String file) {
+        if (file == null) {
+            return;
+        }
+        String parent = new File(file).getParent();
+        if (parent != null) {
+            Preferences.setPreference(prefKey, parent);
+        }
     }
 
     /**
@@ -181,6 +256,9 @@ public class AlignFilePickerController {
         initializeFilePicker(picker);
         // add the main listener.
         picker.okButton.addActionListener(e -> {
+            persistLanguages(sourceLanguage, targetLanguage);
+            persistInputDir(AlignerPrefs.ALIGNER_LAST_SOURCE_DIR, sourceFile);
+            persistInputDir(AlignerPrefs.ALIGNER_LAST_TARGET_DIR, targetFile);
             picker.bottomPanel.remove(picker.messageTextArea);
             picker.bottomPanel.add(picker.progressBar, BorderLayout.CENTER);
             picker.bottomPanel.revalidate();
@@ -334,6 +412,7 @@ public class AlignFilePickerController {
                     "aligner_choose_source");
             if (file != null) {
                 sourceDefaultDir = file.getParent();
+                Preferences.setPreference(AlignerPrefs.ALIGNER_LAST_SOURCE_DIR, sourceDefaultDir);
                 targetDefaultDir = targetDefaultDir == null ? sourceDefaultDir : targetDefaultDir;
                 defaultSaveDir = defaultSaveDir == null ? sourceDefaultDir : defaultSaveDir;
                 picker.sourceLanguageFileField.setText(file.getAbsolutePath());
@@ -349,6 +428,7 @@ public class AlignFilePickerController {
                     "aligner_choose_target");
             if (file != null) {
                 targetDefaultDir = file.getParent();
+                Preferences.setPreference(AlignerPrefs.ALIGNER_LAST_TARGET_DIR, targetDefaultDir);
                 sourceDefaultDir = sourceDefaultDir == null ? targetDefaultDir : sourceDefaultDir;
                 defaultSaveDir = defaultSaveDir == null ? targetDefaultDir : defaultSaveDir;
                 picker.targetLanguageFileField.setText(file.getAbsolutePath());

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2016 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -112,6 +113,7 @@ import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.DelegatingComboBoxRenderer;
 import org.omegat.util.gui.RoundedCornerBorder;
+import org.omegat.util.gui.StaticUIUtils;
 import org.omegat.util.gui.Styles;
 
 import gen.core.filters.Filters;
@@ -226,6 +228,7 @@ public class AlignPanelController {
             AlgorithmClass newValue = (AlgorithmClass) ((JComboBox<?>) e.getSource()).getSelectedItem();
             if (newValue != aligner.algorithmClass && confirmReset(alignMenuFrame)) {
                 aligner.algorithmClass = newValue;
+                persistSettings(aligner);
                 reloadBeads(aligner);
             } else {
                 alignPanel.algorithmComboBox.setSelectedItem(aligner.algorithmClass);
@@ -238,6 +241,7 @@ public class AlignPanelController {
             CalculatorType newValue = (CalculatorType) ((JComboBox<?>) e.getSource()).getSelectedItem();
             if (newValue != aligner.calculatorType && confirmReset(alignMenuFrame)) {
                 aligner.calculatorType = newValue;
+                persistSettings(aligner);
                 reloadBeads(aligner);
             } else {
                 alignPanel.calculatorComboBox.setSelectedItem(aligner.calculatorType);
@@ -250,6 +254,7 @@ public class AlignPanelController {
             CounterType newValue = (CounterType) ((JComboBox<?>) e.getSource()).getSelectedItem();
             if (newValue != aligner.counterType && confirmReset(alignMenuFrame)) {
                 aligner.counterType = newValue;
+                persistSettings(aligner);
                 reloadBeads(aligner);
             } else {
                 alignPanel.counterComboBox.setSelectedItem(aligner.counterType);
@@ -262,6 +267,7 @@ public class AlignPanelController {
             boolean newValue = ((AbstractButton) e.getSource()).isSelected();
             if (newValue != aligner.segment && confirmReset(alignMenuFrame)) {
                 aligner.segment = newValue;
+                persistSettings(aligner);
                 reloadBeads(aligner);
             } else {
                 alignPanel.segmentingCheckBox.setSelected(aligner.segment);
@@ -384,7 +390,13 @@ public class AlignPanelController {
             }
             while (true) {
                 JFileChooser chooser = new JFileChooser();
-                chooser.setSelectedFile(new File(defaultSaveDir, getOutFileName(aligner)));
+                // Offer the directory of the last saved TMX first, so that
+                // aligning several file pairs in a row does not require
+                // navigating to the same location again (feature request
+                // #1358).
+                String lastSaveDir = Preferences.getPreferenceDefault(AlignerPrefs.ALIGNER_LAST_SAVE_DIR, "");
+                String startDir = StringUtil.isEmpty(lastSaveDir) ? defaultSaveDir : lastSaveDir;
+                chooser.setSelectedFile(new File(startDir, getOutFileName(aligner)));
                 chooser.setDialogTitle(BUNDLE.getString("ALIGNER_PANEL_DIALOG_SAVE"));
                 if (JFileChooser.APPROVE_OPTION == chooser.showSaveDialog(alignMenuFrame)) {
                     File file = chooser.getSelectedFile();
@@ -403,6 +415,7 @@ public class AlignPanelController {
                             aligner.writePairsToTMX(file,
                                     MutableBead.beadsToEntries(aligner.srcLang, aligner.trgLang, beads));
                             modified = false;
+                            Preferences.setPreference(AlignerPrefs.ALIGNER_LAST_SAVE_DIR, file.getParent());
                         } else {
                             throw new IllegalArgumentException("srcLang and trgLang must not be null");
                         }
@@ -423,6 +436,7 @@ public class AlignPanelController {
             if (confirmReset(alignMenuFrame)) {
                 if (phase == Phase.ALIGN) {
                     aligner.restoreDefaults();
+                    persistSettings(aligner);
                 }
                 reloadBeads(aligner);
             }
@@ -442,6 +456,7 @@ public class AlignPanelController {
             boolean newValue = ((AbstractButton) e.getSource()).isSelected();
             if (newValue != aligner.removeTags && confirmReset(alignMenuFrame)) {
                 aligner.removeTags = newValue;
+                persistSettings(aligner);
                 aligner.clearLoaded();
                 reloadBeads(aligner);
             } else {
@@ -550,6 +565,7 @@ public class AlignPanelController {
         CoreEvents.registerFontChangedEventListener(alignPanel.table::setFont);
 
         // Set initial state
+        restorePersistedSettings(aligner);
         updateHighlight();
         updatePanel(aligner);
         reloadBeads(aligner);
@@ -557,8 +573,56 @@ public class AlignPanelController {
         alignMenuFrame.add(alignPanel);
         alignMenuFrame.pack();
         alignMenuFrame.setMinimumSize(alignMenuFrame.getSize());
-        alignMenuFrame.setLocationRelativeTo(parent);
+        // Reuse position and size from the previous aligner session (feature
+        // request #1456); center on the parent only on the very first run.
+        boolean hasStoredGeometry = StaticUIUtils
+                .hasStoredGeometry(AlignerPrefs.ALIGNER_WINDOW_GEOMETRY_PREFIX);
+        StaticUIUtils.persistGeometry(alignMenuFrame, AlignerPrefs.ALIGNER_WINDOW_GEOMETRY_PREFIX);
+        if (!hasStoredGeometry) {
+            alignMenuFrame.setLocationRelativeTo(parent);
+        }
         alignMenuFrame.setVisible(true);
+    }
+
+    /**
+     * Restore the align parameters chosen in a previous aligner session
+     * (feature request #1456). The comparison mode is deliberately not
+     * restored: which modes are available depends on the files being aligned,
+     * and loading the files picks the best mode automatically.
+     *
+     * @param aligner
+     *            aligner to apply the stored parameters to
+     */
+    static void restorePersistedSettings(Aligner aligner) {
+        aligner.algorithmClass = Preferences.getPreferenceEnumDefault(AlignerPrefs.ALIGNER_ALGORITHM_CLASS,
+                aligner.algorithmClass);
+        aligner.calculatorType = Preferences.getPreferenceEnumDefault(AlignerPrefs.ALIGNER_CALCULATOR_TYPE,
+                aligner.calculatorType);
+        aligner.counterType = Preferences.getPreferenceEnumDefault(AlignerPrefs.ALIGNER_COUNTER_TYPE,
+                aligner.counterType);
+        aligner.segment = Preferences.isPreferenceDefault(AlignerPrefs.ALIGNER_SEGMENT, aligner.segment);
+        aligner.removeTags = Preferences.isPreferenceDefault(AlignerPrefs.ALIGNER_REMOVE_TAGS,
+                aligner.removeTags);
+    }
+
+    /**
+     * Remember the current align parameters for the next aligner session.
+     *
+     * @param aligner
+     *            aligner whose parameters are stored
+     */
+    static void persistSettings(Aligner aligner) {
+        if (aligner.algorithmClass != null) {
+            Preferences.setPreference(AlignerPrefs.ALIGNER_ALGORITHM_CLASS, aligner.algorithmClass.name());
+        }
+        if (aligner.calculatorType != null) {
+            Preferences.setPreference(AlignerPrefs.ALIGNER_CALCULATOR_TYPE, aligner.calculatorType.name());
+        }
+        if (aligner.counterType != null) {
+            Preferences.setPreference(AlignerPrefs.ALIGNER_COUNTER_TYPE, aligner.counterType.name());
+        }
+        Preferences.setPreference(AlignerPrefs.ALIGNER_SEGMENT, aligner.segment);
+        Preferences.setPreference(AlignerPrefs.ALIGNER_REMOVE_TAGS, aligner.removeTags);
     }
 
     private static void setKeyboardShortcut(JComponent comp, Object actionName, char stroke) {

--- a/aligner/src/main/java/org/omegat/gui/align/Aligner.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Aligner.java
@@ -193,8 +193,14 @@ public class Aligner {
         restoreDefaults();
         SRX srx = Preferences.getSRX();
         updateSegmenter(srx != null ? srx : SRX.getDefault());
-        Filters filters = Preferences.getFilters() != null ? Preferences.getFilters()
-                : FilterMaster.createDefaultFiltersConfig();
+        // An empty filters configuration (as left behind by a fresh
+        // preferences store that never saved filter settings) would make the
+        // FilterMaster unable to parse any file, so fall back to the defaults
+        // in that case as well.
+        Filters filters = Preferences.getFilters();
+        if (filters == null || filters.getFilters().isEmpty()) {
+            filters = FilterMaster.createDefaultFiltersConfig();
+        }
         fm = new FilterMaster(filters);
     }
 

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
@@ -107,8 +107,17 @@ public final class AlignerModule implements IApplicationEventListener {
             }
             alignerShow(sourceLanguage, sourceFile, targetlanguage, null, srcRoot, props.getTMRoot());
         } else {
-            String srcLang = Preferences.getPreference(Preferences.SOURCE_LOCALE);
-            String trgLang = Preferences.getPreference(Preferences.TARGET_LOCALE);
+            // Prefer the languages of the previous aligner session (feature
+            // request #1456); the locales of the last created project only
+            // serve as a first-use fallback.
+            String srcLang = Preferences.getPreference(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE);
+            if (srcLang.isEmpty()) {
+                srcLang = Preferences.getPreference(Preferences.SOURCE_LOCALE);
+            }
+            String trgLang = Preferences.getPreference(AlignerPrefs.ALIGNER_TARGET_LANGUAGE);
+            if (trgLang.isEmpty()) {
+                trgLang = Preferences.getPreference(Preferences.TARGET_LOCALE);
+            }
             alignerShow(srcLang, null, trgLang, null);
         }
     }

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerPrefs.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerPrefs.java
@@ -1,0 +1,51 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.align;
+
+/**
+ * Preference keys of the aligner module. The values are stored through the
+ * core preferences system, but the keys are owned by this module and are
+ * therefore defined here instead of in {@code org.omegat.util.Preferences}.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+final class AlignerPrefs {
+
+    static final String ALIGNER_WINDOW_GEOMETRY_PREFIX = "aligner_window";
+    static final String ALIGNER_LAST_SAVE_DIR = "aligner_last_save_dir";
+    static final String ALIGNER_ALGORITHM_CLASS = "aligner_algorithm_class";
+    static final String ALIGNER_CALCULATOR_TYPE = "aligner_calculator_type";
+    static final String ALIGNER_COUNTER_TYPE = "aligner_counter_type";
+    static final String ALIGNER_SEGMENT = "aligner_segment";
+    static final String ALIGNER_REMOVE_TAGS = "aligner_remove_tags";
+    static final String ALIGNER_SOURCE_LANGUAGE = "aligner_source_language";
+    static final String ALIGNER_TARGET_LANGUAGE = "aligner_target_language";
+    static final String ALIGNER_LAST_SOURCE_DIR = "aligner_last_source_dir";
+    static final String ALIGNER_LAST_TARGET_DIR = "aligner_last_target_dir";
+
+    private AlignerPrefs() {
+    }
+}

--- a/aligner/src/test/java/org/omegat/gui/align/AlignSettingsPersistenceTest.java
+++ b/aligner/src/test/java/org/omegat/gui/align/AlignSettingsPersistenceTest.java
@@ -1,0 +1,157 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.align;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import gen.core.filters.Filters;
+
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
+import org.omegat.filters2.text.bundles.ResourceBundleFilter;
+import org.omegat.gui.align.Aligner.AlgorithmClass;
+import org.omegat.gui.align.Aligner.CalculatorType;
+import org.omegat.gui.align.Aligner.CounterType;
+import org.omegat.util.Language;
+import org.omegat.util.Preferences;
+import org.omegat.util.TestPreferencesInitializer;
+
+/**
+ * Tests for remembering the align parameters between aligner sessions,
+ * see feature request #1456.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class AlignSettingsPersistenceTest {
+
+    private Aligner aligner;
+
+    @Before
+    public final void setUp() throws Exception {
+        TestPreferencesInitializer.init();
+        aligner = new Aligner(null, null, null, null);
+    }
+
+    @Test
+    public void testDefaultsAreKeptWhenNothingStored() {
+        AlignPanelController.restorePersistedSettings(aligner);
+        assertEquals(AlgorithmClass.VITERBI, aligner.algorithmClass);
+        assertEquals(CalculatorType.NORMAL, aligner.calculatorType);
+        assertEquals(CounterType.WORD, aligner.counterType);
+        assertTrue(aligner.segment);
+        assertFalse(aligner.removeTags);
+    }
+
+    @Test
+    public void testRoundTrip() {
+        aligner.algorithmClass = AlgorithmClass.FB;
+        aligner.calculatorType = CalculatorType.POISSON;
+        aligner.counterType = CounterType.CHAR;
+        aligner.segment = false;
+        aligner.removeTags = true;
+        AlignPanelController.persistSettings(aligner);
+
+        Aligner other = new Aligner(null, null, null, null);
+        AlignPanelController.restorePersistedSettings(other);
+        assertEquals(AlgorithmClass.FB, other.algorithmClass);
+        assertEquals(CalculatorType.POISSON, other.calculatorType);
+        assertEquals(CounterType.CHAR, other.counterType);
+        assertFalse(other.segment);
+        assertTrue(other.removeTags);
+    }
+
+    @Test
+    public void testStoredValuesRestored() {
+        Preferences.setPreference(AlignerPrefs.ALIGNER_ALGORITHM_CLASS, AlgorithmClass.FB.name());
+        Preferences.setPreference(AlignerPrefs.ALIGNER_SEGMENT, false);
+        AlignPanelController.restorePersistedSettings(aligner);
+        assertEquals(AlgorithmClass.FB, aligner.algorithmClass);
+        assertFalse(aligner.segment);
+        assertEquals(CalculatorType.NORMAL, aligner.calculatorType);
+    }
+
+    @Test
+    public void testLanguageFallbackWhenNothingStored() {
+        Language fallback = new Language("eo");
+        assertEquals(fallback,
+                AlignFilePickerController.restorePersistedLanguage(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, fallback));
+    }
+
+    @Test
+    public void testLanguageFallbackWhenStoredCodeInvalid() {
+        Preferences.setPreference(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, "not a code");
+        Language fallback = new Language("eo");
+        assertEquals(fallback,
+                AlignFilePickerController.restorePersistedLanguage(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, fallback));
+    }
+
+    @Test
+    public void testEmptyFiltersConfigFallsBackToDefaults() throws Exception {
+        // A preferences store that never saved filter settings hands out an
+        // empty filters configuration; the aligner must not end up with a
+        // FilterMaster that cannot parse anything (latent bug uncovered by
+        // running these tests before AlignerTest in the same JVM).
+        Preferences.setFilters(new Filters());
+        FilterMaster.setFilterClasses(Arrays.asList(TextFilter.class, ResourceBundleFilter.class));
+        String srcFile = AlignSettingsPersistenceTest.class.getResource("/data/align/heapSource.txt")
+                .getFile();
+        String trgFile = AlignSettingsPersistenceTest.class.getResource("/data/align/heapTarget.txt")
+                .getFile();
+        Aligner other = new Aligner(srcFile, new Language("en"), trgFile, new Language("ja"));
+        other.comparisonMode = Aligner.ComparisonMode.HEAPWISE;
+        assertFalse(other.align().isEmpty());
+    }
+
+    @Test
+    public void testInputDirRoundTrip() {
+        File inputDir = new File("tmp", "foo");
+        File inputFile = new File(inputDir, "src.txt");
+        AlignFilePickerController.persistInputDir(AlignerPrefs.ALIGNER_LAST_SOURCE_DIR, inputFile.getPath());
+        AlignFilePickerController.persistInputDir(AlignerPrefs.ALIGNER_LAST_TARGET_DIR, null);
+        assertEquals(inputDir.getPath(),
+                AlignFilePickerController.restorePersistedDir(AlignerPrefs.ALIGNER_LAST_SOURCE_DIR));
+        assertNull(AlignFilePickerController.restorePersistedDir(AlignerPrefs.ALIGNER_LAST_TARGET_DIR));
+    }
+
+    @Test
+    public void testLanguageRoundTrip() {
+        AlignFilePickerController.persistLanguages(new Language("fr-FR"), new Language("de"));
+        Language fallback = new Language("eo");
+        assertEquals(new Language("fr-FR"),
+                AlignFilePickerController.restorePersistedLanguage(AlignerPrefs.ALIGNER_SOURCE_LANGUAGE, fallback));
+        assertEquals(new Language("de"),
+                AlignFilePickerController.restorePersistedLanguage(AlignerPrefs.ALIGNER_TARGET_LANGUAGE, fallback));
+    }
+}

--- a/src/docs/manual/en/Windows_Aligner.xml
+++ b/src/docs/manual/en/Windows_Aligner.xml
@@ -42,6 +42,11 @@
          use the languages from that project, as well the project-specific
          segmentation rules, if any.</para>
    </note>
+   <para>The aligner remembers its window position and size, the align
+      parameters, the selected languages, and the folders last used for the
+      input files and the saved TMX file between sessions. When a translation
+      project is open, its languages take precedence over the remembered
+      ones.</para>
    <para>After selecting the language and files, click 
       <guibutton>OK</guibutton>
       button to bring up the 

--- a/src/docs/manual/en/Windows_Aligner.xml
+++ b/src/docs/manual/en/Windows_Aligner.xml
@@ -42,7 +42,7 @@
          use the languages from that project, as well the project-specific
          segmentation rules, if any.</para>
    </note>
-   <para>The aligner remembers its window position and size, the align
+   <para>The aligner remembers its window position and size, the alignment
       parameters, the selected languages, and the folders last used for the
       input files and the saved TMX file between sessions. When a translation
       project is open, its languages take precedence over the remembered

--- a/src/main/java/org/omegat/util/gui/StaticUIUtils.java
+++ b/src/main/java/org/omegat/util/gui/StaticUIUtils.java
@@ -331,6 +331,20 @@ public final class StaticUIUtils {
         return cs;
     }
 
+    /**
+     * Tell whether window geometry is stored under the given key. Callers of
+     * {@link #persistGeometry(Window, String)} can use this to find out
+     * whether a previous session left geometry to restore, e.g. to decide
+     * between the restored position and centering on a parent window.
+     *
+     * @param key
+     *            preference key prefix, same as used for persistGeometry
+     * @return true when a previous session stored geometry under the key
+     */
+    public static boolean hasStoredGeometry(String key) {
+        return getStoredRectangle(key).isPresent();
+    }
+
     private static Optional<Rectangle> getStoredRectangle(String key) {
         String xStr = Preferences.getPreference(key + "_x");
         String yStr = Preferences.getPreference(key + "_y");


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Aligner to remember window position, size, and values of parameters.
  * https://sourceforge.net/p/omegat/feature-requests/1456/
- Remember aligned TMX save location
  * https://sourceforge.net/p/omegat/feature-requests/1358/

## What does this PR change?

- The aligner window remembers its position and size between sessions (via the existing `StaticUIUtils.persistGeometry` mechanism); it is centered on the parent window only on the very first run.
- The align parameters (algorithm, calculator, counter type, segmenting, remove tags) are persisted and restored. The comparison mode is deliberately not persisted because the available modes depend on the files being aligned.
- The languages chosen in the file picker are persisted; they take precedence over the locales of the last created project when no project is open (those remain the first-use fallback).
- The source and target file choosers reopen in the directories last used.
- The save dialog offers the directory of the last saved TMX.
- Hardens the `Aligner` constructor against an empty non-null filters configuration from the preferences store, which previously left the `FilterMaster` unable to parse any file (a latent bug that surfaced as an order-dependent test interaction).
- Covered by eight test cases in the new `AlignSettingsPersistenceTest`.
