### PR TITLE
fix(build): branch workflow task compatibility with configuration cache (SF-1801)

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.spotless-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.spotless-conventions.gradle
@@ -5,35 +5,47 @@ plugins {
     id 'org.omegat.common-utilities'
 }
 
-tasks.register('changedOnBranch') {
-    description = 'Lists files that have been modified on this git branch.'
-    doLast {
-        def branch = providers.exec {commandLine("git", "name-rev", "--name-only", "HEAD")}
-                .standardOutput.asText.get().trim()
+// The git queries run at configuration time, and only when one of the branch
+// workflow tasks was requested: their results become configuration inputs,
+// which keeps the tasks compatible with the configuration cache.
+def branchWorkflowRequested = gradle.startParameter.taskNames.any {
+    def taskName = it.tokenize(':').last()
+    taskName == 'changedOnBranch' || taskName == 'spotlessChangedApply'
+}
+
+def changedFiles = []
+if (branchWorkflowRequested) {
+    def branch = providers.exec {
+        commandLine("git", "name-rev", "--name-only", "HEAD")
+    }.standardOutput.asText.get().trim()
+    def remote = ''
+    for (key in ["branch.${branch}.pushRemote", "branch.${branch}.remote"]) {
         def exe = providers.exec {
             ignoreExitValue = true
-            commandLine("git", "config", "branch.${branch}.pushRemote")
+            commandLine("git", "config", key)
         }
-        def remote = exe.result.get() == 0 ? exe.standardOutput.asText.get().trim() : ''
-        if (remote.empty) {
-            exe = providers.exec {
-                ignoreExitValue = true
-                commandLine("git", "config", "branch.${branch}.remote")
-            }
-            remote = exe.result.get() == 0 ? exe.standardOutput.asText.get().trim() : ''
+        if (exe.result.get().exitValue == 0) {
+            remote = exe.standardOutput.asText.get().trim()
+            break
         }
-        if (remote.empty) {
-            logger.warn("Could not detect git remote name. Assuming 'origin'.")
-            remote = 'origin'
-        }
-        def splitPoint = providers.exec {
-            commandLine("git", "merge-base", "HEAD", "$remote/master")
-        }.standardOutput.asText.get().trim()
-        def gitModifiedFiles = providers.exec {
-            commandLine("git", "diff", "--name-only", "HEAD", "$splitPoint")
-        }.standardOutput.asText.get().trim().tokenize()
-        ext.files = project.files(gitModifiedFiles)
-        files.each { println(it) }
+    }
+    if (remote.empty) {
+        logger.warn("Could not detect git remote name. Assuming 'origin'.")
+        remote = 'origin'
+    }
+    def splitPoint = providers.exec {
+        commandLine("git", "merge-base", "HEAD", "$remote/master")
+    }.standardOutput.asText.get().trim()
+    changedFiles = providers.exec {
+        commandLine("git", "diff", "--name-only", "HEAD", splitPoint)
+    }.standardOutput.asText.get().trim().tokenize()
+}
+
+tasks.register('changedOnBranch') {
+    description = 'Lists files that have been modified on this git branch.'
+    def listedFiles = changedFiles
+    doLast {
+        listedFiles.each { println(it) }
     }
 }
 
@@ -41,17 +53,15 @@ tasks.register('spotlessChangedApply') {
     description = 'Applies code formatting to files that have been changed on the current branch.'
     group = 'verification'
     finalizedBy 'spotlessApply'
-    dependsOn changedOnBranch
-    doFirst {
-        spotlessJava.target = changedOnBranch.files.findAll {
-            it.path.endsWith('.java')
-        }
-    }
+    dependsOn 'changedOnBranch'
 }
 
 spotless {
     enforceCheck = false
     java {
+        if (branchWorkflowRequested) {
+            target changedFiles.findAll { it.endsWith('.java') }
+        }
         eclipse().configFile layout.settingsDirectory.file("config/spotless/eclipse-formatting.xml")
         removeUnusedImports()
     }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug] (build tooling only, so [build/release] may fit as well)

## Which ticket is resolved?

- changedOnBranch and spotlessChangedApply fail with the configuration cache; git remote detection is broken
  * https://sourceforge.net/p/omegat/bugs/1801/

## What does this PR change?

- Moves the git queries of `changedOnBranch` out of the task actions to configuration time, guarded so they only run when `changedOnBranch` or `spotlessChangedApply` was actually requested. Their results become configuration inputs, which makes both tasks compatible with the configuration cache (enabled by default in gradle.properties).
- Fixes the git remote detection: the previous code compared an `ExecResult` object with the integer `0`, which is always false, so `branch.<name>.pushRemote` / `branch.<name>.remote` were never honored and the task always fell back to the remote name `origin`. The comparison now uses `exitValue`.
- The changed-files list is computed once and shared by `changedOnBranch` (printing) and the spotless java target, instead of being recomputed and assigned in a `doFirst` block.

## Other information

Manual verification on this branch (no automated tests exist for build-logic):

- `./gradlew changedOnBranch` — BUILD SUCCESSFUL with the configuration cache enabled; prints the files changed on the branch.
- Second invocation: "Reusing configuration cache." with correct output.
- After committing a new file: "Calculating task graph as configuration cache cannot be reused because output of the external process 'git' has changed." — the new file is listed. So the cached git results are correctly invalidated when the branch content changes (Gradle treats `providers.exec` output at configuration time as a configuration input).
- `./gradlew spotlessChangedApply` with an unformatted probe `.java` file committed on the branch: the probe file is reformatted, files not changed on the branch are untouched.
- Remote detection: on a branch whose `branch.<name>.remote` is not `origin`, the configured remote is now used and the "Assuming 'origin'" warning no longer appears.

build-logic currently has no test infrastructure at all. If the project is interested, I would be happy to contribute a Gradle TestKit based functional test setup for these tasks (temporary git repository fixture, assertions on the behaviour above) as a follow-up PR.
