### PR TITLE
fix(core): return empty collections instead null from NotLoadedProject

### DIFF
--- a/src/main/java/org/omegat/core/data/NotLoadedProject.java
+++ b/src/main/java/org/omegat/core/data/NotLoadedProject.java
@@ -27,6 +27,7 @@
 package org.omegat.core.data;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -71,11 +72,11 @@ public class NotLoadedProject implements IProject {
     }
 
     public List<SourceTextEntry> getAllEntries() {
-        return null;
+        return Collections.emptyList();
     }
 
     public List<StringEntry> getUniqueEntries() {
-        return null;
+        return Collections.emptyList();
     }
 
     public TMXEntry getTranslationInfo(SourceTextEntry ste) {
@@ -104,15 +105,15 @@ public class NotLoadedProject implements IProject {
     }
 
     public Map<String, ExternalTMX> getTransMemories() {
-        return null;
+        return Collections.emptyMap();
     }
 
     public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
-        return null;
+        return Collections.emptyMap();
     }
 
     public List<FileInfo> getProjectFiles() {
-        return null;
+        return Collections.emptyList();
     }
 
     public ProjectProperties getProjectProperties() {
@@ -160,7 +161,7 @@ public class NotLoadedProject implements IProject {
     }
 
     public List<String> getSourceFilesOrder() {
-        return null;
+        return Collections.emptyList();
     }
 
     public void setSourceFilesOrder(List<String> filesList) {

--- a/src/test/java/org/omegat/core/data/NotLoadedProjectTest.java
+++ b/src/test/java/org/omegat/core/data/NotLoadedProjectTest.java
@@ -1,0 +1,58 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The placeholder project must honor the collection contracts of
+ * {@link IProject}: listeners that fire while no project is loaded (e.g.
+ * during project switch) iterate these collections and must not hit null.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NotLoadedProjectTest {
+
+    private final NotLoadedProject project = new NotLoadedProject();
+
+    @Test
+    public void collectionGettersReturnEmptyCollectionsNotNull() {
+        assertNotNull(project.getAllEntries());
+        assertTrue(project.getAllEntries().isEmpty());
+        assertNotNull(project.getUniqueEntries());
+        assertTrue(project.getUniqueEntries().isEmpty());
+        assertNotNull(project.getProjectFiles());
+        assertTrue(project.getProjectFiles().isEmpty());
+        assertNotNull(project.getSourceFilesOrder());
+        assertTrue(project.getSourceFilesOrder().isEmpty());
+        assertNotNull(project.getTransMemories());
+        assertTrue(project.getTransMemories().isEmpty());
+        assertNotNull(project.getOtherTargetLanguageTMs());
+        assertTrue(project.getOtherTargetLanguageTMs().isEmpty());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

no ticket exists, coincidental finding.
- NotLoadedProject returns null from collection getters despite the IProject contract

## What does this PR change?

- `NotLoadedProject` now returns empty collections instead of `null` from its six collection getters (`getAllEntries`, `getUniqueEntries`, `getTransMemories`, `getOtherTargetLanguageTMs`, `getProjectFiles`, `getSourceFilesOrder`).
- The `IProject` javadoc promises an unmodifiable list, so callers do not expect `null` and code iterating over these results could throw a `NullPointerException` while no project is loaded.
- The only existing null check (`EditorController`) remains correct, since it also accepts an empty list.
- Adds a regression test asserting all six getters return non-null, empty collections.

## Other information

No behavioural change for loaded projects; `NotLoadedProject` is only active while no project is open.
