### PR TITLE
fix(build): copy tips into the distribution from src/docs/tips

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -273,7 +273,7 @@ def firstStepLangsProvider = providers.gradleProperty("org.omegat.firstStepLangs
 firstStepLangsProvider.get().each { lang ->
     def firstStepsHtmlFinally = tasks.register("firstSteps${lang.capitalize()}Finally", Copy) {
         description = 'Copy CSS files to target'
-        from layout.projectDirectory.file("src_docs/style/greeting.css")
+        from layout.projectDirectory.file("src/docs/style/greeting.css")
         into layout.buildDirectory.dir("docs/greetings/${lang}/")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -357,7 +357,7 @@ distributions {
                 from(layout.buildDirectory.dir('docs/manuals'))
             }
             into('docs/tips') {
-                from('src_docs/tips')
+                from('src/docs/tips')
             }
             from(layout.settingsDirectory.dir('scripts')) {
                 into 'scripts'

--- a/src/docs/developer/40.ContributingDocument.md
+++ b/src/docs/developer/40.ContributingDocument.md
@@ -2,16 +2,16 @@
 
 Work on the OmegaT related documentation is carried out in the OmegaT repository.
 
-The source files of manuals are in `src_docs/manual` folder.
+The source files of manuals are in `src/docs/manual` folder.
 Manual source uses the [Docbook 5.2](https://tdg.docbook.org/tdg/5.2/) format.
 
 There are also contribution manual for developers, manual writers and translators.
-The source files of contribution manual are in `src_docs/developer`
+The source files of contribution manual are in `src/docs/developer`
 Contribution manual source uses the MarkDown, and we convert it into HTML using MkDocs processing system.
 
 When OmegaT start without project folder in command line,
 you will find First Steps short document on OmegaT editor screen.
-Its sources are stored in `src_docs/greeting` folder.
+Its sources are stored in `src/docs/greeting` folder.
 
 ## Documentation rules and procedures
 
@@ -26,7 +26,7 @@ on the web server at [https://omegat.sourceforge.io/manual-snapshot/](https://om
 
 ### License
 
-All the files in `src_docs` folder and below are published under the terms of the GNU General
+All the files in `src/docs` folder and below are published under the terms of the GNU General
 Public License as published by the Free Software Foundation; either version 3 of
 the License, or (at your option) any later version.
 

--- a/src/docs/developer/96.ContinuousIntegration.md
+++ b/src/docs/developer/96.ContinuousIntegration.md
@@ -24,7 +24,7 @@ Runs on every push and pull request (but not on scheduled or manual runs, and no
 A `CheckChanges` job first inspects which files have changed since the previous commit (or since
 `master` for pull requests). Based on the result, downstream jobs are conditionally executed:
 
-- **BuildDocument** — runs only when documentation files under `src_docs/` or tip-of-the-day files have changed.
+- **BuildDocument** — runs only when documentation files under `src/docs/` or tip-of-the-day files have changed.
 - **testOnLinux / testOnWindows / testOnMac** — run only when non-documentation source files have changed.
 
 ### Stage 2: Weekly
@@ -101,7 +101,7 @@ The **publish** job then:
 ## Daily Quality Checks on GitHub Actions
 
 The following workflows run on every push to `master` / `releases/*` and on every pull request,
-providing continuous quality feedback. Most workflows skip `ci/`, `src_docs/`, and `*.md` changes
+providing continuous quality feedback. Most workflows skip `ci/`, `src/docs/`, and `*.md` changes
 to avoid unnecessary runs on non-code changes.
 
 | Workflow file                  | Name                     | What it checks                                                                                                                                                                                      |

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/OmegaTTipOfTheDayModel.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/OmegaTTipOfTheDayModel.java
@@ -69,6 +69,12 @@ public final class OmegaTTipOfTheDayModel implements TipOfTheDayModel {
 
     private void initTips() {
         try (InputStream is = TipOfTheDayUtils.getIndexStream()) {
+            if (is == null) {
+                // No tips index for the current locale (or none shipped at
+                // all): leave the model empty instead of feeding null into
+                // the parser.
+                return;
+            }
             JsonNode data = mapper.readTree(is);
             if (data != null) {
                 data.get("tips").forEach(this::addIfExist);

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayUtils.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayUtils.java
@@ -66,8 +66,10 @@ public final class TipOfTheDayUtils {
     }
 
     static boolean hasIndex() {
-        try (InputStream ignored = getIndexStream()) { // validate exists
-            return true;
+        try (InputStream is = getIndexStream()) { // validate exists
+            // try-with-resources tolerates a null resource, so check
+            // explicitly: no index found means there are no tips to show.
+            return is != null;
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- No SourceForge ticket: incidental finding — installed builds ship without `docs/tips`, so Tip of the Day fails at startup with a Jackson exception.

## What does this PR change?

- The distribution copy spec in `build.gradle` and the greeting-page path in the document conventions still pointed at `src_docs`, which no longer exists since the source tree reorganization (#2117). Both now point at `src/docs`, so `docs/tips` is included in distributions again.
- Updates the two developer documentation pages that still referred to `src_docs`.
- The tip loader (`TipOfTheDayUtils.hasIndex`, `OmegaTTipOfTheDayModel.initTips`) now tolerates a missing tips index instead of throwing, so a broken or trimmed installation degrades to simply not showing tips.

## Other information

Verified with `installDist`: `build/install/OmegaT/docs/tips/en/tips.yaml` is present again and Tip of the Day opens in the installed layout.
