### PR TITLE
docs(adr): user-base measurement channels and adoption among professionals and academia

### DIFF
--- a/src/docs/developer/adr/2026004.UserBaseMeasurement.md
+++ b/src/docs/developer/adr/2026004.UserBaseMeasurement.md
@@ -1,21 +1,22 @@
-# ADR: User Base Measurement and Market Position
+# ADR: User Base Measurement and Adoption
 
 ## Status
 
-**Proposed** (Date: 2026-07-25)
+**Proposed** (Date: 2026-07-25, revised 2026-07-26)
 
 ## Context
 
 OmegaT collects no usage telemetry, so the project has no direct knowledge of how many
-people use it, on which platforms, or in which market segments. That information matters
+people use it, on which platforms, or in which fields of work. That information matters
 for recurring development decisions: which platforms and Java runtimes to prioritize,
 how much weight to give backward compatibility, which file formats and workflows deserve
-attention, and how to position OmegaT relative to commercial CAT tools.
+attention, and how significant OmegaT is for the translation community it serves.
 
 The question can nevertheless be answered, to a useful approximation, from public and
 privacy-friendly sources. This record documents the available measurement channels, a
 baseline of their readings, and the resulting estimate, so that future discussions can
-start from shared numbers instead of anecdote.
+start from shared numbers instead of anecdote. An appendix collects verified public
+statements about OmegaT that illustrate its acceptance and the needs of its users.
 
 ### Public data, baseline July 2026
 
@@ -40,20 +41,41 @@ start from shared numbers instead of anecdote.
   translation team) and individual professional translators, as reflected in the
   testimonials collected on omegat.org.
 
-### Market position
+### Adoption in training and daily practice
 
-Independent surveys of professional translators consistently place the commercial tools
-first. In the Inbox Translation freelance survey (2023), 81% of respondents use CAT
-tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%, while
-OmegaT appears among the most-mentioned write-in tools below the 15% line. The MET
-survey (2020, 157 respondents) shows the same shape. RWS states that more than 250,000
-translation professionals use Trados Studio.
+- University translation programmes teach OmegaT alongside proprietary tools; the
+  University of Bologna, for example, lists it in its CAT course units for 2024/25 and
+  later years. The EMT survey 2023 (Rothwell, Moorkens, Svoboda) records at the same
+  time a general drift of teaching programmes towards "cloud-based software with
+  cost-free academic access", which affects the exposure of new graduates to
+  desktop tools such as OmegaT.
+- Practitioner voices document long-term acceptance: reviews on the project's
+  SourceForge page average 5.0 of 5 over 53 reviews; trainer and translator
+  Corinne McKay (2025) calls OmegaT "a free and open-source tool that I still love"
+  and finds "its matching algorithm to be better than commercial tools'"; the South
+  African Translators' Institute recommends it as a fully functional no-cost option;
+  and community discussions repeatedly recommend OmegaT to translators looking for
+  an alternative when subscription prices of proprietary tools rise.
+- The same public feedback names recurring needs — a friendlier first-run
+  experience, more discoverable machine-translation and dictionary setup, richer
+  terminology data, built-in bilingual review export, easier team-project setup —
+  which are collected with sources in the appendix and can seed the feature-request
+  tracker.
+
+### Acceptance and relative adoption
+
+Independent surveys of professional translators consistently show the proprietary tools
+in the lead. In the Inbox Translation freelance survey (2023), 81% of respondents use
+CAT tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%,
+while OmegaT appears among the most-mentioned write-in tools below the 15% line. The
+MET survey (2020, 157 respondents) shows the same shape. RWS states that more than
+250,000 translation professionals use Trados Studio.
 
 Within open source, OmegaT is the only full-featured desktop CAT tool under active
 development: Virtaal and Pootle are discontinued, and the active open-source projects
 occupy adjacent niches (MateCat in the browser, Weblate and friends in software
-localization). OmegaT's direct competition is therefore commercial, while its own niche
-has no serious open-source rival.
+localization). For translators who want or need a free desktop tool, OmegaT therefore
+carries a significance well beyond its share in the surveys.
 
 ### Estimate
 
@@ -78,7 +100,7 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
    - the SourceForge download statistics API (volume, platform, and country trends);
    - packaging channel statistics (Flathub API, Debian popcon, and similar);
    - independent professional surveys (Inbox Translation, MET, ProZ) for relative
-     market position;
+     adoption;
    - server-side log analysis of the existing update check: `VersionChecker` fetches a
      static version file from the project web space, so aggregate, anonymous hit counts
      on that file approximate active installations without any client-side change. This
@@ -97,6 +119,8 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
   inform platform-support discussions.
 - The documented institutional adopters (DGT, Autshumato) illustrate that changes to
   core behavior can affect downstream forks beyond the visible user community.
+- The recurring user needs collected in the appendix provide sourced starting points
+  for new feature-request tickets and for prioritizing existing ones.
 
 ## References
 
@@ -122,3 +146,87 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
   https://www.translationtribulations.com/2014/06/omegats-growing-place-in-language.html
 
 All links verified on 2026-07-25.
