### PR TITLE
chore(editor): improve translation handling and add synchronization for segment export

### DIFF
--- a/src/main/java/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentBuilder.java
@@ -310,8 +310,11 @@ public class SegmentBuilder {
                     altTrans = entry.getValue().getDefaultTranslation(ste.getSrcText());
                 }
                 if (altTrans != null && altTrans.isTranslated()) {
-                    Language language = entry.getKey();
-                    addOtherLanguagePart(altTrans.translation, language);
+                    var currentAltTranslation = altTrans.translation;
+                    if (currentAltTranslation != null) {
+                        Language language = entry.getKey();
+                        addOtherLanguagePart(currentAltTranslation, language);
+                    }
                 }
             }
 
@@ -326,8 +329,8 @@ public class SegmentBuilder {
                 // Preferences.DONT_INSERT_SOURCE_TEXT = false
                 boolean insertSource = !Preferences.isPreferenceDefault(Preferences.DONT_INSERT_SOURCE_TEXT,
                         DONT_INSERT_SOURCE_TEXT_DEFAULT);
-                if (controller.entriesFilter != null
-                        && controller.entriesFilter.isSourceAsEmptyTranslation()) {
+                IEditorFilter activeFilter = controller.entriesFilter;
+                if (activeFilter != null && activeFilter.isSourceAsEmptyTranslation()) {
                     insertSource = true;
                 }
                 if (insertSource) {
@@ -343,7 +346,8 @@ public class SegmentBuilder {
                 }
             }
 
-            translationText = addActiveSegPart(translationText);
+            String activeTranslationText = translationText == null ? "" : translationText;
+            translationText = addActiveSegPart(activeTranslationText);
             posTranslationBeg = null;
 
             doc.activeTranslationBeginM1 = doc.createPosition(activeTranslationBeginOffset - 1);

--- a/src/main/java/org/omegat/gui/editor/SegmentExportImport.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentExportImport.java
@@ -52,6 +52,8 @@ import org.omegat.util.gui.UIThreadsUtil;
 public class SegmentExportImport {
     static final int WAIT_TIME = 100;
 
+    private static final Object EXPORT_LOCK = new Object();
+
     private final IEditor controller;
     private volatile long exportLastModified = Long.MAX_VALUE;
     private final File importFile;
@@ -89,26 +91,28 @@ public class SegmentExportImport {
     /**
      * Export the current source and target segments in text files.
      */
-    public synchronized void exportCurrentSegment(@Nullable SourceTextEntry ste) {
-        importFile.delete();
-        if (ste == null) {
-            // entry deactivated
-            exportLastModified = Long.MAX_VALUE;
-            return;
-        }
+    public void exportCurrentSegment(@Nullable SourceTextEntry ste) {
+        synchronized (EXPORT_LOCK) {
+            importFile.delete();
+            if (ste == null) {
+                // entry deactivated
+                exportLastModified = Long.MAX_VALUE;
+                return;
+            }
 
-        String s1 = ste.getSrcText();
-        TMXEntry te = Core.getProject().getTranslationInfo(ste);
-        String s2 = te.isTranslated() ? te.translation : "";
+            String s1 = ste.getSrcText();
+            TMXEntry te = Core.getProject().getTranslationInfo(ste);
+            String s2 = te.isTranslated() ? te.translation : "";
 
-        File sourceFile = getFile(SOURCE_EXPORT);
-        File targetFile = getFile(TARGET_EXPORT);
-        try {
-            writeFile(sourceFile, s1);
-            writeFile(targetFile, s2);
-            exportLastModified = sourceFile.lastModified();
-        } catch (IOException ex) {
-            Log.log(ex);
+            File sourceFile = getFile(SOURCE_EXPORT);
+            File targetFile = getFile(TARGET_EXPORT);
+            try {
+                writeFile(sourceFile, s1);
+                writeFile(targetFile, s2 == null ? "" : s2);
+                exportLastModified = sourceFile.lastModified();
+            } catch (IOException ex) {
+                Log.log(ex);
+            }
         }
     }
 
@@ -120,15 +124,17 @@ public class SegmentExportImport {
         }
     }
 
-    public static synchronized void exportCurrentSelection(String selection) {
-        try {
-            writeFile(getFile(SELECTION_EXPORT), selection);
-        } catch (IOException ex) {
-            Log.log(ex);
+    public static void exportCurrentSelection(String selection) {
+        synchronized (EXPORT_LOCK) {
+            try {
+                writeFile(getFile(SELECTION_EXPORT), selection);
+            } catch (IOException ex) {
+                Log.log(ex);
+            }
         }
     }
 
-    synchronized void importText() {
+    void importText() {
         if (importFile.lastModified() < exportLastModified) {
             // check again inside synchronized block
             return;
@@ -146,14 +152,16 @@ public class SegmentExportImport {
     /**
      * Empties the exported segments.
      */
-    public static synchronized void flushExportedSegments() {
-        File sourceFile = getFile(SOURCE_EXPORT);
-        File targetFile = getFile(TARGET_EXPORT);
-        try {
-            writeFile(sourceFile, "");
-            writeFile(targetFile, "");
-        } catch (IOException ex) {
-            Log.log(ex);
+    public static void flushExportedSegments() {
+        synchronized (EXPORT_LOCK) {
+            File sourceFile = getFile(SOURCE_EXPORT);
+            File targetFile = getFile(TARGET_EXPORT);
+            try {
+                writeFile(sourceFile, "");
+                writeFile(targetFile, "");
+            } catch (IOException ex) {
+                Log.log(ex);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix SpotBugs synchronization error

## Pull request type
refactor
## Which ticket is resolved?
none
## What does this PR change?
- Refactor `SegmentBuilder` to handle null values in translations more robustly
- Introduce `EXPORT_LOCK` for thread-safe operations in `SegmentExportImport`
- Replace method-level synchronization with block-level synchronized statements
- Enhance handling of empty or null translation data during export


## Other information
The issue is detected in #2145 
