### PR TITLE
fix(gui): treat empty status msg key as null to avoid MissingResourceException

### DIFF
--- a/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
@@ -108,7 +108,7 @@ public final class MainWindowStatusBarController {
     }
 
     private String getLocalizedString(String messageKey, Object... params) {
-        if (messageKey == null) {
+        if (messageKey == null || messageKey.isEmpty()) {
             return " ";
         } else if (params == null) {
             return OStrings.getString(messageKey);


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- No SourceForge ticket: this fixes a regression of an unreleased change on master, introduced by GH pull request #2142.

## What does this PR change?

- #2142 replaced `showStatusMessageRB(null)` with `showStatusMessageRB("")` at the call sites, but extended the null guard only in `showTimedStatusMessageRB`. `getLocalizedString` still passes empty keys to the resource bundle lookup, which throws `MissingResourceException`.
- Since one of the affected call sites is `RealProject.loadProject` (right after a successful load), every project open on current master fails with `TF_LOAD_ERROR` ("Failed to load the specified project"), even though the project loaded fine.
- This change treats an empty key like null in `getLocalizedString`, clearing the status label instead of looking the key up.

## Other information

Stack trace of the failure on current master:

```
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:567)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:523)
	at org.omegat.util.OStrings.getString(OStrings.java:122)
	at org.omegat.gui.main.MainWindowStatusBarController.getLocalizedString(MainWindowStatusBarController.java:116)
	at org.omegat.gui.main.MainWindowStatusBarController.showStatusMessageRB(MainWindowStatusBarController.java:106)
	at org.omegat.gui.main.MainWindow.showStatusMessageRB(MainWindow.java:367)
	at org.omegat.core.data.RealProject.loadProject(RealProject.java:407)
```
