### PR TITLE
chore(test): refactor `YamlFilterTest` to use AssertJ for assertions

### DIFF
--- a/src/test/java/org/omegat/filters/TestFilterBase.java
+++ b/src/test/java/org/omegat/filters/TestFilterBase.java
@@ -28,7 +28,6 @@ package org.omegat.filters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
-import static org.xmlunit.assertj3.XmlAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -46,10 +45,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.w3c.dom.Document;
+import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
 
@@ -455,7 +457,7 @@ public abstract class TestFilterBase extends TestCore {
 
         Document doc1 = builder.parse(f1);
         Document doc2 = builder.parse(f2);
-        assertThat(doc1).and(doc2).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+        XmlAssert.assertThat(doc1).and(doc2).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
                 .withAttributeFilter(attr -> !("creationtoolversion".equals(attr.getName())
                         || "creationtool".equals(attr.getName())))
                 .ignoreWhitespace().areIdentical();
@@ -476,7 +478,7 @@ public abstract class TestFilterBase extends TestCore {
         DocumentBuilder builder = factory.newDocumentBuilder();
         var doc1 = builder.parse(f1.toExternalForm());
         var doc2 = builder.parse(f2.toExternalForm());
-        assertThat(doc2).and(doc1).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+        XmlAssert.assertThat(doc2).and(doc1).withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
                 .areIdentical();
     }
 
@@ -551,6 +553,44 @@ public abstract class TestFilterBase extends TestCore {
 
     protected void skipMulti() {
         fiCount++;
+    }
+
+    protected static Tuple entry(String sourceText, String id, String path, String prev, String next, String comment) {
+        return Assertions.tuple(sourceText, id, path, prev, next, comment);
+    }
+
+    /**
+     * Asserts that the entries in the given file information match the expected tuples.
+     * This method verifies that all entries have a file name equal to the provided file name,
+     * and that the source text of each entry matches its key's source text. Additionally,
+     * it checks that the extracted properties of the entries match the expected tuples.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * assertEntries(fi, file,
+     *         entry("Title", "mainWindow.title", null, null, null, null),
+     *         entry("File", "fileMenu.label", null, null, null, null),
+     *         entry("Edit", "editMenu.label", null, null, null, null));
+     * }</pre>
+     *
+     * @param fi the file information containing the entries to be asserted
+     * @param file the expected file name to be matched for all entries
+     * @param entries the expected tuples that the extracted properties of the entries should match
+     */
+    protected void assertEntries(IProject.FileInfo fi, String file, Tuple... entries) {
+        Assertions.assertThat(fi.entries)
+                .allSatisfy(ste -> {
+                    Assertions.assertThat(ste.getKey().file).isEqualTo(file);
+                    Assertions.assertThat(ste.getSrcText()).isEqualTo(ste.getKey().sourceText);
+                })
+                .extracting(
+                        SourceTextEntry::getSrcText,
+                        ste -> ste.getKey().id,
+                        ste -> ste.getKey().path,
+                        ste -> ste.getKey().prev,
+                        ste -> ste.getKey().next,
+                        SourceTextEntry::getComment)
+                .containsExactly(entries);
     }
 
     /**

--- a/src/test/java/org/omegat/filters/YamlFilterTest.java
+++ b/src/test/java/org/omegat/filters/YamlFilterTest.java
@@ -25,8 +25,8 @@
 
 package org.omegat.filters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -51,15 +51,8 @@ public class YamlFilterTest extends TestFilterBase {
     public void testParse() throws Exception {
         List<String> entries = parse(new YamlFilter(), "src/test/resources/data/filters/yaml/sample1.yaml");
         // Expected extraction order follows insertion order in YAML
-        assertEquals(8, entries.size());
-        assertEquals("Welcome", entries.get(0));
-        assertEquals("Home", entries.get(1));
-        assertEquals("About", entries.get(2));
-        assertEquals("Contact", entries.get(3));
-        assertEquals("(c) 2025 Example Co.", entries.get(4));
-        assertEquals("/help", entries.get(5));
-        assertEquals("/terms", entries.get(6));
-        assertEquals("Enabled features", entries.get(7));
+        assertThat(entries).containsExactly("Welcome", "Home", "About", "Contact", "(c) 2025 Example Co.",
+                         "/help", "/terms", "Enabled features");
     }
 
     @Test
@@ -114,53 +107,40 @@ public class YamlFilterTest extends TestFilterBase {
     public void testLoad() throws Exception {
         String f = "src/test/resources/data/filters/yaml/sample1.yaml";
         IProject.FileInfo fi = loadSourceFiles(new YamlFilter(), f);
-
-        checkMultiStart(fi, f);
-        checkMulti("Welcome", "title_0", null, null, null, "name=title");
-        checkMulti("Home", "menu/items[0]_0", null, null, null, "name=menu/items[0]");
-        checkMulti("About", "menu/items[1]_0", null, null, null, "name=menu/items[1]");
-        checkMulti("Contact", "menu/items[2]_0", null, null, null, "name=menu/items[2]");
-        checkMulti("(c) 2025 Example Co.", "footer/copyright_0", null, null, null, "name=footer/copyright");
-        checkMulti("/help", "footer/links/help_0", null, null, null, "name=footer/links/help");
-        checkMulti("/terms", "footer/links/terms_0", null, null, null, "name=footer/links/terms");
-        checkMulti("Enabled features", "features/description_0", null, null, null, "name=features/description");
-        checkMultiEnd();
+        assertEntries(fi, f,
+                entry("Welcome", "title_0", null, null, null, "name=title"),
+                entry("Home", "menu/items[0]_0", null, null, null, "name=menu/items[0]"),
+                entry("About", "menu/items[1]_0", null, null, null, "name=menu/items[1]"),
+                entry("Contact", "menu/items[2]_0", null, null, null, "name=menu/items[2]"),
+                entry("(c) 2025 Example Co.", "footer/copyright_0", null, null, null,
+                        "name=footer/copyright"),
+                entry("/help", "footer/links/help_0", null, null, null, "name=footer/links/help"),
+                entry("/terms", "footer/links/terms_0", null, null, null, "name=footer/links/terms"),
+                entry("Enabled features", "features/description_0", null, null, null,
+                        "name=features/description"));
     }
 
     @Test
     public void testParseWithExclude() throws Exception {
         Map<String, String> options = Map.of(YamlOptions.OPTION_EXCLUDE, "footer/links/help;footer/links/terms");
         List<String> entries = parse(new YamlFilter(), "src/test/resources/data/filters/yaml/sample1.yaml", options);
-        assertEquals(6, entries.size());
-        assertEquals("Welcome", entries.get(0));
-        assertEquals("Home", entries.get(1));
-        assertEquals("About", entries.get(2));
-        assertEquals("Contact", entries.get(3));
-        assertEquals("(c) 2025 Example Co.", entries.get(4));
-        assertEquals("Enabled features", entries.get(5));
+        assertThat(entries).containsExactly("Welcome", "Home", "About", "Contact", "(c) 2025 Example Co.",
+                "Enabled features");
     }
 
     @Test
     public void testParseWithInclude() throws Exception {
         Map<String, String> options = Map.of(YamlOptions.OPTION_INCLUDE, "menu/**");
         List<String> entries = parse(new YamlFilter(), "src/test/resources/data/filters/yaml/sample1.yaml", options);
-        assertEquals(3, entries.size());
-        assertEquals("Home", entries.get(0));
-        assertEquals("About", entries.get(1));
-        assertEquals("Contact", entries.get(2));
+        assertThat(entries).containsExactly("Home", "About", "Contact");
     }
 
     @Test
     public void testParseWithWildcard() throws Exception {
         Map<String, String> options = Map.of(YamlOptions.OPTION_EXCLUDE, "footer/*/*");
         List<String> entries = parse(new YamlFilter(), "src/test/resources/data/filters/yaml/sample1.yaml", options);
-        assertEquals(6, entries.size());
-        assertEquals("Welcome", entries.get(0));
-        assertEquals("Home", entries.get(1));
-        assertEquals("About", entries.get(2));
-        assertEquals("Contact", entries.get(3));
-        assertEquals("(c) 2025 Example Co.", entries.get(4));
-        assertEquals("Enabled features", entries.get(5));
+        assertThat(entries).containsExactly("Welcome", "Home", "About", "Contact", "(c) 2025 Example Co.",
+                "Enabled features");
     }
 
     @Test
@@ -170,8 +150,7 @@ public class YamlFilterTest extends TestFilterBase {
             YamlOptions.OPTION_EXCLUDE, "**/links/**"
         );
         List<String> entries = parse(new YamlFilter(), "src/test/resources/data/filters/yaml/sample1.yaml", options);
-        assertEquals(1, entries.size());
-        assertEquals("(c) 2025 Example Co.", entries.get(0));
+        assertThat(entries).containsExactly("(c) 2025 Example Co.");
     }
 
     @Test
@@ -196,9 +175,6 @@ public class YamlFilterTest extends TestFilterBase {
         options.setExcludeKeys(List.of("key;with;semicolons", "key\\with\\backslashes", "normal/key"));
         
         List<String> recovered = options.getExcludeKeys();
-        assertEquals(3, recovered.size());
-        assertTrue(recovered.contains("key;with;semicolons"));
-        assertTrue(recovered.contains("key\\with\\backslashes"));
-        assertTrue(recovered.contains("normal/key"));
+        assertThat(recovered).containsExactly("key;with;semicolons", "key\\with\\backslashes", "normal/key");
     }
 }


### PR DESCRIPTION
Example of the AssertJ usage in the filter test.

## Pull request type

- Other (describe below)
Test enhancement

## Which ticket is resolved?
none of the bug/feature, but ground work of the tests
## What does this PR change?

- Introduce assetEntries helper
- Rewrite YamlFilterTest with the new helper and assertj
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
