### PR TITLE
fix(util): load JNA again after the thread-safety refactor broke it

### DIFF
--- a/src/main/java/org/omegat/util/JnaLoader.java
+++ b/src/main/java/org/omegat/util/JnaLoader.java
@@ -34,7 +34,7 @@ import com.sun.jna.Native;
  */
 public final class JnaLoader {
     private static final Object LOCK = new Object();
-    private static Boolean ourJnaLoaded = false;
+    private static Boolean ourJnaLoaded = null;
 
     public static void load() {
         synchronized (LOCK) {


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

No SourceForge ticket: this is a regression introduced by #2151 on master, noticed because OmegaT stopped following the operating system's dark mode.

## What does this PR change?

The synchronization refactor in #2151 changed the initial value of `JnaLoader.ourJnaLoaded` from `null` to `false`, while `load()` still only performs the actual loading when the field is `null`. As a result JNA was never loaded and `isLoaded()` always returned `false`. This restores the `null` initial state; the tri-state field (`null` = not attempted, `false` = attempted and failed, `true` = loaded) works again as before the refactor.

## Other information

The visible symptom: `MacOSDarkThemeDetector` and `WindowsDarkThemeDetector` both guard on `JnaLoader.isLoaded()`, so since #2151 the default flat theme could no longer detect the system dark mode on macOS and Windows and always rendered light. Verified on macOS: before the fix the startup log shows no JNA line and the UI ignores the system dark mode; with the fix the log shows "JNA library (64-bit) loaded" again and the theme follows the system. Full test suite and checkstyle pass.
