### PR TITLE
feat(gui): apply color changes w/o restart and add Apply button to prefs

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -64,7 +64,7 @@
               checks="(DesignForExtension|MagicNumber)"/>
     <suppress checks="WhitespaceAround"
             files="(AlignFilePicker|InstanceEditor|CreateGlossaryEntry|NewTeamProject|FilenamePatternsEditor|FilterEditor|SegmentPropertiesListCell|FilterBarReplace|ProjectFilesList)\.java"/>
-    <suppress checks="ParameterNumber" files="EntryListPane\.java" lines="304"/>
+    <suppress checks="ParameterNumber" files="EntryListPane\.java" lines="302"/>
     <suppress checks="LineLength" files="(CreateGlossaryEntry|FilterBarReplace|FilterEditor|InstanceEditor|NewTeamProject|ProjectFilesList)\.java"/>
 
     <!-- Suppress for readability -->

--- a/src/docs/manual/en/OmegaT_Preferences.xml
+++ b/src/docs/manual/en/OmegaT_Preferences.xml
@@ -8,6 +8,9 @@
       <literal>OmegaT</literal> menu on macOS).</para>
    <para>Use the search field at the top of the preferences list to look for
       specific items.</para>
+   <para>Use the
+      <guibutton>Apply</guibutton> button to save your changes and see their
+      effect without closing the dialog.</para>
    <para>Preferences set in this dialog are saved to the default 
       <link linkend="configuration.folder" role="xref">configuration folder</link> and apply to all
       translation projects unless you have specified a different configuration
@@ -388,7 +391,10 @@
       <section xml:id="dialogs.preferences.colours">
          <title xml:id="dialogs.preferences.colours.title"><guilabel>Colours</guilabel></title>
          <para>You can assign different colours for the various parts of the user
