### PR TITLE
feat(editor): decouple segment sorting from filtering (SF-1094)

### DIFF
--- a/src/main/java/org/omegat/gui/editor/EditorController.java
+++ b/src/main/java/org/omegat/gui/editor/EditorController.java
@@ -256,6 +256,8 @@ public class EditorController implements IEditor {
     volatile @Nullable IEditorFilter entriesFilter;
     private @Nullable Component entriesFilterControlComponent;
 
+    volatile @Nullable IEditorSorter entriesSorter;
+
     private final SegmentExportImport segmentExportImport;
 
     protected @Nullable String currentEntryOrigin;
@@ -722,6 +724,13 @@ public class EditorController implements IEditor {
                 SegmentBuilder sb = new SegmentBuilder(this, doc, settings, ste, ste.entryNum(), hasRTL);
                 tmpSegList.add(sb);
             }
+        }
+        // Apply the optional display sort to the segments being displayed. The
+        // default (no sorter) preserves natural file order because tmpSegList is
+        // already built in file order. List.sort is stable, so equal keys keep
+        // that order.
+        if (entriesSorter != null) {
+            tmpSegList.sort(entriesSorter.getComparator());
         }
         m_docSegList = tmpSegList.toArray(new SegmentBuilder[0]);
 
@@ -1673,13 +1682,10 @@ public class EditorController implements IEditor {
                         displayedFileIndex = i;
                         loadDocument();
                     }
-                    // find correct displayedEntryIndex
-                    for (int j = 0; j < m_docSegList.length; j++) {
-                        if (m_docSegList[j].segmentNumberInProject >= entryNum) { //
-                            displayedEntryIndex = j;
-                            break;
-                        }
-                    }
+                    // find correct displayedEntryIndex. The list may be in any
+                    // display order (a sorter can reorder it), so locate by exact
+                    // entry number, falling back to the nearest available entry.
+                    displayedEntryIndex = findDisplayIndexForEntry(entryNum);
                     break;
                 }
             }
@@ -1687,6 +1693,30 @@ public class EditorController implements IEditor {
         activateEntry(pos);
         editor.setCursor(oldCursor);
         updateTitleCurrentFile();
+    }
+
+    /**
+     * Find the index in {@link #m_docSegList} of the segment with the given
+     * project entry number. The list may be in any display order (a sorter can
+     * reorder it), so we cannot assume ascending order. If the exact entry is not
+     * present (e.g. filtered out), return the index of the segment whose entry
+     * number is closest to entryNum, or 0 if the list is empty.
+     */
+    private int findDisplayIndexForEntry(int entryNum) {
+        int fallback = 0;
+        int bestDelta = Integer.MAX_VALUE;
+        for (int j = 0; j < m_docSegList.length; j++) {
+            int num = m_docSegList[j].segmentNumberInProject;
+            if (num == entryNum) {
+                return j;
+            }
+            int delta = Math.abs(num - entryNum);
+            if (delta < bestDelta) {
+                bestDelta = delta;
+                fallback = j;
+            }
+        }
+        return fallback;
     }
 
     @Override
@@ -2232,16 +2262,30 @@ public class EditorController implements IEditor {
             if (entriesFilter == null || entriesFilter.allowed(curEntry)) {
                 gotoEntry(curEntry.entryNum());
             } else {
-                // Go to next (available) segment. But first, we need to reset
-                // the displayedEntryIndex to the number where the current but
-                // filtered entry could have been if it was not filtered.
+                // The current entry was filtered out. Go to the visible segment
+                // closest after it in entry-number space (or the closest before it
+                // if none follows). The list may be in any display order, so search
+                // by entry number rather than by position.
+                int best = -1;
+                int bestNum = Integer.MAX_VALUE;
+                int prev = -1;
+                int prevNum = Integer.MIN_VALUE;
                 for (int j = 0; j < m_docSegList.length; j++) {
-                    if (m_docSegList[j].segmentNumberInProject >= curEntryNum) { //
-                        displayedEntryIndex = j - 1;
-                        break;
+                    int num = m_docSegList[j].segmentNumberInProject;
+                    if (num >= curEntryNum && num < bestNum) {
+                        bestNum = num;
+                        best = j;
+                    }
+                    if (num < curEntryNum && num > prevNum) {
+                        prevNum = num;
+                        prev = j;
                     }
                 }
-                nextEntry();
+                int target = (best >= 0) ? best : prev;
+                if (target >= 0) {
+                    displayedEntryIndex = target;
+                    activateEntry();
+                }
             }
         }
     }