+
+## Appendix: verified public statements about OmegaT
+
+Collected 2026-07-26 from a structured search of surveys, teaching material, reviews,
+practitioner blogs, and community discussions. Every URL below was retrieved
+successfully on that date; statements behind login walls or blocked to automated
+retrieval were discarded.
+
+### Surveys and studies
+
+- Inbox Translation, Freelance Translator Survey 2023 (n=2,005 on the tool question):
+  https://inboxtranslation.com/resources/research/freelance-translator-survey-2023/
+- Rothwell, Moorkens, Svoboda: "Training in translation tools and technologies:
+  Findings of the EMT survey 2023": https://arxiv.org/abs/2503.22735
+  (overview: https://www.alphaxiv.org/overview/2503.22735v1)
+- Veiga Díaz, García González: "Usability of Free and Open-Source Tools for Translator
+  Training: OmegaT and Bitext2tmx":
+  https://www2.uibk.ac.at/downloads/trans/publik/open-veigadiazgarciagonzalez.pdf
+- Balashov: "OPUS-CAT: A State-of-the-Art Neural Machine Translation Engine on Your
+  Local Computer" (ATA Chronicle reprint, mentions OmegaT plugin support):
+  https://www.yuribalashov.com/Papers/OPUS_CAT_RR_YB.pdf
+
+### Teaching and institutions
+
+- University of Bologna, CAT course unit 2024/25 (OmegaT in the syllabus):
+  https://www.unibo.it/en/study/course-units-transferable-skills-moocs/course-unit-catalogue/course-unit/2024/470047
+- Master TSM, Université de Lille, student blog: "OmegaT : le meilleur ami du
+  traducteur freelance" (2026-01-11):
+  https://mastertsmlille.wordpress.com/2026/01/11/omegat-le-meilleur-ami-du-traducteur-freelance/
+- DGT-OmegaT documentation ("OmegaT in DGT, its Wizard, Tagwipe and TeamBase"):
+  https://archive.org/details/omegat-in-dgt-its-wizard-tagwipe-and-teambase-documentation
+- South African Translators' Institute: "OmegaT: an open-source alternative to
+  translation memory programs" (2023-04-20):
+  https://translators.org.za/omegat-an-open-source-alternative-to-translation-memory-programs/
+
+### Practitioner blogs and testimonials
+
+- Corinne McKay: "How to choose a translation memory tool" (2024-10-15):
+  https://www.trainingfortranslators.com/2024/10/15/how-to-choose-a-translation-memory-tool/
+- Corinne McKay: "Changes in the translation software landscape" (2025-07-16):
+  https://www.trainingfortranslators.com/2025/07/16/changes-in-the-translation-software-landscape/
+- Christopher Köbel (DeFrEnT): "Wege von Trados zu OmegaT im Frühling 2026"
+  (2026-04-18, detailed feature-gap list from a Trados switcher):
+  https://www.defrent.de/2026/04/wege-von-trados-zu-omegat-im-fruehling-2026/
+- Cotelangues: CAT tool survey among freelance translators (2020-08-05):
+  https://cotelangues.com/de/uebersetzer-cat-tools/
+- Abdunnasir Althobaity: OmegaT review: https://althobaity.com/abdunnasir/omegat-review/
+
+### Reviews and tool directories
+
+- SourceForge user reviews (5.0/5, 53 reviews):
+  https://sourceforge.net/projects/omegat/reviews/
+- Softpedia editorial review: https://www.softpedia.com/get/Programming/Other-Programming-Files/OmegaT.shtml
+- Lokalise: "The best CAT tools" (updated 2024-09-02): https://lokalise.com/blog/best-cat-tools/
+- Dokutech: "CAT tools in 2026": https://dokutechtranslations.com/en/cat-tools-in-2026-the-complete-guide-for-translators-and-project-managers/
+- Tomedes: "9 best CAT tools": https://www.tomedes.com/translator-hub/cat-tools
+
+### Community discussions (Reddit)
+
+- Bilingual review export is missing from the base application (2025):
+  https://www.reddit.com/r/TranslationStudies/comments/1j90kt9/
+- Editing TMX files inside OmegaT, repeatedly requested (2024):
+  https://www.reddit.com/r/OmegaT/comments/1cvy69h/
+- Team projects perceived as complicated to set up (2024, two independent threads):
+  https://www.reddit.com/r/TranslationStudies/comments/1f2rvjd/ and
+  https://www.reddit.com/r/TranslationStudies/comments/1d7aloj/
+- Dated look of the user interface (2024):
+  https://www.reddit.com/r/TranslationStudies/comments/1hhtk9l/
+- OmegaT recommended when proprietary subscription prices rise (2024):
+  https://www.reddit.com/r/TranslationStudies/comments/1e0krsy/
+- Two-column source/target editor view expected by switchers (2025):
+  https://www.reddit.com/r/OmegaT/comments/1k5umck/
+- Spellchecker ignored/learned words do not carry over between projects (2025):
+  https://www.reddit.com/r/OmegaT/comments/1ilmuzi/
+- Confusion between the Okapi plugin and the built-in XLIFF filter (2025):
+  https://www.reddit.com/r/OmegaT/comments/1ieby4k/
+- Dictionary pane display issue in 6.0.0 (2024):
+  https://www.reddit.com/r/OmegaT/comments/1adadgh/
+- Protected numbers cannot be deleted with backspace (2024):
+  https://www.reddit.com/r/OmegaT/comments/1cevysj/
+- Glossary matching for Korean (2024):
+  https://www.reddit.com/r/OmegaT/comments/1al45av/
+
+All appendix links verified on 2026-07-26.

--- a/src/docs/developer/adr/2026004.UserBaseMeasurement.md
+++ b/src/docs/developer/adr/2026004.UserBaseMeasurement.md
@@ -1,0 +1,124 @@
+# ADR: User Base Measurement and Market Position
+
+## Status
+
+**Proposed** (Date: 2026-07-25)
+
+## Context
+
+OmegaT collects no usage telemetry, so the project has no direct knowledge of how many
+people use it, on which platforms, or in which market segments. That information matters
+for recurring development decisions: which platforms and Java runtimes to prioritize,
+how much weight to give backward compatibility, which file formats and workflows deserve
+attention, and how to position OmegaT relative to commercial CAT tools.
+
+The question can nevertheless be answered, to a useful approximation, from public and
+privacy-friendly sources. This record documents the available measurement channels, a
+baseline of their readings, and the resulting estimate, so that future discussions can
+start from shared numbers instead of anecdote.
+
+### Public data, baseline July 2026
+
+| Channel | Reading | Notes |
+|---|---|---|
+| SourceForge downloads, 2025-07 to 2026-06 | 93,920 | stable 6,600–10,000/month |
+| SourceForge downloads, all time since 2002 | ~1.90 million | peak in 2023 (16,000–21,000/month) |
+| Download platforms (SourceForge) | 66% Windows, 11% macOS, 5% Linux | remainder unknown/other |
+| Top download countries (SourceForge) | US (9%), ES, CN, BR, FR | broad long tail |
+| Flathub installs | 10,182 total, ~180/month | Linux Flatpak channel |
+| Debian popcon | 61 reporting installations | opt-in panel, small sample |
+| GitHub development mirror | 526 stars, 135 forks | code review mirror since 2015 |
+
+### Documented adopters
+
+- The **Directorate-General for Translation of the European Commission** maintains
+  DGT-OmegaT, an in-house fork with additional tooling (Wizard, TagWipe, TeamBase),
+  described by DGT staff in the Commission's *a folha* bulletin (see References).
+- The **Autshumato Integrated Translation Environment**, funded by the South African
+  government for its eleven official languages, is a derived work of OmegaT.
+- Free-software localization communities (for example the Italian LibreOffice
+  translation team) and individual professional translators, as reflected in the
+  testimonials collected on omegat.org.
+
+### Market position
+
+Independent surveys of professional translators consistently place the commercial tools
+first. In the Inbox Translation freelance survey (2023), 81% of respondents use CAT
+tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%, while
+OmegaT appears among the most-mentioned write-in tools below the 15% line. The MET
+survey (2020, 157 respondents) shows the same shape. RWS states that more than 250,000
+translation professionals use Trados Studio.
+
+Within open source, OmegaT is the only full-featured desktop CAT tool under active
+development: Virtaal and Pootle are discontinued, and the active open-source projects
+occupy adjacent niches (MateCat in the browser, Weblate and friends in software
+localization). OmegaT's direct competition is therefore commercial, while its own niche
+has no serious open-source rival.
+
+### Estimate
+
+Two independent estimates converge:
+
+1. **From downloads**: roughly 100,000 downloads per year across channels, with no
+   auto-update mechanism (active users typically download one to three installers per
+   year, and one-time evaluators inflate the count), suggests **25,000–60,000 active
+   installations**.
+2. **From surveys**: OmegaT is used by an estimated 2–5% of CAT tool users. Against a
+   worldwide population of professional translators in the hundreds of thousands, that
+   suggests **10,000–25,000 professional users** with OmegaT as a primary or secondary
+   tool.
+
+Order of magnitude: **low tens of thousands of active users**, most of them on Windows.
+
+## Decision
+
+1. The project does **not** add usage telemetry. User-base estimates rely exclusively on
+   data that users already generate voluntarily.
+2. The measurement channels of record are, in order of usefulness:
+   - the SourceForge download statistics API (volume, platform, and country trends);
+   - packaging channel statistics (Flathub API, Debian popcon, and similar);
+   - independent professional surveys (Inbox Translation, MET, ProZ) for relative
+     market position;
+   - server-side log analysis of the existing update check: `VersionChecker` fetches a
+     static version file from the project web space, so aggregate, anonymous hit counts
+     on that file approximate active installations without any client-side change. This
+     channel requires access to the project web server statistics and is listed here as
+     an option for maintainers, not as a new mechanism.
+3. This baseline should be refreshed when a decision actually depends on it, rather than
+   on a fixed schedule; the channels above are all repeatable on demand.
+
+## Consequences
+
+- Estimates stay estimates: downloads are not users, updates are counted repeatedly,
+  and distribution through Linux repositories is only partially visible. Every figure
+  above is therefore given with its channel and date.
+- No privacy impact and no client code changes; all channels are external observation.
+- The platform split (two-thirds of downloads on Windows) is now on record and should
+  inform platform-support discussions.
+- The documented institutional adopters (DGT, Autshumato) illustrate that changes to
+  core behavior can affect downstream forks beyond the visible user community.
+
+## References
+
+- SourceForge download statistics: https://sourceforge.net/projects/omegat/files/stats/timeline
+  (JSON API: `https://sourceforge.net/projects/omegat/files/stats/json?start_date=…&end_date=…`)
+- Flathub listing and statistics: https://flathub.org/apps/org.omegat.OmegaT
+  (API: `https://flathub.org/api/v2/stats/org.omegat.OmegaT`)
+- Debian popularity contest: https://qa.debian.org/popcon.php?package=omegat
+- Inbox Translation, Freelance Translator Survey 2023:
+  https://inboxtranslation.com/resources/research/freelance-translator-survey-2023/
+- MET CAT tool survey 2020: https://www.metmeetings.org/documentacion/files/CAT_survey_report_2020.pdf
+- ProZ.com CAT tool survey: https://go.proz.com/blog/cat-tool-use-by-translators-what-are-they-using
+- RWS press release on Trados Studio 2026 (user count claim):
+  https://www.prnewswire.com/news-releases/rws-launches-trados-studio-2026-delivering-major-advances-in-ai-performance-and-productivity-for-language-professionals-302816052.html
+- DGT-OmegaT, described by DGT staff: "Interoperability between DGT-OmegaT and SDL Trados
+  Studio", *a folha* No. 58, 2018: https://op.europa.eu/webpub/dgt/afolha/documents/afolha_058-S_en.pdf
+  and "OmegaT in DGT, its Wizard, TagWipe and TeamBase":
+  https://archive.org/details/omegat-in-dgt-its-wizard-tagwipe-and-teambase-documentation
+- The Autshumato project: https://autshumato.nwu.ac.za/about/
+- Feature comparison of CAT tools:
+  https://en.wikipedia.org/wiki/Comparison_of_computer-assisted_translation_tools
+- John Moran: "OmegaT's Growing Place in the Language Services Industry" (2014):
+  https://www.translationtribulations.com/2014/06/omegats-growing-place-in-language.html
+
+All links verified on 2026-07-25.

--- a/src/docs/developer/adr/2026005.InternationalAdoptionFootprint.md
+++ b/src/docs/developer/adr/2026005.InternationalAdoptionFootprint.md
@@ -1,0 +1,228 @@
+# ADR: International and Multilingual Adoption Footprint
+
+## Status
+
+**Proposed** (Date: 2026-07-28)
+
+## Context
+
+[2026006](2026006.UserBaseMeasurement.md) estimates *how many* people use OmegaT and
+records adoption largely through English-language channels (international surveys,
+English practitioner blogs, and community threads on Reddit). It deliberately leaves a
+gap: it says little about *where* and *in which communities* OmegaT is actually adopted,
+in the local languages of those communities.
+
+That gap matters for recurring prioritization decisions that are inherently
+multilingual: which interface and manual localizations have a real audience, how much
+desktop and Linux support to invest in for university labs, which file formats and
+workflows to favor, and where teaching outreach is worthwhile. Anecdote in one language
+(usually English) is a poor basis for those calls.
+
+This record collects **verified, third-party, largely non-English** evidence of OmegaT
+adoption, grouped by region and sector, together with **honest negative findings** about
+ecosystems where OmegaT is demonstrably *absent*. It is a qualitative reach map that
+complements the quantitative baseline in 2026006.
+
+**Method.** Each source was found by native-language search and then retrieved to confirm
+it genuinely names OmegaT; leads that could not be retrieved (403/TLS/binary) are marked
+as unverified rather than presented as fact. The project's own pages (omegat.org,
+SourceForge, GitHub, Wikipedia) and social-media sources are excluded; sources already
+listed in 2026006 (University of Bologna, Université de Lille, DGT-OmegaT, Autshumato,
+SATI, DeFrEnT, Veiga Díaz & García González) are cross-referenced there and not repeated
+in the appendix below.
+
+## Decision
+
+1. Treat non-English **institutional** adoption — professional associations, university
+   curricula, and language-technology infrastructure — as first-class evidence for
+   prioritization, on a par with download numbers and English surveys.
+2. Record **negative findings** explicitly. Where a large translation or localization
+   ecosystem uses other tools, that absence is itself decision-relevant and is kept in
+   the record instead of being silently dropped.
+3. Keep this catalog free of social-media and project-owned sources; Reddit and the
+   testimonials on omegat.org remain in 2026006. Every entry here is dated and carries a
+   confidence note when the page could not be fully retrieved.
+
+## Consequences
+
+- **A clear adoption pattern emerges.** OmegaT concentrates where two conditions meet:
+  (a) a professional association or university actively promotes free/open-source CAT for
+  reasons of cost, platform freedom, no vendor lock-in, or teaching on Linux labs; and
+  (b) a translation-memory / glossary *workflow culture* already exists. It is comparatively
+  absent where translation is driven by neural MT, by rule-based MT (Apertium), or by
+  other FOSS localization stacks (Pootle / Virtaal / Weblate).
+- **The verified non-English footprint is broad**: strong, independent institutional or
+  association evidence in France, Italy, Spain, Argentina, Brazil, Russia, Ukraine, Japan,
+  South Korea, Vietnam and Indonesia; a distinctive minority-language niche (the Sámi
+  languages via GiellaLT/UiT); and a values-driven niche (a maintained Esperanto interface
+  localization). This substantiates that interface and manual localization in these
+  languages address real audiences.
+- **Notable absences, on the record**: the African localization ecosystem organized around
+  ANLoc / PanAfriL10n / IDRC standardizes on Pootle/Virtaal/Translate Toolkit, not OmegaT;
+  indigenous-language technology in the Americas and the Pacific (Quechua, Guaraní,
+  Nahuatl, Maya, Mapudungun, Māori, Hawaiian, and Pacific languages) overwhelmingly relies
+  on neural MT, Apertium, or bespoke apps. OmegaT's indigenous-language strength is the
+  exception that proves the rule — the Sámi case — where a TM/glossary workflow culture and
+  Apertium integration coincide.
+- **Practical implications.** Desktop and Linux support remain load-bearing for the
+  university-lab audience; the drift of teaching programmes toward cloud tools with free
+  academic access (EMT survey 2023, already noted in 2026006) is the principal headwind for
+  new-graduate exposure; and the languages listed above are where localization effort has
+  demonstrable reach.
+- Estimates and reach stay qualitative here by design; the numeric baseline remains in
+  2026006. This record should be read together with it.
+
+## References
+
+Grouped, verified sources are collected in the appendix below. All links were retrieved
+on 2026-07-28 unless flagged otherwise.
+
+## Appendix: verified international adoption evidence
+
+Collected 2026-07-28 by native-language search and page retrieval. Confidence is "high"
+unless a retrieval problem is noted.
+
+### Professional associations
+
+- **SFT — Société française des traducteurs** (France), journal *Traduire* No. 224 (2011),
+  article by Didier Briel: free CAT tools "designed by and for professional translators",
+  noting that many professional translators use OmegaT.
+  https://journals.openedition.org/traduire/184
+- **CTPCBA — Colegio de Traductores Públicos de la Ciudad de Buenos Aires** (Argentina):
+  dedicated guide "OMEGA T: una herramienta eficaz, gratuita y de código abierto"
+  (Comisión de Recursos Tecnológicos, 2019), presenting OmegaT as "the perfect alternative
+  to expensive tools like SDL Trados, memoQ or Wordfast".
+  https://www.traductores.org.ar/cartapacio-tecnologico/omega-t-una-herramienta-eficaz-gratuita-y-de-codigo-abierto/
+  — plus a chapter in the association's *Manual de informática aplicada a la traducción*
+  (Santilli coord., Editorial del CTPCBA, 2016), attested via the *TRANS* review indexed at
+  https://dialnet.unirioja.es/servlet/articulo?codigo=6323792
+- **ASETRAD** (Spain): training course "OmegaT para traductores: rendimiento sin dispendio"
+  (2021). https://formacion.asetrad.org/courses/omegat-para-traductores-rendimiento-sin-dispendio-04may2021/
+- **EIZIE** (Basque translators' association, Spain): computer-assisted-translation
+  resources page listing OmegaT.
+  https://eizie.eus/es/recursos/herramientas/traduccion-asisitida-por-ordenador-tao
+- **TradInFo** (Italy): association course "Guida pratica all'uso di OmegaT per traduttori"
+  (Bologna, 2016).
+  https://www.tradinfo.org/eventi-e-formazione/corso-a-bologna-guida-pratica-all-uso-di-omegat-per-traduttori/
+- **A.T.I. — Associazione no profit di traduttori e interpreti** (Italy): calls OmegaT
+  "the most widely used free computer-assisted translation software".
+  https://www.ati-associazione.org/blog/omega-t-per-principianti
+- **ATA — American Translators Association** (USA): interview with OmegaT project manager
+  Didier Briel (2017), a primary source for the user-base figures cited in 2026006
+  (~10,000 downloads/month, ~2,596 user-group members; "very diverse user base").
+  https://www.atanet.org/resources/speaking-with-omegats-project-manager/
+- **ATIDA — Arabic Translators International** (pan-Arab): forum discussion of open-source
+  CAT tools centered on OmegaT for Arabic translators (2009).
+  https://atinternational.org/forums/forum/translation-the-computer/computer-assisted-translation/6811-
+- **JTF — Japan Translation Federation** (Japan): official journal event report
+  "翻訳支援ツール「Isometry」「OmegaT」の紹介" (2013). *Medium confidence: title confirmed on
+  the JTF journal domain, page body blocked to automated retrieval.*
+  https://webjournal.jtf.jp/2013/03/07/1835/
+
+### University teaching and academic literature
+
+(Beyond Bologna and Lille, already in 2026006.)
+
+- **Université de Lorraine** (France): ~10-hour OmegaT module in the master's in technical
+  translation (J.-C. Helary), presented at Open Source Experience 2021.
+  https://doublet.jp/utiliser-omegat-pour-preparer-les-traducteurs-a-la-resilience/
+- **Universitat de València** (Spain): course "Informática Aplicada a la Traducción"
+  (L. Ramírez Polo). https://laurapo.blogs.uv.es/omegat-una-herramienta-tao-gratuita/
+- **Universidad de Valladolid** (Spain): academic work on free CAT tools featuring OmegaT.
+  https://uvadoc.uva.es/handle/10324/6115
+- **Universitat Oberta de Catalunya** (Spain): MTUOC micro-MOOC, unit on OmegaT and Trados.
+  https://xwiki.recursos.uoc.edu/ (module "Tema 4")
+- **Universidade Federal do Ceará — POET** (Brazil): postgraduate workshop "Tradução
+  Literária com OmegaT" (2020). https://ppgpoet.ufc.br/pt/oficina-traducao-literaria-com-omegat/
+- **Universidade Federal da Paraíba** (Brazil): official OmegaT tutorial as course material
+  (2023). https://www.cchla.ufpb.br/ctrad/tutorial-omega-t_2023-tanialiparini.pdf/view
+- **Texto Livre: Linguagem e Tecnologia** (Brazil, peer-reviewed): "OmegaT, uma alternativa
+  viável" (Villela, 2016). https://www.redalyc.org/journal/5771/577161381016/html/
+- **Tula State University** (Russia): the "Translation and Translation Studies" programme
+  lists OmegaT among taught tools ("Trados, SmartCat, OmegaT").
+  https://abitur71.tsu.tula.ru/programmes/perevod-i-perevodovedenie-angliyskiy-i-frantsuzskiy-yazyki
+- **NULES / Lviv (LDUBGD) journal** (Ukraine): peer-reviewed article on LMS-based translator
+  training listing OmegaT among CAT tools (2025).
+  https://journal.ldubgd.edu.ua/index.php/pp/article/view/3034
+- **KCI journal *통번역교육연구*** (South Korea): article on CAT tools in translation education
+  citing OmegaT (2017). https://kci.go.kr/kciportal/landing/article.kci?arti_id=ART002299625
+- **Rocznik Przekładoznawczy, Nicolaus Copernicus University, Toruń** (Poland): "Wolne
+  oprogramowanie dla tłumacza" (Sosnowski, 2008), OmegaT as the central FOSS example.
+  *Medium confidence: peer-reviewed source confirmed by index; PDF blocked to the fetcher.*
+  https://apcz.umk.pl/RP/article/download/RP.2008.014/1819/7195
+- **Nguyễn Tất Thành University, Faculty of Foreign Languages** (Vietnam): faculty review of
+  translation platforms naming OmegaT ("công cụ dịch thuật mã nguồn mở, miễn phí và linh hoạt").
+  https://nn.ntt.edu.vn/tin-tuc/danh-gia-mot-so-nen-tang-dich-thuat-pho-thong/
+- **University of Auckland** (New Zealand): course TRANSLAT 712 "Computer-aided Translation
+  Tools" lists OmegaT in the syllabus.
+  https://canvas.auckland.ac.nz/courses/40079/assignments/syllabus
+
+### Minority, indigenous, and constructed-language technology
+
+- **GiellaLT / UiT — The Arctic University of Norway** (Sámi languages): distributes
+  ready-made OmegaT project packs (TMX, glossaries, segmentation rules) for five Sámi
+  varieties and recommends OmegaT for its Apertium MT integration, including MT between
+  Sámi languages. https://giellalt.github.io/tm/OmegaT.html and
+  https://giellalt.github.io/mt/omegat/OmegaT.html
+- **Cherokee Lessons** (USA, Cherokee): Cherokee–English translation-memory and glossary
+  files "designed to work with OmegaT". *Medium confidence: live site returned 522 during
+  research; content and the `-omegat.tmx` asset filenames confirm usage.*
+  https://www.cherokeelessons.com/content/cherokee-cat-computer-aided-translation-translation-memory-and-glossary-files/
+- **Esperanto**: OmegaT ships an Esperanto interface localization (one of ~37 UI languages)
+  with a maintained Esperanto glossary — a level of language inclusion essentially unmatched
+  by commercial CAT tools. Community resource page (Esperanto translation links) lists it:
+  http://www.tekstoj.nl/esperanto/tradligoj.htm *(Lead: retrieval blocked by a TLS
+  certificate mismatch on the domain; the interface localization itself is the primary,
+  verifiable fact.)*
+
+### Native-language media and practitioner communities
+
+- **Tuổi Trẻ** (Vietnam, national newspaper): feature on OmegaT as a free CAT tool (2009).
+  https://tuoitre.vn/khoahocphothong/omegat-cong-cu-tro-giup-bien-dich-cat-104230805.htm
+- **ROSETTA.vn** (Vietnam): detailed guides on team translation in OmegaT with Git/GitLab/SVN
+  (2018). https://rosetta.vn/translate/category/cat/omegat/
+- **Dịch giả trẻ / Young Translators** (Vietnam, Ho Chi Minh City): screencast tutorial on
+  OmegaT (2012). https://dichgiatre.blogspot.com/2012/10/translating-with-omegat.html
+- **PCplus** (Indonesia, national IT magazine): OmegaT review (2013).
+  https://www.pcplus.co.id/2013/06/aplikasi-penerjemah-omegat/
+- **Anindyatrans** (Indonesia, sworn-translation agency, Jakarta): practical guide to using
+  Microsoft Translator inside OmegaT.
+  https://www.anindyatrans.com/cara-mudah-menggunakan-fitur-microsoft-translator-pada-omegat/
+- **Habr** (Russia, large tech community): OmegaT walkthrough with Yandex MT integration.
+  https://habr.com/ru/articles/404061/
+- **WordCracker** (South Korea, professional translator): OmegaT review emphasizing its
+  cross-platform advantage over Trados/DéjàVu (2015).
+  https://www.thewordcracker.com/translation/free-computer-aided-tool-omegat/
+- **Naganuma / lingvistika.blog** (Japan, professional translator): OmegaT as a free Trados
+  alternative. https://lingvistika.blog.jp/archives/1066770111.html
+- **Vertalersnieuws** (Netherlands, translator news blog): "OmegaT: vrije vertaalsoftware
+  groeit op" (2011). https://vertalersnieuws.blogspot.com/2011/12/omegat-vrije-vertaalsoftware-groeit-op.html
+- **gds Sprachenwelt** (Germany): webinar "OmegaT – eines der letzten kostenfreien CAT-Tools"
+  (2021). https://www.gds.eu/de/blog/webinar-omegat-%E2%80%93-eines-der-letzten-kostenfreien-cat-tools
+
+### Software-localization workflows (Southeast Asia)
+
+- **CCJK** (language-services vendor): documented Khmer/Lao localization workflow built on
+  Okapi + OmegaT, including a Lao example with the Saysettha OT font.
+  https://www.ccjk.com/multilingual-translation-using-okapi-omegat/
+
+### Negative and boundary findings
+
+- **African localization ecosystem** (ANLoc / PanAfriL10n / IDRC, coordinated by
+  D. Osborn): the localization toolchain of record is **Pootle / Virtaal / Translate
+  Toolkit**, not OmegaT. The ANLoc projects and training pages name Virtaal/Pootle; the
+  ANLoc manual is itself translated with Pootle/Virtaal.
+  https://africanlocalization.net/projects/ and
+  http://docs.translatehouse.org/projects/localization-guide/en/latest/guide/localising_anloc_manual.html
+- **Indigenous languages of the Americas and the Pacific**: for Quechua, Aymara, Guaraní,
+  Nahuatl, Maya, Mapudungun, Navajo, Inuktitut, Māori (te reo) and Hawaiian, no verifiable
+  source names OmegaT; these ecosystems use neural MT, Apertium, or bespoke applications.
+- **Khmer/Lao government localization** (KhmerOS, PAN Localization Cambodia/Laos): real and
+  well documented as FOSS-localization efforts, but not verifiably tied to OmegaT beyond the
+  single vendor workflow above.
+- **Spanish-speaking South America outside Argentina** (Chile, Colombia, Peru, Uruguay,
+  Venezuela, Ecuador, Bolivia, Paraguay): curricular presence is plausible (repeatedly via
+  the fetch-blocked UNIR portals) but no locally-founded institutional page naming OmegaT
+  could be verified. PUCV Valparaíso's programme page names CAT tools only generically.
+
+All appendix links verified on 2026-07-28 except where a retrieval problem is noted.

