### PR TITLE
fix(build): declare the XSD schema as input of the JAXB codegen tasks

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.jaxb-conventions.gradle
@@ -19,13 +19,18 @@ def genjaxb = tasks.register('genJAXB') {
 }
 compileJava.dependsOn(genjaxb)
 
-ext.makeJaxbTask = { args ->
-    def taskName = "gen${args.name.capitalize()}"
+ext.makeJaxbTask = { spec ->
+    def taskName = "gen${spec.name.capitalize()}"
     tasks.register(taskName, JavaExec) {
         classpath = configurations.jaxb
         mainClass = 'com.sun.tools.xjc.XJCFacade'
-        delegate.args args.args
-        outputs.dir args.outdir
+        args(spec.args + [spec.schema])
+        // The schema is the real input; without it a schema edit leaves the
+        // previously generated (now stale) sources in place. The options are
+        // an input too, so package or flag changes also regenerate.
+        inputs.file(spec.schema).withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.property('xjcArgs', spec.args.join(' '))
+        outputs.dir spec.outdir
         group = 'jaxb'
     }
     genJAXB.dependsOn taskName
@@ -34,12 +39,14 @@ ext.makeJaxbTask = { args ->
 def schemaSourcePath = 'src/main/resources/schemas/'
 def generatedSourcePath = 'build/generated/sources/jaxb/main/java/'
 makeJaxbTask(name: 'segmentation', outdir: generatedSourcePath + 'gen/core/segmentation',
-        args: ['-no-header', '-npa', '-d', generatedSourcePath, '-p', 'gen.core.segmentation',
-               schemaSourcePath + 'srx20.xsd'])
+        schema: schemaSourcePath + 'srx20.xsd',
+        args: ['-no-header', '-npa', '-d', generatedSourcePath, '-p', 'gen.core.segmentation'])
 makeJaxbTask(name: 'filters', outdir: generatedSourcePath + 'gen/core/filters',
-        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.filters', schemaSourcePath + 'filters.xsd'])
+        schema: schemaSourcePath + 'filters.xsd',
+        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.filters'])
 makeJaxbTask(name: 'tbx', outdir: generatedSourcePath + 'gen/core/tbx',
-        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.tbx', schemaSourcePath + 'tbx.xsd'])
+        schema: schemaSourcePath + 'tbx.xsd',
+        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.tbx'])
 makeJaxbTask(name: 'project', outdir: generatedSourcePath + 'gen/core/project',
-        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.project',
-               schemaSourcePath + 'project_properties.xsd'])
+        schema: schemaSourcePath + 'project_properties.xsd',
+        args: ['-no-header', '-d', generatedSourcePath, '-p', 'gen.core.project'])


### PR DESCRIPTION
## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

- No SourceForge ticket: incidental finding — editing an XSD schema does not retrigger JAXB code generation, so the build keeps compiling stale generated sources.

## What does this PR change?

- The four `gen*` tasks (segmentation, filters, tbx, project) passed the schema file only inside the xjc argument list, so Gradle never registered it as a task input: repeated runs were correctly UP-TO-DATE, but a schema edit did not re-run generation.
- The JAXB conventions now take the schema as a dedicated key and declare it as a path-sensitive input file, together with the xjc arguments as an input property.

## Other information

The arguments passed to xjc are unchanged (the schema is still appended to the argument list), so the generated output is identical. Verified locally: a content change to `srx.xsd` re-runs only `genSegmentation`; unchanged repeat runs stay UP-TO-DATE.