@@ -2277,6 +2321,72 @@ public class EditorController implements IEditor {
                 gotoEntry(curEntryNum);
             }
         }
+    }
+
+    @Override
+    public @Nullable IEditorSorter getSort() {
+        return entriesSorter;
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded to immediately apply the new display
+     * order, keeping the current entry active.
+     */
+    @Override
+    public void setSort(IEditorSorter sorter) {
+        UIThreadsUtil.mustBeSwingThread();
+        // Fail fast on misuse: clearing the sort is done via removeSort(), not by
+        // passing null.
+        Objects.requireNonNull(sorter, "sorter must not be null; use removeSort() to clear the sort");
+
+        entriesSorter = sorter;
+
+        SourceTextEntry curEntry = getCurrentEntry();
+        // The current entry is never removed by sorting, only repositioned.
+        if (curEntry != null && canReloadDocument()) {
+            commitAndDeactivate();
+            loadDocument(); // rebuild + re-sort entrylist
+            gotoEntry(curEntry.entryNum());
+        }
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded if appropriate to revert to natural file
+     * order.
+     */
+    @Override
+    public void removeSort() {
+        UIThreadsUtil.mustBeSwingThread();
+
+        if (entriesSorter == null) {
+            return;
+        }
+
+        entriesSorter = null;
+
+        int curEntryNum = getCurrentEntryNumber();
+        if (canReloadDocument()) {
+            commitAndDeactivate();
+            loadDocument();
+            gotoEntry(curEntryNum);
+        }
+    }
+
+    /**
+     * Whether the editor currently holds a loaded document that can be safely
+     * rebuilt via {@link #loadDocument()}. Guards setSort/removeSort against NPEs
+     * when there is no document or no loaded project (e.g. an empty project).
+     */
+    private boolean canReloadDocument() {
+        if (editor.getOmDocument() == null) {
+            return false;
+        }
+        IProject project = Core.getProject();
+        if (project == null || !project.isProjectLoaded()) {
+            return false;
+        }
+        List<FileInfo> files = project.getProjectFiles();
+        return files != null && !files.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/omegat/gui/editor/EditorController.java
+++ b/src/main/java/org/omegat/gui/editor/EditorController.java
@@ -255,6 +255,8 @@ public class EditorController implements IEditor {
     volatile @Nullable IEditorFilter entriesFilter;
     private @Nullable Component entriesFilterControlComponent;
 
+    volatile @Nullable IEditorSorter entriesSorter;
+
     private final SegmentExportImport segmentExportImport;
 
     protected @Nullable String currentEntryOrigin;
@@ -717,6 +719,12 @@ public class EditorController implements IEditor {
                 SegmentBuilder sb = new SegmentBuilder(this, doc, settings, ste, ste.entryNum(), hasRTL);
                 tmpSegList.add(sb);
             }
+        }
+        // Filtering is done; now apply the optional display sort. The default
+        // (no sorter) preserves natural file order because tmpSegList is already
+        // built in file order. List.sort is stable, so equal keys keep that order.
+        if (entriesSorter != null) {
+            tmpSegList.sort(entriesSorter.getComparator());
         }
         m_docSegList = tmpSegList.toArray(new SegmentBuilder[0]);
 
@@ -1668,13 +1676,10 @@ public class EditorController implements IEditor {
                         displayedFileIndex = i;
                         loadDocument();
                     }
-                    // find correct displayedEntryIndex
-                    for (int j = 0; j < m_docSegList.length; j++) {
-                        if (m_docSegList[j].segmentNumberInProject >= entryNum) { //
-                            displayedEntryIndex = j;
-                            break;
-                        }
-                    }
+                    // find correct displayedEntryIndex. The list may be in any
+                    // display order (a sorter can reorder it), so locate by exact
+                    // entry number, falling back to the nearest available entry.
+                    displayedEntryIndex = findDisplayIndexForEntry(entryNum);
                     break;
                 }
             }
@@ -1682,6 +1687,30 @@ public class EditorController implements IEditor {
         activateEntry(pos);
         editor.setCursor(oldCursor);
         updateTitleCurrentFile();
+    }
+
+    /**
+     * Find the index in {@link #m_docSegList} of the segment with the given
+     * project entry number. The list may be in any display order (a sorter can
+     * reorder it), so we cannot assume ascending order. If the exact entry is not
+     * present (e.g. filtered out), return the index of the segment whose entry
+     * number is closest to entryNum, or 0 if the list is empty.
+     */
+    private int findDisplayIndexForEntry(int entryNum) {
+        int fallback = 0;
+        int bestDelta = Integer.MAX_VALUE;
+        for (int j = 0; j < m_docSegList.length; j++) {
+            int num = m_docSegList[j].segmentNumberInProject;
+            if (num == entryNum) {
+                return j;
+            }
+            int delta = Math.abs(num - entryNum);
+            if (delta < bestDelta) {
+                bestDelta = delta;
+                fallback = j;
+            }
+        }
+        return fallback;
     }
 
     @Override
@@ -2171,16 +2200,30 @@ public class EditorController implements IEditor {
             if (entriesFilter == null || entriesFilter.allowed(curEntry)) {
                 gotoEntry(curEntry.entryNum());
             } else {
-                // Go to next (available) segment. But first, we need to reset
-                // the displayedEntryIndex to the number where the current but
-                // filtered entry could have been if it was not filtered.
+                // The current entry was filtered out. Go to the visible segment
+                // closest after it in entry-number space (or the closest before it
+                // if none follows). The list may be in any display order, so search
+                // by entry number rather than by position.
+                int best = -1;
+                int bestNum = Integer.MAX_VALUE;
+                int prev = -1;
+                int prevNum = Integer.MIN_VALUE;
                 for (int j = 0; j < m_docSegList.length; j++) {
-                    if (m_docSegList[j].segmentNumberInProject >= curEntryNum) { //
-                        displayedEntryIndex = j - 1;
-                        break;
+                    int num = m_docSegList[j].segmentNumberInProject;
+                    if (num >= curEntryNum && num < bestNum) {
+                        bestNum = num;
+                        best = j;
+                    }
+                    if (num < curEntryNum && num > prevNum) {
+                        prevNum = num;
+                        prev = j;
                     }
                 }
-                nextEntry();
+                int target = (best >= 0) ? best : prev;
+                if (target >= 0) {
+                    displayedEntryIndex = target;
+                    activateEntry();
+                }
             }
         }
     }
@@ -2216,6 +2259,72 @@ public class EditorController implements IEditor {
                 gotoEntry(curEntryNum);
             }
         }