--- a/src/docs/developer/adr/2026005.InternationalAdoptionFootprint.md
+++ b/src/docs/developer/adr/2026005.InternationalAdoptionFootprint.md
@@ -1,0 +1,228 @@
+# ADR: International and Multilingual Adoption Footprint
+
+## Status
+
+**Proposed** (Date: 2026-07-28)
+
+## Context
+
+[2026004](2026004.UserBaseMeasurement.md) estimates *how many* people use OmegaT and
+records adoption largely through English-language channels (international surveys,
+English practitioner blogs, and community threads on Reddit). It deliberately leaves a
+gap: it says little about *where* and *in which communities* OmegaT is actually adopted,
+in the local languages of those communities.
+
+That gap matters for recurring prioritization decisions that are inherently
+multilingual: which interface and manual localizations have a real audience, how much
+desktop and Linux support to invest in for university labs, which file formats and
+workflows to favor, and where teaching outreach is worthwhile. Anecdote in one language
+(usually English) is a poor basis for those calls.
+
+This record collects **verified, third-party, largely non-English** evidence of OmegaT
+adoption, grouped by region and sector, together with **honest negative findings** about
+ecosystems where OmegaT is demonstrably *absent*. It is a qualitative reach map that
+complements the quantitative baseline in 2026004.
+
+**Method.** Each source was found by native-language search and then retrieved to confirm
+it genuinely names OmegaT; leads that could not be retrieved (403/TLS/binary) are marked
+as unverified rather than presented as fact. The project's own pages (omegat.org,
+SourceForge, GitHub, Wikipedia) and social-media sources are excluded; sources already
+listed in 2026004 (University of Bologna, Université de Lille, DGT-OmegaT, Autshumato,
+SATI, DeFrEnT, Veiga Díaz & García González) are cross-referenced there and not repeated
+in the appendix below.
+
+## Decision
+
+1. Treat non-English **institutional** adoption — professional associations, university
+   curricula, and language-technology infrastructure — as first-class evidence for
+   prioritization, on a par with download numbers and English surveys.
+2. Record **negative findings** explicitly. Where a large translation or localization
+   ecosystem uses other tools, that absence is itself decision-relevant and is kept in
+   the record instead of being silently dropped.
+3. Keep this catalog free of social-media and project-owned sources; Reddit and the
+   testimonials on omegat.org remain in 2026004. Every entry here is dated and carries a
+   confidence note when the page could not be fully retrieved.
+
+## Consequences
+
+- **A clear adoption pattern emerges.** OmegaT concentrates where two conditions meet:
+  (a) a professional association or university actively promotes free/open-source CAT for
+  reasons of cost, platform freedom, no vendor lock-in, or teaching on Linux labs; and
+  (b) a translation-memory / glossary *workflow culture* already exists. It is comparatively
+  absent where translation is driven by neural MT, by rule-based MT (Apertium), or by
+  other FOSS localization stacks (Pootle / Virtaal / Weblate).
+- **The verified non-English footprint is broad**: strong, independent institutional or
+  association evidence in France, Italy, Spain, Argentina, Brazil, Russia, Ukraine, Japan,
+  South Korea, Vietnam and Indonesia; a distinctive minority-language niche (the Sámi
+  languages via GiellaLT/UiT); and a values-driven niche (a maintained Esperanto interface
+  localization). This substantiates that interface and manual localization in these
+  languages address real audiences.
+- **Notable absences, on the record**: the African localization ecosystem organized around
+  ANLoc / PanAfriL10n / IDRC standardizes on Pootle/Virtaal/Translate Toolkit, not OmegaT;
+  indigenous-language technology in the Americas and the Pacific (Quechua, Guaraní,
+  Nahuatl, Maya, Mapudungun, Māori, Hawaiian, and Pacific languages) overwhelmingly relies
+  on neural MT, Apertium, or bespoke apps. OmegaT's indigenous-language strength is the
+  exception that proves the rule — the Sámi case — where a TM/glossary workflow culture and
+  Apertium integration coincide.
+- **Practical implications.** Desktop and Linux support remain load-bearing for the
+  university-lab audience; the drift of teaching programmes toward cloud tools with free
+  academic access (EMT survey 2023, already noted in 2026004) is the principal headwind for
+  new-graduate exposure; and the languages listed above are where localization effort has
+  demonstrable reach.
+- Estimates and reach stay qualitative here by design; the numeric baseline remains in
+  2026004. This record should be read together with it.
+
+## References
+
+Grouped, verified sources are collected in the appendix below. All links were retrieved
+on 2026-07-28 unless flagged otherwise.
+
+## Appendix: verified international adoption evidence
+
+Collected 2026-07-28 by native-language search and page retrieval. Confidence is "high"
+unless a retrieval problem is noted.
+
+### Professional associations
+
+- **SFT — Société française des traducteurs** (France), journal *Traduire* No. 224 (2011),
+  article by Didier Briel: free CAT tools "designed by and for professional translators",
+  noting that many professional translators use OmegaT.
+  https://journals.openedition.org/traduire/184
+- **CTPCBA — Colegio de Traductores Públicos de la Ciudad de Buenos Aires** (Argentina):
+  dedicated guide "OMEGA T: una herramienta eficaz, gratuita y de código abierto"
+  (Comisión de Recursos Tecnológicos, 2019), presenting OmegaT as "the perfect alternative
+  to expensive tools like SDL Trados, memoQ or Wordfast".
+  https://www.traductores.org.ar/cartapacio-tecnologico/omega-t-una-herramienta-eficaz-gratuita-y-de-codigo-abierto/
+  — plus a chapter in the association's *Manual de informática aplicada a la traducción*
+  (Santilli coord., Editorial del CTPCBA, 2016), attested via the *TRANS* review indexed at
+  https://dialnet.unirioja.es/servlet/articulo?codigo=6323792
+- **ASETRAD** (Spain): training course "OmegaT para traductores: rendimiento sin dispendio"
+  (2021). https://formacion.asetrad.org/courses/omegat-para-traductores-rendimiento-sin-dispendio-04may2021/
+- **EIZIE** (Basque translators' association, Spain): computer-assisted-translation
+  resources page listing OmegaT.
+  https://eizie.eus/es/recursos/herramientas/traduccion-asisitida-por-ordenador-tao
+- **TradInFo** (Italy): association course "Guida pratica all'uso di OmegaT per traduttori"
+  (Bologna, 2016).
+  https://www.tradinfo.org/eventi-e-formazione/corso-a-bologna-guida-pratica-all-uso-di-omegat-per-traduttori/
+- **A.T.I. — Associazione no profit di traduttori e interpreti** (Italy): calls OmegaT
+  "the most widely used free computer-assisted translation software".
+  https://www.ati-associazione.org/blog/omega-t-per-principianti
+- **ATA — American Translators Association** (USA): interview with OmegaT project manager
+  Didier Briel (2017), a primary source for the user-base figures cited in 2026004
+  (~10,000 downloads/month, ~2,596 user-group members; "very diverse user base").
+  https://www.atanet.org/resources/speaking-with-omegats-project-manager/
+- **ATIDA — Arabic Translators International** (pan-Arab): forum discussion of open-source
+  CAT tools centered on OmegaT for Arabic translators (2009).
+  https://atinternational.org/forums/forum/translation-the-computer/computer-assisted-translation/6811-
+- **JTF — Japan Translation Federation** (Japan): official journal event report
+  "翻訳支援ツール「Isometry」「OmegaT」の紹介" (2013). *Medium confidence: title confirmed on
+  the JTF journal domain, page body blocked to automated retrieval.*
+  https://webjournal.jtf.jp/2013/03/07/1835/
+
+### University teaching and academic literature
+
+(Beyond Bologna and Lille, already in 2026004.)
+
+- **Université de Lorraine** (France): ~10-hour OmegaT module in the master's in technical
+  translation (J.-C. Helary), presented at Open Source Experience 2021.
+  https://doublet.jp/utiliser-omegat-pour-preparer-les-traducteurs-a-la-resilience/
+- **Universitat de València** (Spain): course "Informática Aplicada a la Traducción"
+  (L. Ramírez Polo). https://laurapo.blogs.uv.es/omegat-una-herramienta-tao-gratuita/
+- **Universidad de Valladolid** (Spain): academic work on free CAT tools featuring OmegaT.
+  https://uvadoc.uva.es/handle/10324/6115
+- **Universitat Oberta de Catalunya** (Spain): MTUOC micro-MOOC, unit on OmegaT and Trados.
+  https://xwiki.recursos.uoc.edu/ (module "Tema 4")
+- **Universidade Federal do Ceará — POET** (Brazil): postgraduate workshop "Tradução
+  Literária com OmegaT" (2020). https://ppgpoet.ufc.br/pt/oficina-traducao-literaria-com-omegat/
+- **Universidade Federal da Paraíba** (Brazil): official OmegaT tutorial as course material
+  (2023). https://www.cchla.ufpb.br/ctrad/tutorial-omega-t_2023-tanialiparini.pdf/view
+- **Texto Livre: Linguagem e Tecnologia** (Brazil, peer-reviewed): "OmegaT, uma alternativa
+  viável" (Villela, 2016). https://www.redalyc.org/journal/5771/577161381016/html/
+- **Tula State University** (Russia): the "Translation and Translation Studies" programme
+  lists OmegaT among taught tools ("Trados, SmartCat, OmegaT").
+  https://abitur71.tsu.tula.ru/programmes/perevod-i-perevodovedenie-angliyskiy-i-frantsuzskiy-yazyki
+- **NULES / Lviv (LDUBGD) journal** (Ukraine): peer-reviewed article on LMS-based translator
+  training listing OmegaT among CAT tools (2025).
+  https://journal.ldubgd.edu.ua/index.php/pp/article/view/3034
+- **KCI journal *통번역교육연구*** (South Korea): article on CAT tools in translation education
+  citing OmegaT (2017). https://kci.go.kr/kciportal/landing/article.kci?arti_id=ART002299625
+- **Rocznik Przekładoznawczy, Nicolaus Copernicus University, Toruń** (Poland): "Wolne
+  oprogramowanie dla tłumacza" (Sosnowski, 2008), OmegaT as the central FOSS example.
+  *Medium confidence: peer-reviewed source confirmed by index; PDF blocked to the fetcher.*
+  https://apcz.umk.pl/RP/article/download/RP.2008.014/1819/7195
+- **Nguyễn Tất Thành University, Faculty of Foreign Languages** (Vietnam): faculty review of
+  translation platforms naming OmegaT ("công cụ dịch thuật mã nguồn mở, miễn phí và linh hoạt").
+  https://nn.ntt.edu.vn/tin-tuc/danh-gia-mot-so-nen-tang-dich-thuat-pho-thong/
+- **University of Auckland** (New Zealand): course TRANSLAT 712 "Computer-aided Translation
+  Tools" lists OmegaT in the syllabus.
+  https://canvas.auckland.ac.nz/courses/40079/assignments/syllabus
+
+### Minority, indigenous, and constructed-language technology
+
+- **GiellaLT / UiT — The Arctic University of Norway** (Sámi languages): distributes
+  ready-made OmegaT project packs (TMX, glossaries, segmentation rules) for five Sámi
+  varieties and recommends OmegaT for its Apertium MT integration, including MT between
+  Sámi languages. https://giellalt.github.io/tm/OmegaT.html and
+  https://giellalt.github.io/mt/omegat/OmegaT.html
+- **Cherokee Lessons** (USA, Cherokee): Cherokee–English translation-memory and glossary
+  files "designed to work with OmegaT". *Medium confidence: live site returned 522 during
+  research; content and the `-omegat.tmx` asset filenames confirm usage.*
+  https://www.cherokeelessons.com/content/cherokee-cat-computer-aided-translation-translation-memory-and-glossary-files/
+- **Esperanto**: OmegaT ships an Esperanto interface localization (one of ~37 UI languages)
+  with a maintained Esperanto glossary — a level of language inclusion essentially unmatched
+  by commercial CAT tools. Community resource page (Esperanto translation links) lists it:
+  http://www.tekstoj.nl/esperanto/tradligoj.htm *(Lead: retrieval blocked by a TLS
+  certificate mismatch on the domain; the interface localization itself is the primary,
+  verifiable fact.)*
+
+### Native-language media and practitioner communities
+
+- **Tuổi Trẻ** (Vietnam, national newspaper): feature on OmegaT as a free CAT tool (2009).
+  https://tuoitre.vn/khoahocphothong/omegat-cong-cu-tro-giup-bien-dich-cat-104230805.htm
+- **ROSETTA.vn** (Vietnam): detailed guides on team translation in OmegaT with Git/GitLab/SVN
+  (2018). https://rosetta.vn/translate/category/cat/omegat/
+- **Dịch giả trẻ / Young Translators** (Vietnam, Ho Chi Minh City): screencast tutorial on
+  OmegaT (2012). https://dichgiatre.blogspot.com/2012/10/translating-with-omegat.html
+- **PCplus** (Indonesia, national IT magazine): OmegaT review (2013).
+  https://www.pcplus.co.id/2013/06/aplikasi-penerjemah-omegat/
+- **Anindyatrans** (Indonesia, sworn-translation agency, Jakarta): practical guide to using
+  Microsoft Translator inside OmegaT.
+  https://www.anindyatrans.com/cara-mudah-menggunakan-fitur-microsoft-translator-pada-omegat/
+- **Habr** (Russia, large tech community): OmegaT walkthrough with Yandex MT integration.
+  https://habr.com/ru/articles/404061/
+- **WordCracker** (South Korea, professional translator): OmegaT review emphasizing its
+  cross-platform advantage over Trados/DéjàVu (2015).
+  https://www.thewordcracker.com/translation/free-computer-aided-tool-omegat/
+- **Naganuma / lingvistika.blog** (Japan, professional translator): OmegaT as a free Trados
+  alternative. https://lingvistika.blog.jp/archives/1066770111.html
+- **Vertalersnieuws** (Netherlands, translator news blog): "OmegaT: vrije vertaalsoftware
+  groeit op" (2011). https://vertalersnieuws.blogspot.com/2011/12/omegat-vrije-vertaalsoftware-groeit-op.html
+- **gds Sprachenwelt** (Germany): webinar "OmegaT – eines der letzten kostenfreien CAT-Tools"
+  (2021). https://www.gds.eu/de/blog/webinar-omegat-%E2%80%93-eines-der-letzten-kostenfreien-cat-tools
+
+### Software-localization workflows (Southeast Asia)
+
+- **CCJK** (language-services vendor): documented Khmer/Lao localization workflow built on
+  Okapi + OmegaT, including a Lao example with the Saysettha OT font.
+  https://www.ccjk.com/multilingual-translation-using-okapi-omegat/
+
+### Negative and boundary findings
+
+- **African localization ecosystem** (ANLoc / PanAfriL10n / IDRC, coordinated by
+  D. Osborn): the localization toolchain of record is **Pootle / Virtaal / Translate
+  Toolkit**, not OmegaT. The ANLoc projects and training pages name Virtaal/Pootle; the
+  ANLoc manual is itself translated with Pootle/Virtaal.
+  https://africanlocalization.net/projects/ and
+  http://docs.translatehouse.org/projects/localization-guide/en/latest/guide/localising_anloc_manual.html
+- **Indigenous languages of the Americas and the Pacific**: for Quechua, Aymara, Guaraní,
+  Nahuatl, Maya, Mapudungun, Navajo, Inuktitut, Māori (te reo) and Hawaiian, no verifiable
+  source names OmegaT; these ecosystems use neural MT, Apertium, or bespoke applications.
+- **Khmer/Lao government localization** (KhmerOS, PAN Localization Cambodia/Laos): real and
+  well documented as FOSS-localization efforts, but not verifiably tied to OmegaT beyond the
+  single vendor workflow above.
+- **Spanish-speaking South America outside Argentina** (Chile, Colombia, Peru, Uruguay,
+  Venezuela, Ecuador, Bolivia, Paraguay): curricular presence is plausible (repeatedly via
+  the fetch-blocked UNIR portals) but no locally-founded institutional page naming OmegaT
+  could be verified. PUCV Valparaíso's programme page names CAT tools only generically.
+
+All appendix links verified on 2026-07-28 except where a retrieval problem is noted.

