### PR TITLE
chore: replace `null` with empty string in `showStatusMessageRB` call…

### DIFF
--- a/src/main/java/org/omegat/core/data/LastSegmentManager.java
+++ b/src/main/java/org/omegat/core/data/LastSegmentManager.java
@@ -140,7 +140,7 @@ public final class LastSegmentManager {
 
         if (allEntries.size() < lastEntryNumber) {
             LOGGER.atDebug().log("Not enough segments to jump to {}", lastEntryNumber);
-            Core.getMainWindow().showStatusMessageRB(null);
+            Core.getMainWindow().showStatusMessageRB("");
             return 1;
         }
 
@@ -153,7 +153,7 @@ public final class LastSegmentManager {
         // filename, it's still okay)
         if (propEntry.getSrcText().equals(lastSrc)) {
             // gotoEntry(propEntry.entryNum(), editor);
-            Core.getMainWindow().showStatusMessageRB(null);
+            Core.getMainWindow().showStatusMessageRB("");
             return propEntry.entryNum();
         }
 
@@ -165,7 +165,7 @@ public final class LastSegmentManager {
 
         if (fileIndex == -1) {
             LOGGER.atDebug().log("File \"{}\" is not in the project anymore.", lastFile);
-            Core.getMainWindow().showStatusMessageRB(null);
+            Core.getMainWindow().showStatusMessageRB("");
             return 1;
         }
 
@@ -187,7 +187,7 @@ public final class LastSegmentManager {
             }
         }
 
-        Core.getMainWindow().showStatusMessageRB(null);
+        Core.getMainWindow().showStatusMessageRB("");
         return 1;
     }
 

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -309,7 +309,7 @@ public class RealProject implements IProject {
             loaded = true;
 
             // clear status message
-            Core.getMainWindow().showStatusMessageRB(null);
+            Core.getMainWindow().showStatusMessageRB("");
         } catch (Exception e) {
             // trouble in Tinseltown...
             Log.logErrorRB(e, "CT_ERROR_CREATING_PROJECT");
@@ -404,7 +404,7 @@ public class RealProject implements IProject {
             loaded = true;
 
             // Project Loaded...
-            Core.getMainWindow().showStatusMessageRB(null);
+            Core.getMainWindow().showStatusMessageRB("");
 
             setProjectModified(importHandler.didAnyChange);
         } catch (OutOfMemoryError oome) {

--- a/src/main/java/org/omegat/gui/main/ConsoleWindow.java
+++ b/src/main/java/org/omegat/gui/main/ConsoleWindow.java
@@ -74,7 +74,7 @@ public class ConsoleWindow implements IMainWindow {
             return;
         }
         final String msg;
-        if (messageKey == null) {
+        if (messageKey == null || messageKey.isEmpty()) {
             msg = " ";
         } else {
             if (params != null) {

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -69,7 +69,7 @@ public interface IMainWindow {
      * @param params
      *            message parameters for formatting
      */
-    void showStatusMessageRB(@Nullable String messageKey, Object... params);
+    void showStatusMessageRB(String messageKey, Object... params);
 
     /**
      * Same as {@link #showStatusMessageRB(String, Object...)} but this will

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -33,7 +33,6 @@ import javax.swing.JFrame;
 
 import com.vlsolutions.swing.docking.Dockable;
 import com.vlsolutions.swing.docking.DockingDesktop;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Interface for access to main window functionality.

--- a/src/main/java/org/omegat/gui/main/MainWindow.java
+++ b/src/main/java/org/omegat/gui/main/MainWindow.java
@@ -363,7 +363,7 @@ public class MainWindow implements IMainWindow {
         return matcher instanceof JTextComponent ? ((JTextComponent) matcher).getSelectedText() : null;
     }
 
-    public void showStatusMessageRB(final String messageKey, final Object... params) {
+    public void showStatusMessageRB(String messageKey, Object... params) {
         mainWindowStatusBarController.showStatusMessageRB(messageKey, params);
     }
 

--- a/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
@@ -120,7 +120,7 @@ public final class MainWindowStatusBarController {
     public void showTimedStatusMessageRB(String messageKey, Object... params) {
         showStatusMessageRB(messageKey, params);
 
-        if (messageKey == null) {
+        if (messageKey == null || messageKey.isEmpty()) {
             return;
         }
 

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import javax.swing.JFileChooser;
@@ -187,8 +188,8 @@ public final class ProjectUICommands {
 
             @Override
             protected Void doInBackground() throws Exception {
-                mainWindow = Core.getMainWindow();
-                mainWindow.showStatusMessageRB(null);
+                mainWindow = Objects.requireNonNull(Core.getMainWindow());
+                mainWindow.showStatusMessageRB("");
                 NewTeamProjectController newTeamProjectController = new NewTeamProjectController(mainWindow);
                 File dir = newTeamProjectController.show();
                 if (dir == null || !ensureProjectDir(dir)) {

--- a/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
+++ b/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
@@ -221,11 +221,11 @@ class TestMainWindow implements IMainWindow {
     }
 
     @Override
-    public void showStatusMessageRB(final String messageKey, final Object... params) {
+    public void showStatusMessageRB(String messageKey, Object... params) {
     }
 
     @Override
-    public void showTimedStatusMessageRB(final String messageKey, final Object... params) {
+    public void showTimedStatusMessageRB(String messageKey, Object... params) {
     }
 
     @Override


### PR DESCRIPTION
…s and remove redundant `final` modifiers


## Pull request type
refactor
## Which ticket is resolved?
none


## What does this PR change?


- Make `Core.getMainWIndow().showStatusMessageRB` to accept empty string to remove message.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
