### PR TITLE
test(gui): decouple locale-dependent tests from the runtime locale

### DIFF
--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -151,7 +151,6 @@ import static org.omegat.util.gui.DataTableStyling.getTextCellRenderer;
 @NullMarked
 public class ProjectFilesListController implements IProjectFilesList {
 
-    private static final NumberFormat PROGRESS_PERCENT_FORMAT = createProgressPercentFormat();
     private static final int MIN_PROGRESS_WIDTH = 3;
 
     private ProjectFilesList list;
@@ -1192,9 +1191,10 @@ public class ProjectFilesListController implements IProjectFilesList {
         if (translated <= 0 || total <= 0) {
             return "0%";
         }
-        synchronized (PROGRESS_PERCENT_FORMAT) {
-            return PROGRESS_PERCENT_FORMAT.format((double) translated / total);
-        }
+        // Create the format per call: a static instance would freeze the
+        // locale active when this class was first loaded, and DecimalFormat
+        // is not thread-safe anyway.
+        return createProgressPercentFormat().format((double) translated / total);
     }
 
     private static boolean isProjectFilesProgressEnabled() {

--- a/src/test/java/org/omegat/gui/dialogs/DialogsTest.java
+++ b/src/test/java/org/omegat/gui/dialogs/DialogsTest.java
@@ -36,19 +36,26 @@ import java.util.Locale;
 
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.omegat.core.TestCore;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.util.LocaleRule;
 import org.omegat.util.Platform;
 
 public class DialogsTest extends TestCore {
 
+    /**
+     * Use English so that uses of old/stale resource keys can't be masked by
+     * out-of-date translated resources when the runtime locale is not English.
+     * The rule restores the original locale so it does not leak into tests
+     * running later in the same JVM.
+     */
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(Locale.ENGLISH);
+
     @Before
     public final void setUp() {
-        // Set default locale to English so that uses of old/stale
-        // resource keys can't be masked by out-of-date translated
-        // resources when runtime locale is not English.
-        Locale.setDefault(Locale.ENGLISH);
         // All tests in this class should require a GUI; any tests that can be
         // run when headless should be put in a different class.
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());

--- a/src/test/java/org/omegat/gui/editor/mark/WhitespaceMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/WhitespaceMarkerTest.java
@@ -31,16 +31,26 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.core.Core;
 import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.util.LocaleRule;
 
 public class WhitespaceMarkerTest extends MarkerTestBase {
+
+    /**
+     * The expected tooltips come from the English resource bundle; pin the
+     * locale so the test does not depend on the runtime locale.
+     */
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(Locale.ENGLISH);
 
     @Before
     public void preUp() {

--- a/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
+++ b/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
@@ -30,22 +30,32 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableColumn;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.util.LocaleRule;
 import org.omegat.util.TestPreferencesInitializer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ProjectFilesListControllerTest {
+
+    /**
+     * The expected percent strings use the English decimal separator; pin the
+     * locale so the test does not depend on the runtime locale.
+     */
+    @Rule
+    public final LocaleRule localeRule = new LocaleRule(Locale.ENGLISH);
 
     @BeforeClass
     public static void setUpClass() throws Exception {


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

No SourceForge ticket: these are incidental findings from failing tests. While investigating test flakiness, running the test suite under a non-English default locale (e.g. de_DE or tr_TR) made three tests fail, which pointed at the issues fixed here.

## What does this PR change?

- `WhitespaceMarkerTest` and `ProjectFilesListControllerTest` expected English resource strings and number formats ("Tab", "50.0%") but used whatever locale the test JVM ran under. They now pin the locale with the existing `LocaleRule`, which also restores it afterwards.
- `DialogsTest` set `Locale.setDefault(Locale.ENGLISH)` without restoring it, leaking English into every test running later in the same JVM. This leak masked the two failures above. It now uses `LocaleRule` as well.
- `ProjectFilesListController` cached the progress percent format in a static field, freezing whatever locale was active when the class was first loaded. The format is now created per call; this also removes the `synchronized` workaround for `DecimalFormat` not being thread-safe.

## Other information

No behavior change for users running OmegaT itself: the file list still formats percentages with the current locale, only no longer with a stale one. The full `check` suite passes, and the previously failing tests now pass both in isolation and when the suite runs under tr_TR or de_DE.
