### PR TITLE
feat(search): add find previous/next buttons to the Search window

### DIFF
--- a/src/docs/manual/en/Windows_TextSearch.xml
+++ b/src/docs/manual/en/Windows_TextSearch.xml
@@ -382,6 +382,21 @@
             </listitem>
          </varlistentry>
       </variablelist>
+      <para>The
+         <guibutton>Find Previous</guibutton> and
+         <guibutton>Find Next</guibutton> buttons below the results, as well as
+         <keycombo>
+            <keycap>S</keycap>
+            <keycap>F3</keycap>
+         </keycombo> and
+         <keycap>F3</keycap> from anywhere in the window, move the selection one
+         	result backward or forward, wrapping around at both ends of the list.
+         	The reached segment is always displayed in the
+         <link linkend="panes.editor" endterm="panes.editor.title"></link> pane,
+         	regardless of the
+         <guilabel>Auto-sync with editor</guilabel> option, without moving the
+         	focus away from the Search window. When the navigation wraps around,
+         	a short note appears next to the number of results.</para>
       <para>The selected segment is highlighted in green:</para>
       <example xml:id="select.second.match">
          <title xml:id="select.second.match.title">Select the second match</title>

--- a/src/main/java/org/omegat/gui/search/EntryListPane.java
+++ b/src/main/java/org/omegat/gui/search/EntryListPane.java
@@ -447,6 +447,49 @@ class EntryListPane extends JTextPane {
         return searcher;
     }
 