--- a/src/docs/developer/adr/2026006.UserBaseMeasurement.md
+++ b/src/docs/developer/adr/2026006.UserBaseMeasurement.md
@@ -1,21 +1,22 @@
-# ADR: User Base Measurement and Market Position
+# ADR: User Base Measurement and Adoption
 
 ## Status
 
-**Proposed** (Date: 2026-07-25)
+**Proposed** (Date: 2026-07-25, revised 2026-07-26)
 
 ## Context
 
 OmegaT collects no usage telemetry, so the project has no direct knowledge of how many
-people use it, on which platforms, or in which market segments. That information matters
+people use it, on which platforms, or in which fields of work. That information matters
 for recurring development decisions: which platforms and Java runtimes to prioritize,
 how much weight to give backward compatibility, which file formats and workflows deserve
-attention, and how to position OmegaT relative to commercial CAT tools.
+attention, and how significant OmegaT is for the translation community it serves.
 
 The question can nevertheless be answered, to a useful approximation, from public and
 privacy-friendly sources. This record documents the available measurement channels, a
 baseline of their readings, and the resulting estimate, so that future discussions can
-start from shared numbers instead of anecdote.
+start from shared numbers instead of anecdote. An appendix collects verified public
+statements about OmegaT that illustrate its acceptance and the needs of its users.
 
 ### Public data, baseline July 2026
 
