### PR TITLE
refactor: replace `Stack` with `ArrayDeque` for process cache in `RealProject`

### DIFF
--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -46,6 +46,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Stack;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -215,7 +215,7 @@ public class RealProject implements IProject {
      * long-running processes to be forcibly terminated when compiling the
      * project anew or when closing the project.
      */
-    private final Stack<Process> processCache = new Stack<>();
+    private final ArrayDeque<Process> processCache = new ArrayDeque<>();
 
     /**
      * Create new project instance. It required to call {@link #createProject()}


### PR DESCRIPTION

`Stack` extends `Vector`, which means every operation (`push`, `pop`, `peek`) is synchronized even though this cache is very unlikely to need thread-safety guarantees across concurrent access in a coordinated way — and even if it did, `Vector`'s per-method locking doesn't protect compound operations like "check-then-remove" from race conditions anyway, so the synchronization is mostly just overhead, not real safety. `Stack` is a legacy class (pre-Collections Framework) that the `Deque` Javadoc itself recommends against, explicitly suggesting ArrayDeque as the modern replacement for stack-like use cases.
`ArrayDeque`:

- Is unsynchronized and faster for single-threaded or externally-synchronized use.
- Has no legacy baggage (no Enumeration, no inherited Vector grab-bag of methods like elementAt, insertElementAt, etc. that don't fit stack/queue semantics).
- Gives you both stack (push/pop) and queue (offer/poll) operations if the usage pattern for processCache ever needs FIFO iteration order instead of LIFO (e.g., killing oldest hung processes first).
- Has no capacity limit and resizes more efficiently (no null elements allowed, so no ambiguity on empty checks).

## Pull request type

refactor

## Which ticket is resolved?

## What does this PR change?

- replace `Stack` with `ArrayDeque`


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
