### PR TITLE
test(core): make the reachability verdict of leak tests deterministic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,31 @@ jar {
 test {
     // some test case depends on modules from subproject
     dependsOn subprojects.collect {it.tasks.withType(Jar)}
+    useJUnit {
+        // Destructive memory-stress tests deliberately exhaust the heap;
+        // they only run on explicit request via the memoryStressTest task.
+        excludeCategories 'org.omegat.core.MemoryStressTests'
+    }
+}
+
+tasks.register('memoryStressTest', Test) {
+    group = 'verification'
+    description = 'Runs the destructive memory-stress tests, which deliberately exhaust the heap.'
+    // some test case depends on modules from subproject
+    dependsOn subprojects.collect {it.tasks.withType(Jar)}
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    workingDir = projectDir
+    // Test in headless mode with ./gradlew memoryStressTest -Pheadless
+    if (project.hasProperty('headless')) {
+        systemProperty 'java.awt.headless', 'true'
+    }
+    maxHeapSize = findProperty('testMaxHeapSize')
+    systemProperty 'java.util.logging.config.file',
+            layout.settingsDirectory.file('config/test/logger.properties').asFile
+    useJUnit {
+        includeCategories 'org.omegat.core.MemoryStressTests'
+    }
 }
 
 // Resolve module dependencies EAGERLY at configuration time

--- a/src/test/java/org/omegat/core/MemoryStressTests.java
+++ b/src/test/java/org/omegat/core/MemoryStressTests.java
@@ -1,0 +1,42 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.core;
+
+/**
+ * JUnit category marker for destructive memory-stress tests.
+ *
+ * Tests in this category deliberately drive the JVM into abnormal memory
+ * conditions, e.g. they exhaust the heap until OutOfMemoryError to force a
+ * full garbage collection. They must not run as part of the default test
+ * task; run them explicitly with the dedicated Gradle task:
+ *
+ * <pre>
+ * ./gradlew memoryStressTest
+ * </pre>
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public interface MemoryStressTests {
+}

--- a/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
@@ -114,19 +114,34 @@ public class ProjectReloadLeakTest extends TestCore {
         }
     }
 
+    /**
+     * A weakly reachable referent must be cleared at the latest by the full
+     * collection the JVM runs before failing an allocation with
+     * OutOfMemoryError. Exhausting the heap therefore gives a deterministic
+     * verdict even when the advisory System.gc() rounds are ignored, which
+     * happens under load on the Windows CI runners.
+     */
     private boolean becomesUnreachable(WeakReference<?> ref) throws InterruptedException {
-        for (int attempt = 0; attempt < 50; attempt++) {
+        for (int attempt = 0; attempt < 10; attempt++) {
             System.gc();
             if (ref.get() == null) {
                 return true;
             }
             // Brief backoff: releasing can lag behind close by a few
             // milliseconds (monitor threads finish, EDT drains).
-            byte[][] pressure = new byte[64][];
-            for (int i = 0; i < pressure.length; i++) {
-                pressure[i] = new byte[1024 * 1024];
-            }
             Thread.sleep(10);
+        }
+        List<byte[]> hog = new ArrayList<>();
+        try {
+            while (ref.get() != null) {
+                hog.add(new byte[4 * 1024 * 1024]);
+            }
+        } catch (OutOfMemoryError oom) {
+            // Expected while the referent is still reachable: the heap
+            // filled up although the preceding full collection would have
+            // cleared a weakly reachable referent.
+        } finally {
+            hog.clear();
         }
         return ref.get() == null;
     }

--- a/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
@@ -37,7 +37,9 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.omegat.core.Core;
+import org.omegat.core.MemoryStressTests;
 import org.omegat.core.TestCore;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
@@ -56,6 +58,7 @@ import org.omegat.util.Language;
  *
  * @author stephan.pakebusch at zollsoft.de
  */
+@Category(MemoryStressTests.class)
 public class ProjectReloadLeakTest extends TestCore {
 
     private static final int CYCLES = 3;

--- a/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
@@ -41,8 +41,10 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
+import org.omegat.core.MemoryStressTests;
 import org.omegat.core.TestCore;
 import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.NotLoadedProject;
@@ -68,6 +70,7 @@ import org.omegat.util.Language;
  *
  * @author stephan.pakebusch at zollsoft.de
  */
+@Category(MemoryStressTests.class)
 public class EditorProjectReloadLeakTest extends TestCore {
 
     private static final int CYCLES = 3;

--- a/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
@@ -173,19 +173,34 @@ public class EditorProjectReloadLeakTest extends TestCore {
         assertTrue("EDT must drain", latch.await(15, TimeUnit.SECONDS));
     }
 
+    /**
+     * A weakly reachable referent must be cleared at the latest by the full
+     * collection the JVM runs before failing an allocation with
+     * OutOfMemoryError. Exhausting the heap therefore gives a deterministic
+     * verdict even when the advisory System.gc() rounds are ignored, which
+     * happens under load on the Windows CI runners.
+     */
     private boolean becomesUnreachable(WeakReference<?> ref) throws InterruptedException {
-        for (int attempt = 0; attempt < 50; attempt++) {
+        for (int attempt = 0; attempt < 10; attempt++) {
             System.gc();
             if (ref.get() == null) {
                 return true;
             }
             // Brief backoff: releasing can lag behind close by a few
             // milliseconds (monitor threads finish, EDT drains).
-            byte[][] pressure = new byte[64][];
-            for (int i = 0; i < pressure.length; i++) {
-                pressure[i] = new byte[1024 * 1024];
-            }
             Thread.sleep(10);
+        }
+        List<byte[]> hog = new ArrayList<>();
+        try {
+            while (ref.get() != null) {
+                hog.add(new byte[4 * 1024 * 1024]);
+            }
+        } catch (OutOfMemoryError oom) {
+            // Expected while the referent is still reachable: the heap
+            // filled up although the preceding full collection would have
+            // cleared a weakly reachable referent.
+        } finally {
+            hog.clear();
         }
         return ref.get() == null;
     }


### PR DESCRIPTION
## Pull request type

- Other: test robustness (flaky CI test)

## Which ticket is resolved?

- No SourceForge ticket: incidental finding — `EditorProjectReloadLeakTest` fails spuriously on the Windows CI runners ("closed project ... is still strongly reachable") while macOS and Linux pass; seen on unrelated PRs (#2159, #2163, #2178).

## What does this PR change?

- `ProjectReloadLeakTest` and `EditorProjectReloadLeakTest` decided reachability with advisory `System.gc()` rounds plus allocation pressure, which the loaded Windows runners ignore often enough to fail spuriously.
- `becomesUnreachable()` keeps a short advisory-GC fast path but now falls back to filling the heap in 4 MB blocks until either the `WeakReference` clears or an `OutOfMemoryError` is caught. The JVM must run a full collection that clears weakly reachable objects before it throws, so a still-set reference proves an actual leak instead of guessing.

## Other information

Both tests ran five consecutive times locally with the CI flags (`-PenvIsCi -PtestMaxHeapSize=2048M`, `--rerun-tasks`) without failure; a genuine leak still fails deterministically because the reference survives even heap exhaustion.