@@ -40,20 +41,41 @@ start from shared numbers instead of anecdote.
   translation team) and individual professional translators, as reflected in the
   testimonials collected on omegat.org.
 
-### Market position
+### Adoption in training and daily practice
 
-Independent surveys of professional translators consistently place the commercial tools
-first. In the Inbox Translation freelance survey (2023), 81% of respondents use CAT
-tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%, while
-OmegaT appears among the most-mentioned write-in tools below the 15% line. The MET
-survey (2020, 157 respondents) shows the same shape. RWS states that more than 250,000
-translation professionals use Trados Studio.
+- University translation programmes teach OmegaT alongside proprietary tools; the
+  University of Bologna, for example, lists it in its CAT course units for 2024/25 and
+  later years. The EMT survey 2023 (Rothwell, Moorkens, Svoboda) records at the same
+  time a general drift of teaching programmes towards "cloud-based software with
+  cost-free academic access", which affects the exposure of new graduates to
+  desktop tools such as OmegaT.
+- Practitioner voices document long-term acceptance: reviews on the project's
+  SourceForge page average 5.0 of 5 over 53 reviews; trainer and translator
+  Corinne McKay (2025) calls OmegaT "a free and open-source tool that I still love"
+  and finds "its matching algorithm to be better than commercial tools'"; the South
+  African Translators' Institute recommends it as a fully functional no-cost option;
+  and community discussions repeatedly recommend OmegaT to translators looking for
+  an alternative when subscription prices of proprietary tools rise.
+- The same public feedback names recurring needs — a friendlier first-run
+  experience, more discoverable machine-translation and dictionary setup, richer
+  terminology data, built-in bilingual review export, easier team-project setup —
+  which are collected with sources in the appendix and can seed the feature-request
+  tracker.
+
+### Acceptance and relative adoption
+
+Independent surveys of professional translators consistently show the proprietary tools
+in the lead. In the Inbox Translation freelance survey (2023), 81% of respondents use
+CAT tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%,
+while OmegaT appears among the most-mentioned write-in tools below the 15% line. The
+MET survey (2020, 157 respondents) shows the same shape. RWS states that more than
+250,000 translation professionals use Trados Studio.
 
 Within open source, OmegaT is the only full-featured desktop CAT tool under active
 development: Virtaal and Pootle are discontinued, and the active open-source projects
 occupy adjacent niches (MateCat in the browser, Weblate and friends in software
-localization). OmegaT's direct competition is therefore commercial, while its own niche
-has no serious open-source rival.
+localization). For translators who want or need a free desktop tool, OmegaT therefore
+carries a significance well beyond its share in the surveys.
 
 ### Estimate
 