+    }
+
+    @Override
+    public @Nullable IEditorSorter getSort() {
+        return entriesSorter;
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded to immediately apply the new display
+     * order, keeping the current entry active.
+     */
+    @Override
+    public void setSort(IEditorSorter sorter) {
+        UIThreadsUtil.mustBeSwingThread();
+        // Fail fast on misuse: clearing the sort is done via removeSort(), not by
+        // passing null (mirrors setFilter, which also requires a non-null filter).
+        Objects.requireNonNull(sorter, "sorter must not be null; use removeSort() to clear the sort");
+
+        entriesSorter = sorter;
+
+        SourceTextEntry curEntry = getCurrentEntry();
+        // The current entry is never removed by sorting, only repositioned.
+        if (curEntry != null && canReloadDocument()) {
+            commitAndDeactivate();
+            loadDocument(); // rebuild + re-sort entrylist
+            gotoEntry(curEntry.entryNum());
+        }
+    }
+
+    /**
+     * {@inheritDoc} Document is reloaded if appropriate to revert to natural file
+     * order.
+     */
+    @Override
+    public void removeSort() {
+        UIThreadsUtil.mustBeSwingThread();
+
+        if (entriesSorter == null) {
+            return;
+        }
+
+        entriesSorter = null;
+
+        int curEntryNum = getCurrentEntryNumber();
+        if (canReloadDocument()) {
+            commitAndDeactivate();
+            loadDocument();
+            gotoEntry(curEntryNum);
+        }
+    }
+
+    /**
+     * Whether the editor currently holds a loaded document that can be safely
+     * rebuilt via {@link #loadDocument()}. Guards setSort/removeSort against NPEs
+     * when there is no document or no loaded project (e.g. an empty project).
+     */
+    private boolean canReloadDocument() {
+        if (editor.getOmDocument() == null) {
+            return false;
+        }
+        IProject project = Core.getProject();
+        if (project == null || !project.isProjectLoaded()) {
+            return false;
+        }
+        List<FileInfo> files = project.getProjectFiles();
+        return files != null && !files.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/omegat/gui/editor/IEditor.java
+++ b/src/main/java/org/omegat/gui/editor/IEditor.java
@@ -478,6 +478,46 @@ public interface IEditor {
     void removeFilter();
 
     /**
+     * Gets the sorter for this editor, or null if no custom sort is applied (i.e.
+     * segments are shown in natural file order).
+     *
+     * @implSpec
+     *           The default implementation returns {@code null}, i.e. no custom
+     *           sort. Editors that support sorting override this.
+     */
+    @Nullable
+    default IEditorSorter getSort() {
+        return null;
+    }
+
+    /**
+     * Sets a sorter for this editor. The sorter changes the order in which the
+     * segments of the currently displayed file are displayed, without changing
+     * which segments are shown. The document is reloaded so the new order
+     * takes effect immediately. To clear the sort and revert to natural file order
+     * use {@link #removeSort()}.
+     *
+     * @param sorter
+     *            Sorter instance, must not be {@code null}
+     * @throws NullPointerException
+     *             if {@code sorter} is {@code null}
+     * @implSpec
+     *           The default implementation does nothing. Editors that support
+     *           sorting override this.
+     */
+    default void setSort(IEditorSorter sorter) {
+    }
+
+    /**
+     * Removes the current sorter, reverting to natural file order.
+     *
+     * @implSpec
+     *           The default implementation does nothing.
+     */
+    default void removeSort() {
+    }
+
+    /**
      * Returns current translation or null.
      */
     String getCurrentTranslation();

--- a/src/main/java/org/omegat/gui/editor/IEditor.java
+++ b/src/main/java/org/omegat/gui/editor/IEditor.java
@@ -478,6 +478,46 @@ public interface IEditor {
     void removeFilter();
 
     /**
+     * Gets the sorter for this editor, or null if no custom sort is applied (i.e.
+     * segments are shown in natural file order).
+     *
+     * @implSpec
+     *           The default implementation returns {@code null}, i.e. no custom
+     *           sort. Editors that support sorting override this.
+     */
+    @Nullable
+    default IEditorSorter getSort() {
+        return null;
+    }
+
+    /**
+     * Sets a sorter for this editor. The sorter changes the order in which the
+     * (filtered) segments of the currently displayed file are displayed, without
+     * changing which segments are shown. The document is reloaded so the new order
+     * takes effect immediately. To clear the sort and revert to natural file order
+     * use {@link #removeSort()}.
+     *
+     * @param sorter
+     *            Sorter instance, must not be {@code null}
+     * @throws NullPointerException
+     *             if {@code sorter} is {@code null}
+     * @implSpec
+     *           The default implementation does nothing. Editors that support
+     *           sorting override this.
+     */
+    default void setSort(IEditorSorter sorter) {
+    }
+
+    /**
+     * Removes the current sorter, reverting to natural file order.
+     *
+     * @implSpec
+     *           The default implementation does nothing.
+     */
+    default void removeSort() {
+    }
+
+    /**
      * Returns current translation or null.
      */
     String getCurrentTranslation();

--- a/src/main/java/org/omegat/gui/editor/IEditorSorter.java
+++ b/src/main/java/org/omegat/gui/editor/IEditorSorter.java
@@ -1,0 +1,55 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import java.util.Comparator;
+
+/**
+ * Hook for ordering the editor's displayed segments: it decides in which
+ * order the segments of the currently displayed file appear, without any
+ * influence on which segments the editor displays.
+ * This is an extension point: the core applies the comparator to the
+ * segments being displayed while it loads the editor document. The sorter
+ * itself (criteria, UI, etc.) can live outside the core, e.g. in a plugin
+ * that calls {@link IEditor#setSort}.
+ * <p>
+ * <b>Scope:</b> the editor loads one source file at a time, so the comparator
+ * only reorders the segments <em>within the currently displayed file</em>. It
+ * does not establish a project-wide order across files; navigation still moves
+ * from file to file in natural project order.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public interface IEditorSorter {
+
+    /**
+     * The comparator used to order the displayed list of segments. It must
+     * define a stable, total order; implementations should fall back to the
+     * natural project order (by {@code entryNum}) for otherwise-equal segments so
+     * that the result is fully deterministic.
+     */
+    Comparator<SegmentBuilder> getComparator();
+}

--- a/src/main/java/org/omegat/gui/editor/IEditorSorter.java
+++ b/src/main/java/org/omegat/gui/editor/IEditorSorter.java
@@ -1,0 +1,54 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import java.util.Comparator;
+
+/**
+ * Hook for ordering the editor's displayed segments. While {@link IEditorFilter}
+ * decides which segments are shown, an {@code IEditorSorter} decides in which
+ * order the already filtered segments are displayed.
+ * This is an extension point: the core applies the comparator after filtering
+ * during the editor's document loading. The sorter itself (criteria, UI, etc.) can
+ * live outside the core, e.g. in a plugin that calls {@link IEditor#setSort}.
+ * <p>
+ * <b>Scope:</b> the editor loads one source file at a time, so the comparator
+ * only reorders the segments <em>within the currently displayed file</em>. It
+ * does not establish a project-wide order across files; navigation still moves
+ * from file to file in natural project order.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public interface IEditorSorter {
+
+    /**
+     * The comparator used to order the (already filtered) list of segments. It
+     * must define a stable, total order; implementations should fall back to the
+     * natural project order (by {@code entryNum}) for otherwise-equal segments so
+     * that the result is fully deterministic.
+     */
+    Comparator<SegmentBuilder> getComparator();
+}

--- a/src/test/java/org/omegat/gui/editor/EditorControllerTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorControllerTest.java
@@ -60,6 +60,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -68,6 +69,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
@@ -78,6 +80,10 @@ public class EditorControllerTest extends TestCore {
 
     private final Language sourceLang = new Language("en");
     private final Language targetLang = new Language("pl");
+
+    /** Orders displayed segments by descending project entry number. */
+    private static final IEditorSorter REVERSE_BY_ENTRYNUM = () ->
+            Comparator.comparingInt((SegmentBuilder sb) -> sb.segmentNumberInProject).reversed();
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -118,6 +124,29 @@ public class EditorControllerTest extends TestCore {
         Core.setProject(new RealProjectWithTMX(props));
     }
 
+    private void setMultiEntryProject() {
+        TestProjectProperties props = new TestProjectProperties();
+        props.setProjectRoot(projectRootDir.getAbsolutePath());
+        props.setSupportDefaultTranslations(false);
+        props.setTargetTokenizer(DefaultTokenizer.class);
+        TestCoreInitializer.initNotes(new MyNotes());
+        Core.setProject(new RealProjectMultiEntry(props));
+    }
+
+    /**
+     * Assert that {@link EditorController#m_docSegList} holds exactly the given
+     * project entry numbers, in the given order.
+     */
+    private void assertSegmentOrder(int... expectedEntryNums) {
+        SegmentBuilder[] segments = editorController.m_docSegList;
+        assertNotNull(segments);
+        assertEquals(expectedEntryNums.length, segments.length);
+        for (int i = 0; i < expectedEntryNums.length; i++) {
+            assertEquals("segment at display index " + i, expectedEntryNums[i],
+                    segments[i].segmentNumberInProject);
+        }
+    }
+
     @Test
     public void testEditorControllerDefaults() {
         assertNotNull(editorController);
@@ -155,6 +184,75 @@ public class EditorControllerTest extends TestCore {
         fireCaretEvent(editorController.editor, 0);
         assertEquals(31, editorController.editor.getOmDocument().getTranslationEnd());
         assertEquals(31, editorController.editor.getOmDocument().getTranslationStart());
+    }
+
+    @Test
+    public void testGetSortDefaultsToNull() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+        assertNull(editorController.getSort());
+        // No sorter => natural file order.
+        assertSegmentOrder(1, 2, 3, 4);
+    }
+
+    @Test
+    public void testSetSortReordersSegmentsAndKeepsCurrentEntry() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+        int current = editorController.getCurrentEntryNumber();
+
+        editorController.setSort(REVERSE_BY_ENTRYNUM);
+
+        assertSame(REVERSE_BY_ENTRYNUM, editorController.getSort());
+        assertSegmentOrder(4, 3, 2, 1);
+        // Sorting repositions the current entry, it never removes it.
+        assertEquals(current, editorController.getCurrentEntryNumber());
+    }
+
+    @Test
+    public void testRemoveSortRevertsToNaturalOrder() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+        editorController.setSort(REVERSE_BY_ENTRYNUM);
+        assertSegmentOrder(4, 3, 2, 1);
+
+        editorController.removeSort();
+
+        assertNull(editorController.getSort());
+        assertSegmentOrder(1, 2, 3, 4);
+    }
+
+    @Test
+    public void testGotoEntryLocatesByEntryNumberUnderSort() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+        editorController.setSort(REVERSE_BY_ENTRYNUM);
+
+        // Entry 2 sits at display index 2 in the reversed order [4, 3, 2, 1];
+        // gotoEntry must find it by entry number, not by position.
+        editorController.gotoEntry(2);
+
+        assertEquals(2, editorController.getCurrentEntryNumber());
+        assertEquals(2, editorController.displayedEntryIndex);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetSortRejectsNull() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+        // Clearing the sort is done via removeSort(); null is a programming error.
+        editorController.setSort(null);
+    }
+
+    @Test
+    public void testRemoveSortWithoutActiveSortIsNoop() {
+        setMultiEntryProject();
+        fireLoadProjectEvent();
+
+        editorController.removeSort();
+
+        assertNull(editorController.getSort());
+        assertSegmentOrder(1, 2, 3, 4);
     }
 
     private void fireLoadProjectEvent() {
@@ -264,6 +362,64 @@ public class EditorControllerTest extends TestCore {
             ste.add(files.get(0).entries.get(0));
             ste.add(files.get(1).entries.get(0));
             return ste;
+        }
+
+        @Override
+        public boolean isProjectLoaded() {
+            return true;
+        }
+    }
+
+    /**
+     * Project with a single source file holding four entries, used to exercise
+     * within-file display ordering. Source texts are chosen so that alphabetical
+     * order is the reverse of natural entry order.
+     */
+    protected static class RealProjectMultiEntry extends RealProject {
+
+        private static final String SOURCE_FILE = "multi.txt";
+
+        private final List<FileInfo> files;
+
+        public RealProjectMultiEntry(ProjectProperties props) {
+            super(props);
+            files = new ArrayList<>();
+            FileInfo file = new FileInfo(SOURCE_FILE);
+            file.entries.add(entry("delta", 1));
+            file.entries.add(entry("charlie", 2));
+            file.entries.add(entry("bravo", 3));
+            file.entries.add(entry("alpha", 4));
+            files.add(file);
+        }
+
+        private static SourceTextEntry entry(String source, int entryNum) {
+            return new SourceTextEntry(new EntryKey(SOURCE_FILE, source, null, "", "", null),
+                    entryNum, null, null, Collections.emptyList());
+        }
+
+        @Override
+        public ITokenizer getSourceTokenizer() {
+            return new LuceneEnglishTokenizer();
+        }
+
+        @Override
+        public ITokenizer getTargetTokenizer() {
+            return new DefaultTokenizer();
+        }
+
+        @Override
+        public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public List<FileInfo> getProjectFiles() {
+            return files;
+        }
+
+        @Override
+        public List<SourceTextEntry> getAllEntries() {
+            return new ArrayList<>(files.get(0).entries);
         }
 
         @Override


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement] (groundwork; no user-visible change on its own)

## Which ticket is resolved?

No ticket is resolved by this PR alone. It is the first, minimal step towards:

- Sorting segments
  * https://sourceforge.net/p/omegat/feature-requests/1094/

## What does this PR change?

- Separates two concerns in the editor that were previously fused: filtering decides which segments are shown, a new `IEditorSorter` decides their order. The sorter is applied in `loadDocument()` after filtering; with no sorter set, the document order is byte-identical to before.
- `setSort` / `getSort` / `removeSort` on `IEditor` mirror the existing filter API, so plugins and scripts (via `ConsoleBindings`) can reorder the editor without touching filtering.
- Entry navigation now locates entries by their exact entry number (with a nearest-entry fallback) instead of assuming ascending positional order, so navigation keeps working under any custom order.
- Tests: `EditorControllerTest` covers the sorter contract, the unchanged-order guarantee and the navigation fallback.

## Other information

Second groundwork PR of the segment-sorting series (see #2154 for the numeral foundation): the sorter model and the sort bar UI follow as separate pull requests, so each step stays small and independently reviewable. Making sortability of segments available as a plugin or in any other way depends on this.

Verification: full test suite and checkstyleMain pass on this branch, rebased onto current master.
