### PR TITLE
feat(editor): add CollapsibleBar base for stacked north bars

### DIFF
--- a/src/main/java/org/omegat/gui/editor/CollapsibleBar.java
+++ b/src/main/java/org/omegat/gui/editor/CollapsibleBar.java
@@ -1,0 +1,151 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import java.awt.Cursor;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+
+/**
+ * Base class for the stacked, collapsible control bars shown in the editor's
+ * north container (currently the sort bar, and later the filter bar).
+ *
+ * A collapsible bar has a permanently visible header row - a toggle arrow plus
+ * a one-line summary label - and a body that holds the expanded controls. The
+ * body is hidden by default, so the bar costs only a single line of vertical
+ * space until the user opens it. Clicking anywhere on the header toggles
+ * between collapsed and expanded.
+ *
+ * Subclasses put their expanded controls into {@link #getBody()} and supply the
+ * collapsed summary text through {@link #buildSummary()}. The summary is meant
+ * to be assembled from the same localized building blocks the expanded controls
+ * already use, so that collapsing introduces no new translatable strings.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+@SuppressWarnings("serial")
+public abstract class CollapsibleBar extends JPanel {
+
+    /** Triangle pointing down: the bar is expanded. */
+    private static final String ARROW_EXPANDED = "▾";
+    /** Triangle pointing right: the bar is collapsed. */
+    private static final String ARROW_COLLAPSED = "▸";
+
+    private final JLabel arrow = new JLabel(ARROW_COLLAPSED);
+    private final JLabel summary = new JLabel();
+    private final JPanel body = new JPanel();
+    private boolean expanded;
+
+    protected CollapsibleBar() {
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        Border border = UIManager.getBorder("OmegaTEditorFilter.border");
+        if (border != null) {
+            setBorder(border);
+        }
+
+        JPanel header = new JPanel();
+        header.setLayout(new BoxLayout(header, BoxLayout.LINE_AXIS));
+        header.add(arrow);
+        header.add(Box.createHorizontalStrut(4));
+        header.add(summary);
+        header.add(Box.createHorizontalGlue());
+        header.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+        MouseAdapter toggleOnClick = new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                toggle();
+            }
+        };
+        header.addMouseListener(toggleOnClick);
+        arrow.addMouseListener(toggleOnClick);
+        summary.addMouseListener(toggleOnClick);
+
+        body.setLayout(new BoxLayout(body, BoxLayout.Y_AXIS));
+
+        add(header);
+        add(body);
+
+        // Start collapsed. buildSummary() is intentionally NOT called from this
+        // constructor: subclass fields are not initialized yet at this point, so
+        // subclasses call refreshSummary() themselves once their state is built.
+        applyExpandedState(false);
+    }
+
+    /** The container a subclass fills with its expanded controls (rows). */
+    protected final JPanel getBody() {
+        return body;
+    }
+
+    /**
+     * The one-line text shown next to the arrow while collapsed, assembled from
+     * the subclass's already-localized building blocks. Invoked on every
+     * {@link #refreshSummary()} call and never from the constructor.
+     */
+    protected abstract String buildSummary();
+
+    /**
+     * Recompute the summary label from the current model. Subclasses call this
+     * after their model changes (criterion/condition added, removed, edited).
+     */
+    protected final void refreshSummary() {
+        summary.setText(buildSummary());
+        revalidate();
+        repaint();
+    }
+
+    public final boolean isExpanded() {
+        return expanded;
+    }
+
+    public final void setExpanded(boolean expand) {
+        applyExpandedState(expand);
+    }
+
+    public final void toggle() {
+        applyExpandedState(!expanded);
+    }
+
+    private void applyExpandedState(boolean expand) {
+        expanded = expand;
+        body.setVisible(expand);
+        arrow.setText(expand ? ARROW_EXPANDED : ARROW_COLLAPSED);
+        revalidate();
+        repaint();
+    }
+
+    /** Test hook: the current collapsed-summary text. */
+    String getSummaryText() {
+        return summary.getText();
+    }
+}

--- a/src/test/java/org/omegat/gui/editor/CollapsibleBarTest.java
+++ b/src/test/java/org/omegat/gui/editor/CollapsibleBarTest.java
@@ -1,0 +1,100 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.swing.JLabel;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CollapsibleBar} - the shared collapse/expand behavior
+ * and summary composition used by the sort and filter bars.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class CollapsibleBarTest {
+
+    /** Minimal concrete bar whose summary reflects a mutable field. */
+    private static final class TestBar extends CollapsibleBar {
+        String summaryText = "empty";
+
+        TestBar() {
+            getBody().add(new JLabel("row"));
+            refreshSummary();
+        }
+
+        @Override
+        protected String buildSummary() {
+            return summaryText;
+        }
+    }
+
+    @Test
+    public void startsCollapsedByDefault() {
+        TestBar bar = new TestBar();
+        assertFalse("bar must start collapsed", bar.isExpanded());
+    }
+
+    @Test
+    public void toggleExpandsAndCollapses() {
+        TestBar bar = new TestBar();
+        bar.toggle();
+        assertTrue(bar.isExpanded());
+        bar.toggle();
+        assertFalse(bar.isExpanded());
+    }
+
+    @Test
+    public void setExpandedControlsState() {
+        TestBar bar = new TestBar();
+        bar.setExpanded(true);
+        assertTrue(bar.isExpanded());
+        bar.setExpanded(false);
+        assertFalse(bar.isExpanded());
+    }
+
+    @Test
+    public void summaryReflectsModelAfterRefresh() {
+        TestBar bar = new TestBar();
+        assertEquals("empty", bar.getSummaryText());
+        bar.summaryText = "src:foo AND tgt:bar";
+        bar.refreshSummary();
+        assertEquals("src:foo AND tgt:bar", bar.getSummaryText());
+    }
+
+    @Test
+    public void constructorDoesNotCallBuildSummaryBeforeSubclassInit() {
+        // Regression guard: if the base called buildSummary() during its own
+        // constructor, the subclass field would not be set yet and this would
+        // observe null instead of the initialized value.
+        TestBar bar = new TestBar();
+        assertEquals("empty", bar.getSummaryText());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement] (groundwork; no user-visible change on its own)

## Which ticket is resolved?

No ticket is resolved by this PR alone. It is UI groundwork for:

- Sorting segments
  * https://sourceforge.net/p/omegat/feature-requests/1094/

## What does this PR change?

- Adds `CollapsibleBar`, an abstract collapsible control bar for the editor's north container: a permanently visible header (toggle arrow plus a one-line summary label) and a body that is hidden by default, so a bar costs only one line of vertical space until the user opens it.
- Subclasses provide the body via `getBody()` and the collapsed summary via `buildSummary()`, assembled from their own already-localized building blocks — collapsing adds no new translatable strings.
- Purely additive: no existing code is touched.
- Tests: `CollapsibleBarTest` (collapse/expand state, summary refresh, and a guard that `buildSummary()` is not called before subclass initialization).

## Other information

Part of the segment-sorting series (see #2154 for the numeral foundation and #2161 for the sorting hook): the sort bar built on this base follows as a separate pull request. This PR is independent of the other groundwork PRs and can be reviewed on its own.

Verification: full test suite and checkstyleMain pass on this branch, rebased onto current master.
