### PR TITLE
chore: Introduce numeral value parser in org.omegat.util

### DIFF
--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -187,6 +187,15 @@ public final class NumeralValueParser {
     private static final String ROMAN_DIGITS = "IVXLCDMivxlcdm";
 
     /**
+     * Digit-group and decimal punctuation accepted by the rule-based parsers'
+     * loose number matching: period, comma, apostrophe, right single quote,
+     * modifier apostrophe, middle dot, Arabic decimal and thousands
+     * separators. "99'999" or "1.234" must reach the parsers (they read such
+     * groupings), but these characters alone make no numeral.
+     */
+    private static final String SEPARATOR_CHARS = ".,'’ʼ·٫٬";
+
+    /**
      * Cheap pre-filter for the rule-based parse attempts: only a string whose
      * every code point can occur in one of the supported algorithmic numeral
      * systems is worth handing to the ICU parsers. Ordinary prose tokens (the
@@ -195,14 +204,19 @@ public final class NumeralValueParser {
      * is orders of magnitude more expensive.
      */
     private static boolean mayBeAlgorithmicNumeral(String s) {
+        boolean sawNumeral = false;
         for (int i = 0; i < s.length();) {
             int cp = s.codePointAt(i);
-            if (!isNumeralPlausible(cp)) {
-                return false;
+            if (SEPARATOR_CHARS.indexOf(cp) < 0) {
+                if (!isNumeralPlausible(cp)) {
+                    return false;
+                }
+                sawNumeral = true;
             }
             i += Character.charCount(cp);
         }
-        return true;
+        // Pure punctuation ("...") is not worth the parse attempts.
+        return sawNumeral;
     }
 
     private static boolean isNumeralPlausible(int cp) {

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -1,0 +1,700 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParsePosition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.ibm.icu.lang.UCharacter;
+import com.ibm.icu.text.Normalizer2;
+import com.ibm.icu.text.RuleBasedNumberFormat;
+import com.ibm.icu.util.ULocale;
+
+/**
+ * Parses textual numerals of many writing and numbering systems to their
+ * integer value.
+ *
+ * Decimal positional digits of every script are handled directly through their
+ * Unicode value ({@link Character#digit}), so Western, Arabic-Indic, Devanagari,
+ * Thai, fullwidth and astral-plane decimal digits all work. Non-decimal
+ * algorithmic systems are parsed with ICU's {@link RuleBasedNumberFormat}:
+ * Roman, Chinese/Japanese ideographic, Ethiopic, Armenian, Greek, Hebrew,
+ * Tamil, Georgian and Cyrillic. Inputs are NFKC-normalized first, so single
+ * code point forms such as the Roman numeral for twelve at U+216B and fullwidth
+ * digits
+ * are recognized too.
+ *
+ * A value is only returned when a candidate system consumes the WHOLE (trimmed)
+ * string, so partial or ambiguous input is rejected and the caller can fall
+ * back to plain text ordering. Kaktovik/Inuktitut numerals are not available in
+ * the bundled ICU version and are therefore not recognized.
+ *
+ * On top of the integer core, {@link #parseValue} and {@link #firstValue}
+ * expose signed real numbers as an exact reduced {@link Rational}
+ * (numerator/denominator of arbitrary-precision integers). They recognize a
+ * leading sign (ASCII hyphen-minus, Unicode minus U+2212, or plus), a single
+ * decimal point, fractions written with an ASCII or a Unicode fraction slash
+ * ("a/b"), mixed numbers ("1 1/2"), and the Unicode vulgar fractions.
+ * A rational is exact for every one of those inputs, so comparison by
+ * cross-multiplication is a provably total, transitive order with no rounding,
+ * and values such as 1/3 order correctly against any terminating decimal.
+ * A comma is deliberately NOT treated as a decimal or grouping separator (it is
+ * irreducibly locale-ambiguous), so "1,000" and "1,5" contribute only their
+ * leading integer. Division by zero yields no value.
+ *
+ * As a final step, a single code point that carries a Unicode numeric value but
+ * is neither a decimal digit nor an algorithmic numeral is resolved from its
+ * value: enclosed and parenthesized numbers and many
+ * historic script numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...).
+ * Only single, non-negative integer values are taken; multi-sign additive
+ * sequences are not composed. Symbols without a numeric value (such as the emoji
+ * for a hundred points or the keycap ten) are correctly ignored.
+ *
+ * The class is stateless from the caller's perspective; the (non-thread-safe)
+ * ICU formatters are cached per thread.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class NumeralValueParser {
+
+    private NumeralValueParser() {
+    }
+
+    /** One ICU rule set to try, in priority order. */
+    private record RuleSpec(ULocale locale, int type, String ruleSet) {
+    }
+
+    private static final List<RuleSpec> SPECS = List.of(
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%roman-upper"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%roman-lower"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%ethiopic"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%armenian-upper"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%armenian-lower"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%greek-upper"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%greek-lower"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%hebrew"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%tamil"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%georgian"),
+            new RuleSpec(ULocale.ROOT, RuleBasedNumberFormat.NUMBERING_SYSTEM, "%cyrillic-lower"),
+            new RuleSpec(ULocale.forLanguageTag("zh"), RuleBasedNumberFormat.SPELLOUT, "%spellout-numbering"),
+            new RuleSpec(ULocale.forLanguageTag("zh-Hant"), RuleBasedNumberFormat.SPELLOUT,
+                    "%spellout-numbering"),
+            new RuleSpec(ULocale.forLanguageTag("ja"), RuleBasedNumberFormat.SPELLOUT, "%spellout-numbering"));
+
+    /** RuleBasedNumberFormat is not thread-safe, so build one set of parsers per thread. */
+    private static final ThreadLocal<List<RuleBasedNumberFormat>> PARSERS = ThreadLocal.withInitial(() -> {
+        List<RuleBasedNumberFormat> list = new ArrayList<>();
+        for (RuleSpec s : SPECS) {
+            try {
+                RuleBasedNumberFormat f = new RuleBasedNumberFormat(s.locale(), s.type());
+                f.setDefaultRuleSet(s.ruleSet());
+                f.setLenientParseMode(false);
+                list.add(f);
+            } catch (RuntimeException ignore) {
+                // Rule set not available in this ICU build; skip it.
+            }
+        }
+        return list;
+    });
+
+    private static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
+
+    /**
+     * The integer value if the whole (trimmed) string is a single numeral of a
+     * supported system, otherwise empty. Decimal digits of any script and the
+     * ICU algorithmic systems are recognized.
+     */
+    public static Optional<BigInteger> parseWhole(String s) {
+        if (s == null) {
+            return Optional.empty();
+        }
+        String trimmed = s.trim();
+        if (trimmed.isEmpty()) {
+            return Optional.empty();
+        }
+        // Try the text as-is first. NFKC would alter the numeral marks of some
+        // systems (Greek/Hebrew/Armenian numeral signs), so raw parsing must be
+        // attempted before normalization.
+        Optional<BigInteger> value = parseExact(trimmed);
+        if (value.isPresent()) {
+            return value;
+        }
+        // Then try NFKC-normalized, which folds single-codepoint Roman numerals
+        // (U+216B becomes XII), fullwidth digits, etc. into a parseable form.
+        String norm = NFKC.normalize(trimmed);
+        if (!norm.equals(trimmed)) {
+            value = parseExact(norm);
+        }
+        return value;
+    }
+
+    /** Parse the exact string (no trimming/normalization) as decimal or one ICU system. */
+    private static Optional<BigInteger> parseExact(String s) {
+        Optional<BigInteger> decimal = allDecimalDigits(s);
+        if (decimal.isPresent()) {
+            return decimal;
+        }
+        for (RuleBasedNumberFormat parser : PARSERS.get()) {
+            ParsePosition pp = new ParsePosition(0);
+            Number value;
+            try {
+                value = parser.parse(s, pp);
+            } catch (RuntimeException ex) {
+                continue;
+            }
+            if (value != null && pp.getIndex() == s.length()) {
+                double d = value.doubleValue();
+                if (Double.isNaN(d) || Double.isInfinite(d)) {
+                    continue; // ICU parses "NaN"/"Infinity"; those are not numerals
+                }
+                return Optional.of(BigInteger.valueOf(value.longValue()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The value of the FIRST number occurring in the text, or empty if none.
+     * Decimal digit runs are recognized anywhere (even inside a word, e.g.
+     * "item2"); numerals of the algorithmic systems are only recognized when
+     * they form a whole token delimited by whitespace/punctuation, so ordinary
+     * words are not misread as (for example) Roman numerals.
+     */
+    public static Optional<BigInteger> firstNumber(String text) {
+        if (text == null || text.isEmpty()) {
+            return Optional.empty();
+        }
+        int i = 0;
+        int n = text.length();
+        while (i < n) {
+            int cp = text.codePointAt(i);
+            if (isSeparator(cp)) {
+                i += Character.charCount(cp);
+                continue;
+            }
+            int start = i;
+            while (i < n) {
+                int c = text.codePointAt(i);
+                if (isSeparator(c)) {
+                    break;
+                }
+                i += Character.charCount(c);
+            }
+            Optional<BigInteger> value = tokenNumber(text.substring(start, i));
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** A number for this token: its first decimal-digit run, else a whole-token algorithmic numeral. */
+    private static Optional<BigInteger> tokenNumber(String token) {
+        Optional<BigInteger> decimalRun = firstDecimalRun(token);
+        if (decimalRun.isPresent()) {
+            return decimalRun;
+        }
+        return parseWhole(token);
+    }
+
+    private static Optional<BigInteger> allDecimalDigits(String s) {
+        BigInteger value = BigInteger.ZERO;
+        boolean any = false;
+        int i = 0;
+        int n = s.length();
+        while (i < n) {
+            int cp = s.codePointAt(i);
+            int d = Character.digit(cp, 10);
+            if (d < 0) {
+                return Optional.empty();
+            }
+            value = value.multiply(BigInteger.TEN).add(BigInteger.valueOf(d));
+            any = true;
+            i += Character.charCount(cp);
+        }
+        return any ? Optional.of(value) : Optional.empty();
+    }
+
+    private static Optional<BigInteger> firstDecimalRun(String s) {
+        int i = 0;
+        int n = s.length();
+        while (i < n) {
+            int cp = s.codePointAt(i);
+            if (Character.digit(cp, 10) >= 0) {
+                BigInteger value = BigInteger.ZERO;
+                while (i < n) {
+                    int c = s.codePointAt(i);
+                    int d = Character.digit(c, 10);
+                    if (d < 0) {
+                        break;
+                    }
+                    value = value.multiply(BigInteger.TEN).add(BigInteger.valueOf(d));
+                    i += Character.charCount(c);
+                }
+                return Optional.of(value);
+            }
+            i += Character.charCount(cp);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Whitespace and punctuation delimit tokens. Letters (including Roman
+     * numeral letters and CJK ideographs), decimal digits and the number
+     * categories (No/Nl, e.g. the Roman numeral code points, Ethiopic digits)
+     * stay inside a token so they can be parsed as numerals.
+     */
+    private static boolean isSeparator(int cp) {
+        if (Character.isWhitespace(cp)) {
+            return true;
+        }
+        switch (Character.getType(cp)) {
+            case Character.CONNECTOR_PUNCTUATION:
+            case Character.DASH_PUNCTUATION:
+            case Character.START_PUNCTUATION:
+            case Character.END_PUNCTUATION:
+            case Character.INITIAL_QUOTE_PUNCTUATION:
+            case Character.FINAL_QUOTE_PUNCTUATION:
+            case Character.OTHER_PUNCTUATION:
+            case Character.MATH_SYMBOL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Real values (signed decimals, fractions, mixed numbers, vulgar fractions)
+    // ------------------------------------------------------------------------
+
+    /**
+     * An exact, reduced rational value: {@code num / den} with {@code den > 0}
+     * and {@code gcd(|num|, den) == 1}. Because both denominators are always
+     * positive, comparing two rationals by cross-multiplication
+     * ({@code num1 * den2} vs {@code num2 * den1}) is a total, transitive order
+     * with no rounding, so 1/3 orders correctly against any terminating decimal.
+     * The canonical zero is {@code 0/1}, so {@code -0}, {@code 0/5} and the "zero
+     * thirds" glyph all compare equal to {@code 0}.
+     */
+    public static final class Rational implements Comparable<Rational> {
+
+        private final BigInteger num;
+        private final BigInteger den;
+
+        private Rational(BigInteger num, BigInteger den) {
+            this.num = num;
+            this.den = den;
+        }
+
+        /** Reduced rational for num/den; the caller must ensure den != 0. */
+        static Rational of(BigInteger num, BigInteger den) {
+            if (den.signum() < 0) {
+                num = num.negate();
+                den = den.negate();
+            }
+            BigInteger g = num.gcd(den); // non-negative; gcd(0, d) == d
+            if (g.signum() != 0 && !g.equals(BigInteger.ONE)) {
+                num = num.divide(g);
+                den = den.divide(g);
+            }
+            return new Rational(num, den);
+        }
+
+        /** Reduced rational for an integer value. */
+        static Rational ofInteger(BigInteger value) {
+            return new Rational(value, BigInteger.ONE);
+        }
+
+        Rational negate() {
+            return new Rational(num.negate(), den);
+        }
+
+        public BigInteger numerator() {
+            return num;
+        }
+
+        public BigInteger denominator() {
+            return den;
+        }
+
+        @Override
+        public int compareTo(Rational o) {
+            return num.multiply(o.den).compareTo(o.num.multiply(den));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Rational r && num.equals(r.num) && den.equals(r.den);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * num.hashCode() + den.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return den.equals(BigInteger.ONE) ? num.toString() : num + "/" + den;
+        }
+    }
+
+    /** Unicode vulgar fractions (Number, Other), mapped to their exact value. */
+    private static final Map<Integer, Rational> VULGAR = Map.ofEntries(
+            Map.entry(0x00BC, Rational.of(BigInteger.ONE, BigInteger.valueOf(4))),   // 1/4
+            Map.entry(0x00BD, Rational.of(BigInteger.ONE, BigInteger.TWO)),          // 1/2
+            Map.entry(0x00BE, Rational.of(BigInteger.valueOf(3), BigInteger.valueOf(4))),   // 3/4
+            Map.entry(0x2150, Rational.of(BigInteger.ONE, BigInteger.valueOf(7))),   // 1/7
+            Map.entry(0x2151, Rational.of(BigInteger.ONE, BigInteger.valueOf(9))),   // 1/9
+            Map.entry(0x2152, Rational.of(BigInteger.ONE, BigInteger.TEN)),          // 1/10
+            Map.entry(0x2153, Rational.of(BigInteger.ONE, BigInteger.valueOf(3))),   // 1/3
+            Map.entry(0x2154, Rational.of(BigInteger.TWO, BigInteger.valueOf(3))),   // 2/3
+            Map.entry(0x2155, Rational.of(BigInteger.ONE, BigInteger.valueOf(5))),   // 1/5
+            Map.entry(0x2156, Rational.of(BigInteger.TWO, BigInteger.valueOf(5))),   // 2/5
+            Map.entry(0x2157, Rational.of(BigInteger.valueOf(3), BigInteger.valueOf(5))),   // 3/5
+            Map.entry(0x2158, Rational.of(BigInteger.valueOf(4), BigInteger.valueOf(5))),   // 4/5
+            Map.entry(0x2159, Rational.of(BigInteger.ONE, BigInteger.valueOf(6))),   // 1/6
+            Map.entry(0x215A, Rational.of(BigInteger.valueOf(5), BigInteger.valueOf(6))),   // 5/6
+            Map.entry(0x215B, Rational.of(BigInteger.ONE, BigInteger.valueOf(8))),   // 1/8
+            Map.entry(0x215C, Rational.of(BigInteger.valueOf(3), BigInteger.valueOf(8))),   // 3/8
+            Map.entry(0x215D, Rational.of(BigInteger.valueOf(5), BigInteger.valueOf(8))),   // 5/8
+            Map.entry(0x215E, Rational.of(BigInteger.valueOf(7), BigInteger.valueOf(8))),   // 7/8
+            Map.entry(0x2189, Rational.of(BigInteger.ZERO, BigInteger.ONE)));        // 0/3 -> 0
+
+    private static final int MINUS_SIGN = 0x2212;   // U+2212 MINUS SIGN
+    private static final int FRACTION_SLASH = 0x2044; // U+2044 FRACTION SLASH
+
+    /**
+     * The exact real value if the whole (trimmed) string is a single signed
+     * number, otherwise empty. Handles a leading sign, a single decimal point,
+     * ASCII/Unicode and mixed fractions, and the Unicode vulgar fractions. The
+     * integer numeral systems of {@link #parseWhole} are also accepted (as whole
+     * values).
+     */
+    public static Optional<Rational> parseValue(String s) {
+        if (s == null) {
+            return Optional.empty();
+        }
+        String t = s.trim();
+        if (t.isEmpty()) {
+            return Optional.empty();
+        }
+        boolean negative = false;
+        int first = t.codePointAt(0);
+        if (first == '-' || first == MINUS_SIGN) {
+            negative = true;
+            t = t.substring(Character.charCount(first));
+        } else if (first == '+') {
+            t = t.substring(Character.charCount(first));
+        }
+        String mag = t.trim();
+        if (mag.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<Rational> value = parseMagnitude(mag);
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(negative ? value.get().negate() : value.get());
+    }
+
+    /**
+     * The exact real value of the FIRST number occurring in the text, or empty
+     * if none. The scanner keeps sign, decimal point and fraction slashes inside
+     * a token (so "-5", "1.5" and "3/4" are read as one number), but a comma and
+     * other punctuation still separate tokens. A token that is not a clean number
+     * as a whole falls back to its first decimal-digit run (so "item2" is 2).
+     * Mixed numbers with an internal space ("1 1/2") are only recognized by
+     * {@link #parseValue} on the whole string, not when embedded in a sentence.
+     */
+    public static Optional<Rational> firstValue(String text) {
+        if (text == null || text.isEmpty()) {
+            return Optional.empty();
+        }
+        int i = 0;
+        int n = text.length();
+        while (i < n) {
+            int cp = text.codePointAt(i);
+            if (isValueSeparator(cp)) {
+                i += Character.charCount(cp);
+                continue;
+            }
+            int start = i;
+            while (i < n) {
+                int c = text.codePointAt(i);
+                if (isValueSeparator(c)) {
+                    break;
+                }
+                i += Character.charCount(c);
+            }
+            Optional<Rational> value = tokenValue(text.substring(start, i));
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * A value for this token: the whole token as a number, else its first decimal
+     * run, else the first embedded single Nl/No numeric code point (so a numeral
+     * glued to punctuation, an enclosed number before a period say, is found).
+     */
+    private static Optional<Rational> tokenValue(String token) {
+        Optional<Rational> whole = parseValue(token);
+        if (whole.isPresent()) {
+            return whole;
+        }
+        Optional<BigInteger> run = firstDecimalRun(token);
+        if (run.isPresent()) {
+            return Optional.of(Rational.ofInteger(run.get()));
+        }
+        for (int i = 0; i < token.length();) {
+            int cp = token.codePointAt(i);
+            Optional<Rational> v = singleCodePointNumericValue(new String(Character.toChars(cp)));
+            if (v.isPresent()) {
+                return v;
+            }
+            i += Character.charCount(cp);
+        }
+        return Optional.empty();
+    }
+
+    /** Non-negative magnitude: vulgar/mixed/fraction/decimal, else an integer numeral. */
+    private static Optional<Rational> parseMagnitude(String u) {
+        // A trailing vulgar fraction char, optionally with an integer prefix.
+        int lastCp = u.codePointBefore(u.length());
+        Rational vulgar = VULGAR.get(lastCp);
+        if (vulgar != null) {
+            String prefix = u.substring(0, u.length() - Character.charCount(lastCp));
+            if (prefix.isEmpty()) {
+                return Optional.of(vulgar);
+            }
+            String digits = asciiDigits(prefix);
+            if (digits != null) {
+                BigInteger whole = new BigInteger(digits);
+                return Optional.of(Rational.of(
+                        whole.multiply(vulgar.denominator()).add(vulgar.numerator()), vulgar.denominator()));
+            }
+            return Optional.empty();
+        }
+        // A mixed number "INT<space>FRACTION" (e.g. "1 1/2").
+        int space = indexOfWhitespace(u);
+        if (space >= 0) {
+            String intPart = u.substring(0, space);
+            String rest = u.substring(space).trim();
+            String intDigits = asciiDigits(intPart);
+            if (intDigits != null && !intDigits.isEmpty()) {
+                Optional<Rational> frac = parseFraction(rest);
+                if (frac.isPresent()) {
+                    Rational f = frac.get();
+                    // A mixed number's fraction part must be proper (0 <= f < 1).
+                    if (f.numerator().signum() >= 0 && f.compareTo(Rational.ofInteger(BigInteger.ONE)) < 0) {
+                        BigInteger whole = new BigInteger(intDigits);
+                        return Optional.of(Rational.of(
+                                whole.multiply(f.denominator()).add(f.numerator()), f.denominator()));
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+        // A slash fraction "a/b".
+        Optional<Rational> fraction = parseFraction(u);
+        if (fraction.isPresent()) {
+            return fraction;
+        }
+        // A decimal number.
+        Optional<Rational> decimal = parseDecimal(u);
+        if (decimal.isPresent()) {
+            return decimal;
+        }
+        // Fall back to an integer numeral of one of the algorithmic systems
+        // (Roman, CJK, Ethiopic ...). Those never contain decimal (Nd) digits, and
+        // every Nd-digit form was already handled above, so a leftover Nd-digit
+        // string here is junk (e.g. "1,000", "1.2.3", "3-5") that ICU would wrongly
+        // grouping-parse; reject it rather than trust that parse.
+        if (hasDecimalDigit(u)) {
+            return Optional.empty();
+        }
+        Optional<Rational> algorithmic = parseWhole(u).map(Rational::ofInteger);
+        if (algorithmic.isPresent()) {
+            return algorithmic;
+        }
+        // Last resort: a single Nl/No code point that carries a Unicode numeric
+        // value but is neither a decimal digit nor an algorithmic numeral -
+        // enclosed/parenthesized numbers and many historic script
+        // numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...). Only a
+        // single, non-negative integer value is taken; fractional forms and
+        // multi-sign additive sequences are left for a later, dedicated step.
+        return singleCodePointNumericValue(u);
+    }
+
+    /**
+     * The value of a single Nl/No code point via its Unicode numeric value, if it
+     * is a non-negative integer. Symbols without a numeric value, the emoji for a
+     * hundred points or the keycap ten say, and fractional values yield empty.
+     */
+    private static Optional<Rational> singleCodePointNumericValue(String u) {
+        if (u.codePointCount(0, u.length()) != 1) {
+            return Optional.empty();
+        }
+        int cp = u.codePointAt(0);
+        int type = Character.getType(cp);
+        if (type != Character.LETTER_NUMBER && type != Character.OTHER_NUMBER) {
+            return Optional.empty();
+        }
+        double v = UCharacter.getUnicodeNumericValue(cp);
+        if (v == UCharacter.NO_NUMERIC_VALUE || v < 0 || Double.isInfinite(v) || v != Math.floor(v)) {
+            return Optional.empty();
+        }
+        return Optional.of(Rational.ofInteger(BigDecimal.valueOf(v).toBigIntegerExact()));
+    }
+
+    private static boolean hasDecimalDigit(String s) {
+        for (int i = 0; i < s.length();) {
+            int cp = s.codePointAt(i);
+            if (Character.digit(cp, 10) >= 0) {
+                return true;
+            }
+            i += Character.charCount(cp);
+        }
+        return false;
+    }
+
+    /** A single vulgar fraction char, or "a/b" with either fraction slash, integer parts, non-zero b. */
+    private static Optional<Rational> parseFraction(String u) {
+        if (u.codePointCount(0, u.length()) == 1) {
+            Rational v = VULGAR.get(u.codePointAt(0));
+            if (v != null) {
+                return Optional.of(v);
+            }
+        }
+        int slash = -1;
+        int slashCount = 0;
+        for (int i = 0; i < u.length();) {
+            int cp = u.codePointAt(i);
+            if (cp == '/' || cp == FRACTION_SLASH) {
+                slash = i;
+                slashCount++;
+            }
+            i += Character.charCount(cp);
+        }
+        if (slashCount != 1) {
+            return Optional.empty();
+        }
+        String numerator = asciiDigits(u.substring(0, slash));
+        String denominator = asciiDigits(u.substring(slash + 1));
+        if (numerator == null || numerator.isEmpty() || denominator == null || denominator.isEmpty()) {
+            return Optional.empty();
+        }
+        BigInteger den = new BigInteger(denominator);
+        if (den.signum() == 0) {
+            return Optional.empty(); // division by zero -> no value
+        }
+        return Optional.of(Rational.of(new BigInteger(numerator), den));
+    }
+
+    /** A decimal number with at most one '.', at least one digit: "3.14", ".5", "1.", "100". */
+    private static Optional<Rational> parseDecimal(String u) {
+        int dot = -1;
+        int dotCount = 0;
+        for (int i = 0; i < u.length();) {
+            int cp = u.codePointAt(i);
+            if (cp == '.') {
+                dot = i;
+                dotCount++;
+            }
+            i += Character.charCount(cp);
+        }
+        if (dotCount == 0) {
+            String digits = asciiDigits(u);
+            return digits == null ? Optional.empty() : Optional.of(Rational.ofInteger(new BigInteger(digits)));
+        }
+        if (dotCount > 1) {
+            return Optional.empty();
+        }
+        String left = u.substring(0, dot);
+        String right = u.substring(dot + 1);
+        String leftDigits = left.isEmpty() ? "" : asciiDigits(left);
+        String rightDigits = right.isEmpty() ? "" : asciiDigits(right);
+        if (leftDigits == null || rightDigits == null) {
+            return Optional.empty();
+        }
+        if (leftDigits.isEmpty() && rightDigits.isEmpty()) {
+            return Optional.empty(); // "." alone
+        }
+        BigInteger num = new BigInteger(leftDigits + rightDigits);
+        BigInteger den = BigInteger.TEN.pow(rightDigits.length());
+        return Optional.of(Rational.of(num, den));
+    }
+
+    /** The ASCII-digit form of a string of decimal digits (any script), or null if any char is not Nd. */
+    private static String asciiDigits(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length();) {
+            int cp = s.codePointAt(i);
+            int d = Character.digit(cp, 10);
+            if (d < 0) {
+                return null;
+            }
+            sb.append((char) ('0' + d));
+            i += Character.charCount(cp);
+        }
+        return sb.toString();
+    }
+
+    private static int indexOfWhitespace(String s) {
+        for (int i = 0; i < s.length();) {
+            int cp = s.codePointAt(i);
+            if (Character.isWhitespace(cp)) {
+                return i;
+            }
+            i += Character.charCount(cp);
+        }
+        return -1;
+    }
+
+    /**
+     * Token boundaries for the real-value scanner. Sign, decimal point and the
+     * fraction slashes stay inside a token so a signed/decimal/fraction number is
+     * read as one unit; a comma, colon and other punctuation still separate.
+     */
+    private static boolean isValueSeparator(int cp) {
+        if (cp == '-' || cp == '+' || cp == '.' || cp == '/' || cp == MINUS_SIGN || cp == FRACTION_SLASH) {
+            return false;
+        }
+        if (Character.digit(cp, 10) >= 0 || Character.isLetter(cp)) {
+            return false;
+        }
+        int type = Character.getType(cp);
+        // Number-letter (Roman numeral code points) and number-other (vulgar fractions) belong here.
+        return type != Character.LETTER_NUMBER && type != Character.OTHER_NUMBER;
+    }
+}

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -162,6 +162,9 @@ public final class NumeralValueParser {
         if (decimal.isPresent()) {
             return decimal;
         }
+        if (!mayBeAlgorithmicNumeral(s)) {
+            return Optional.empty();
+        }
         for (RuleBasedNumberFormat parser : PARSERS.get()) {
             ParsePosition pp = new ParsePosition(0);
             Number value;
@@ -179,6 +182,59 @@ public final class NumeralValueParser {
             }
         }
         return Optional.empty();
+    }
+
+    private static final String ROMAN_DIGITS = "IVXLCDMivxlcdm";
+
+    /**
+     * Cheap pre-filter for the rule-based parse attempts: only a string whose
+     * every code point can occur in one of the supported algorithmic numeral
+     * systems is worth handing to the ICU parsers. Ordinary prose tokens (the
+     * overwhelming majority of real inputs, and in Latin scripts almost every
+     * word) are rejected here instead of failing through all rule sets, which
+     * is orders of magnitude more expensive.
+     */
+    private static boolean mayBeAlgorithmicNumeral(String s) {
+        for (int i = 0; i < s.length();) {
+            int cp = s.codePointAt(i);
+            if (!isNumeralPlausible(cp)) {
+                return false;
+            }
+            i += Character.charCount(cp);
+        }
+        return true;
+    }
+
+    private static boolean isNumeralPlausible(int cp) {
+        int type = Character.getType(cp);
+        if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER
+                || type == Character.OTHER_NUMBER) {
+            return true;
+        }
+        if (cp == 0x02B9 || cp == 0x0374 || cp == 0x0375 || cp == 0x00B4) {
+            // Greek numeral marks (keraia in its various forms, and the acute
+            // accent ICU emits for it); these have script Common.
+            return true;
+        }
+        switch (Character.UnicodeScript.of(cp)) {
+        case LATIN:
+            // Latin letters form numerals only in the Roman system.
+            return ROMAN_DIGITS.indexOf(cp) >= 0;
+        case INHERITED:
+            // Combining marks (e.g. the Cyrillic titlo) inherit their script.
+            return true;
+        case GREEK:
+        case HEBREW:
+        case ARMENIAN:
+        case ETHIOPIC:
+        case TAMIL:
+        case GEORGIAN:
+        case CYRILLIC:
+        case HAN:
+            return true;
+        default:
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -1,0 +1,432 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.omegat.util.NumeralValueParser.Rational;
+
+import com.ibm.icu.text.RuleBasedNumberFormat;
+import com.ibm.icu.util.ULocale;
+
+/**
+ * Tests for {@link NumeralValueParser}: value parsing across many numbering
+ * systems (via ICU), the "first number in text" scanner, and the guardrails
+ * that keep ordinary words from being read as (e.g.) Roman numerals.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NumeralValueParserTest {
+
+    private static BigInteger whole(String s) {
+        Optional<BigInteger> v = NumeralValueParser.parseWhole(s);
+        assertTrue("expected a parsed value for: " + s, v.isPresent());
+        return v.get();
+    }
+
+    private static String format(int type, String ruleSet, ULocale loc, long value) {
+        RuleBasedNumberFormat f = new RuleBasedNumberFormat(loc, type);
+        f.setDefaultRuleSet(ruleSet);
+        return f.format(value);
+    }
+
+    /** Format each value in the given ICU system, then assert parseWhole round-trips it. */
+    private static void assertRoundTrip(int type, String ruleSet, ULocale loc) {
+        for (long v : new long[] { 1, 2, 7, 12, 20, 49, 88 }) {
+            String text = format(type, ruleSet, loc, v);
+            assertEquals(ruleSet + " '" + text + "'", BigInteger.valueOf(v),
+                    NumeralValueParser.parseWhole(text).orElse(null));
+        }
+    }
+
+    // --- must-work explicit cases -------------------------------------------
+
+    @Test
+    public void romanAndCjkAndEthiopicTwelve() {
+        assertEquals(BigInteger.valueOf(12), whole("XII"));
+        assertEquals(BigInteger.valueOf(12), whole("xii"));
+        assertEquals(BigInteger.valueOf(12), whole("Ⅻ"));   // single codepoint U+216B, needs NFKC
+        assertEquals(BigInteger.valueOf(12), whole("十二"));  // CJK ideographic
+        assertEquals(BigInteger.valueOf(12), whole("፲፪"));   // Ethiopic
+    }
+
+    @Test
+    public void decimalDigitsOfAnyScript() {
+        assertEquals(BigInteger.valueOf(12), whole("12"));
+        assertEquals(BigInteger.valueOf(12), whole("１２"));   // fullwidth
+        assertEquals(BigInteger.valueOf(12), whole("١٢"));    // Arabic-Indic
+        assertEquals(BigInteger.valueOf(12), whole("१२"));    // Devanagari
+    }
+
+    @Test
+    public void sameValueDifferentSystemsAreEqual() {
+        BigInteger twelve = BigInteger.valueOf(12);
+        assertEquals(twelve, whole("XII"));
+        assertEquals(twelve, whole("十二"));
+        assertEquals(twelve, whole("12"));
+        assertEquals(twelve, whole("፲፪"));
+    }
+
+    // --- round-trip across all supported ICU systems ------------------------
+
+    @Test
+    public void roundTripAllNumberingSystems() {
+        int ns = RuleBasedNumberFormat.NUMBERING_SYSTEM;
+        assertRoundTrip(ns, "%roman-upper", ULocale.ROOT);
+        assertRoundTrip(ns, "%roman-lower", ULocale.ROOT);
+        assertRoundTrip(ns, "%ethiopic", ULocale.ROOT);
+        assertRoundTrip(ns, "%armenian-upper", ULocale.ROOT);
+        assertRoundTrip(ns, "%armenian-lower", ULocale.ROOT);
+        assertRoundTrip(ns, "%greek-upper", ULocale.ROOT);
+        assertRoundTrip(ns, "%greek-lower", ULocale.ROOT);
+        assertRoundTrip(ns, "%hebrew", ULocale.ROOT);
+        assertRoundTrip(ns, "%tamil", ULocale.ROOT);
+        assertRoundTrip(ns, "%georgian", ULocale.ROOT);
+        assertRoundTrip(ns, "%cyrillic-lower", ULocale.ROOT);
+    }
+
+    @Test
+    public void roundTripCjkSpellout() {
+        int sp = RuleBasedNumberFormat.SPELLOUT;
+        assertRoundTrip(sp, "%spellout-numbering", ULocale.forLanguageTag("zh"));
+        assertRoundTrip(sp, "%spellout-numbering", ULocale.forLanguageTag("ja"));
+        assertRoundTrip(sp, "%spellout-numbering", ULocale.forLanguageTag("zh-Hant"));
+    }
+
+    // --- non-numerals reject (fall back to text) ----------------------------
+
+    @Test
+    public void nonNumeralsReturnEmpty() {
+        assertFalse(NumeralValueParser.parseWhole("hello").isPresent());
+        assertFalse(NumeralValueParser.parseWhole("").isPresent());
+        assertFalse(NumeralValueParser.parseWhole("   ").isPresent());
+        assertFalse(NumeralValueParser.parseWhole("XIIabc").isPresent()); // partial -> rejected
+    }
+
+    // --- first number in text ----------------------------------------------
+
+    @Test
+    public void firstNumberFindsEmbeddedDecimal() {
+        assertEquals(BigInteger.valueOf(2), NumeralValueParser.firstNumber("item2").orElse(null));
+        assertEquals(BigInteger.valueOf(10), NumeralValueParser.firstNumber("item10").orElse(null));
+        assertEquals(BigInteger.valueOf(3), NumeralValueParser.firstNumber("Section 3 and 4").orElse(null));
+        assertEquals(BigInteger.valueOf(3), NumeralValueParser.firstNumber("٣ apples").orElse(null));
+    }
+
+    @Test
+    public void firstNumberFindsDelimitedNonDecimalToken() {
+        assertEquals(BigInteger.valueOf(12), NumeralValueParser.firstNumber("Kapitel XII").orElse(null));
+        assertEquals(BigInteger.valueOf(12), NumeralValueParser.firstNumber("章 十二 節").orElse(null));
+    }
+
+    @Test
+    public void edgeCasesSignDecimalAndSeparators() {
+        // '-' is a separator, so a leading sign is dropped: "-5" -> 5
+        assertEquals(BigInteger.valueOf(5), NumeralValueParser.firstNumber("-5").orElse(null));
+        // '.' and ',' are separators: only the leading integer part is taken
+        assertEquals(BigInteger.ONE, NumeralValueParser.firstNumber("1.5").orElse(null));
+        assertEquals(BigInteger.ONE, NumeralValueParser.firstNumber("1,000").orElse(null));
+        assertEquals(BigInteger.ZERO, NumeralValueParser.parseWhole("0").orElse(null));
+    }
+
+    @Test
+    public void guardrailWordsAreNotMisreadAsNumerals() {
+        // A whole word that is not a valid complete numeral must not be a hit.
+        assertFalse(NumeralValueParser.firstNumber("the VILLA").isPresent());
+        assertFalse(NumeralValueParser.firstNumber("hello world").isPresent());
+        // Non-Nd numerals embedded inside an unsegmented run are not detected.
+        assertFalse(NumeralValueParser.firstNumber("第十二章").isPresent());
+    }
+
+    // --- higher-value numerals across writing systems -----------------------
+
+    @Test
+    public void japaneseHigherValueUnits() {
+        assertEquals(BigInteger.valueOf(100), whole("百"));       // hyaku
+        assertEquals(BigInteger.valueOf(1000), whole("千"));      // sen
+        assertEquals(BigInteger.valueOf(10000), whole("一万"));   // man (10^4)
+        assertEquals(BigInteger.valueOf(100000000L), whole("一億")); // oku (10^8)
+    }
+
+    @Test
+    public void japaneseComposedSevenDigitValues() {
+        assertEquals(BigInteger.valueOf(2500034), whole("二百五十万三十四"));
+        assertEquals(BigInteger.valueOf(3400025), whole("三百四十万二十五"));
+        assertEquals(BigInteger.valueOf(4300052), whole("四百三十万五十二"));
+        assertEquals(BigInteger.valueOf(5200043), whole("五百二十万四十三"));
+    }
+
+    @Test
+    public void higherValueOtherScripts() {
+        // Roman thousands/hundreds (M/D/C).
+        assertEquals(BigInteger.valueOf(1984), whole("MCMLXXXIV"));
+        assertEquals(BigInteger.valueOf(2024), whole("MMXXIV"));
+        // Chinese higher unit for 10^8.
+        assertEquals(BigInteger.valueOf(100000000L), whole("一亿"));
+        // Ethiopic higher-value marks for 100 and 10000, and a composed value.
+        assertEquals(BigInteger.valueOf(100), whole("፻"));
+        assertEquals(BigInteger.valueOf(10000), whole("፼"));
+        assertEquals(BigInteger.valueOf(2500034), whole("፪፻፶፼፴፬"));
+    }
+
+    @Test
+    public void firstNumberFindsHigherValueTokenInSentence() {
+        assertEquals(BigInteger.valueOf(2500034),
+                NumeralValueParser.firstNumber("Betrag 二百五十万三十四 Yen.").orElse(null));
+        assertEquals(BigInteger.valueOf(1984),
+                NumeralValueParser.firstNumber("Baujahr MCMLXXXIV ist dokumentiert.").orElse(null));
+        assertEquals(BigInteger.valueOf(10000),
+                NumeralValueParser.firstNumber("Posten ፼ ist auf Lager.").orElse(null));
+    }
+
+    // ========================================================================
+    // Real values: sign, decimals, fractions, mixed and vulgar fractions.
+    // parseValue / firstValue return an exact reduced Rational.
+    // ========================================================================
+
+    private static Rational r(long num, long den) {
+        return Rational.of(BigInteger.valueOf(num), BigInteger.valueOf(den));
+    }
+
+    /** Assert parseValue(input) is present and exactly equal to num/den. */
+    private static void assertValue(String input, long num, long den) {
+        Optional<Rational> v = NumeralValueParser.parseValue(input);
+        assertTrue("expected a value for: " + input, v.isPresent());
+        assertEquals("value of " + input, r(num, den), v.get());
+    }
+
+    private static void assertNoValue(String input) {
+        assertFalse("expected no value for: " + input, NumeralValueParser.parseValue(input).isPresent());
+    }
+
+    @Test
+    public void signedIntegers() {
+        assertValue("5", 5, 1);
+        assertValue("-5", -5, 1);
+        assertValue("−5", -5, 1); // U+2212 MINUS SIGN
+        assertValue("+5", 5, 1);
+        assertValue("0", 0, 1);
+    }
+
+    @Test
+    public void negativeZeroCollapsesToZero() {
+        assertValue("-0", 0, 1);
+        assertValue("-0.0", 0, 1);
+        assertValue("↉", 0, 1); // ↉ zero thirds
+        // canonical zero: numerator 0, denominator 1
+        Rational z = NumeralValueParser.parseValue("-0").orElseThrow();
+        assertEquals(BigInteger.ZERO, z.numerator());
+        assertEquals(BigInteger.ONE, z.denominator());
+    }
+
+    @Test
+    public void decimals() {
+        assertValue("3.14", 157, 50);
+        assertValue(".5", 1, 2);
+        assertValue("1.", 1, 1);
+        assertValue("1.0", 1, 1);
+        assertValue("-1.5", -3, 2);
+    }
+
+    @Test
+    public void asciiFractions() {
+        assertValue("3/4", 3, 4);
+        assertValue("7/4", 7, 4);   // improper
+        assertValue("0/5", 0, 1);
+        assertValue("-1/2", -1, 2);
+        assertValue("2/4", 1, 2);   // reduces
+    }
+
+    @Test
+    public void mixedNumbers() {
+        assertValue("1 1/2", 3, 2);
+        assertValue("2 3/4", 11, 4);
+        assertValue("-1 1/2", -3, 2); // sign applies to the whole value
+    }
+
+    @Test
+    public void vulgarFractions() {
+        assertValue("¼", 1, 4);
+        assertValue("½", 1, 2);
+        assertValue("¾", 3, 4);
+        assertValue("⅓", 1, 3);
+        assertValue("⅔", 2, 3);
+        assertValue("⅕", 1, 5);
+        assertValue("⅛", 1, 8);
+        assertValue("⅞", 7, 8);
+        assertValue("⅐", 1, 7);
+        assertValue("⅑", 1, 9);
+        assertValue("⅒", 1, 10);
+        assertValue("↉", 0, 1); // ↉
+        assertValue("-¾", -3, 4);
+    }
+
+    @Test
+    public void integerPlusVulgarFractionWithoutNfkcGluing() {
+        // NFKC would turn the digit followed by the vulgar fraction into eleven
+        // halves; the parser must read the glyph directly and yield 3/2.
+        assertValue("1½", 3, 2);
+        assertValue("2½", 5, 2);
+        assertValue("-2½", -5, 2);
+        assertValue("12¾", 51, 4); // 12 + 3/4
+    }
+
+    @Test
+    public void unicodeFractionSlash() {
+        assertValue("1⁄4", 1, 4);   // U+2044
+        assertValue("3⁄8", 3, 8);
+    }
+
+    @Test
+    public void exactRationalBeatsRoundedDecimal() {
+        // 1/3 is strictly greater than 0.3333333 and strictly less than 0.3334;
+        // an exact rational gets this right where a rounded decimal/double would tie.
+        assertTrue(cmp("1/3", "0.3333333") > 0);
+        assertTrue(cmp("1/3", "0.3334") < 0);
+        assertTrue(cmp("⅐", "0.142857") > 0); // 1/7 > 0.142857
+    }
+
+    @Test
+    public void divisionByZeroAndMalformedRejected() {
+        assertNoValue("1/0");
+        assertNoValue("0/0");
+        assertNoValue("-1/0");
+        assertNoValue("/");
+        assertNoValue("1/");
+        assertNoValue("/4");
+        assertNoValue("1/2/3");
+        assertNoValue("NaN");
+        assertNoValue("∞"); // ∞
+        assertNoValue("");
+        assertNoValue("hello");
+    }
+
+    @Test
+    public void commaIsNotADecimalOrGroupingSeparator() {
+        // Deliberate, documented policy: comma is locale-ambiguous, so a comma
+        // string is not a whole number; the first embedded integer is used.
+        assertNoValue("1,000");
+        assertNoValue("1,5");
+        assertEquals(r(1, 1), NumeralValueParser.firstValue("1,000").orElse(null));
+    }
+
+    @Test
+    public void hugeValuesAreExactNoOverflow() {
+        String big = "1" + "0".repeat(40); // 10^40, overflows long
+        assertTrue(cmp(big, "999999999999999999999") > 0);
+        Rational v = NumeralValueParser.parseValue(big).orElseThrow();
+        assertEquals(BigInteger.TEN.pow(40), v.numerator());
+        assertEquals(BigInteger.ONE, v.denominator());
+        // a huge fraction still cross-multiplies exactly
+        assertTrue(cmp("100000000000000000000000000000000000000000/1",
+                "999999999999999999999999999999999999999") > 0);
+    }
+
+    @Test
+    public void firstValueFindsEmbeddedSignedAndFractionalNumbers() {
+        assertEquals(r(2, 1), NumeralValueParser.firstValue("item2").orElse(null));
+        assertEquals(r(-5, 1), NumeralValueParser.firstValue("Zeile -5 cm").orElse(null));
+        assertEquals(r(3, 4), NumeralValueParser.firstValue("3/4 inch").orElse(null));
+        assertEquals(r(1, 4), NumeralValueParser.firstValue("ca. ¼ Tasse").orElse(null));
+        assertEquals(r(12, 1), NumeralValueParser.firstValue("Kapitel 十二 folgt").orElse(null));
+    }
+
+    private static int cmp(String a, String b) {
+        return NumeralValueParser.parseValue(a).orElseThrow()
+                .compareTo(NumeralValueParser.parseValue(b).orElseThrow());
+    }
+
+    // ========================================================================
+    // Single-code-point Unicode numeric values (Mechanism C): enclosed,
+    // parenthesized and historic script numerals that are neither decimal
+    // digits nor algorithmic numerals. Only single, non-negative integers.
+    // ========================================================================
+
+    @Test
+    public void enclosedAndParenthesizedNumbers() {
+        assertValue("⑼", 9, 1);   // ⑼ PARENTHESIZED DIGIT NINE
+        assertValue("㈨", 9, 1);   // ㈨ PARENTHESIZED IDEOGRAPH NINE
+        assertValue("⒂", 15, 1);  // ⒂ PARENTHESIZED NUMBER FIFTEEN
+        assertValue("⑰", 17, 1);  // ⑰ CIRCLED NUMBER SEVENTEEN
+        assertValue("㉕", 25, 1);  // ㉕ CIRCLED NUMBER TWENTY FIVE
+        assertValue("㉋", 40, 1);  // ㉋ CIRCLED NUMBER FORTY ON BLACK SQUARE
+        assertValue("⓾", 10, 1);  // ⓾ DOUBLE CIRCLED NUMBER TEN
+        assertValue("⓬", 12, 1);  // ⓬ NEGATIVE CIRCLED NUMBER TWELVE
+        assertValue("⒔", 13, 1);  // ⒔ NUMBER THIRTEEN FULL STOP
+        assertValue("①", 1, 1);   // ① CIRCLED DIGIT ONE
+    }
+
+    @Test
+    public void historicScriptNumerals() {
+        assertValue("𒐄", 6, 1);      // 𒐄 CUNEIFORM NUMERIC SIGN SIX ASH
+        assertValue("𒐩", 7, 1);      // 𒐩 CUNEIFORM NUMERIC SIGN SEVEN SHAR2
+        assertValue("𐡚", 3, 1);      // 𐡚 IMPERIAL ARAMAIC NUMBER THREE
+        assertValue("𐤛", 3, 1);      // 𐤛 PHOENICIAN NUMBER THREE
+        assertValue("𐄎", 8, 1);      // 𐄎 AEGEAN NUMBER EIGHT
+        assertValue("𐄡", 900, 1);    // 𐄡 AEGEAN NUMBER NINE HUNDRED
+        assertValue("𐄩", 8000, 1);   // 𐄩 AEGEAN NUMBER EIGHT THOUSAND
+        assertValue("𐅰", 500, 1);    // 𐅰 GREEK ACROPHONIC NAXIAN FIVE HUNDRED
+    }
+
+    @Test
+    public void mathematicalDigitFamiliesAndSingleRoman() {
+        // Five mathematical "digit nine" families (all Nd) -> 9.
+        assertValue("𝟗", 9, 1);   // 𝟗 MATHEMATICAL BOLD
+        assertValue("𝟡", 9, 1);   // 𝟡 MATHEMATICAL DOUBLE-STRUCK
+        assertValue("𝟫", 9, 1);   // 𝟫 MATHEMATICAL SANS-SERIF
+        assertValue("𝟵", 9, 1);   // 𝟵 MATHEMATICAL SANS-SERIF BOLD
+        assertValue("𝟿", 9, 1);   // 𝟿 MATHEMATICAL MONOSPACE
+        assertValue("Ⅷ", 8, 1);         // Ⅷ ROMAN NUMERAL EIGHT (single code point)
+        assertValue("Ⅻ", 12, 1);        // Ⅻ ROMAN NUMERAL TWELVE (single code point)
+    }
+
+    @Test
+    public void superscriptSubscriptAndIdeographicZero() {
+        assertValue("²", 2, 1);   // ² SUPERSCRIPT TWO (NFKC -> "2")
+        assertValue("₃", 3, 1);   // ₃ SUBSCRIPT THREE (NFKC -> "3")
+        assertValue("〇", 0, 1);   // 〇 IDEOGRAPHIC NUMBER ZERO
+    }
+
+    @Test
+    public void symbolsWithoutNumericValueAreNotNumbers() {
+        assertNoValue("💯"); // 💯 HUNDRED POINTS SYMBOL (emoji, no numeric value)
+        assertNoValue("🔟"); // 🔟 KEYCAP TEN (emoji, no numeric value)
+    }
+
+    @Test
+    public void firstValueFindsEnclosedAndHistoricNumbers() {
+        assertEquals(r(25, 1), NumeralValueParser.firstValue("Nr. ㉕ folgt").orElse(null));
+        assertEquals(r(8000, 1), NumeralValueParser.firstValue("Aegean 𐄩 hier").orElse(null));
+        assertEquals(r(9, 1), NumeralValueParser.firstValue("Punkt ⑼.").orElse(null));
+    }
+
+}

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -429,4 +429,21 @@ public class NumeralValueParserTest {
         assertEquals(r(9, 1), NumeralValueParser.firstValue("Punkt ⑼.").orElse(null));
     }
 
+    /**
+     * Prose tokens must be rejected by the cheap pre-filter, not by failing
+     * through all ICU rule sets: sorting a large project evaluates the parser
+     * for (nearly) every segment, and without the pre-filter that froze the
+     * UI for minutes.
+     */
+    @Test
+    public void prosePreFilterKeepsParsingCheap() {
+        NumeralValueParser.parseWhole("XII"); // warm up the ICU parsers
+        long t0 = System.nanoTime();
+        for (int i = 0; i < 100_000; i++) {
+            assertFalse(NumeralValueParser.parseWhole("Beispielwort" + (i % 97)).isPresent());
+        }
+        long ms = (System.nanoTime() - t0) / 1_000_000;
+        assertTrue("100k prose tokens must be rejected cheaply, took " + ms + " ms", ms < 2000);
+    }
+
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -446,4 +446,26 @@ public class NumeralValueParserTest {
         assertTrue("100k prose tokens must be rejected cheaply, took " + ms + " ms", ms < 2000);
     }
 
+    /**
+     * The pre-filter must not cut off separator-grouped digit runs: the
+     * rule-based parsers read "99'999" via their loose number matching, and
+     * NumberAutoConverter relies on that for foreign-grouping repair.
+     */
+    @Test
+    public void separatorGroupedDigitsReachTheParsers() {
+        assertEquals(Optional.of(BigInteger.valueOf(99999)), NumeralValueParser.parseWhole("99'999"));
+        assertEquals(Optional.of(BigInteger.valueOf(1234567)),
+                NumeralValueParser.parseWhole("1'234'567"));
+        // "1.234" stays unpinned: the dot doubles as a decimal point, so its
+        // whole-string value is locale-ambiguous by design.
+    }
+
+    /** Separator punctuation alone is prose, not a numeral. */
+    @Test
+    public void pureSeparatorPunctuationIsRejected() {
+        assertFalse(NumeralValueParser.parseWhole("...").isPresent());
+        assertFalse(NumeralValueParser.parseWhole(",").isPresent());
+        assertFalse(NumeralValueParser.parseWhole("don't").isPresent());
+    }
+
 }

--- a/src/test/resources/data/editor/sort/numeric-sort-demo.xliff
+++ b/src/test/resources/data/editor/sort/numeric-sort-demo.xliff
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="benutzerhandbuch.txt" source-language="de" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="demo" tool-name="sort-demo" tool-version="1.0"/>
+    </header>
+    <body>
+
+      <!-- Western numbers embedded in text; numeric IDs. target = source. -->
+      <trans-unit id="1">
+        <source>Kapitel 1: Einführung in das Programm.</source>
+        <target>Kapitel 1: Einführung in das Programm.</target>
+      </trans-unit>
+      <trans-unit id="2">
+        <source>Kapitel 2: Installation und erste Schritte.</source>
+        <target>Kapitel 2: Installation und erste Schritte.</target>
+      </trans-unit>
+      <trans-unit id="10">
+        <source>Kapitel 10: Erweiterte Fehlerbehebung.</source>
+        <target>Kapitel 10: Erweiterte Fehlerbehebung.</target>
+      </trans-unit>
+      <trans-unit id="20">
+        <source>Kapitel 20: Anhang und Referenzen.</source>
+        <target>Kapitel 20: Anhang und Referenzen.</target>
+      </trans-unit>
+
+      <!-- Roman numerals as whole tokens; roman IDs. -->
+      <trans-unit id="III">
+        <source>Anhang III enthält die Lizenzbedingungen.</source>
+        <target>Anhang III enthält die Lizenzbedingungen.</target>
+      </trans-unit>
+      <trans-unit id="IX">
+        <source>Anhang IX beschreibt die Programmierschnittstelle.</source>
+        <target>Anhang IX beschreibt die Programmierschnittstelle.</target>
+      </trans-unit>
+      <trans-unit id="XII">
+        <source>Anhang XII listet alle Tastenkürzel auf.</source>
+        <target>Anhang XII listet alle Tastenkürzel auf.</target>
+      </trans-unit>
+
+      <!-- Roman higher-value numerals (analog: thousands/hundreds). -->
+      <trans-unit id="rom-1984">
+        <source>Baujahr MCMLXXXIV ist dokumentiert.</source>
+        <target>Baujahr MCMLXXXIV ist dokumentiert.</target>
+      </trans-unit>
+      <trans-unit id="rom-2024">
+        <source>Baujahr MMXXIV ist geplant.</source>
+        <target>Baujahr MMXXIV ist geplant.</target>
+      </trans-unit>
+
+      <!-- CJK ideographic numerals as delimited tokens (low values). -->
+      <trans-unit id="cjk-3">
+        <source>Abschnitt 三 folgt im nächsten Kapitel.</source>
+        <target>Abschnitt 三 folgt im nächsten Kapitel.</target>
+      </trans-unit>
+      <trans-unit id="cjk-10">
+        <source>Abschnitt 十 ist völlig optional.</source>
+        <target>Abschnitt 十 ist völlig optional.</target>
+      </trans-unit>
+      <trans-unit id="cjk-12">
+        <source>Abschnitt 十二 behandelt die Details.</source>
+        <target>Abschnitt 十二 behandelt die Details.</target>
+      </trans-unit>
+
+      <!-- Japanese higher-value numerals: 百 (100), 千 (1000), 万 (10000), 億 (10^8). -->
+      <trans-unit id="ja-100">
+        <source>Zeile 百 kommt bald.</source>
+        <target>Zeile 百 kommt bald.</target>
+      </trans-unit>
+      <trans-unit id="ja-1000">
+        <source>Kapitel 千 ist umfangreich.</source>
+        <target>Kapitel 千 ist umfangreich.</target>
+      </trans-unit>
+      <trans-unit id="ja-10000">
+        <source>Posten 一万 wird geliefert.</source>
+        <target>Posten 一万 wird geliefert.</target>
+      </trans-unit>
+      <trans-unit id="ja-oku">
+        <source>Summe 一億 ist gewaltig.</source>
+        <target>Summe 一億 ist gewaltig.</target>
+      </trans-unit>
+
+      <!-- Japanese composed 7-digit values; must sort 2500034 < 3400025 < 4300052 < 5200043. -->
+      <trans-unit id="ja-2500034">
+        <source>Betrag 二百五十万三十四 Yen.</source>
+        <target>Betrag 二百五十万三十四 Yen.</target>
+      </trans-unit>
+      <trans-unit id="ja-3400025">
+        <source>Betrag 三百四十万二十五 Yen.</source>
+        <target>Betrag 三百四十万二十五 Yen.</target>
+      </trans-unit>
+      <trans-unit id="ja-4300052">
+        <source>Betrag 四百三十万五十二 Yen.</source>
+        <target>Betrag 四百三十万五十二 Yen.</target>
+      </trans-unit>
+      <trans-unit id="ja-5200043">
+        <source>Betrag 五百二十万四十三 Yen.</source>
+        <target>Betrag 五百二十万四十三 Yen.</target>
+      </trans-unit>
+
+      <!-- Chinese higher unit 亿 (10^8) as delimited token. -->
+      <trans-unit id="zh-oku">
+        <source>Gesamt 一亿 Einheiten.</source>
+        <target>Gesamt 一亿 Einheiten.</target>
+      </trans-unit>
+
+      <!-- Non-Latin decimal digits (Arabic-Indic, Devanagari) and Ethiopic numerals. -->
+      <trans-unit id="ai-3">
+        <source>Seite ٣ zeigt das Ablaufdiagramm.</source>
+        <target>Seite ٣ zeigt das Ablaufdiagramm.</target>
+      </trans-unit>
+      <trans-unit id="ai-10">
+        <source>Seite ١٠ zeigt die Vergleichstabelle.</source>
+        <target>Seite ١٠ zeigt die Vergleichstabelle.</target>
+      </trans-unit>
+      <trans-unit id="dev-2">
+        <source>Regel २ gilt in jedem Fall.</source>
+        <target>Regel २ gilt in jedem Fall.</target>
+      </trans-unit>
+      <trans-unit id="ethi-12">
+        <source>Die Ziffer ፲፪ dient als Beispiel.</source>
+        <target>Die Ziffer ፲፪ dient als Beispiel.</target>
+      </trans-unit>
+
+      <!-- Ethiopic higher-value numerals: ፻ (100), ፼ (10000). -->
+      <trans-unit id="ethi-100">
+        <source>Kapitel ፻ endet hier.</source>
+        <target>Kapitel ፻ endet hier.</target>
+      </trans-unit>
+      <trans-unit id="ethi-10000">
+        <source>Posten ፼ ist auf Lager.</source>
+        <target>Posten ፼ ist auf Lager.</target>
+      </trans-unit>
+
+      <!-- Duplicated source (duplicate status / count). -->
+      <trans-unit id="save-a">
+        <source>Bitte speichern Sie das Dokument regelmäßig.</source>
+        <target>Bitte speichern Sie das Dokument regelmäßig.</target>
+      </trans-unit>
+      <trans-unit id="save-b">
+        <source>Bitte speichern Sie das Dokument regelmäßig.</source>
+        <target>Bitte speichern Sie das Dokument regelmäßig.</target>
+      </trans-unit>
+      <trans-unit id="save-c">
+        <source>Bitte speichern Sie das Dokument regelmäßig.</source>
+        <target>Bitte speichern Sie das Dokument regelmäßig.</target>
+      </trans-unit>
+
+      <!-- Length variety (source length sort). -->
+      <trans-unit id="short-1">
+        <source>Ende.</source>
+        <target>Ende.</target>
+      </trans-unit>
+      <trans-unit id="long-1">
+        <source>Dieser besonders lange Absatz dient dazu, die Sortierung nach Segmentlänge zu prüfen, indem er deutlich mehr Zeichen enthält als alle anderen Beispielsätze in diesem Dokument.</source>
+        <target>Dieser besonders lange Absatz dient dazu, die Sortierung nach Segmentlänge zu prüfen, indem er deutlich mehr Zeichen enthält als alle anderen Beispielsätze in diesem Dokument.</target>
+      </trans-unit>
+
+      <!-- Inline tags (tag-count sort): one, two and three tags. target = source. -->
+      <trans-unit id="tag-1">
+        <source>Klicken Sie auf <g id="1">Speichern</g>, um fortzufahren.</source>
+        <target>Klicken Sie auf <g id="1">Speichern</g>, um fortzufahren.</target>
+      </trans-unit>
+      <trans-unit id="tag-2">
+        <source>Wählen Sie <g id="1">Datei</g> und dann <x id="2"/> Öffnen.</source>
+        <target>Wählen Sie <g id="1">Datei</g> und dann <x id="2"/> Öffnen.</target>
+      </trans-unit>
+      <trans-unit id="tag-3">
+        <source>Nutzen Sie <g id="1">Kopieren</g>, <g id="2">Einfügen</g> und <x id="3"/> zum Abschluss.</source>
+        <target>Nutzen Sie <g id="1">Kopieren</g>, <g id="2">Einfügen</g> und <x id="3"/> zum Abschluss.</target>
+      </trans-unit>
+
+      <!-- Source comments via <note>. target = source. -->
+      <trans-unit id="note-1">
+        <source>Der Assistent führt Sie durch die Einrichtung.</source>
+        <target>Der Assistent führt Sie durch die Einrichtung.</target>
+        <note>Bitte in formeller Anrede übersetzen.</note>
+      </trans-unit>
+      <trans-unit id="note-2">
+        <source>Weitere Hinweise finden Sie in der Hilfe.</source>
+        <target>Weitere Hinweise finden Sie in der Hilfe.</target>
+        <note>Kontext: Fußzeile der Startseite.</note>
+      </trans-unit>
+
+      <!-- Plain alphabetical variety (alphabetical / rhyme sort). -->
+      <trans-unit id="alpha-1">
+        <source>Achtung: Diese Aktion kann nicht rückgängig gemacht werden.</source>
+        <target>Achtung: Diese Aktion kann nicht rückgängig gemacht werden.</target>
+      </trans-unit>
+      <trans-unit id="alpha-2">
+        <source>Zusammenfassung der wichtigsten Funktionen.</source>
+        <target>Zusammenfassung der wichtigsten Funktionen.</target>
+      </trans-unit>
+
+      <!-- === Numeric hardening examples: signs, decimals, fractions === -->
+      <trans-unit id="neg-5"><source>Temperatur -5 Grad gemessen.</source><target>Temperatur -5 Grad gemessen.</target></trans-unit>
+      <trans-unit id="neg-half"><source>Abweichung -1/2 Punkt.</source><target>Abweichung -1/2 Punkt.</target></trans-unit>
+      <trans-unit id="dec-1_5"><source>Ausgabe 1.5 ist verfügbar.</source><target>Ausgabe 1.5 ist verfügbar.</target></trans-unit>
+      <trans-unit id="dec-3_14"><source>Pi beträgt etwa 3.14 hier.</source><target>Pi beträgt etwa 3.14 hier.</target></trans-unit>
+      <trans-unit id="frac-3_4"><source>Anteil 3/4 der Summe.</source><target>Anteil 3/4 der Summe.</target></trans-unit>
+      <trans-unit id="frac-7_4"><source>Faktor 7/4 angewendet.</source><target>Faktor 7/4 angewendet.</target></trans-unit>
+      <trans-unit id="mixed-1_5"><source>Menge 1 1/2 Liter benötigt.</source><target>Menge 1 1/2 Liter benötigt.</target></trans-unit>
+
+      <!-- === Vulgar fractions (¼ ½ ¾ ⅓) === -->
+      <trans-unit id="vulg-quarter"><source>Rest ¼ übrig.</source><target>Rest ¼ übrig.</target></trans-unit>
+      <trans-unit id="vulg-half"><source>Etwa ½ erledigt.</source><target>Etwa ½ erledigt.</target></trans-unit>
+      <trans-unit id="vulg-third"><source>Nur ⅓ verbraucht.</source><target>Nur ⅓ verbraucht.</target></trans-unit>
+
+      <!-- === Enclosed / parenthesized numbers (No): value via Unicode numeric === -->
+      <trans-unit id="enc-9"><source>Punkt ⑼ folgt.</source><target>Punkt ⑼ folgt.</target></trans-unit>
+      <trans-unit id="enc-25"><source>Regel ㉕ gilt.</source><target>Regel ㉕ gilt.</target></trans-unit>
+      <trans-unit id="enc-12"><source>Absatz ⓬ endet.</source><target>Absatz ⓬ endet.</target></trans-unit>
+
+      <!-- === Single-code-point Roman and mathematical digit === -->
+      <trans-unit id="rom-8"><source>Kapitel Ⅷ beginnt.</source><target>Kapitel Ⅷ beginnt.</target></trans-unit>
+      <trans-unit id="math-9"><source>Ziffer 𝟵 erscheint.</source><target>Ziffer 𝟵 erscheint.</target></trans-unit>
+
+      <!-- === Historic script numerals (Aegean, cuneiform, Aramaic, Greek acrophonic) === -->
+      <trans-unit id="aeg-8"><source>Ägäisch 𐄎 als Beispiel.</source><target>Ägäisch 𐄎 als Beispiel.</target></trans-unit>
+      <trans-unit id="aeg-900"><source>Ägäisch 𐄡 als Beispiel.</source><target>Ägäisch 𐄡 als Beispiel.</target></trans-unit>
+      <trans-unit id="cun-6"><source>Keilschrift 𒐄 als Beispiel.</source><target>Keilschrift 𒐄 als Beispiel.</target></trans-unit>
+      <trans-unit id="ara-3"><source>Aramäisch 𐡚 als Beispiel.</source><target>Aramäisch 𐡚 als Beispiel.</target></trans-unit>
+      <trans-unit id="grk-500"><source>Akrophonisch 𐅰 als Beispiel.</source><target>Akrophonisch 𐅰 als Beispiel.</target></trans-unit>
+
+      <!-- === Guardrail: emoji symbol has NO numeric value, sorts as non-number === -->
+      <trans-unit id="emoji-100"><source>Bewertung 💯 Prozent.</source><target>Bewertung 💯 Prozent.</target></trans-unit>
+
+      <!-- === More systems: superscript/subscript, ideographic zero, Phoenician, mixed vulgar === -->
+      <trans-unit id="sup-2"><source>Fläche 5 km² gemessen.</source><target>Fläche 5 km² gemessen.</target></trans-unit>
+      <trans-unit id="ideo-0"><source>Wert 〇 als Null.</source><target>Wert 〇 als Null.</target></trans-unit>
+      <trans-unit id="phoen-3"><source>Phönizisch 𐤛 als Beispiel.</source><target>Phönizisch 𐤛 als Beispiel.</target></trans-unit>
+      <trans-unit id="mixed-vulgar"><source>Strecke 2½ Meilen.</source><target>Strecke 2½ Meilen.</target></trans-unit>
+      <trans-unit id="dec-point5"><source>Faktor 0.3 im Modell.</source><target>Faktor 0.3 im Modell.</target></trans-unit>
+
+      <!-- === Alphabetical order != numeric order (the whole point of numeric sort) === -->
+      <!-- Roman: alpha -> IV, IX, V, VIII, X ; numeric -> IV, V, VIII, IX, X -->
+      <trans-unit id="div-rom-4"><source>Norm IV wird geprüft.</source><target>Norm IV wird geprüft.</target></trans-unit>
+      <trans-unit id="div-rom-5"><source>Norm V wird geprüft.</source><target>Norm V wird geprüft.</target></trans-unit>
+      <trans-unit id="div-rom-8"><source>Norm VIII wird geprüft.</source><target>Norm VIII wird geprüft.</target></trans-unit>
+      <trans-unit id="div-rom-9"><source>Norm IX wird geprüft.</source><target>Norm IX wird geprüft.</target></trans-unit>
+      <trans-unit id="div-rom-10"><source>Norm X wird geprüft.</source><target>Norm X wird geprüft.</target></trans-unit>
+      <!-- Decimal: alpha -> 10, 100, 2, 21 ; numeric -> 2, 10, 21, 100 -->
+      <trans-unit id="div-dec-2"><source>Schritt 2 ausführen.</source><target>Schritt 2 ausführen.</target></trans-unit>
+      <trans-unit id="div-dec-10"><source>Schritt 10 ausführen.</source><target>Schritt 10 ausführen.</target></trans-unit>
+      <trans-unit id="div-dec-21"><source>Schritt 21 ausführen.</source><target>Schritt 21 ausführen.</target></trans-unit>
+      <trans-unit id="div-dec-100"><source>Schritt 100 ausführen.</source><target>Schritt 100 ausführen.</target></trans-unit>
+
+      <!-- ================================================================= -->
+      <!-- Three-orders-differ set across mixed numeral systems (CJK,         -->
+      <!-- full-width, Arabic-Indic, Devanagari, Ethiopic, Roman, Western).   -->
+      <!-- File order, alphabetical order and numeric-value order are all     -->
+      <!-- pairwise distinct. target = source.                                -->
+      <!--   file order   : Z A M D T G K B                                   -->
+      <!--   alphabetical : A B D G K M T Z                                   -->
+      <!--   numeric value: Z(1) M(7) K(15) T(20) B(40) G(50) A(90) D(300)    -->
+      <!-- ================================================================= -->
+      <trans-unit id="tri-z"><source>Zebras zählen bis 一 im Zoo.</source><target>Zebras zählen bis 一 im Zoo.</target></trans-unit>
+      <trans-unit id="tri-a"><source>Apfelernte erreicht ９０ Kisten.</source><target>Apfelernte erreicht ９０ Kisten.</target></trans-unit>
+      <trans-unit id="tri-m"><source>Mango Nummer ٧ ist reif.</source><target>Mango Nummer ٧ ist reif.</target></trans-unit>
+      <trans-unit id="tri-d"><source>Delta umfasst 三百 Hektar.</source><target>Delta umfasst 三百 Hektar.</target></trans-unit>
+      <trans-unit id="tri-t"><source>Tiger leben ፳ Jahre hier.</source><target>Tiger leben ፳ Jahre hier.</target></trans-unit>
+      <trans-unit id="tri-g"><source>Gamma misst ५० Einheiten.</source><target>Gamma misst ५० Einheiten.</target></trans-unit>
+      <trans-unit id="tri-k"><source>Kilo wiegt 15 Gramm genau.</source><target>Kilo wiegt 15 Gramm genau.</target></trans-unit>
+      <trans-unit id="tri-b"><source>Bravo Team gewann XL Spiele.</source><target>Bravo Team gewann XL Spiele.</target></trans-unit>
+
+      <!-- === Translated segments (target != source) with exotic numerals. === -->
+      <trans-unit id="tr-rom8"><source>Siehe Anhang Ⅷ für Details.</source><target>See appendix Ⅷ for details.</target></trans-unit>
+      <trans-unit id="tr-cjk12"><source>Kapitel 十二 ist wichtig.</source><target>Chapter 十二 is important.</target></trans-unit>
+      <trans-unit id="tr-ai25"><source>Seite ٢٥ enthält die Tabelle.</source><target>Page ٢٥ contains the table.</target></trans-unit>
+      <trans-unit id="tr-dev3"><source>Regel ३ gilt immer.</source><target>Rule ३ always applies.</target></trans-unit>
+      <trans-unit id="tr-vul34"><source>Etwa ¾ sind fertig.</source><target>About ¾ are done.</target></trans-unit>
+      <trans-unit id="tr-rom2025"><source>Das Jahr MMXXV beginnt.</source><target>The year MMXXV begins.</target></trans-unit>
+      <trans-unit id="tr-fw9"><source>Ziffer ９ erscheint zuerst.</source><target>Digit ９ appears first.</target></trans-unit>
+      <trans-unit id="tr-eth20"><source>Punkt ፳ folgt gleich.</source><target>Item ፳ follows soon.</target></trans-unit>
+      <trans-unit id="tr-half"><source>Rund ½ ist verbraucht.</source><target>Around ½ is used up.</target></trans-unit>
+      <trans-unit id="tr-cjk300"><source>Fläche 三百 Quadratmeter.</source><target>Area 三百 square meters.</target></trans-unit>
+
+      <!-- === Segments carrying a translator <note> that itself holds exotic numerals. === -->
+      <trans-unit id="nt-cjk30"><source>Bitte prüfen Sie die Fußnote.</source><target>Bitte prüfen Sie die Fußnote.</target><note>Verweist auf Formel 三十 im Anhang.</note></trans-unit>
+      <trans-unit id="nt-ai42"><source>Hier folgt ein Hinweis.</source><target>Hier folgt ein Hinweis.</target><note>Vergleiche Seite ٤٢ im Original.</note></trans-unit>
+      <trans-unit id="nt-rom"><source>Der Absatz endet hier.</source><target>Der Absatz endet hier.</target><note>Siehe Normen Ⅺ und Ⅻ.</note></trans-unit>
+      <trans-unit id="nt-vul23"><source>Diese Zeile ist speziell.</source><target>Diese Zeile ist speziell.</target><note>Menge ⅔ laut Rezept.</note></trans-unit>
+      <trans-unit id="nt-eth2000"><source>Ein weiterer Satz folgt.</source><target>Ein weiterer Satz folgt.</target><note>Baujahr ፳፻ ist belegt.</note></trans-unit>
+      <trans-unit id="nt-dev55"><source>Kurzer Kommentarfall hier.</source><target>Kurzer Kommentarfall hier.</target><note>Wert ५५ in Devanagari.</note></trans-unit>
+      <trans-unit id="nt-cjkrange"><source>Noch ein Notizfall folgt.</source><target>Noch ein Notizfall folgt.</target><note>Kapitel 十 bis 二十 lesen.</note></trans-unit>
+      <trans-unit id="nt-frac"><source>Vorletzter Notizsatz steht.</source><target>Vorletzter Notizsatz steht.</target><note>Anteil 7/8 verbleibt.</note></trans-unit>
+      <trans-unit id="nt-fwpct"><source>Weiterer Hinweis steht hier.</source><target>Weiterer Hinweis steht hier.</target><note>Rabatt ９０％ gewährt.</note></trans-unit>
+      <trans-unit id="nt-mixed"><source>Letzter Notizfall steht hier.</source><target>Letzter Notizfall steht hier.</target><note>Etwa 2½ Einheiten übrig.</note></trans-unit>
+      <trans-unit id="nt-arm"><source>Zusatznotiz mit Wert.</source><target>Zusatznotiz mit Wert.</target><note>Armenisch ԺԲ als Zahl.</note></trans-unit>
+      <trans-unit id="nt-grk"><source>Weitere Zusatznotiz hier.</source><target>Weitere Zusatznotiz hier.</target><note>Griechisch ιβʹ als Zahl.</note></trans-unit>
+
+      <!-- === Data formats expected for #794: NUMBER-ONLY segments, no surrounding text. === -->
+      <!-- Surrounding prose would take them out of the ticket's "number only" scope. -->
+      <!-- Some targets show the locale-aware re-render #794 would produce; others stay untranslated. -->
+      <trans-unit id="fmt-cur-eur"><source>1.234,56 €</source><target>€1,234.56</target></trans-unit>
+      <trans-unit id="fmt-cur-usd"><source>$2,500.00</source><target>$2,500.00</target></trans-unit>
+      <trans-unit id="fmt-date-de"><source>05.03.2026</source><target>2026-03-05</target></trans-unit>
+      <trans-unit id="fmt-date-iso"><source>2026-12-31</source><target>2026-12-31</target></trans-unit>
+      <trans-unit id="fmt-pct-de"><source>12,5 %</source><target>12.5%</target></trans-unit>
+      <trans-unit id="fmt-pct-fw"><source>９０％</source><target>９０％</target></trans-unit>
+      <trans-unit id="fmt-ord-en"><source>3.</source><target>3rd</target></trans-unit>
+      <trans-unit id="fmt-ord-de"><source>21.</source><target>21.</target></trans-unit>
+      <trans-unit id="fmt-time"><source>14:30</source><target>2:30 PM</target></trans-unit>
+      <trans-unit id="fmt-sci"><source>1,5×10³</source><target>1.5×10³</target></trans-unit>
+
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement] (shared groundwork; no user-visible change on its own)

## Which ticket is resolved?

No ticket is resolved by this PR alone. It provides the shared numeral-parsing foundation for three open feature requests; the implementations follow as separate pull requests building on this branch:

- Consider numbers for fuzzy matches
  * https://sourceforge.net/p/omegat/feature-requests/465/
- Auto fill "number only" segments
  * https://sourceforge.net/p/omegat/feature-requests/794/
- Sorting segments
  * https://sourceforge.net/p/omegat/feature-requests/1094/

## What does this PR change?

- Adds `org.omegat.util.NumeralValueParser`, a locale-independent parser from textual numerals to their numeric value, built on the ICU4J library OmegaT already ships:
  - decimal positional digits of every script (Western, Arabic-Indic, Devanagari, Thai, fullwidth, ...) via their Unicode value;
  - algorithmic numbering systems (Roman, Chinese/Japanese ideographic, Ethiopic, Armenian, Greek, Hebrew, Tamil, Georgian, Cyrillic) via ICU `RuleBasedNumberFormat`;
  - signed real numbers as exact rationals: decimal point, ASCII/Unicode/mixed fractions and the Unicode vulgar fractions — comparison by cross-multiplication is exact, with no floating-point rounding;
  - single code points with a Unicode numeric value (enclosed numbers, historic script numerals) as a final fallback.
  - A value is only returned when a numbering system consumes the whole trimmed string, so ambiguous input is rejected and callers can fall back to plain text handling. A comma is deliberately not treated as a decimal or grouping separator (irreducibly locale-ambiguous).
- A cheap pre-filter rejects tokens that cannot be numerals before the expensive rule-based ICU parsing is attempted; separator-grouped digit runs (e.g. `1.234.567`) pass it correctly.
- `NumeralValueParserTest` covers the above (about 470 lines).
- Also carries a shared demonstration fixture (`numeric-sort-demo.xliff`, a mixed-script sample project file) that the follow-up segment-sorting PR uses as an in-repo manual test document.

The class is not yet referenced by production code; application behaviour does not change.

## Other information

First PR of a series: the follow-up PRs for SF-465 (number-aware fuzzy matching), SF-794 (number-only autofill) and SF-1094 (segment sorting) are stacked on this branch and will reference this PR.

Verification: full test suite and checkstyleMain pass on this branch, rebased onto current master.
