### PR TITLE
chore(test): replace anonymous classes with lambda expressions in alignment tests

### DIFF
--- a/src/test/java/org/omegat/filters/ILIASFilterTest.java
+++ b/src/test/java/org/omegat/filters/ILIASFilterTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.omegat.filters2.IAlignCallback;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.text.ilias.ILIASFilter;
 
 /**
@@ -44,14 +43,16 @@ public class ILIASFilterTest extends TestFilterBase {
 
     @Test
     public void testParse() throws Exception {
-        List<String> entries = parse(new ILIASFilter(), "src/test/resources/data/filters/ilias/ILIASFilter.lang");
+        List<String> entries = parse(new ILIASFilter(),
+                "src/test/resources/data/filters/ilias/ILIASFilter.lang");
         assertEquals(7, entries.size());
         int i = 0;
         assertEquals("Good line", entries.get(i++));
         assertEquals("Another good line with HTML <br/> entity", entries.get(i++));
         assertEquals("The text may include : too", entries.get(i++));
         assertEquals("The text may include # as well", entries.get(i++));
-        assertEquals("The text may include  #:# or ", entries.get(i++)); // note the space after "or"
+        // note the space after "or"
+        assertEquals("The text may include  #:# or ", entries.get(i++));
         assertEquals("have it at the end #:#", entries.get(i++));
         assertEquals("#:#", entries.get(i++));
     }
@@ -65,15 +66,10 @@ public class ILIASFilterTest extends TestFilterBase {
     public void testAlign() throws Exception {
         final AlignResultHolder alignResult = new AlignResultHolder();
 
-        align(new ILIASFilter(), "ilias/ILIASFilterAlign.lang",
-                "ilias/ILIASFilterAlign-tr.lang", new IAlignCallback() {
-                    @Override
-                    public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                            String comment, IFilter filter) {
-                        alignResult.aligned = id.equals("module_name#:#variable_name") && source.equals("original")
-                                && translation.equals("translated");
-                    }
-                });
+        align(new ILIASFilter(), "ilias/ILIASFilterAlign.lang", "ilias/ILIASFilterAlign-tr.lang",
+                (IAlignCallback) (id, source, translation, isFuzzy, comment,
+                        filter) -> alignResult.aligned = "module_name#:#variable_name".equals(id)
+                                && "original".equals(source) && "translated".equals(translation));
 
         assertTrue(alignResult.aligned);
     }

--- a/src/test/java/org/omegat/filters/MagentoFilterTest.java
+++ b/src/test/java/org/omegat/filters/MagentoFilterTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.omegat.filters2.IAlignCallback;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.text.magento.MagentoFilter;
 
 /**
@@ -44,7 +43,8 @@ public class MagentoFilterTest extends TestFilterBase {
 
     @Test
     public void testParse() throws Exception {
-        List<String> entries = parse(new MagentoFilter(), "src/test/resources/data/filters/magento/MagentoFilter.csv");
+        List<String> entries = parse(new MagentoFilter(),
+                "src/test/resources/data/filters/magento/MagentoFilter.csv");
         assertEquals(5, entries.size());
         int i = 0;
         assertEquals("Tr: %s", entries.get(i++));
@@ -65,13 +65,9 @@ public class MagentoFilterTest extends TestFilterBase {
         final AlignResultHolder alignResult = new AlignResultHolder();
 
         align(new MagentoFilter(), "magento/MagentoFilterAlign.csv", "magento/MagentoFilterAlign-tr.csv",
-                new IAlignCallback() {
-                    public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                            String comment, IFilter filter) {
-                        alignResult.aligned = id.equals("code") && source.equals("original")
-                                && translation.equals("translated");
-                    }
-                });
+                (IAlignCallback) (id, source, translation, isFuzzy, comment,
+                        filter) -> alignResult.aligned = "code".equals(id) && "original".equals(source)
+                                && "translated".equals(translation));
 
         assertTrue(alignResult.aligned);
     }

--- a/src/test/java/org/omegat/filters/MoodlePHPFilterTest.java
+++ b/src/test/java/org/omegat/filters/MoodlePHPFilterTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.IAlignCallback;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.moodlephp.MoodlePHPFilter;
 
 public class MoodlePHPFilterTest extends TestFilterBase {
@@ -47,30 +46,29 @@ public class MoodlePHPFilterTest extends TestFilterBase {
         checkMultiStart(fi, f);
         checkMulti("Accessibility", "access", null, null, null, null);
         checkMulti("Accessibility help", "accesshelp", null, null, null, null);
-        checkMulti("Unrecognised options:\n" +
-                "  {$a}\n" +
-                "Please use --help option.", "cliunknowoption", null, null, null, null);
-        checkMulti("You cannot uninstall the \\'{$a->filter}\\' because it is part of the \\'{$a->module}\\' module.", "cannotdeletemodfilter", null, null, null, null);
-        checkMulti("List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \\';\\'. Usually something like \\'cn=teachers,ou=staff,o=myorg\\'", "auth_ldap_attrcreators", null, null, null, null);
+        checkMulti("Unrecognised options:\n" + "  {$a}\n" + "Please use --help option.", "cliunknowoption",
+                null, null, null, null);
+        checkMulti(
+                "You cannot uninstall the \\'{$a->filter}\\' because it is part of the \\'{$a->module}\\' module.",
+                "cannotdeletemodfilter", null, null, null, null);
+        checkMulti(
+                "List of groups or contexts whose members are allowed to create attributes. Separate multiple groups with \\';\\'. Usually something like \\'cn=teachers,ou=staff,o=myorg\\'",
+                "auth_ldap_attrcreators", null, null, null, null);
         checkMultiEnd();
     }
 
     @Test
     public void testTranslate() throws Exception {
-        translateText(new MoodlePHPFilter(),
-                "src/test/resources/data/filters/MoodlePHP/file.php");
+        translateText(new MoodlePHPFilter(), "src/test/resources/data/filters/MoodlePHP/file.php");
     }
 
     @Test
     public void testAlign() throws Exception {
         final AlignResult ar = new AlignResult();
-        align(new MoodlePHPFilter(), "MoodlePHP/filesAlign.php",
-                "MoodlePHP/filesAlign_gl.php", new IAlignCallback() {
-            public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                    String path, IFilter filter) {
-                ar.found = id.equals("access") && source.equals("Accessibility") && translation.equals("Accesibilidade");
-            }
-        });
+        align(new MoodlePHPFilter(), "MoodlePHP/filesAlign.php", "MoodlePHP/filesAlign_gl.php",
+                (IAlignCallback) (id, source, translation, isFuzzy, path,
+                        filter) -> ar.found = "access".equals(id) && "Accessibility".equals(source)
+                                && "Accesibilidade".equals(translation));
         assertTrue(ar.found);
     }
 

--- a/src/test/java/org/omegat/filters/MozillaDTDFilterTest.java
+++ b/src/test/java/org/omegat/filters/MozillaDTDFilterTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.IAlignCallback;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.mozdtd.MozillaDTDFilter;
 
 public class MozillaDTDFilterTest extends TestFilterBase {
@@ -59,14 +58,10 @@ public class MozillaDTDFilterTest extends TestFilterBase {
     @Test
     public void testAlign() throws Exception {
         final AlignResult ar = new AlignResult();
-        align(new MozillaDTDFilter(), "MozillaDTD/file.dtd",
-                "MozillaDTD/file-be.dtd",
-                new IAlignCallback() {
-                    @Override
-                    public void addTranslation(final String id, final String source, final String translation, final boolean isFuzzy, final String path, final IFilter filter) {
-                        ar.found |= id.equals("mainWindow.title") && source.equals("Title") && translation.equals("Title-be");
-                    }
-                });
+        align(new MozillaDTDFilter(), "MozillaDTD/file.dtd", "MozillaDTD/file-be.dtd",
+                (IAlignCallback) (id, source, translation, isFuzzy, path,
+                        filter) -> ar.found |= "mainWindow.title".equals(id) && "Title".equals(source)
+                                && "Title-be".equals(translation));
         assertTrue(ar.found);
     }
 }

--- a/src/test/java/org/omegat/filters/ResourceBundleFilterTest.java
+++ b/src/test/java/org/omegat/filters/ResourceBundleFilterTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.omegat.core.Core;
 import org.omegat.core.data.IProject;
 import org.omegat.filters2.IAlignCallback;
-import org.omegat.filters2.IFilter;
 import org.omegat.filters2.TranslationException;
 import org.omegat.filters2.text.bundles.ResourceBundleFilter;
 
@@ -54,19 +53,18 @@ public class ResourceBundleFilterTest extends TestFilterBase {
         Map<String, String> options = new TreeMap<>();
         options.put(ResourceBundleFilter.OPTION_FORCE_JAVA8_LITERALS_ESCAPE, "true");
         translateText(new ResourceBundleFilter(),
-                "src/test/resources/data/filters/resourceBundle/file-ResourceBundleFilter.properties", options);
+                "src/test/resources/data/filters/resourceBundle/file-ResourceBundleFilter.properties",
+                options);
     }
 
     @Test
     public void testAlign() throws Exception {
         final AlignResult ar = new AlignResult();
         align(new ResourceBundleFilter(), "resourceBundle/file-ResourceBundleFilter.properties",
-                "resourceBundle/file-ResourceBundleFilter_be.properties", new IAlignCallback() {
-                    public void addTranslation(String id, String source, String translation, boolean isFuzzy,
-                            String path, IFilter filter) {
-                        ar.found = id.equals("ID") && source.equals("Value") && translation.equals("test");
-                    }
-                });
+                "resourceBundle/file-ResourceBundleFilter_be.properties",
+                (IAlignCallback) (id, source, translation, isFuzzy, path,
+                        filter) -> ar.found = "ID".equals(id) && "Value".equals(source)
+                                && "test".equals(translation));
         assertTrue(ar.found);
     }
 
@@ -86,7 +84,8 @@ public class ResourceBundleFilterTest extends TestFilterBase {
         checkMulti("Value3", "ID3", null, null, null, "# some comment");
         checkMulti("Value4", "ID4", null, null, null, "# multiple line\n# comment");
         checkMulti("Value5", "ID5", null, null, null, "! alternate comment style");
-        checkMulti("Value\u2603", "ID6", null, null, null, "# Unicode escape \u2603"); // U+2603 SNOWMAN
+        checkMulti("Value\u2603", "ID6", null, null, null, "# Unicode escape \u2603"); // U+2603
+                                                                                       // SNOWMAN
         checkMultiEnd();
 
         f = "src/test/resources/data/filters/resourceBundle/file-ResourceBundleFilter-SMP.properties";
@@ -115,7 +114,9 @@ public class ResourceBundleFilterTest extends TestFilterBase {
 
     /**
      * Test Unicode case.
-     * @throws Exception when error occurred.
+     * 
+     * @throws Exception
+     *             when error occurred.
      */
     @Test
     public void testNonEscapeUnicode() throws Exception {
@@ -132,11 +133,12 @@ public class ResourceBundleFilterTest extends TestFilterBase {
     }
 
     /**
-     * Test Unicode case, when the filter configured not to force escape
-     * and output encoding context is US-ASCII.
-     * Check loaded Unicode literals are in code points out of ASCII,
-     * then check the output file is escaped.
-     * @throws Exception when error occurred.
+     * Test Unicode case, when the filter configured not to force escape and
+     * output encoding context is US-ASCII. Check loaded Unicode literals are in
+     * code points out of ASCII, then check the output file is escaped.
+     * 
+     * @throws Exception
+     *             when error occurred.
      */
     @Test
     public void testEscapeUnicodeWhenASCII() throws Exception {
@@ -190,12 +192,14 @@ public class ResourceBundleFilterTest extends TestFilterBase {
         checkMultiStart(fi, f);
         checkMulti("Value", "KEY", null, null, null, "# Tab->\t<-Tab");
         checkMulti("Value    ", "KEY2", null, null, null, "# Trailing whitespace must be preserved");
-        checkMulti("Value1\tValue2", "KEY3", null, null, null, "# Significant whitespace on continuation line");
+        checkMulti("Value1\tValue2", "KEY3", null, null, null,
+                "# Significant whitespace on continuation line");
         checkMulti("Value1 Value2", "KEY4", null, null, null, null);
         checkMultiEnd();
 
         translate(filter, f);
-        compareBinary(new File("src/test/resources/data/filters/resourceBundle/file-ResourceBundleFilter-WhiteSpace-gold.properties"),
+        compareBinary(new File(
+                "src/test/resources/data/filters/resourceBundle/file-ResourceBundleFilter-WhiteSpace-gold.properties"),
                 outFile);
 
         // Restore old value
@@ -239,31 +243,25 @@ public class ResourceBundleFilterTest extends TestFilterBase {
         IProject.FileInfo fi = loadSourceFiles(filter, f, config);
         checkMultiStart(fi, f);
         checkMulti("Unpack project from OMT file...", "omt.menu.import", null, null, null,
-                "#/**************************************************************************\n" +
-                        "# OmegaT Plugin - OMT Package Manager\n" +
-                        "#\n" +
-                        "# Copyright (C) 2019 Briac Pilpr\u00E9\n" +
-                        "# Home page: http://www.omegat.org/\n" +
-                        "# Support center: http://groups.yahoo.com/group/OmegaT/\n" +
-                        "#\n" +
-                        "# This program is free software: you can redistribute it and/or modify\n" +
-                        "# it under the terms of the GNU General Public License as published by\n" +
-                        "# the Free Software Foundation, either version 3 of the License, or\n" +
-                        "# (at your option) any later version.\n" +
-                        "#\n" +
-                        "# This program is distributed in the hope that it will be useful,\n" +
-                        "# but WITHOUT ANY WARRANTY; without even the implied warranty of\n" +
-                        "# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n" +
-                        "# GNU General Public License for more details.\n" +
-                        "#\n" +
-                        "# You should have received a copy of the GNU General Public License\n" +
-                        "# along with this program. If not, see <http://www.gnu.org/licenses/>.\n" +
-                        "#\n" +
-                        "# **************************************************************************/"
-        );
+                "#/**************************************************************************\n"
+                        + "# OmegaT Plugin - OMT Package Manager\n" + "#\n"
+                        + "# Copyright (C) 2019 Briac Pilpr\u00E9\n" + "# Home page: http://www.omegat.org/\n"
+                        + "# Support center: http://groups.yahoo.com/group/OmegaT/\n" + "#\n"
+                        + "# This program is free software: you can redistribute it and/or modify\n"
+                        + "# it under the terms of the GNU General Public License as published by\n"
+                        + "# the Free Software Foundation, either version 3 of the License, or\n"
+                        + "# (at your option) any later version.\n" + "#\n"
+                        + "# This program is distributed in the hope that it will be useful,\n"
+                        + "# but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+                        + "# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+                        + "# GNU General Public License for more details.\n" + "#\n"
+                        + "# You should have received a copy of the GNU General Public License\n"
+                        + "# along with this program. If not, see <http://www.gnu.org/licenses/>.\n" + "#\n"
+                        + "# **************************************************************************/");
         checkMulti("Pack project as OMT file...", "omt.menu.export", null, null, null, null);
         checkMulti("Pack and delete project...", "omt.menu.export.delete", null, null, null, null);
-        checkMulti("The project already has an ongoing translation.\nDo you want to overwrite it with the translation from the package ?",
+        checkMulti(
+                "The project already has an ongoing translation.\nDo you want to overwrite it with the translation from the package ?",
                 "omt.dialog.overwrite_project_save", null, null, null, null);
         checkMulti("Deleting project...", "omt.status.delete_project", null, null, null, null);
         checkMultiEnd();


### PR DESCRIPTION
Fix Spobugs warning

## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?
none
## What does this PR change?


- Simplify test cases by replacing `IAlignCallback` anonymous classes with lambda expressions for cleaner and more concise code.
- change equals order for nullable value check

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