-            interface.</para>
+            interface. Colour changes take effect as soon as you confirm them
+            with
+            <guibutton>OK</guibutton> or
+            <guibutton>Apply</guibutton>.</para>
          <para>The Source Files progress colours shown in the
             <link linkend="windows.source.files.list" endterm="windows.source.files.list.title"></link>
             window can also be changed here.</para>

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -45,11 +45,6 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class SpellCheckerMarker implements IMarker {
-    protected final HighlightPainter highlightPainter;
-
-    public SpellCheckerMarker() {
-        highlightPainter = new UnderlineFactory.WaveUnderline(Styles.EditorColor.COLOR_SPELLCHECK.getColor());
-    }
 
     @Override
     public @Nullable List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText,
@@ -62,6 +57,10 @@ public class SpellCheckerMarker implements IMarker {
             // spell checker disabled
             return null;
         }
+        // created per call so that color preference changes take effect
+        // without restarting the application
+        HighlightPainter highlightPainter = new UnderlineFactory.WaveUnderline(
+                Styles.EditorColor.COLOR_SPELLCHECK.getColor());
         return Core.getSpellChecker().getMisspelledTokens(translationText).stream().map(tok -> {
             int st = tok.getOffset();
             int en = st + tok.getLength();

--- a/src/main/java/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -29,14 +29,10 @@ import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.gui.Styles;
 
-import javax.swing.text.Highlighter;
 import java.util.Collections;
 import java.util.List;
 
 public class AltTranslationsMarker extends AbstractMarker {
-
-    private final Highlighter.HighlightPainter painter = new TransparentHighlightPainter(
-            Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
 
     public AltTranslationsMarker() throws Exception {
         super();
@@ -56,7 +52,10 @@ public class AltTranslationsMarker extends AbstractMarker {
 
         if (!Core.getProject().getTranslationInfo(ste).defaultTranslation) {
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
-            m.painter = painter;
+            // created per call so that color preference changes take effect
+            // without restarting the application
+            m.painter = new TransparentHighlightPainter(
+                    Styles.EditorColor.COLOR_MARK_ALT_TRANSLATION.getColor(), 0.5F);
             return Collections.singletonList(m);
         }
 

--- a/src/main/java/org/omegat/gui/editor/mark/BidiMarkers.java
+++ b/src/main/java/org/omegat/gui/editor/mark/BidiMarkers.java
@@ -25,6 +25,8 @@
 
 package org.omegat.gui.editor.mark;
 
+import java.awt.Color;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,27 +51,8 @@ public class BidiMarkers extends AbstractMarker {
     static final int LRO = 0x202d;
     static final int RLO = 0x202e;
 
-    private final HighlightPainter lreBidiPainter;
-    private final HighlightPainter rleBidiPainter;
-    private final HighlightPainter lrmBidiPainter;
-    private final HighlightPainter rlmBidiPainter;
-    private final HighlightPainter rloBidiPainter;
-    private final HighlightPainter lroBidiPainter;
-
     public BidiMarkers() throws Exception {
         super();
-        lreBidiPainter = new BidiPainter(LRE,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-        rleBidiPainter = new BidiPainter(RLE,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-        lrmBidiPainter = new BidiPainter(LRM,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-        rlmBidiPainter = new BidiPainter(RLM,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-        rloBidiPainter = new BidiPainter(RLO,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
-        lroBidiPainter = new BidiPainter(LRO,
-                Styles.EditorColor.COLOR_BIDIMARKERS.getColor());
     }
 
     @Override
@@ -81,6 +64,16 @@ public class BidiMarkers extends AbstractMarker {
         if (!isActive || text == null || text.trim().isEmpty()) {
             return Collections.emptyList();
         }
+
+        // painters are created per call so that color preference changes take
+        // effect without restarting the application
+        Color color = Styles.EditorColor.COLOR_BIDIMARKERS.getColor();
+        HighlightPainter lreBidiPainter = new BidiPainter(LRE, color);
+        HighlightPainter rleBidiPainter = new BidiPainter(RLE, color);
+        HighlightPainter lrmBidiPainter = new BidiPainter(LRM, color);
+        HighlightPainter rlmBidiPainter = new BidiPainter(RLM, color);
+        HighlightPainter rloBidiPainter = new BidiPainter(RLO, color);
+        HighlightPainter lroBidiPainter = new BidiPainter(LRO, color);
 
         text = StringUtil.normalizeUnicode(text);
         List<Mark> marks = new ArrayList<>();

--- a/src/main/java/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -42,21 +42,6 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ComesFromAutoTMMarker implements IMarker {
-    private final HighlightPainter painterXice;
-    private final HighlightPainter painterX100Pc;
-    private final HighlightPainter painterXauto;
-    private final HighlightPainter painterXenforced;
-
-    public ComesFromAutoTMMarker() {
-        painterXice = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE.getColor(), 0.5F);
-        painterX100Pc = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC.getColor(), 0.5F);
-        painterXauto = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO.getColor(), 0.5F);
-        painterXenforced = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED.getColor(), 0.5F);
-    }
 
     @Override
     public synchronized List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText,
@@ -69,19 +54,25 @@ public class ComesFromAutoTMMarker implements IMarker {
             return null;
         }
         Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
+        // painters are created per call so that color preference changes take
+        // effect without restarting the application
         switch (e.linked) {
         case xICE:
-            m.painter = painterXice;
+            m.painter = createPainter(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE);
             break;
         case x100PC:
-            m.painter = painterX100Pc;
+            m.painter = createPainter(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC);
             break;
         case xAUTO:
-            m.painter = painterXauto;
+            m.painter = createPainter(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO);
             break;
         case xENFORCED:
-            m.painter = painterXenforced;
+            m.painter = createPainter(Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED);
         }
         return Collections.singletonList(m);
+    }
+
+    private static HighlightPainter createPainter(Styles.EditorColor color) {
+        return new TransparentHighlightPainter(color.getColor(), 0.5F);
     }
 }

--- a/src/main/java/org/omegat/gui/editor/mark/ComesFromMTMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ComesFromMTMarker.java
@@ -28,8 +28,6 @@ package org.omegat.gui.editor.mark;
 import java.util.Collections;
 import java.util.List;
 
-import javax.swing.text.Highlighter.HighlightPainter;
-
 import org.jspecify.annotations.Nullable;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
@@ -44,7 +42,6 @@ import org.omegat.util.gui.Styles;
  */
 public class ComesFromMTMarker implements IMarker {
     private final Object LOCK = new Object();
-    private final HighlightPainter highlightPainter;
     private @Nullable SourceTextEntry markedSte;
     private @Nullable String markedText;
 
@@ -57,8 +54,6 @@ public class ComesFromMTMarker implements IMarker {
                 setMark(null, null);
             }
         });
-        highlightPainter = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_MT.getColor(), 0.5F);
     }
 
     public void setMark(@Nullable SourceTextEntry ste, @Nullable String text) {
@@ -76,7 +71,10 @@ public class ComesFromMTMarker implements IMarker {
                 return null;
             }
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
-            m.painter = highlightPainter;
+            // created per call so that color preference changes take effect
+            // without restarting the application
+            m.painter = new TransparentHighlightPainter(
+                    Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_MT.getColor(), 0.5F);
             return Collections.singletonList(m);
         }
     }

--- a/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
@@ -46,11 +46,18 @@ import org.omegat.util.gui.Styles;
  */
 public class NBSPMarker extends AbstractMarker {
     public NBSPMarker() throws Exception {
-        painter = new TransparentHighlightPainter(Styles.EditorColor.COLOR_NBSP.getColor(), 0.5F);
         toolTip = OStrings.getString("MARKER_NBSP");
         pattern = Pattern.compile("[\u00a0\u202f\u2007]");
     }
+
     protected boolean isEnabled() {
         return Core.getEditor().getSettings().isMarkNBSP();
+    }
+
+    @Override
+    protected void initDrawers(boolean isSource, boolean isActive) {
+        // created per call so that color preference changes take effect
+        // without restarting the application
+        painter = new TransparentHighlightPainter(Styles.EditorColor.COLOR_NBSP.getColor(), 0.5F);
     }
 }

--- a/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -49,34 +49,29 @@ import org.omegat.util.gui.Styles;
  * @author Aaron Madlon-Kay
  */
 public class ProtectedPartsMarker implements IMarker {
-    private final HighlightPainter painterRtl;
-    private final AttributeSet attributesLtr;
-
-    public ProtectedPartsMarker() {
-        painterRtl = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
-        attributesLtr = Styles
-                .createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null, null);
-    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText, boolean isActive)
             throws Exception {
-        HighlightPainter painter;
-        AttributeSet attrs;
-        if (Core.getEditor().isOrientationAllLtr()) {
-            attrs = attributesLtr;
-            painter = null;
-        } else {
-            attrs = null;
-            painter = painterRtl;
-        }
-
         if (ste.getProtectedParts().length == 0) {
             return null;
         }
         if (sourceText == null && translationText == null) {
             return null;
+        }
+
+        // painter and attributes are created per call so that color
+        // preference changes take effect without restarting the application
+        HighlightPainter painter;
+        AttributeSet attrs;
+        if (Core.getEditor().isOrientationAllLtr()) {
+            attrs = Styles.createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null,
+                    null);
+            painter = null;
+        } else {
+            attrs = null;
+            painter = new TransparentHighlightPainter(
+                    Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
         }
 
         List<Mark> r = new ArrayList<Mark>();

--- a/src/main/java/org/omegat/gui/editor/mark/RemoveTagMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/RemoveTagMarker.java
@@ -27,9 +27,6 @@
 
 package org.omegat.gui.editor.mark;
 
-import javax.swing.text.AttributeSet;
-import javax.swing.text.Highlighter.HighlightPainter;
-
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.util.OStrings;
@@ -44,17 +41,9 @@ import org.omegat.util.gui.Styles;
  * @author Aaron Madlon-Kay
  */
 public class RemoveTagMarker extends AbstractMarker {
-    private final HighlightPainter painterRtl;
-    private final AttributeSet attributesLtrSource;
-    private final AttributeSet attributesLtrTranslation;
 
     public RemoveTagMarker() throws Exception {
-        painterRtl = new TransparentHighlightPainter(Styles.EditorColor.COLOR_REMOVETEXT_TARGET.getColor(), 0.2f);
         toolTip = OStrings.getString("MARKER_REMOVETAG");
-
-        attributesLtrSource = Styles.createAttributeSet(null, null, null, true);
-        attributesLtrTranslation = Styles.createAttributeSet(Styles.EditorColor.COLOR_REMOVETEXT_TARGET.getColor(),
-                null, null, null);
         CoreEvents.registerProjectChangeListener(e -> pattern = PatternConsts.getRemovePattern());
     }
 
@@ -65,12 +54,17 @@ public class RemoveTagMarker extends AbstractMarker {
 
     @Override
     protected void initDrawers(boolean isSource, boolean isActive) {
+        // painters and attributes are created per call so that color
+        // preference changes take effect without restarting the application
         if (Core.getEditor().isOrientationAllLtr()) {
-            attributes = isSource ? attributesLtrSource : attributesLtrTranslation;
+            attributes = isSource ? Styles.createAttributeSet(null, null, null, true)
+                    : Styles.createAttributeSet(Styles.EditorColor.COLOR_REMOVETEXT_TARGET.getColor(),
+                            null, null, null);
             painter = null;
         } else {
             attributes = null;
-            painter = painterRtl;
+            painter = new TransparentHighlightPainter(
+                    Styles.EditorColor.COLOR_REMOVETEXT_TARGET.getColor(), 0.2f);
         }
     }
 }

--- a/src/main/java/org/omegat/gui/editor/mark/ReplaceMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ReplaceMarker.java
@@ -44,12 +44,6 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class ReplaceMarker implements IMarker {
-    private final HighlightPainter highlightPainter;
-
-    public ReplaceMarker() {
-        highlightPainter = new TransparentHighlightPainter(
-                Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
-    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
@@ -66,6 +60,10 @@ public class ReplaceMarker implements IMarker {
             return Collections.emptyList();
         }
 
+        // created per call so that color preference changes take effect
+        // without restarting the application
+        HighlightPainter highlightPainter = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_REPLACE.getColor(), 0.4F);
         List<Mark> r = new ArrayList<>(matches.size());
         for (SearchMatch s : matches) {
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, s.getStart(), s.getEnd());

--- a/src/main/java/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
+++ b/src/main/java/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
@@ -56,6 +56,10 @@ public class TransparentHighlightPainter extends Underliner {
         this.alphaComposite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha);
     }
 
+    Color getColor() {
+        return color;
+    }
+
     protected void paint(Graphics g, Rectangle rect, JTextComponent c) {
         Graphics2D g2d = (Graphics2D) g;
         Composite originalComposite = g2d.getComposite();

--- a/src/main/java/org/omegat/gui/editor/mark/WhitespaceMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/WhitespaceMarker.java
@@ -50,26 +50,6 @@ public final class WhitespaceMarker implements IMarker {
     public static void unloadPlugins() {
     }
 
-    private final SymbolPainter spacePainter;
-    /**
-     * Marker for tab
-     */
-    private final SymbolPainter tabPainter;
-
-    /**
-     * Marker for linefeed.
-     *
-     * There is a linefeed symbol: U+240A. But it is so small / hard to see,
-     * that instead we use U+00B6 as the symbol to show, like other applications do.
-     */
-    private final SymbolPainter lfPainter;
-
-    public WhitespaceMarker() {
-        spacePainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "·");
-        tabPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "»");
-        lfPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "¶");
-    }
-
     /**
      * Marker for whitespaces.
      *
@@ -82,6 +62,14 @@ public final class WhitespaceMarker implements IMarker {
         if (sourceText == null || !isEnabled()) {
             return null;
         }
+        // painters are created per call so that color preference changes take
+        // effect without restarting the application.
+        // There is a linefeed symbol: U+240A. But it is so small / hard to
+        // see, that instead we use U+00B6 as the symbol to show, like other
+        // applications do.
+        SymbolPainter spacePainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "·");
+        SymbolPainter tabPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "»");
+        SymbolPainter lfPainter = new SymbolPainter(Styles.EditorColor.COLOR_WHITESPACE.getColor(), "¶");
         List<Mark> marks = new ArrayList<>();
         char spacePatternChar = ' ';
         String tabToolTip = OStrings.getString("MARKER_TAB");

--- a/src/main/java/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/main/java/org/omegat/gui/glossary/TransTipsMarker.java
@@ -47,12 +47,6 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class TransTipsMarker implements IMarker {
-    private final HighlightPainter transtipsUnderliner;
-
-    public TransTipsMarker() {
-        transtipsUnderliner = new UnderlineFactory.SolidBoldUnderliner(
-                Styles.EditorColor.COLOR_TRANSTIPS.getColor());
-    }
 
     @Override
     public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
@@ -67,6 +61,10 @@ public class TransTipsMarker implements IMarker {
         if (glossaryEntries == null || glossaryEntries.isEmpty()) {
             return null;
         }
+        // created per call so that color preference changes take effect
+        // without restarting the application
+        HighlightPainter transtipsUnderliner = new UnderlineFactory.SolidBoldUnderliner(
+                Styles.EditorColor.COLOR_TRANSTIPS.getColor());
 
         List<Mark> marks = new ArrayList<>();
 
@@ -74,12 +72,13 @@ public class TransTipsMarker implements IMarker {
         for (GlossaryEntry ent : glossaryEntries) {
             String tooltip = renderer.renderToHtml(ent);
             List<Token[]> tokens = Core.getGlossaryManager().searchSourceMatchTokens(ste, ent);
-            marks.addAll(getMarksForTokens(tokens, ste.getSrcText(), tooltip));
+            marks.addAll(getMarksForTokens(tokens, ste.getSrcText(), tooltip, transtipsUnderliner));
         }
         return marks;
     }
 
-    private List<Mark> getMarksForTokens(List<Token[]> tokens, String srcText, String tooltip) {
+    private List<Mark> getMarksForTokens(List<Token[]> tokens, String srcText, String tooltip,
+            HighlightPainter underliner) {
         if (tokens.isEmpty() || srcText.isEmpty()) {
             return Collections.emptyList();
         }
@@ -103,7 +102,7 @@ public class TransTipsMarker implements IMarker {
                     newMark = new Mark(Mark.ENTRY_PART.SOURCE, currStart, currEnd);
                     result.add(newMark);
                 }
-                newMark.painter = transtipsUnderliner;
+                newMark.painter = underliner;
                 newMark.toolTipText = tooltip;
             }
         }

--- a/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
@@ -81,13 +81,17 @@ class SpellingIssueProvider implements IIssueProvider {
      *
      */
     static class SpellingIssue implements IIssue {
-        private static final Icon ICON = new SimpleColorIcon(EditorColor.COLOR_SPELLCHECK.getColor());
-        private static final AttributeSet ERROR_STYLE;
-        static {
+        // created on demand so that color preference changes take effect
+        // without restarting the application
+        private static Icon icon() {
+            return new SimpleColorIcon(EditorColor.COLOR_SPELLCHECK.getColor());
+        }
+
+        private static AttributeSet errorStyle() {
             SimpleAttributeSet attr = new SimpleAttributeSet();
             StyleConstants.setForeground(attr, EditorColor.COLOR_SPELLCHECK.getColor());
             StyleConstants.setBold(attr, true);
-            ERROR_STYLE = attr;
+            return attr;
         }
 
         private final SourceTextEntry ste;
@@ -102,7 +106,7 @@ class SpellingIssueProvider implements IIssueProvider {
 
         @Override
         public Icon getIcon() {
-            return ICON;
+            return icon();
         }
 
         @Override
@@ -128,7 +132,7 @@ class SpellingIssueProvider implements IIssueProvider {
             panel.lastTextPane.setText(tmxEntry.translation);
             StyledDocument doc = panel.lastTextPane.getStyledDocument();
             for (Token tok : misspelledTokens) {
-                doc.setCharacterAttributes(tok.getOffset(), tok.getLength(), ERROR_STYLE, false);
+                doc.setCharacterAttributes(tok.getOffset(), tok.getLength(), errorStyle(), false);
             }
             panel.setMinimumSize(new Dimension(0, panel.firstTextPane.getFont().getSize() * 6));
             return panel;

--- a/src/main/java/org/omegat/gui/issues/TagIssue.java
+++ b/src/main/java/org/omegat/gui/issues/TagIssue.java
@@ -65,7 +65,11 @@ import org.openide.awt.Mnemonics;
  *
  */
 public class TagIssue implements IIssue {
-    private static final Icon ICON = new SimpleColorIcon(EditorColor.COLOR_PLACEHOLDER.getColor());
+    // created on demand so that color preference changes take effect
+    // without restarting the application
+    private static Icon icon() {
+        return new SimpleColorIcon(EditorColor.COLOR_PLACEHOLDER.getColor());
+    }
 
     private final ErrorReport report;
 
@@ -75,7 +79,7 @@ public class TagIssue implements IIssue {
 
     @Override
     public Icon getIcon() {
-        return ICON;
+        return icon();
     }
 
     @Override

--- a/src/main/java/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -101,13 +101,17 @@ class TerminologyIssueProvider implements IIssueProvider {
      *
      */
     static class TerminologyIssue implements IIssue {
-        private static final Icon ICON = new SimpleColorIcon(EditorColor.COLOR_TERMINOLOGY.getColor());
-        private static final AttributeSet ERROR_STYLE;
-        static {
+        // created on demand so that color preference changes take effect
+        // without restarting the application
+        private static Icon icon() {
+            return new SimpleColorIcon(EditorColor.COLOR_TERMINOLOGY.getColor());
+        }
+
+        private static AttributeSet errorStyle() {
             SimpleAttributeSet attr = new SimpleAttributeSet();
             StyleConstants.setForeground(attr, EditorColor.COLOR_TERMINOLOGY.getColor());
             StyleConstants.setBold(attr, true);
-            ERROR_STYLE = attr;
+            return attr;
         }
 
         private final String delim = OStrings.getString("ISSUES_TERMINOLOGY_ORIGIN_DETAIL_DELIMITER");
@@ -128,7 +132,7 @@ class TerminologyIssueProvider implements IIssueProvider {
 
         @Override
         public Icon getIcon() {
-            return ICON;
+            return icon();
         }
 
         @Override
@@ -217,7 +221,7 @@ class TerminologyIssueProvider implements IIssueProvider {
             StyledDocument doc = splitPanel.firstTextPane.getStyledDocument();
             for (Token[] toks : Core.getGlossaryManager().searchSourceMatchTokens(ste, glossaryEntry)) {
                 for (Token tok : toks) {
-                    doc.setCharacterAttributes(tok.getOffset(), tok.getLength(), ERROR_STYLE, false);
+                    doc.setCharacterAttributes(tok.getOffset(), tok.getLength(), errorStyle(), false);
                 }
             }
             splitPanel.setMinimumSize(new Dimension(0, splitPanel.firstTextPane.getFont().getSize() * 6));

--- a/src/main/java/org/omegat/gui/preferences/PreferencePanel.form
+++ b/src/main/java/org/omegat/gui/preferences/PreferencePanel.form
@@ -162,6 +162,17 @@
                 <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
               </AuxValues>
             </Component>
+            <Component class="javax.swing.JButton" name="applyButton">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/omegat/Bundle.properties" key="BUTTON_APPLY" replaceFormat="OStrings.getString(&quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+                <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+            </Component>
           </SubComponents>
         </Container>
       </SubComponents>

--- a/src/main/java/org/omegat/gui/preferences/PreferencePanel.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencePanel.java
@@ -59,6 +59,7 @@ public class PreferencePanel extends javax.swing.JPanel {
         filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(20, 0), new java.awt.Dimension(20, 0), new java.awt.Dimension(20, 32767));
         okButton = new javax.swing.JButton();
         cancelButton = new javax.swing.JButton();
+        applyButton = new javax.swing.JButton();
 
         jLabel1.setText("jLabel1");
 
@@ -93,12 +94,16 @@ public class PreferencePanel extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL")); // NOI18N
         bottomButtonsPanel.add(cancelButton);
 
+        org.openide.awt.Mnemonics.setLocalizedText(applyButton, OStrings.getString("BUTTON_APPLY")); // NOI18N
+        bottomButtonsPanel.add(applyButton);
+
         bottomPanel.add(bottomButtonsPanel, java.awt.BorderLayout.EAST);
 
         add(bottomPanel, java.awt.BorderLayout.SOUTH);
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    public javax.swing.JButton applyButton;
     public javax.swing.JPanel bottomButtonsPanel;
     public javax.swing.JPanel bottomPanel;
     public javax.swing.JButton cancelButton;

--- a/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -82,6 +83,7 @@ import javax.swing.JScrollBar;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
@@ -99,6 +101,7 @@ import javax.swing.tree.TreeSelectionModel;
 import org.omegat.core.Core;
 import org.omegat.core.team2.gui.RepositoriesCredentialsController;
 import org.omegat.externalfinder.gui.ExternalFinderPreferencesController;
+import org.omegat.gui.editor.IEditor;
 import org.omegat.gui.filters2.FiltersCustomizerController;
 import org.omegat.gui.main.ProjectUICommands;
 import org.omegat.gui.preferences.IPreferencesController.FurtherActionListener;
@@ -148,6 +151,7 @@ public class PreferencesWindowController implements FurtherActionListener {
     private static final String ACTION_KEY_NEW_SEARCH = "clearSearch";
     private static final String ACTION_KEY_CLEAR_OR_CLOSE = "clearSearchOrClose";
     private static final String ACTION_KEY_DO_SEARCH = "doSearch";
+    private static final int APPLIED_MESSAGE_TIMEOUT_MS = 5000;
 
     private JDialog dialog;
     private PreferencePanel outerPanel;
@@ -262,12 +266,41 @@ public class PreferencesWindowController implements FurtherActionListener {
 
                     @Override
                     protected void done() {
+                        refreshEditorView();
                         if (getIsReloadRequired()) {
                             SwingUtilities.invokeLater(ProjectUICommands::promptReload);
                         }
                     }
                 }.execute();
                 StaticUIUtils.closeWindowByEvent(dialog);
+            }
+        });
+        outerPanel.applyButton.addActionListener(e -> {
+            if (currentView == null || currentView.validate()) {
+                outerPanel.applyButton.setEnabled(false);
+                new SwingWorker<Void, Void>() {
+                    @Override
+                    protected Void doInBackground() throws Exception {
+                        doSave();
+                        return null;
+                    }
+
+                    @Override
+                    protected void done() {
+                        outerPanel.applyButton.setEnabled(true);
+                        try {
+                            get();
+                        } catch (InterruptedException | ExecutionException ex) {
+                            LOGGER.log(Level.SEVERE, "Error saving preferences", ex);
+                            return;
+                        }
+                        refreshEditorView();
+                        showAppliedMessage();
+                        if (getIsReloadRequired()) {
+                            SwingUtilities.invokeLater(ProjectUICommands::promptReload);
+                        }
+                    }
+                }.execute();
             }
         });
         outerPanel.cancelButton.addActionListener(e -> StaticUIUtils.closeWindowByEvent(dialog));
@@ -750,6 +783,39 @@ public class PreferencesWindowController implements FurtherActionListener {
                 }
             }
         });
+    }
+
+    /**
+     * Confirm in the message area that the changes were applied, unless a
+     * more important restart/reload notice is displayed there. The
+     * confirmation disappears again after a few seconds.
+     */
+    private void showAppliedMessage() {
+        updateMessage();
+        if (StringUtil.isEmpty(outerPanel.messageTextArea.getText())) {
+            outerPanel.messageTextArea.setText(OStrings.getString("PREFERENCES_MESSAGE_APPLIED"));
+            Timer timer = new Timer(APPLIED_MESSAGE_TIMEOUT_MS, e -> updateMessage());
+            timer.setRepeats(false);
+            timer.start();
+        }
+    }
+
+    /**
+     * Redisplay the current document so that saved preferences (e.g. colors)
+     * take effect immediately. refreshView reloads the document the same way
+     * as the editor settings toggles; a pending edit is committed by that
+     * sequence, so nothing is lost.
+     */
+    public static void refreshEditorView() {
+        IEditor editor = Core.getEditor();
+        if (editor == null || !Core.getProject().isProjectLoaded()) {
+            return;
+        }
+        if (editor.getCurrentFile() == null) {
+            // empty project: no document is displayed, nothing to refresh
+            return;
+        }
+        editor.refreshView(true);
     }
 
     private void doSave() {

--- a/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
@@ -35,7 +35,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.swing.Icon;
@@ -48,6 +47,7 @@ import javax.swing.colorchooser.AbstractColorChooserPanel;
 import javax.swing.table.AbstractTableModel;
 
 import org.omegat.gui.preferences.BasePreferencesController;
+import org.omegat.gui.preferences.PreferencesWindowController;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.Styles.EditorColor;
 
@@ -111,7 +111,6 @@ public class CustomColorSelectionController extends BasePreferencesController {
     private void recordTemporaryPreference() {
         getSelection().ifPresent(style -> {
             temporaryPreferences.put(style, panel.colorChooser.getColor());
-            setRestartRequired(hasChanges());
             updateSelectionIcon();
         });
     }
@@ -176,9 +175,6 @@ public class CustomColorSelectionController extends BasePreferencesController {
             Color color = temporaryPreferences.getOrDefault(style, style.getColor());
             setColorChooserWithoutNotifying(color);
         });
-        if (enabled) {
-            setRestartRequired(hasChanges());
-        }
     }
 
     private void resetCurrentColor() {
@@ -190,25 +186,25 @@ public class CustomColorSelectionController extends BasePreferencesController {
             } else {
                 panel.colorChooser.setColor(defaultColor);
             }
-            setRestartRequired(hasChanges());
+            // resetting is an explicit action and takes effect immediately
+            style.setColor(null);
+            PreferencesWindowController.refreshEditorView();
             updateSelectionIcon();
         });
-    }
-
-    private boolean hasChanges() {
-        return !temporaryPreferences.entrySet().stream()
-                .allMatch(e -> Objects.equals(e.getKey().getColor(), e.getValue()));
     }
 
     @Override
     public void restoreDefaults() {
         for (EditorColor style : EditorColor.values()) {
             temporaryPreferences.put(style, style.getDefault());
+            // restoring the defaults is an explicit action and takes effect
+            // immediately
+            style.setColor(null);
         }
         panel.colorStylesTable.repaint();
         panel.colorStylesTable.clearSelection();
         onSelectionChanged();
-        setRestartRequired(hasChanges());
+        PreferencesWindowController.refreshEditorView();
     }
 
     @Override

--- a/src/main/java/org/omegat/gui/search/EntryListPane.java
+++ b/src/main/java/org/omegat/gui/search/EntryListPane.java
@@ -90,8 +90,6 @@ import org.omegat.util.gui.UIThreadsUtil;
  */
 @SuppressWarnings("serial")
 class EntryListPane extends JTextPane {
-    protected static final AttributeSet FOUND_MARK = Styles.createAttributeSet(Styles.EditorColor.COLOR_SEARCH_FOUND_MARK.getColor(), null, true, null);
-    protected static final AttributeSet REPLACE_MARK = Styles.createAttributeSet(Styles.EditorColor.COLOR_SEARCH_REPLACE_MARK.getColor(), null, false, null);
     protected static final int MARKS_PER_REQUEST = 100;
     protected static final String ENTRY_SEPARATOR = "---------\n";
     private static final String KEY_GO_TO_NEXT_SEGMENT = "gotoNextSegmentMenuItem";
@@ -398,14 +396,20 @@ class EntryListPane extends JTextPane {
             }
 
             StyledDocument doc = (StyledDocument) getDocument();
+            // attributes are created per request so that color preference
+            // changes take effect without restarting the application
+            AttributeSet foundMark = Styles.createAttributeSet(
+                    Styles.EditorColor.COLOR_SEARCH_FOUND_MARK.getColor(), null, true, null);
+            AttributeSet replaceMark = Styles.createAttributeSet(
+                    Styles.EditorColor.COLOR_SEARCH_REPLACE_MARK.getColor(), null, false, null);
             List<SearchMatch> matchesToMark = matches.subList(0, Math.min(MARKS_PER_REQUEST, matches.size()));
             for (SearchMatch m : matchesToMark) {
-                doc.setCharacterAttributes(m.getStart(), m.getLength(), FOUND_MARK, true);
+                doc.setCharacterAttributes(m.getStart(), m.getLength(), foundMark, true);
             }
             matchesToMark.clear();
             List<SearchMatch> replToMark = replMatches.subList(0, Math.min(MARKS_PER_REQUEST, replMatches.size()));
             for (SearchMatch m : replToMark) {
-                doc.setCharacterAttributes(m.getStart(), m.getLength(), REPLACE_MARK, true);
+                doc.setCharacterAttributes(m.getStart(), m.getLength(), replaceMark, true);
             }
             replToMark.clear();
 

--- a/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
@@ -83,13 +83,17 @@ public class LanguageToolIssueProvider implements IIssueProvider {
 
     static class LanguageToolIssue implements IIssue {
 
-        static final Icon ICON = new SimpleColorIcon(EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
-        static final AttributeSet ERROR_STYLE;
-        static {
+        // created on demand so that color preference changes take effect
+        // without restarting the application
+        private static Icon icon() {
+            return new SimpleColorIcon(EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
+        }
+
+        private static AttributeSet errorStyle() {
             SimpleAttributeSet attr = new SimpleAttributeSet();
             StyleConstants.setForeground(attr, EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
             StyleConstants.setBold(attr, true);
-            ERROR_STYLE = attr;
+            return attr;
         }
 
         private final SourceTextEntry ste;
@@ -104,7 +108,7 @@ public class LanguageToolIssueProvider implements IIssueProvider {
 
         @Override
         public Icon getIcon() {
-            return ICON;
+            return icon();
         }
 
         @Override
@@ -129,7 +133,7 @@ public class LanguageToolIssueProvider implements IIssueProvider {
             panel.firstTextPane.setText(ste.getSrcText());
             panel.lastTextPane.setText(targetText);
             StyledDocument doc = panel.lastTextPane.getStyledDocument();
-            doc.setCharacterAttributes(result.start, result.end - result.start, ERROR_STYLE, false);
+            doc.setCharacterAttributes(result.start, result.end - result.start, errorStyle(), false);
             panel.setMinimumSize(new Dimension(0, panel.firstTextPane.getFont().getSize() * 6));
             return panel;
         }

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -95,6 +95,7 @@ TEAM_TOOL_INIT_COMPLETE=Initialized {0}-{1} team project. Place source files in 
 # buttons
 BUTTON_OK=&OK
 BUTTON_CANCEL=&Cancel
+BUTTON_APPLY=&Apply
 BUTTON_CLOSE=&Close
 
 BUTTON_SEARCH=&Search
@@ -2676,6 +2677,7 @@ PREFERENCES_BUTTON_UNDO=&Undo Changes
 PREFERENCES_BUTTON_RESET=Restore De&faults
 PREFERENCES_WARNING_NEEDS_RESTART=Restart OmegaT to apply these changes
 PREFERENCES_WARNING_NEEDS_RELOAD=Reload the current project to apply these changes
+PREFERENCES_MESSAGE_APPLIED=Changes applied
 
 # PREFERENCES - GENERAL
 PREFS_TITLE_GENERAL=General

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -98,6 +98,7 @@ TEAM_TOOL_INIT_COMPLETE={0}-{1}-Teamprojekt initialisiert. Platzieren Sie die Qu
 # buttons
 BUTTON_OK=&OK
 BUTTON_CANCEL=Abbre&chen
+BUTTON_APPLY=An&wenden
 BUTTON_CLOSE=S&chlie\u00DFen
 
 BUTTON_SEARCH=&Suchen
@@ -2540,6 +2541,7 @@ PREFERENCES_BUTTON_UNDO=\u00C4nder&ungen r\u00FCckg\u00E4ngig machen
 PREFERENCES_BUTTON_RESET=Standardwerte &wiederherstellen
 PREFERENCES_WARNING_NEEDS_RESTART=Starten Sie OmegaT neu, um diese \u00C4nderungen zu \u00FCbernehmen
 PREFERENCES_WARNING_NEEDS_RELOAD=Laden Sie das aktuelle Projekt neu, um diese \u00C4nderungen zu \u00FCbernehmen
+PREFERENCES_MESSAGE_APPLIED=\u00C4nderungen angewendet
 
 # PREFERENCES - GENERAL
 PREFS_TITLE_GENERAL=Allgemein

--- a/src/test/java/org/omegat/gui/editor/mark/MarkerColorFreshnessTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/MarkerColorFreshnessTest.java
@@ -1,0 +1,113 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2026 Stephan Pakebusch.
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.gui.editor.mark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.Color;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.util.gui.Styles;
+
+/**
+ * Checks that markers pick up color preference changes without requiring an
+ * application restart, i.e. that painters are not cached at marker
+ * construction time.
+ */
+public class MarkerColorFreshnessTest extends MarkerTestBase {
+
+    private Styles.EditorColor changedColor;
+
+    @Before
+    public void preUp() throws Exception {
+        TestCoreInitializer.initEditor(editor);
+        Segmenter segmenter = new Segmenter(SRX.getDefault());
+        Core.setSegmenter(segmenter);
+        Core.setProject(new MarkTestProject(
+                Paths.get("src/test/resources/data/autotmx/auto1.tmx").toFile(), segmenter));
+    }
+
+    @After
+    public void tearDown() {
+        if (changedColor != null) {
+            // restore the default so other tests see pristine colors
+            changedColor.setColor(null);
+        }
+    }
+
+    @Test
+    public void testPainterFollowsColorPreferenceChange() throws Exception {
+        IMarker marker = new ComesFromAutoTMMarker();
+        Core.getEditor().getSettings().setMarkAutoPopulated(true);
+
+        String sourceText = "Edit";
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText,
+                Collections.emptyList());
+        TMXEntry entry = Core.getProject().getTranslationInfo(ste);
+        assertNotNull(entry.linked);
+        switch (entry.linked) {
+        case xICE:
+            changedColor = Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XICE;
+            break;
+        case x100PC:
+            changedColor = Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_X100PC;
+            break;
+        case xAUTO:
+            changedColor = Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XAUTO;
+            break;
+        case xENFORCED:
+        default:
+            changedColor = Styles.EditorColor.COLOR_MARK_COMES_FROM_TM_XENFORCED;
+            break;
+        }
+
+        List<Mark> before = marker.getMarksForEntry(ste, sourceText, "target", true);
+        assertNotNull(before);
+        assertEquals(changedColor.getColor(),
+                ((TransparentHighlightPainter) before.get(0).painter).getColor());
+
+        Color newColor = new Color(0x12, 0x34, 0x56);
+        changedColor.setColor(newColor);
+
+        List<Mark> after = marker.getMarksForEntry(ste, sourceText, "target", true);
+        assertNotNull(after);
+        assertEquals(newColor, ((TransparentHighlightPainter) after.get(0).painter).getColor());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Preferences/CutomColorSelector don't show notification immediately when modifying color
  * https://sourceforge.net/p/omegat/bugs/1273/

## What does this PR change?

- Colour changes in Preferences > Colours no longer require an application
  restart: after saving, the open document is redisplayed with the new
  colours. The workflow becomes WYSIWYG instead of
  change-restart-inspect-repeat.
- Adds an **Apply** button to the Preferences dialog: save and see the effect
  without closing the dialog, for every preferences view. A short "Changes
  applied" notice appears in the message area (restart/reload warnings take
  precedence), and reload-requiring changes prompt for a project reload just
  like OK.
- "Reset colour" and "Restore defaults" are explicit restore actions and take
  effect immediately.
- Markers and some windows cached their painters/attributes at construction
  time, freezing the colours of the first start; painters are now created
  when marks are (re)calculated. A regression test
  (`MarkerColorFreshnessTest`) asserts that a colour change is reflected in
  the very next mark calculation.

## Other information

The discussion in bug SF-1273 ended with an invitation to implement a live
update of colours; this PR implements it. Performance note: mark
recalculation already creates one `Mark` object per match, while painters are
created at most a handful of times per entry and marker; the Swing
highlighter removes old highlights before re-adding, so nothing accumulates.
