### PR TITLE
test(glossary): wait for the linkifier instead of sleeping a fixed time

### DIFF
--- a/src/test/java/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -97,9 +97,31 @@ public class GlossaryTextAreaTest extends TestCore {
         renderer.render(entries.get(0), doc);
         renderer.render(entries.get(1), doc);
         renderer.render(entries.get(2), doc);
-        Thread.sleep(300);
         String expected = doc.getText(0, doc.getLength()).replaceAll("%C3%A8", "è");
-        assertEquals(expected, gta.getText());
+        assertTextEventually(gta, expected);
+    }
+
+    /**
+     * The linkifier rewrites the URL asynchronously: the document insert
+     * schedules a refresh with invokeLater, decoding the URL triggers a
+     * second one, and further refreshes run on a Swing timer. A fixed sleep
+     * is either too short on a busy machine or wastes time, so poll the
+     * text on the EDT until it reaches the expected state.
+     */
+    private static void assertTextEventually(GlossaryTextArea gta, String expected) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        String actual = getTextOnEdt(gta);
+        while (!expected.equals(actual) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+            actual = getTextOnEdt(gta);
+        }
+        assertEquals(expected, actual);
+    }
+
+    private static String getTextOnEdt(GlossaryTextArea gta) throws Exception {
+        String[] result = new String[1];
+        SwingUtilities.invokeAndWait(() -> result[0] = gta.getText());
+        return result[0];
     }
 
     /**


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

No SourceForge ticket: this is an incidental finding from a test-flakiness investigation. The fixed sleep showed up as a flake candidate while looking into why tests fail sporadically on busy CI machines.

## What does this PR change?

- `GlossaryTextAreaTest.testSetGlossaryEntriesWithLink` slept a fixed 300 ms before asserting, to outwait the linkifier: `JTextPaneLinkifier` rewrites the inserted URL asynchronously through two chained `invokeLater` rounds plus a 200 ms Swing timer. On a busy machine 300 ms can be too short (sporadic failure), on a fast one it just wastes time.
- The test now polls the text area on the EDT every 10 ms until it shows the expected text, with a 5-second deadline, and then asserts normally. A comment on the helper explains the asynchronous chain so future readers do not have to rediscover it.

## Other information

Test-only change. The test class runs about three times in a row without failures and finishes faster than before; the full `check` suite passes.
