### PR TITLE
fix(filelist): let ProjectFilesListController unregister its listeners

### DIFF
--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -51,6 +51,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.math.RoundingMode;
@@ -105,6 +106,8 @@ import org.omegat.core.data.IProject;
 import org.omegat.core.data.IProject.FileInfo;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IEntryEventListener;
+import org.omegat.core.events.IFontChangedEventListener;
+import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.util.Java8Compat;
@@ -164,6 +167,15 @@ public class ProjectFilesListController implements IProjectFilesList {
 
     private final Font defaultFont;
 
+    /**
+     * The global (static-registry) listeners this controller registers, kept
+     * so {@link #dispose()} can unregister them again.
+     */
+    private final IProjectEventListener projectListener;
+    private final IEntryEventListener entryListener;
+    private final IFontChangedEventListener fontListener;
+    private final PropertyChangeListener showProgressListener;
+
     public ProjectFilesListController() {
 
         list = new ProjectFilesList();
@@ -218,8 +230,8 @@ public class ProjectFilesListController implements IProjectFilesList {
 
         // set the position and size
         initWindowLayout();
-        Preferences.addPropertyChangeListener(Preferences.PROJECT_FILES_SHOW_PROGRESS,
-                e -> SwingUtilities.invokeLater(this::updateProjectFilesProgressDisplay));
+        showProgressListener = e -> SwingUtilities.invokeLater(this::updateProjectFilesProgressDisplay);
+        Preferences.addPropertyChangeListener(Preferences.PROJECT_FILES_SHOW_PROGRESS, showProgressListener);
 
         list.m_addNewFileButton.addActionListener(e -> doImportSourceFiles());
         list.m_wikiImportButton.addActionListener(e -> doWikiImport());
@@ -243,7 +255,7 @@ public class ProjectFilesListController implements IProjectFilesList {
             }
         });
 
-        CoreEvents.registerProjectChangeListener(eventType -> {
+        projectListener = eventType -> {
             switch (eventType) {
             case CLOSE:
                 // Drop every reference to the closed project's file list: the
@@ -277,9 +289,10 @@ public class ProjectFilesListController implements IProjectFilesList {
             default:
                 // Nothing
             }
-        });
+        };
+        CoreEvents.registerProjectChangeListener(projectListener);
 
-        CoreEvents.registerEntryEventListener(new IEntryEventListener() {
+        entryListener = new IEntryEventListener() {
             @Override
             public void onNewFile(String activeFileName) {
                 list.tableFiles.repaint();
@@ -304,14 +317,16 @@ public class ProjectFilesListController implements IProjectFilesList {
                     model.fireTableDataChanged();
                 }
             }
-        });
+        };
+        CoreEvents.registerEntryEventListener(entryListener);
 
-        CoreEvents.registerFontChangedEventListener(newFont -> {
+        fontListener = newFont -> {
             if (!Preferences.isPreference(Preferences.PROJECT_FILES_USE_FONT)) {
                 newFont = defaultFont;
             }
             setFont(newFont);
-        });
+        };
+        CoreEvents.registerFontChangedEventListener(fontListener);
 
         list.tableFiles.addMouseListener(new MouseAdapter() {
             @Override
@@ -393,6 +408,21 @@ public class ProjectFilesListController implements IProjectFilesList {
         list.btnDown.addActionListener(moveAction);
         list.btnFirst.addActionListener(moveAction);
         list.btnLast.addActionListener(moveAction);
+    }
+
+    /**
+     * Unregisters the globally registered listeners and disposes the window.
+     * The controller is defunct afterwards; anything that creates more than
+     * one controller per JVM (tests, embedders) must call this, or the stale
+     * controller keeps reacting to project events forever.
+     */
+    public void dispose() {
+        CoreEvents.unregisterProjectChangeListener(projectListener);
+        CoreEvents.unregisterEntryEventListener(entryListener);
+        CoreEvents.unregisterFontChangedEventListener(fontListener);
+        Preferences.removePropertyChangeListener(Preferences.PROJECT_FILES_SHOW_PROGRESS,
+                showProgressListener);
+        list.dispose();
     }
 
     private void updateTitle() {

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -696,6 +696,21 @@ public final class Preferences {
         PROP_CHANGE_SUPPORT.addPropertyChangeListener(property, listener);
     }
 
+    /**
+     * Stop receiving notifications when preferences change.
+     */
+    public static void removePropertyChangeListener(PropertyChangeListener listener) {
+        PROP_CHANGE_SUPPORT.removePropertyChangeListener(listener);
+    }
+
+    /**
+     * Stop receiving notifications when the specified preference changes. The
+     * listener must be removed with the same property it was registered with.
+     */
+    public static void removePropertyChangeListener(String property, PropertyChangeListener listener) {
+        PROP_CHANGE_SUPPORT.removePropertyChangeListener(property, listener);
+    }
+
     public static void setFilters(Filters newFilters) {
         Filters oldValue = filters;
         filters = newFilters;

--- a/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,6 +55,7 @@ import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.filters2.text.TextFilter;
+import org.omegat.gui.filelist.ProjectFilesListController;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.util.Language;
 
@@ -73,6 +75,7 @@ public class EditorProjectReloadLeakTest extends TestCore {
     private static final int CYCLES = 3;
 
     private EditorController editorController;
+    private ProjectFilesListController projectFilesListController;
     private File projectRoot;
 
     @BeforeClass
@@ -197,7 +200,17 @@ public class EditorProjectReloadLeakTest extends TestCore {
      */
     @Before
     public final void setUpProjectFilesWindow() {
-        new org.omegat.gui.filelist.ProjectFilesListController();
+        projectFilesListController = new ProjectFilesListController();
+    }
+
+    /**
+     * Unregister the controller's global listeners again: they would stay
+     * registered for the rest of the test JVM and fire on later tests'
+     * project events, against project stubs they were never written for.
+     */
+    @After
+    public final void tearDownProjectFilesWindow() {
+        projectFilesListController.dispose();
     }
 
     @Override

--- a/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerDisposeTest.java
+++ b/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerDisposeTest.java
@@ -1,0 +1,76 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.filelist;
+
+import static org.junit.Assert.assertNull;
+
+import java.awt.GraphicsEnvironment;
+import java.lang.ref.WeakReference;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.omegat.util.TestPreferencesInitializer;
+
+/**
+ * {@link ProjectFilesListController#dispose()} must unhook the controller
+ * from the static event registries ({@code CoreEvents}, the preference
+ * change support): the registered listeners capture the controller, so as
+ * long as any of them stays registered, a disposed controller remains
+ * strongly reachable for the rest of the JVM and keeps reacting to project
+ * events.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectFilesListControllerDisposeTest {
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Assume.assumeFalse("Skipping test: headless environment",
+                GraphicsEnvironment.isHeadless());
+        TestPreferencesInitializer.init();
+    }
+
+    @Test
+    public void disposedControllerBecomesUnreachable() throws Exception {
+        ProjectFilesListController controller = new ProjectFilesListController();
+        controller.dispose();
+        WeakReference<ProjectFilesListController> ref = new WeakReference<>(controller);
+        controller = null;
+
+        for (int attempt = 0; attempt < 50 && ref.get() != null; attempt++) {
+            System.gc();
+            // Nudge collection of the freshly allocated controller graph.
+            byte[][] pressure = new byte[16][];
+            for (int i = 0; i < pressure.length; i++) {
+                pressure[i] = new byte[1024 * 1024];
+            }
+            Thread.sleep(10);
+        }
+        assertNull("a disposed controller must not stay reachable through the"
+                + " global event registries", ref.get());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

no bug ticket, accidental finding.
- ProjectFilesListController never unregisters its CoreEvents and preference listeners

## What does this PR change?

- Adds `ProjectFilesListController.dispose()`, which unregisters the project, entry and font-changed listeners from `CoreEvents`, removes the show-progress listener from `Preferences`, and disposes the window.
- Keeps the listeners in fields so they can be unregistered again; previously they were anonymous registrations with no way to remove them, so every controller instance stayed strongly reachable through the static `CoreEvents` registries for the lifetime of the JVM.
- Adds the missing `Preferences.removePropertyChangeListener` overloads (global and per-property) as counterparts to the existing add methods.
- `EditorProjectReloadLeakTest` now disposes the controller it creates instead of leaving its listeners registered for subsequent tests.
- Adds `ProjectFilesListControllerDisposeTest`, which proves via a weak reference under GC pressure that a disposed controller becomes unreachable.

## Other information

In the running application the controller is created once per main window, so the practical impact is on tests and any embedding code that creates the window repeatedly; the missing `Preferences` remove API affects all per-property listeners.
