### PR TITLE
chore(cli): avoid exit and handle null `RealProject` in commands

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignerCommand.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerCommand.java
@@ -87,6 +87,9 @@ public class AlignerCommand extends BaseSubCommand {
 
         CommandCommon.parseCommonParams(params);
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
+        if (p == null) {
+            return 1;
+        }
         CommandCommon.validateTagsConsoleMode(params);
 
         String tmxFile = p.getProjectProperties().getProjectInternal() + "align.tmx";

--- a/src/main/java/org/omegat/cli/CommandCommon.java
+++ b/src/main/java/org/omegat/cli/CommandCommon.java
@@ -27,6 +27,7 @@ package org.omegat.cli;
 
 import com.vlsolutions.swing.docking.DockingDesktop;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.languagetool.JLanguageTool;
 import org.omegat.core.Core;
 import org.omegat.core.data.NotLoadedProject;
@@ -149,7 +150,7 @@ public final class CommandCommon {
      *            load the project or not
      * @return the project.
      */
-    public static RealProject selectProjectConsoleMode(boolean loadProject, CommonParameters params) {
+    public static @Nullable RealProject selectProjectConsoleMode(boolean loadProject, CommonParameters params) {
 
         if (params.projectLocation == null) {
             Log.logErrorRB("PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
@@ -162,24 +163,22 @@ public final class CommandCommon {
             projectProperties = ProjectFileStorage
                     .loadProjectProperties(Paths.get(params.projectLocation).toFile());
             projectProperties.verifyProject();
+            RealProject p = new RealProject(projectProperties);
+            Core.setProject(p);
+            if (loadProject) {
+                Log.logInfoRB("CONSOLE_LOADING_PROJECT");
+                p.loadProject(true);
+                if (!p.isProjectLoaded()) {
+                    Core.setProject(new NotLoadedProject());
+                } else {
+                    executeConsoleScript(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD, params);
+                }
+            }
+            return p;
         } catch (Exception ex) {
             Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
-            System.exit(1);
         }
-
-        RealProject p = new RealProject(projectProperties);
-        Core.setProject(p);
-        if (loadProject) {
-            Log.logInfoRB("CONSOLE_LOADING_PROJECT");
-            p.loadProject(true);
-            if (!p.isProjectLoaded()) {
-                Core.setProject(new NotLoadedProject());
-            } else {
-                executeConsoleScript(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD, params);
-            }
-
-        }
-        return p;
+        return null;
     }
 
     public static void showStartUpLogInfo() {

--- a/src/main/java/org/omegat/cli/LegacyAlignCommand.java
+++ b/src/main/java/org/omegat/cli/LegacyAlignCommand.java
@@ -66,6 +66,9 @@ public class LegacyAlignCommand {
         params.setProjectLocation(legacyParams.project);
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
+        if (p == null) {
+            return 1;
+        }
 
         Log.logInfoRB("CONSOLE_ALIGN_AGAINST", legacyParams.alignDirPath);
 

--- a/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
+++ b/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
@@ -108,6 +108,9 @@ public class PseudoTranslateCommand implements Callable<Integer> {
         }
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
+        if (p == null) {
+            return 1;
+        }
 
         CommandCommon.validateTagsConsoleMode(params);
 

--- a/src/main/java/org/omegat/cli/StatsCommand.java
+++ b/src/main/java/org/omegat/cli/StatsCommand.java
@@ -124,6 +124,9 @@ public class StatsCommand implements Callable<Integer> {
         }
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
+        if (p == null) {
+            return 1;
+        }
         StatsResult projectStats = Statistics.buildProjectStats(p);
         StatOutputFormat statsMode;
 

--- a/src/main/java/org/omegat/cli/TranslateCommand.java
+++ b/src/main/java/org/omegat/cli/TranslateCommand.java
@@ -95,7 +95,9 @@ public class TranslateCommand implements Callable<Integer> {
         }
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
-
+        if (p == null) {
+            return 1;
+        }
         CommandCommon.validateTagsConsoleMode(params);
 
         Log.logInfoRB("CONSOLE_TRANSLATING");


### PR DESCRIPTION

CommandCommon class has exit(1) when an error is happened. It is bad habit to exit outside of Main class.
This PR to change it with return null and check null and return exit code in the CLI logics. 

## Pull request type
refactor

## Which ticket is resolved?

none

## What does this PR change?

- Change `commandCommon.selectProjectConsoleMode` to return null when error.
- Return exit code from CLI Commands classes.

## Other information

#2132
