### PR TITLE
chore(docker): update Java version to 25 in integration test configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
     build:
       context: test-integration/docker/client
       args:
-        JAVA: 21
+        JAVA: 25
         JDKVER: jdk_25.0.3.0.0+9-1
         GRADLE: 9.6.0
     depends_on:


### PR DESCRIPTION

## Pull request type
- Build and release changes -> [build/release]
- Other (describe below)

## Which ticket is resolved?

none
## What does this PR change?

- Docker compose parameter is inconsistent in JDK version
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
