### PR TITLE
feat(search): add whole words only option to the Search window (SF-849)

### DIFF
--- a/src/docs/manual/en/Windows_TextSearch.xml
+++ b/src/docs/manual/en/Windows_TextSearch.xml
@@ -203,6 +203,19 @@
             </listitem>
          </varlistentry>
          <varlistentry>
+            <term>Whole words only</term>
+            <listitem>
+               <para>Search terms only match whole words: matches that are directly
+                  		  preceded or followed by a letter or digit are ignored. In a
+                  		  keyword search this applies to each keyword separately. Word
+                  		  characters are recognized in any script, not only in the Latin
+                  		  alphabet.</para>
+               <para>The option applies to exact and keyword searches. In a regular
+                  		  expression search you define word boundaries in the expression
+                  		  itself, so the option is disabled there.</para>
+            </listitem>
+         </varlistentry>
+         <varlistentry>
             <term>In source</term>
             <listitem>
                <para>Search in the source segments.</para>

--- a/src/main/java/org/omegat/core/search/SearchExpression.java
+++ b/src/main/java/org/omegat/core/search/SearchExpression.java
@@ -66,6 +66,7 @@ public class SearchExpression {
     public boolean recursive = true;
     public SearchExpressionType searchExpressionType;
     public boolean caseSensitive = false;
+    public boolean wholeWordsOnly = false;
     public boolean widthInsensitive = true;
     public boolean spaceMatchNbsp = false;
     public boolean glossary = true;

--- a/src/main/java/org/omegat/core/search/Searcher.java
+++ b/src/main/java/org/omegat/core/search/Searcher.java
@@ -274,9 +274,6 @@ public class Searcher {
         entryMap.clear();
         matchers.clear();
 
-        // determine pattern matching flags
-        int flags = searchExpression.caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
-
         // Normalize width of search string if width insensitivity is requested.
         // Then, instead of modifying the regex, we also normalize the
         // comparison strings later on.
@@ -294,16 +291,23 @@ public class Searcher {
             // expression
             textSearchExpression = StaticUtils.globToRegex(textSearchExpression,
                     searchExpression.spaceMatchNbsp);
+            if (searchExpression.wholeWordsOnly) {
+                textSearchExpression = anchorWholeWords(textSearchExpression);
+            }
 
             // create a matcher for the search string
-            matchers.add(Pattern.compile(textSearchExpression, flags).matcher(""));
+            matchers.add(Pattern.compile(textSearchExpression, getPatternFlags()).matcher(""));
             break;
         case KEYWORD:
             // break the search string into keywords,
             // each of which is a separate search string
+            final int flags = getPatternFlags();
             Pattern.compile(" ").splitAsStream(textSearchExpression.trim()).filter(word -> !word.isEmpty())
                     .map(word -> {
                         String glob = StaticUtils.globToRegex(word, false);
+                        if (searchExpression.wholeWordsOnly) {
+                            glob = anchorWholeWords(glob);
+                        }
                         return Pattern.compile(glob, flags).matcher("");
                     }).forEach(matchers::add);
             break;
@@ -315,7 +319,7 @@ public class Searcher {
             }
 
             // create a matcher for the search string
-            matchers.add(Pattern.compile(textSearchExpression, flags).matcher(""));
+            matchers.add(Pattern.compile(textSearchExpression, getPatternFlags()).matcher(""));
             break;
         default:
             throw new IllegalStateException("Unknown search expression type");
@@ -345,6 +349,38 @@ public class Searcher {
     @SuppressWarnings("unused")
     public boolean isSearchCompleted() {
         return searchCompleted;
+    }
+
+    /**
+     * Determine the pattern matching flags for the search expression.
+     * When the whole words only option is active for a non-regex search,
+     * Unicode character classes are enabled so that word characters are
+     * recognized in non-ASCII languages as well.
+     *
+     * @return flags to pass to Pattern.compile
+     */
+    private int getPatternFlags() {
+        int flags = searchExpression.caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+        if (searchExpression.wholeWordsOnly
+                && searchExpression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP) {
+            flags |= Pattern.UNICODE_CHARACTER_CLASS;
+        }
+        return flags;
+    }
+
+    /**
+     * Wrap the given regular expression so that it only matches whole words
+     * (RFE#849). Lookaround on word characters is used instead of the word
+     * boundary anchor so that search terms that start or end with a non-word
+     * character (for example punctuation or the wildcards asterisk and
+     * question mark) can still match.
+     *
+     * @param regex
+     *            regular expression for a single search term
+     * @return regular expression matching the term as whole words only
+     */
+    private static String anchorWholeWords(String regex) {
+        return "(?<!\\w)(?:" + regex + ")(?!\\w)";
     }
 
     /** create a matcher for the author search string. */

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -262,6 +262,7 @@ public class SearchWindowController {
         form.m_searchRegexpSearchRB.setName("SearchWindowForm.m_searchRegexpSearchRB");
         form.m_searchCase.setName("SearchWindowForm.m_searchCase");
         form.m_searchSpaceMatchNbsp.setName("SearchWindowForm.m_searchSpaceMatchNbsp");
+        form.m_searchWholeWords.setName("SearchWindowForm.m_searchWholeWords");
         form.m_searchSource.setName("SearchWindowForm.m_searchSource");
         form.m_searchTranslation.setName("SearchWindowForm.m_searchTranslation");
         form.m_searchTranslatedUntranslated.setName("SearchWindowForm.m_searchTranslatedUntranslated");
@@ -346,14 +347,21 @@ public class SearchWindowController {
 
         ActionListener searchFieldRequestFocus = e -> form.m_searchField.requestFocus();
 
+        ActionListener wholeWordsStatusUpdate = e -> updateWholeWordsStatus();
+
         form.m_searchExactSearchRB.addActionListener(searchFieldRequestFocus);
+        form.m_searchExactSearchRB.addActionListener(wholeWordsStatusUpdate);
 
         form.m_searchKeywordSearchRB.addActionListener(searchFieldRequestFocus);
+        form.m_searchKeywordSearchRB.addActionListener(wholeWordsStatusUpdate);
 
         form.m_searchRegexpSearchRB.addActionListener(searchFieldRequestFocus);
+        form.m_searchRegexpSearchRB.addActionListener(wholeWordsStatusUpdate);
 
         form.m_searchCase.addActionListener(searchFieldRequestFocus);
         form.m_searchSpaceMatchNbsp.addActionListener(searchFieldRequestFocus);
+        form.m_searchWholeWords.addActionListener(searchFieldRequestFocus);
+        form.m_searchWholeWords.setToolTipText(OStrings.getString("SW_WHOLE_WORDS_TOOLTIP"));
 
         form.m_searchSource.addActionListener(searchFieldRequestFocus);
         form.m_searchTranslation.addActionListener(searchFieldRequestFocus);
@@ -564,6 +572,11 @@ public class SearchWindowController {
         form.m_searchSpaceMatchNbsp.setSelected(
                 Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP, false));
 
+        // whole words only
+        form.m_searchWholeWords.setSelected(
+                Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_WHOLE_WORDS, false));
+        updateWholeWordsStatus();
+
         // search source
         form.m_searchSource
                 .setSelected(Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_SEARCH_SOURCE, true));
@@ -666,6 +679,8 @@ public class SearchWindowController {
         Preferences.setPreference(Preferences.SEARCHWINDOW_CASE_SENSITIVE, form.m_searchCase.isSelected());
         Preferences.setPreference(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP,
                 form.m_searchSpaceMatchNbsp.isSelected());
+        Preferences.setPreference(Preferences.SEARCHWINDOW_WHOLE_WORDS,
+                form.m_searchWholeWords.isSelected());
 
         Preferences.setPreference(Preferences.SEARCHWINDOW_SEARCH_SOURCE, form.m_searchSource.isSelected());
         Preferences.setPreference(Preferences.SEARCHWINDOW_SEARCH_TRANSLATION,
@@ -757,6 +772,8 @@ public class SearchWindowController {
         form.m_searchCase.setSelected(false);
 
         form.m_searchSpaceMatchNbsp.setSelected(false);
+        form.m_searchWholeWords.setSelected(false);
+        updateWholeWordsStatus();
 
         form.m_searchSource.setSelected(true);
         form.m_searchTranslation.setSelected(true);
@@ -799,6 +816,15 @@ public class SearchWindowController {
         form.m_rbProject.setEnabled(true);
         setEnabled(form.m_SearchInDirPane, form.m_rbDir.isSelected());
         form.m_rbDir.setEnabled(true);
+    }
+
+    /**
+     * The whole words only option (RFE#849) applies to exact and keyword
+     * searches; in a regular expression search the user controls word
+     * boundaries in the expression itself, so the checkbox is disabled there.
+     */
+    private void updateWholeWordsStatus() {
+        form.m_searchWholeWords.setEnabled(!form.m_searchRegexpSearchRB.isSelected());
     }
 
     // //////////////////////////////////////////////////////////////
@@ -1014,6 +1040,7 @@ public class SearchWindowController {
         expression.searchExpressionType = getSearchExpressionTypeForSearchMode();
         expression.caseSensitive = form.m_searchCase.isSelected();
         expression.spaceMatchNbsp = form.m_searchSpaceMatchNbsp.isSelected();
+        expression.wholeWordsOnly = form.m_searchWholeWords.isSelected();
         expression.glossary = form.m_cbSearchInGlossaries.isSelected();
         expression.memory = form.m_cbSearchInMemory.isSelected();
         expression.tm = form.m_cbSearchInTMs.isSelected();

--- a/src/main/java/org/omegat/gui/search/SearchWindowForm.form
+++ b/src/main/java/org/omegat/gui/search/SearchWindowForm.form
@@ -267,6 +267,29 @@
                 <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.HorizontalStrut"/>
               </AuxValues>
             </Component>
+            <Component class="javax.swing.JCheckBox" name="m_searchWholeWords">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="SW_WHOLE_WORDS" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.Box$Filler" name="filler33">
+              <Properties>
+                <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[5, 32767]"/>
+                </Property>
+                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[5, 0]"/>
+                </Property>
+                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[5, 0]"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.HorizontalStrut"/>
+              </AuxValues>
+            </Component>
             <Component class="javax.swing.JCheckBox" name="m_searchSource">
               <Properties>
                 <Property name="selected" type="boolean" value="true"/>

--- a/src/main/java/org/omegat/gui/search/SearchWindowForm.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowForm.java
@@ -93,6 +93,8 @@ public class SearchWindowForm extends javax.swing.JFrame {
         filler29 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_searchSpaceMatchNbsp = new javax.swing.JCheckBox();
         filler5 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
+        m_searchWholeWords = new javax.swing.JCheckBox();
+        filler33 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_searchSource = new javax.swing.JCheckBox();
         filler17 = new javax.swing.Box.Filler(new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 0), new java.awt.Dimension(5, 32767));
         m_searchTranslation = new javax.swing.JCheckBox();
@@ -269,6 +271,10 @@ public class SearchWindowForm extends javax.swing.JFrame {
         org.openide.awt.Mnemonics.setLocalizedText(m_searchSpaceMatchNbsp, OStrings.getString("SW_SEARCH_SPACE_MATCH_NBSP")); // NOI18N
         jPanel3.add(m_searchSpaceMatchNbsp);
         jPanel3.add(filler5);
+
+        org.openide.awt.Mnemonics.setLocalizedText(m_searchWholeWords, OStrings.getString("SW_WHOLE_WORDS")); // NOI18N
+        jPanel3.add(m_searchWholeWords);
+        jPanel3.add(filler33);
 
         m_searchSource.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(m_searchSource, OStrings.getString("SW_SEARCH_SOURCE")); // NOI18N
@@ -690,6 +696,7 @@ public class SearchWindowForm extends javax.swing.JFrame {
     javax.swing.Box.Filler filler30;
     javax.swing.Box.Filler filler31;
     javax.swing.Box.Filler filler32;
+    javax.swing.Box.Filler filler33;
     javax.swing.Box.Filler filler4;
     javax.swing.Box.Filler filler5;
     javax.swing.Box.Filler filler6;
@@ -771,6 +778,7 @@ public class SearchWindowForm extends javax.swing.JFrame {
     javax.swing.JCheckBox m_searchSpaceMatchNbsp;
     javax.swing.JRadioButton m_searchTranslated;
     javax.swing.JRadioButton m_searchTranslatedUntranslated;
+    javax.swing.JCheckBox m_searchWholeWords;
     javax.swing.JCheckBox m_searchTranslation;
     javax.swing.JRadioButton m_searchUntranslated;
     javax.swing.JTextPane m_viewer;

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -149,6 +149,7 @@ public final class Preferences {
     public static final String SEARCHWINDOW_REPLACE_TYPE = "search_window_replace_type";
     public static final String SEARCHWINDOW_CASE_SENSITIVE = "search_window_case_sensitive";
     public static final String SEARCHWINDOW_SPACE_MATCH_NBSP = "search_window_space_match_nbsp";
+    public static final String SEARCHWINDOW_WHOLE_WORDS = "search_window_whole_words";
     public static final String SEARCHWINDOW_CASE_SENSITIVE_REPLACE = "search_window_case_sensitive_replace";
     public static final String SEARCHWINDOW_SPACE_MATCH_NBSP_REPLACE = "search_window_space_match_nbsp_replace";
     public static final String SEARCHWINDOW_REPLACE_UNTRANSLATED = "search_window_replace_untranslated";

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -948,6 +948,10 @@ SW_FULLHALFWIDTH_INSENSITIVE=Full/half-&width char insensitive
 
 SW_SEARCH_SPACE_MATCH_NBSP=S&pace matches nbsp
 
+SW_WHOLE_WORDS=&Whole words only
+
+SW_WHOLE_WORDS_TOOLTIP=Match search terms only as whole words. Applies to exact and keyword searches; in a regular expression search, define word boundaries in the expression itself.
+
 SW_SEARCH_IN_BOX=Search in
 SW_SEARCH_IN_MEMORY=Main Memor&y
 SW_SEARCH_IN_TMS=Reference T&Ms

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -909,6 +909,10 @@ SW_FULLHALFWIDTH_INSENSITIVE=Zeichen unabh\u00E4ngig von voller/halber Breite
 
 SW_SEARCH_SPACE_MATCH_NBSP=Leerzeichen findet nbs&p
 
+SW_WHOLE_WORDS=Nur ganze W\u00F6rter
+
+SW_WHOLE_WORDS_TOOLTIP=Suchbegriffe nur als ganze W\u00F6rter finden. Gilt f\u00FCr exakte Suche und Stichwortsuche; in einem regul\u00E4ren Ausdruck bestimmen Sie die Wortgrenzen selbst.
+
 SW_SEARCH_IN_BOX=Suche in
 SW_SEARCH_IN_MEMORY=&Haupt-TM
 SW_SEARCH_IN_TMS=Referenz-T&Ms

--- a/src/test/java/org/omegat/core/search/SearcherTest.java
+++ b/src/test/java/org/omegat/core/search/SearcherTest.java
@@ -206,6 +206,65 @@ public class SearcherTest {
     }
 
     @Test
+    public void testSearchStringExactWholeWordsOnly() throws Exception {
+        addSTE(fi, "id1", "the Netherlands", null);
+        SearchExpression s = createSearchExpression("the", SearchExpressionType.EXACT, false, false);
+        s.wholeWordsOnly = true;
+        Searcher searcher = startSearcher(s);
+        assertTrue(searcher.searchString("the Netherlands"));
+        assertFalse(searcher.searchString("Netherlands"));
+        assertFalse(searcher.searchString("them"));
+        assertFalse(searcher.searchString("blithe"));
+    }
+
+    @Test
+    public void testSearchStringKeywordWholeWordsOnly() throws Exception {
+        addSTE(fi, "id1", "OmegaT is great software", null);
+        SearchExpression s = createSearchExpression("great soft", SearchExpressionType.KEYWORD, false,
+                false);
+        s.wholeWordsOnly = true;
+        Searcher searcher = startSearcher(s);
+        assertTrue(searcher.searchString("soft and great"));
+        // "soft" must not match inside "software"
+        assertFalse(searcher.searchString("OmegaT is great software"));
+    }
+
+    @Test
+    public void testSearchStringWildcardWholeWordsOnly() throws Exception {
+        addSTE(fi, "id1", "greatness counts", null);
+        SearchExpression s = createSearchExpression("great*", SearchExpressionType.EXACT, false, false);
+        s.wholeWordsOnly = true;
+        Searcher searcher = startSearcher(s);
+        assertTrue(searcher.searchString("greatness counts"));
+        assertTrue(searcher.searchString("great"));
+        assertFalse(searcher.searchString("ungrateful"));
+    }
+
+    @Test
+    public void testSearchStringUnicodeWholeWordsOnly() throws Exception {
+        addSTE(fi, "id1", "слово и дело", null);
+        // "слово" must match as a word but not inside "словообразование";
+        // requires Unicode-aware word characters, see RFE#849
+        SearchExpression s = createSearchExpression("слово",
+                SearchExpressionType.EXACT, false, false);
+        s.wholeWordsOnly = true;
+        Searcher searcher = startSearcher(s);
+        assertTrue(searcher.searchString("слово и дело"));
+        assertFalse(searcher.searchString(
+                "словообразование"));
+    }
+
+    @Test
+    public void testSearchStringWholeWordsOnlyIgnoredForRegex() throws Exception {
+        addSTE(fi, "id1", "the Netherlands", null);
+        SearchExpression s = createSearchExpression("the", SearchExpressionType.REGEXP, false, false);
+        s.wholeWordsOnly = true;
+        Searcher searcher = startSearcher(s);
+        // regular expressions are used as written, no whole-word anchoring
+        assertTrue(searcher.searchString("Netherlands"));
+    }
+
+    @Test
     public void testSearchReplaceExactMatch() throws Exception {
         SearchExpression s = createSearchExpression("great", SearchExpressionType.EXACT, false, false);
         s.mode = SearchMode.REPLACE;


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Add "whole words only" option to Find dialog
  * https://sourceforge.net/p/omegat/feature-requests/849/

## What does this PR change?

- Adds a "Whole words only" checkbox to the search options of the Search window.
- The option applies to exact and keyword searches by anchoring the search terms with lookarounds on Unicode word boundaries (`UNICODE_CHARACTER_CLASS`, so it works for non-ASCII scripts as well).
- In a regular expression search the user controls word boundaries in the expression itself, so the checkbox is disabled there.
- The checkbox state is remembered between sessions.
- New bundle keys are provided in English and German; other languages fall back to English. The German label carries no mnemonic because all its letters are already taken by other options in the Search window.
- Covered by new test cases in `SearcherTest`.

## Other information

### Screenshots

before, without the change:
<img width="1140" height="315" alt="unchanged-withoutGanzeWorte" src="https://github.com/user-attachments/assets/b268bc55-b21e-43fe-a23c-abd6ca4ab491" />

after, including the proposed new checkbox:
<img width="2502" height="1544" alt="withChange-nurGanzeWorte" src="https://github.com/user-attachments/assets/b6b789ae-53ea-41cd-8659-e0682fcb1e8f" />

edit: made the change more visable