@@ -78,7 +100,7 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
    - the SourceForge download statistics API (volume, platform, and country trends);
    - packaging channel statistics (Flathub API, Debian popcon, and similar);
    - independent professional surveys (Inbox Translation, MET, ProZ) for relative
-     market position;
+     adoption;
    - server-side log analysis of the existing update check: `VersionChecker` fetches a
      static version file from the project web space, so aggregate, anonymous hit counts
      on that file approximate active installations without any client-side change. This
@@ -97,6 +119,8 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
   inform platform-support discussions.
 - The documented institutional adopters (DGT, Autshumato) illustrate that changes to
   core behavior can affect downstream forks beyond the visible user community.
+- The recurring user needs collected in the appendix provide sourced starting points
+  for new feature-request tickets and for prioritizing existing ones.
 
 ## References
 
@@ -122,3 +146,87 @@ Order of magnitude: **low tens of thousands of active users**, most of them on W
   https://www.translationtribulations.com/2014/06/omegats-growing-place-in-language.html
 
 All links verified on 2026-07-25.
+
+## Appendix: verified public statements about OmegaT
+
+Collected 2026-07-26 from a structured search of surveys, teaching material, reviews,
+practitioner blogs, and community discussions. Every URL below was retrieved
+successfully on that date; statements behind login walls or blocked to automated
+retrieval were discarded.
+
+### Surveys and studies
+
+- Inbox Translation, Freelance Translator Survey 2023 (n=2,005 on the tool question):
+  https://inboxtranslation.com/resources/research/freelance-translator-survey-2023/
+- Rothwell, Moorkens, Svoboda: "Training in translation tools and technologies:
+  Findings of the EMT survey 2023": https://arxiv.org/abs/2503.22735
+  (overview: https://www.alphaxiv.org/overview/2503.22735v1)
+- Veiga Díaz, García González: "Usability of Free and Open-Source Tools for Translator
+  Training: OmegaT and Bitext2tmx":
+  https://www2.uibk.ac.at/downloads/trans/publik/open-veigadiazgarciagonzalez.pdf
+- Balashov: "OPUS-CAT: A State-of-the-Art Neural Machine Translation Engine on Your
+  Local Computer" (ATA Chronicle reprint, mentions OmegaT plugin support):
+  https://www.yuribalashov.com/Papers/OPUS_CAT_RR_YB.pdf
+
+### Teaching and institutions
+
+- University of Bologna, CAT course unit 2024/25 (OmegaT in the syllabus):
+  https://www.unibo.it/en/study/course-units-transferable-skills-moocs/course-unit-catalogue/course-unit/2024/470047
+- Master TSM, Université de Lille, student blog: "OmegaT : le meilleur ami du
+  traducteur freelance" (2026-01-11):
+  https://mastertsmlille.wordpress.com/2026/01/11/omegat-le-meilleur-ami-du-traducteur-freelance/
+- DGT-OmegaT documentation ("OmegaT in DGT, its Wizard, Tagwipe and TeamBase"):
+  https://archive.org/details/omegat-in-dgt-its-wizard-tagwipe-and-teambase-documentation
+- South African Translators' Institute: "OmegaT: an open-source alternative to
+  translation memory programs" (2023-04-20):
+  https://translators.org.za/omegat-an-open-source-alternative-to-translation-memory-programs/
+
+### Practitioner blogs and testimonials
+
+- Corinne McKay: "How to choose a translation memory tool" (2024-10-15):
+  https://www.trainingfortranslators.com/2024/10/15/how-to-choose-a-translation-memory-tool/
+- Corinne McKay: "Changes in the translation software landscape" (2025-07-16):
+  https://www.trainingfortranslators.com/2025/07/16/changes-in-the-translation-software-landscape/
+- Christopher Köbel (DeFrEnT): "Wege von Trados zu OmegaT im Frühling 2026"
+  (2026-04-18, detailed feature-gap list from a Trados switcher):
+  https://www.defrent.de/2026/04/wege-von-trados-zu-omegat-im-fruehling-2026/
+- Cotelangues: CAT tool survey among freelance translators (2020-08-05):
+  https://cotelangues.com/de/uebersetzer-cat-tools/
+- Abdunnasir Althobaity: OmegaT review: https://althobaity.com/abdunnasir/omegat-review/
+
+### Reviews and tool directories
+
+- SourceForge user reviews (5.0/5, 53 reviews):
+  https://sourceforge.net/projects/omegat/reviews/
+- Softpedia editorial review: https://www.softpedia.com/get/Programming/Other-Programming-Files/OmegaT.shtml
+- Lokalise: "The best CAT tools" (updated 2024-09-02): https://lokalise.com/blog/best-cat-tools/
+- Dokutech: "CAT tools in 2026": https://dokutechtranslations.com/en/cat-tools-in-2026-the-complete-guide-for-translators-and-project-managers/
+- Tomedes: "9 best CAT tools": https://www.tomedes.com/translator-hub/cat-tools
+
+### Community discussions (Reddit)
+
+- Bilingual review export is missing from the base application (2025):
+  https://www.reddit.com/r/TranslationStudies/comments/1j90kt9/
+- Editing TMX files inside OmegaT, repeatedly requested (2024):
+  https://www.reddit.com/r/OmegaT/comments/1cvy69h/
+- Team projects perceived as complicated to set up (2024, two independent threads):
+  https://www.reddit.com/r/TranslationStudies/comments/1f2rvjd/ and
+  https://www.reddit.com/r/TranslationStudies/comments/1d7aloj/
+- Dated look of the user interface (2024):
+  https://www.reddit.com/r/TranslationStudies/comments/1hhtk9l/
+- OmegaT recommended when proprietary subscription prices rise (2024):
+  https://www.reddit.com/r/TranslationStudies/comments/1e0krsy/
+- Two-column source/target editor view expected by switchers (2025):
+  https://www.reddit.com/r/OmegaT/comments/1k5umck/
+- Spellchecker ignored/learned words do not carry over between projects (2025):
+  https://www.reddit.com/r/OmegaT/comments/1ilmuzi/
+- Confusion between the Okapi plugin and the built-in XLIFF filter (2025):
+  https://www.reddit.com/r/OmegaT/comments/1ieby4k/
+- Dictionary pane display issue in 6.0.0 (2024):
+  https://www.reddit.com/r/OmegaT/comments/1adadgh/
+- Protected numbers cannot be deleted with backspace (2024):
+  https://www.reddit.com/r/OmegaT/comments/1cevysj/
+- Glossary matching for Korean (2024):
+  https://www.reddit.com/r/OmegaT/comments/1al45av/
+
+All appendix links verified on 2026-07-26.

--- a/src/docs/developer/adr/2026006.UserBaseMeasurement.md
+++ b/src/docs/developer/adr/2026006.UserBaseMeasurement.md
@@ -1,0 +1,124 @@
+# ADR: User Base Measurement and Market Position
+
+## Status
+
+**Proposed** (Date: 2026-07-25)
+
+## Context
+
+OmegaT collects no usage telemetry, so the project has no direct knowledge of how many
+people use it, on which platforms, or in which market segments. That information matters
+for recurring development decisions: which platforms and Java runtimes to prioritize,
+how much weight to give backward compatibility, which file formats and workflows deserve
+attention, and how to position OmegaT relative to commercial CAT tools.
+
+The question can nevertheless be answered, to a useful approximation, from public and
+privacy-friendly sources. This record documents the available measurement channels, a
+baseline of their readings, and the resulting estimate, so that future discussions can
+start from shared numbers instead of anecdote.
+
+### Public data, baseline July 2026
+
+| Channel | Reading | Notes |
+|---|---|---|
+| SourceForge downloads, 2025-07 to 2026-06 | 93,920 | stable 6,600–10,000/month |
+| SourceForge downloads, all time since 2002 | ~1.90 million | peak in 2023 (16,000–21,000/month) |
+| Download platforms (SourceForge) | 66% Windows, 11% macOS, 5% Linux | remainder unknown/other |
+| Top download countries (SourceForge) | US (9%), ES, CN, BR, FR | broad long tail |
+| Flathub installs | 10,182 total, ~180/month | Linux Flatpak channel |
+| Debian popcon | 61 reporting installations | opt-in panel, small sample |
+| GitHub development mirror | 526 stars, 135 forks | code review mirror since 2015 |
+
+### Documented adopters
+
+- The **Directorate-General for Translation of the European Commission** maintains
+  DGT-OmegaT, an in-house fork with additional tooling (Wizard, TagWipe, TeamBase),
+  described by DGT staff in the Commission's *a folha* bulletin (see References).
+- The **Autshumato Integrated Translation Environment**, funded by the South African
+  government for its eleven official languages, is a derived work of OmegaT.
+- Free-software localization communities (for example the Italian LibreOffice
+  translation team) and individual professional translators, as reflected in the
+  testimonials collected on omegat.org.
+
+### Market position
+
+Independent surveys of professional translators consistently place the commercial tools
+first. In the Inbox Translation freelance survey (2023), 81% of respondents use CAT
+tools; among those, Trados is used by 62%, memoQ by 46%, and Phrase by about 26%, while
+OmegaT appears among the most-mentioned write-in tools below the 15% line. The MET
+survey (2020, 157 respondents) shows the same shape. RWS states that more than 250,000
+translation professionals use Trados Studio.
+
+Within open source, OmegaT is the only full-featured desktop CAT tool under active
+development: Virtaal and Pootle are discontinued, and the active open-source projects
+occupy adjacent niches (MateCat in the browser, Weblate and friends in software
+localization). OmegaT's direct competition is therefore commercial, while its own niche
+has no serious open-source rival.
+
+### Estimate
+
+Two independent estimates converge:
+
+1. **From downloads**: roughly 100,000 downloads per year across channels, with no
+   auto-update mechanism (active users typically download one to three installers per
+   year, and one-time evaluators inflate the count), suggests **25,000–60,000 active
+   installations**.
+2. **From surveys**: OmegaT is used by an estimated 2–5% of CAT tool users. Against a
+   worldwide population of professional translators in the hundreds of thousands, that
+   suggests **10,000–25,000 professional users** with OmegaT as a primary or secondary
+   tool.
+
+Order of magnitude: **low tens of thousands of active users**, most of them on Windows.
+
+## Decision
+
+1. The project does **not** add usage telemetry. User-base estimates rely exclusively on
+   data that users already generate voluntarily.
+2. The measurement channels of record are, in order of usefulness:
+   - the SourceForge download statistics API (volume, platform, and country trends);
+   - packaging channel statistics (Flathub API, Debian popcon, and similar);
+   - independent professional surveys (Inbox Translation, MET, ProZ) for relative
+     market position;
+   - server-side log analysis of the existing update check: `VersionChecker` fetches a
+     static version file from the project web space, so aggregate, anonymous hit counts
+     on that file approximate active installations without any client-side change. This
+     channel requires access to the project web server statistics and is listed here as
+     an option for maintainers, not as a new mechanism.
+3. This baseline should be refreshed when a decision actually depends on it, rather than
+   on a fixed schedule; the channels above are all repeatable on demand.
+
+## Consequences
+
+- Estimates stay estimates: downloads are not users, updates are counted repeatedly,
+  and distribution through Linux repositories is only partially visible. Every figure
+  above is therefore given with its channel and date.
+- No privacy impact and no client code changes; all channels are external observation.
+- The platform split (two-thirds of downloads on Windows) is now on record and should
+  inform platform-support discussions.
+- The documented institutional adopters (DGT, Autshumato) illustrate that changes to
+  core behavior can affect downstream forks beyond the visible user community.
+
+## References
+
+- SourceForge download statistics: https://sourceforge.net/projects/omegat/files/stats/timeline
+  (JSON API: `https://sourceforge.net/projects/omegat/files/stats/json?start_date=…&end_date=…`)
+- Flathub listing and statistics: https://flathub.org/apps/org.omegat.OmegaT
+  (API: `https://flathub.org/api/v2/stats/org.omegat.OmegaT`)
+- Debian popularity contest: https://qa.debian.org/popcon.php?package=omegat
+- Inbox Translation, Freelance Translator Survey 2023:
+  https://inboxtranslation.com/resources/research/freelance-translator-survey-2023/
+- MET CAT tool survey 2020: https://www.metmeetings.org/documentacion/files/CAT_survey_report_2020.pdf
+- ProZ.com CAT tool survey: https://go.proz.com/blog/cat-tool-use-by-translators-what-are-they-using
+- RWS press release on Trados Studio 2026 (user count claim):
+  https://www.prnewswire.com/news-releases/rws-launches-trados-studio-2026-delivering-major-advances-in-ai-performance-and-productivity-for-language-professionals-302816052.html
+- DGT-OmegaT, described by DGT staff: "Interoperability between DGT-OmegaT and SDL Trados
+  Studio", *a folha* No. 58, 2018: https://op.europa.eu/webpub/dgt/afolha/documents/afolha_058-S_en.pdf
+  and "OmegaT in DGT, its Wizard, TagWipe and TeamBase":
+  https://archive.org/details/omegat-in-dgt-its-wizard-tagwipe-and-teambase-documentation
+- The Autshumato project: https://autshumato.nwu.ac.za/about/
+- Feature comparison of CAT tools:
+  https://en.wikipedia.org/wiki/Comparison_of_computer-assisted_translation_tools
+- John Moran: "OmegaT's Growing Place in the Language Services Industry" (2014):
+  https://www.translationtribulations.com/2014/06/omegats-growing-place-in-language.html
+
+All links verified on 2026-07-25.

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -36,6 +36,10 @@
 
 - 2025003 [Comprehensive Static Code Analysis Strategy](2025003.StaticCodeAnalysis.md)
 
+## Project stewardship
+
+- 2026006 [User Base Measurement and Market Position](2026006.UserBaseMeasurement.md)
+
 ## Debugging and Logging
 
 - 2024002 [Logging system and logging format](2024002.LoggingSystem.md)

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -39,6 +39,7 @@
 ## Project stewardship
 
 - 2026004 [User Base Measurement and Adoption](2026004.UserBaseMeasurement.md)
+- 2026005 [International and Multilingual Adoption Footprint](2026005.InternationalAdoptionFootprint.md)
 
 ## Debugging and Logging
 

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -38,7 +38,7 @@
 
 ## Project stewardship
 
-- 2026006 [User Base Measurement and Market Position](2026006.UserBaseMeasurement.md)
+- 2026006 [User Base Measurement and Adoption](2026006.UserBaseMeasurement.md)
 
 ## Debugging and Logging
 

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -38,7 +38,7 @@
 
 ## Project stewardship
 
-- 2026004 [User Base Measurement and Market Position](2026004.UserBaseMeasurement.md)
+- 2026004 [User Base Measurement and Adoption](2026004.UserBaseMeasurement.md)
 
 ## Debugging and Logging
 

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -36,6 +36,10 @@
 
 - 2025003 [Comprehensive Static Code Analysis Strategy](2025003.StaticCodeAnalysis.md)
 
+## Project stewardship
+
+- 2026004 [User Base Measurement and Market Position](2026004.UserBaseMeasurement.md)
+
 ## Debugging and Logging
 
 - 2024002 [Logging system and logging format](2024002.LoggingSystem.md)

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -39,6 +39,7 @@
 ## Project stewardship
 
 - 2026006 [User Base Measurement and Adoption](2026006.UserBaseMeasurement.md)
+- 2026005 [International and Multilingual Adoption Footprint](2026005.InternationalAdoptionFootprint.md)
 
 ## Debugging and Logging
 


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

None. This is a documentation-only ADR.

## What does this PR change?

- Adds ADR 2026004,2026005 "User Base Measurement and Adoption" and "International and Multilingual Adoption Footprint": OmegaT has no telemetry, so the ADR documents the public, privacy-friendly channels that answer "who uses OmegaT?" (SourceForge stats API, Flathub/popcon, independent translator surveys, and optionally server-side hit counts of the existing VersionChecker version file), together with a July 2026 baseline of readings and the resulting estimate (low tens of thousands of active users, two thirds of downloads on Windows).
- Records documented institutional adopters (the European Commission's DGT-OmegaT fork, South Africa's Autshumato ITE) and OmegaT's adoption rate relative to proprietary CAT tools.
- Actively self reported international usage was roughly mapped by simple web searches
- Adds the ADRs to the index under a new "Project stewardship" section.

## Other information

referenced links' existences were verified mid 2026 and are not updated automatically. No code changes; the decision explicitly rules out adding client-side telemetry.