+    /**
+     * Move the active (highlighted) search result one entry forward, wrapping
+     * around to the first result after the last one, and show it in the
+     * editor regardless of the auto-sync option. Used by the Find Next button
+     * and its shortcut (feature requests #1125 and #1380).
+     *
+     * @return true when the navigation wrapped around the end of the results
+     */
+    boolean selectNextEntry() {
+        DisplayedEntry entry = getActiveDisplayedEntry();
+        DisplayedEntry next = entry.getNext();
+        boolean wrapped = false;
+        if (next == entry && getNrEntries() > 0) {
+            next = new DisplayedEntryImpl(0);
+            wrapped = true;
+        }
+        next.activate();
+        if (!autoSyncWithEditor) {
+            getActiveDisplayedEntry().gotoEntryInEditor();
+        }
+        return wrapped;
+    }
+
+    /**
+     * Counterpart of {@link #selectNextEntry()} for the Find Previous button.
+     *
+     * @return true when the navigation wrapped around the start of the results
+     */
+    boolean selectPreviousEntry() {
+        DisplayedEntry entry = getActiveDisplayedEntry();
+        DisplayedEntry previous = entry.getPrevious();
+        boolean wrapped = false;
+        if (previous == entry && getNrEntries() > 0) {
+            previous = new DisplayedEntryImpl(getNrEntries() - 1);
+            wrapped = true;
+        }
+        previous.activate();
+        if (!autoSyncWithEditor) {
+            getActiveDisplayedEntry().gotoEntryInEditor();
+        }
+        return wrapped;
+    }
+
     private void initActions() {
         ActionMap actionMap = getActionMap();
 

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -39,6 +39,7 @@ import java.awt.Font;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -56,6 +57,7 @@ import java.util.Objects;
 import javax.swing.AbstractAction;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.InputMap;
+import javax.swing.JComponent;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -195,6 +197,8 @@ public class SearchWindowController {
             form.m_allResultsCB.setVisible(false);
             form.m_fileNamesCB.setVisible(false);
             form.m_filterButton.setVisible(false);
+            form.m_findPreviousButton.setVisible(false);
+            form.m_findNextButton.setVisible(false);
             form.m_numberLabel.setVisible(false);
             form.m_numberOfResults.setVisible(false);
             form.m_panelSearch.setVisible(false);
@@ -206,6 +210,48 @@ public class SearchWindowController {
         }
         setComponentNames();
         CoreEvents.registerFontChangedEventListener(this::setFont);
+    }
+
+    /**
+     * Update the results label after walking through the results with the
+     * Find Previous and Find Next buttons: while the navigation has just
+     * wrapped around the end of the results, a short note is appended to the
+     * number of results, and it disappears with the next step.
+     *
+     * @param wrapped
+     *            whether the last navigation step wrapped around
+     */
+    private void showResultNavigationStatus(boolean wrapped) {
+        String text = StringUtil.format(OStrings.getString("SW_NR_OF_RESULTS"),
+                ((EntryListPane) form.m_viewer).getNrEntries());
+        if (wrapped) {
+            text = text + " " + OStrings.getString("SW_RESULT_NAV_WRAPPED");
+        }
+        form.m_resultsLabel.setText(text);
+    }
+
+    /**
+     * Let F3 and Shift+F3 walk through the search results from anywhere in
+     * the Search window, mirroring the Find Next and Find Previous buttons
+     * (feature requests #1125 and #1380). The keys go through the buttons so
+     * that they stay inactive while there are no results.
+     */
+    private void bindResultNavigationKeys() {
+        InputMap inputMap = form.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F3, 0), "findNext");
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F3, InputEvent.SHIFT_DOWN_MASK), "findPrevious");
+        form.getRootPane().getActionMap().put("findNext", new AbstractAction() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                form.m_findNextButton.doClick();
+            }
+        });
+        form.getRootPane().getActionMap().put("findPrevious", new AbstractAction() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                form.m_findPreviousButton.doClick();
+            }
+        });
     }
 
     private void setComponentNames() {
@@ -221,6 +267,8 @@ public class SearchWindowController {
         form.m_searchTranslatedUntranslated.setName("SearchWindowForm.m_searchTranslatedUntranslated");
         form.m_searchTranslated.setName("SearchWindowForm.m_searchTranslated");
         form.m_searchButton.setName("SearchWindowForm.m_searchButton");
+        form.m_findPreviousButton.setName("SearchWindowForm.m_findPreviousButton");
+        form.m_findNextButton.setName("SearchWindowForm.m_findNextButton");
         form.m_viewer.setName("SearchWindowForm.m_viewer");
         form.m_rbDir.setName("SearchWindowForm.m_rbDir");
         form.m_rbProject.setName("SearchWindowForm.m_rbProject");
@@ -251,6 +299,15 @@ public class SearchWindowController {
         form.m_replaceAllButton.addActionListener(e -> doReplaceAll());
 
         form.m_searchButton.addActionListener(e -> doSearch());
+
+        if (mode == SearchMode.SEARCH) {
+            form.m_findPreviousButton.addActionListener(e -> showResultNavigationStatus(
+                    ((EntryListPane) form.m_viewer).selectPreviousEntry()));
+            form.m_findNextButton.addActionListener(e -> showResultNavigationStatus(
+                    ((EntryListPane) form.m_viewer).selectNextEntry()));
+            bindResultNavigationKeys();
+        }
+
         form.m_advancedButton
                 .addActionListener(e -> setAdvancedOptionsVisible(!form.m_advancedVisiblePane.isVisible()));
 
@@ -760,6 +817,8 @@ public class SearchWindowController {
             form.m_filterButton.setEnabled(haveResults);
             form.m_replaceButton.setEnabled(haveResults);
             form.m_replaceAllButton.setEnabled(haveResults);
+            form.m_findPreviousButton.setEnabled(haveResults);
+            form.m_findNextButton.setEnabled(haveResults);
             if (!haveResults) {
                 // RFE#1143
                 // https://sourceforge.net/p/omegat/feature-requests/1143/

--- a/src/main/java/org/omegat/gui/search/SearchWindowForm.form
+++ b/src/main/java/org/omegat/gui/search/SearchWindowForm.form
@@ -1228,6 +1228,54 @@
             <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.HorizontalStrut"/>
           </AuxValues>
         </Component>
+        <Component class="javax.swing.JButton" name="m_findPreviousButton">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_FIND_PREVIOUS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.Box$Filler" name="filler31">
+          <Properties>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 32767]"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 0]"/>
+            </Property>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 0]"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.HorizontalStrut"/>
+          </AuxValues>
+        </Component>
+        <Component class="javax.swing.JButton" name="m_findNextButton">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_FIND_NEXT" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+            </Property>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.Box$Filler" name="filler32">
+          <Properties>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 32767]"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 0]"/>
+            </Property>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[5, 0]"/>
+            </Property>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.HorizontalStrut"/>
+          </AuxValues>
+        </Component>
         <Component class="javax.swing.JButton" name="m_filterButton">
           <Properties>
             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">

--- a/src/main/java/org/omegat/gui/search/SearchWindowForm.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowForm.java
@@ -176,6 +176,10 @@ public class SearchWindowForm extends javax.swing.JFrame {
         filler18 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_replaceButton = new javax.swing.JButton();
         filler16 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
+        m_findPreviousButton = new javax.swing.JButton();
+        filler31 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
+        m_findNextButton = new javax.swing.JButton();
+        filler32 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_filterButton = new javax.swing.JButton();
         filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_dismissButton = new javax.swing.JButton();
@@ -628,6 +632,16 @@ public class SearchWindowForm extends javax.swing.JFrame {
         jPanel7.add(m_replaceButton);
         jPanel7.add(filler16);
 
+        org.openide.awt.Mnemonics.setLocalizedText(m_findPreviousButton, OStrings.getString("BUTTON_FIND_PREVIOUS")); // NOI18N
+        m_findPreviousButton.setEnabled(false);
+        jPanel7.add(m_findPreviousButton);
+        jPanel7.add(filler31);
+
+        org.openide.awt.Mnemonics.setLocalizedText(m_findNextButton, OStrings.getString("BUTTON_FIND_NEXT")); // NOI18N
+        m_findNextButton.setEnabled(false);
+        jPanel7.add(m_findNextButton);
+        jPanel7.add(filler32);
+
         org.openide.awt.Mnemonics.setLocalizedText(m_filterButton, OStrings.getString("BUTTON_FILTER")); // NOI18N
         m_filterButton.setEnabled(false);
         jPanel7.add(m_filterButton);
@@ -674,6 +688,8 @@ public class SearchWindowForm extends javax.swing.JFrame {
     javax.swing.Box.Filler filler29;
     javax.swing.Box.Filler filler3;
     javax.swing.Box.Filler filler30;
+    javax.swing.Box.Filler filler31;
+    javax.swing.Box.Filler filler32;
     javax.swing.Box.Filler filler4;
     javax.swing.Box.Filler filler5;
     javax.swing.Box.Filler filler6;
@@ -721,6 +737,8 @@ public class SearchWindowForm extends javax.swing.JFrame {
     javax.swing.JCheckBox m_excludeOrphans;
     javax.swing.JCheckBox m_fileNamesCB;
     javax.swing.JButton m_filterButton;
+    javax.swing.JButton m_findNextButton;
+    javax.swing.JButton m_findPreviousButton;
     javax.swing.JCheckBox m_fullHalfWidthInsensitive;
     javax.swing.JLabel m_numberLabel;
     javax.swing.JSpinner m_numberOfResults;

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -101,6 +101,10 @@ BUTTON_SEARCH=&Search
 BUTTON_FILTER=&Filter
 BUTTON_REPLACE=&Show Replacements
 BUTTON_REPLACE_ALL=Re&place All
+# deliberately the same visible text as BUTTON_FILTER_SKIP (editor filter bar);
+# the mnemonics differ because of the surrounding controls in each context
+BUTTON_FIND_PREVIOUS=Find Pre&vious
+BUTTON_FIND_NEXT=Find Ne&xt
 
 BUTTON_FILTER_SKIP=&Find Next
 BUTTON_FILTER_REPLACE_NEXT=&Replace and Find Next
@@ -1013,6 +1017,9 @@ ST_NOTHING_FOUND=No matches returned by search.
 
 # 0 - Nr of hits
 SW_NR_OF_RESULTS=Matching segments: {0}
+
+# appended to SW_NR_OF_RESULTS while Find Previous/Find Next just wrapped around the results
+SW_RESULT_NAV_WRAPPED=(continued from the other end)
 
 SW_GLOSSARY_RESULT=Glossary
 # 0 Number of search results. There is a non-breaking space between {0} and matches.

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -104,6 +104,8 @@ BUTTON_SEARCH=&Suchen
 BUTTON_FILTER=&Filtern
 BUTTON_REPLACE=E&rsetzungen anzeigen
 BUTTON_REPLACE_ALL=Alle &Ersetzen
+BUTTON_FIND_PREVIOUS=&Vorheriges finden
+BUTTON_FIND_NEXT=&N\u00E4chstes finden
 
 BUTTON_FILTER_SKIP=N\u00E4chstes &finden
 BUTTON_FILTER_REPLACE_NEXT=E&rsetzen und N\u00E4chstes finden
@@ -955,6 +957,8 @@ ST_NOTHING_FOUND=Die Suche ergab keine Treffer.
 
 # 0 - Nr of hits
 SW_NR_OF_RESULTS=Gefundene Segmente: {0}
+
+SW_RESULT_NAV_WRAPPED=(am anderen Ende fortgesetzt)
 
 SW_GLOSSARY_RESULT=Glossar
 # 0 Number of search results. There is a non-breaking space between {0} and matches.


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Add a "Find Previous" button to the Search window
  * https://sourceforge.net/p/omegat/feature-requests/1380/
- Find Next button on Search window
  * https://sourceforge.net/p/omegat/feature-requests/1125/

## What does this PR change?

- Adds Find Previous and Find Next buttons below the search results that walk through the results, wrapping around at both ends. F3 and Shift+F3 trigger the buttons from anywhere in the Search window; the buttons are disabled while there are no results.
- The buttons always show the reached result in the editor, regardless of the auto-sync option: like the existing double-click on a result, an explicit navigation command overrides the passive-sync setting. Unlike double-click they do not bring the main window to the front, so the results can be walked through without losing focus.
- The keyboard navigation inside the results list keeps its previous behavior (stops at the ends, follows the auto-sync option).
- New bundle keys are provided in English and German; other languages fall back to English.

## Other information

### Screenshots

before without the change:
<img width="1251" height="772" alt="unchanged-noPrevNext" src="https://github.com/user-attachments/assets/01ec954e-4b5f-45eb-8922-ca4c006a0850" />

after, including the proposed change:
<img width="1251" height="772" alt="withChange-withPrevNext" src="https://github.com/user-attachments/assets/e063eb39-2d3d-4735-99c2-3a5b9bafd671" />
