### PR TITLE
fix(core): keep enforced translations highlighted after a team save (SF-RFE-1171)

### DIFF
--- a/src/main/java/org/omegat/core/data/ProjectTMX.java
+++ b/src/main/java/org/omegat/core/data/ProjectTMX.java
@@ -70,6 +70,7 @@ public class ProjectTMX {
     protected static final String PROP_XICE = "x-ice";
     protected static final String PROP_X100PC = "x-100pc";
     protected static final String PROP_XAUTO = "x-auto";
+    protected static final String PROP_XENFORCED = "x-enforced";
 
     public static final String PROP_ORIGIN = "origin";
 
@@ -255,6 +256,9 @@ public class ProjectTMX {
                     if (en.getValue().linked == TMXEntry.ExternalLinked.xAUTO) {
                         p.add(PROP_XAUTO);
                         p.add("auto");
+                    } else if (en.getValue().linked == TMXEntry.ExternalLinked.xENFORCED) {
+                        p.add(PROP_XENFORCED);
+                        p.add("enforced");
                     }
                 }
                 if (Preferences.isPreference(Preferences.SAVE_ORIGIN)) {
@@ -287,6 +291,9 @@ public class ProjectTMX {
                     } else if (en.getValue().linked == TMXEntry.ExternalLinked.x100PC) {
                         p.add(PROP_X100PC);
                         p.add(k.id);
+                    } else if (en.getValue().linked == TMXEntry.ExternalLinked.xENFORCED) {
+                        p.add(PROP_XENFORCED);
+                        p.add("enforced");
                     }
                 }
                 wr.writeEntry(en.getKey().sourceText, en.getValue().translation, en.getValue(), p);
@@ -456,6 +463,9 @@ public class ProjectTMX {
         }
         if (externalLinked == null && te.hasPropValue(PROP_XAUTO, null)) {
             externalLinked = TMXEntry.ExternalLinked.xAUTO;
+        }
+        if (externalLinked == null && te.hasPropValue(PROP_XENFORCED, null)) {
+            externalLinked = TMXEntry.ExternalLinked.xENFORCED;
         }
         return externalLinked;
     }

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -1037,6 +1037,7 @@ public class RealProject implements IProject {
                 tmxPrepared = RebaseAndCommit.rebaseAndCommit(tmxPrepared, remoteRepositoryProvider,
                         config.getProjectRootDir(), tmxPath, getTMXRebaseOperation());
             }
+            reapplyEnforcedTMXs();
         }
 
         final String glossaryPath = config.getWritableGlossaryFile().getUnderRoot();
@@ -1369,6 +1370,37 @@ public class RealProject implements IProject {
     void appendFromAutoTMX(ExternalTMX autoTmx, boolean isEnforcedTMX) {
         synchronized (projectTMXLock) {
             importHandler.process(autoTmx, isEnforcedTMX);
+        }
+    }
+
+    /**
+     * The enforced status of a translation exists only in memory: rebasing a
+     * team project replaces the project TMX content with entries parsed from
+     * the merged file, which silently downgrades enforced translations to
+     * plain ones and their highlighting disappears until the next full
+     * project load re-applies the enforce memories (SF bug #1171). Re-apply
+     * the already loaded tm/enforce memories directly after the rebase
+     * instead.
+     */
+    private void reapplyEnforcedTMXs() {
+        if (importHandler == null) {
+            // called during initial load, before the import handler exists;
+            // loadTM will apply the enforce memories right afterwards
+            return;
+        }
+        File tmRoot = new File(config.getTMRoot());
+        // Snapshot: the tm folder monitor replaces transMemories from another
+        // thread, so iterate a copy to avoid a concurrent modification.
+        for (Map.Entry<String, ExternalTMX> en : new TreeMap<>(transMemories).entrySet()) {
+            try {
+                if (FileUtil.computeRelativePath(tmRoot, new File(en.getKey()))
+                        .startsWith(OConsts.AUTO_ENFORCE_TM + '/')) {
+                    appendFromAutoTMX(en.getValue(), true);
+                }
+            } catch (IOException e) {
+                // Memories mapped from outside the tm root cannot be
+                // relativized; they are never enforce memories.
+            }
         }
     }
 

--- a/src/main/java/org/omegat/gui/editor/EditorController.java
+++ b/src/main/java/org/omegat/gui/editor/EditorController.java
@@ -1191,14 +1191,6 @@ public class EditorController implements IEditor {
         boolean isNewDefaultTrans = defaultTranslation && !oldTE.defaultTranslation;
         boolean isNewAltTrans = !defaultTranslation && oldTE.defaultTranslation;
 
-        // When the entry translation is linked with xENFORCED
-        // and the user does not set it as an alternate translation.
-        if (isEnforced && !isNewAltTrans) {
-            deactivateWithoutCommit();
-            mw.displayWarningRB("EC_WARNING_REVERT_ENFORCED_SEGMENT");
-            return;
-        }
-
         PrepareTMXEntry newen;
         if (forceTranslation != null) { // there is force translation
             newen = new PrepareTMXEntry();
@@ -1223,6 +1215,22 @@ public class EditorController implements IEditor {
 
         boolean translationChanged = !Objects.equals(oldTE.translation, newen.translation);
         boolean noteChanged = !Objects.equals(StringUtil.nvl(oldTE.note, ""), StringUtil.nvl(newen.note, ""));
+
+        // When the entry translation is linked with xENFORCED and the user
+        // does not set it as an alternate translation, reverting the enforced
+        // default translation is not allowed. Only warn when the user actually
+        // changed the translation or note; a mere deactivation - navigating
+        // away, or the view refresh after a preferences/colour change - must
+        // leave the enforced segment untouched and stay silent instead of
+        // raising the warning (twice, via gotoFile and gotoEntry).
+        if (isEnforced && !isNewAltTrans) {
+            deactivateWithoutCommit();
+            if (translationChanged || noteChanged) {
+                mw.displayWarningRB("EC_WARNING_REVERT_ENFORCED_SEGMENT");
+            }
+            return;
+        }
+
         resetOrigin();
 
         if (!isNewAltTrans && !translationChanged && noteChanged) {

--- a/src/test/java/org/omegat/core/data/AutoTmxTest.java
+++ b/src/test/java/org/omegat/core/data/AutoTmxTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2014 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,6 +26,7 @@
 package org.omegat.core.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -36,6 +38,7 @@ import org.omegat.core.Core;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.tokenizer.LuceneFrenchTokenizer;
+import org.omegat.util.Preferences;
 import org.omegat.util.TestPreferencesInitializer;
 
 /**
@@ -122,6 +125,96 @@ public class AutoTmxTest {
         p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
         p.appendFromAutoTMX(autoTMX, false);
         checkTranslation(ste, "alternative", TMXEntry.ExternalLinked.xAUTO);
+    }
+
+    /**
+     * The enforced status must survive a save/load cycle of the project TMX
+     * when the user opted into persisting auto states, in the same way the
+     * x-auto/x-ice/x-100pc states do (SF bug #1171).
+     */
+    @Test
+    public void enforcedStatusSurvivesSaveAndReloadWhenOptedIn() throws Exception {
+        ExternalTMX enforceTMX = prepareExternalTMX(new File("src/test/resources/data/enforcetmx/project1.tmx"),
+                new File("src/test/resources/data/enforcetmx/enforce1.tmx"));
+
+        SourceTextEntry ste = createSTE(null, "Edit");
+        p.allProjectEntries.add(ste);
+        p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
+        p.appendFromAutoTMX(enforceTMX, true);
+        checkTranslation(ste, "bizbaz", TMXEntry.ExternalLinked.xENFORCED);
+
+        ProjectTMX reloaded = saveAndReload(true);
+        assertEquals(TMXEntry.ExternalLinked.xENFORCED, reloaded.getDefaultTranslation("Edit").linked);
+    }
+
+    @Test
+    public void enforcedStatusIsDroppedOnSaveWithoutOptIn() throws Exception {
+        ExternalTMX enforceTMX = prepareExternalTMX(new File("src/test/resources/data/enforcetmx/project1.tmx"),
+                new File("src/test/resources/data/enforcetmx/enforce1.tmx"));
+
+        SourceTextEntry ste = createSTE(null, "Edit");
+        p.allProjectEntries.add(ste);
+        p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
+        p.appendFromAutoTMX(enforceTMX, true);
+
+        ProjectTMX reloaded = saveAndReload(false);
+        assertNull(reloaded.getDefaultTranslation("Edit").linked);
+    }
+
+    @Test
+    public void enforcedAlternativeStatusSurvivesSaveAndReloadWhenOptedIn() throws Exception {
+        ExternalTMX enforceTMX = prepareExternalTMX(new File("src/test/resources/data/enforcetmx/project1.tmx"),
+                new File("src/test/resources/data/enforcetmx/alternative.tmx"));
+
+        SourceTextEntry ste = createSTE("1_0", "Edit");
+        p.allProjectEntries.add(ste);
+        p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
+        p.appendFromAutoTMX(enforceTMX, true);
+        checkTranslation(ste, "alternative", TMXEntry.ExternalLinked.xENFORCED);
+
+        ProjectTMX reloaded = saveAndReload(true);
+        assertEquals(TMXEntry.ExternalLinked.xENFORCED,
+                reloaded.getMultipleTranslation(ste.getKey()).linked);
+    }
+
+    /**
+     * Rebasing a team project replaces the project TMX content with entries
+     * parsed from the merged file, which carry no enforced status; re-applying
+     * the enforce memory (as RealProject does after the rebase) must restore
+     * it (SF bug #1171).
+     */
+    @Test
+    public void enforcedStatusIsRestoredByReapplyAfterContentReplacement() throws Exception {
+        ExternalTMX enforceTMX = prepareExternalTMX(new File("src/test/resources/data/enforcetmx/project1.tmx"),
+                new File("src/test/resources/data/enforcetmx/enforce1.tmx"));
+
+        SourceTextEntry ste = createSTE(null, "Edit");
+        p.allProjectEntries.add(ste);
+        p.importHandler = new ImportFromAutoTMX(p, p.allProjectEntries);
+        p.appendFromAutoTMX(enforceTMX, true);
+        checkTranslation(ste, "bizbaz", TMXEntry.ExternalLinked.xENFORCED);
+
+        p.projectTMX.replaceContent(saveAndReload(false));
+        assertNull(p.getTranslationInfo(ste).linked);
+
+        p.appendFromAutoTMX(enforceTMX, true);
+        checkTranslation(ste, "bizbaz", TMXEntry.ExternalLinked.xENFORCED);
+    }
+
+    private ProjectTMX saveAndReload(boolean saveAutoStatus) throws Exception {
+        Preferences.setPreference(Preferences.SAVE_AUTO_STATUS, saveAutoStatus);
+        try {
+            File out = File.createTempFile("omegat-autotmx", ".tmx");
+            out.deleteOnExit();
+            ProjectProperties props = p.getProjectProperties();
+            p.projectTMX.exportTMX(props, out, false, false, true);
+            ProjectTMX reloaded = new ProjectTMX();
+            reloaded.load(props.getSourceLanguage(), props.getTargetLanguage(), false, out,
+                    Core.getSegmenter());
+            return reloaded;
+        } finally {
+            Preferences.setPreference(Preferences.SAVE_AUTO_STATUS, false);
+        }
     }
 
     private ExternalTMX prepareExternalTMX(File projectFile, File tmxFile) throws Exception {

--- a/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
@@ -1,0 +1,316 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.TestCore;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
+import org.omegat.core.data.RealProject;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.data.TestCoreState;
+import org.omegat.core.events.IProjectEventListener;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
+import org.omegat.gui.main.ConsoleWindow;
+import org.omegat.gui.main.IMainMenu;
+import org.omegat.gui.main.IMainWindow;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.Language;
+
+import com.vlsolutions.swing.docking.Dockable;
+
+/**
+ * Leaving a segment whose translation is enforced from a tm/enforce/ memory
+ * must not raise the "reverting enforced segment" warning unless the user
+ * actually changed the translation. A mere deactivation - navigating away or
+ * the editor view refresh triggered by a preferences/colour change - used to
+ * raise the warning, and via {@code refreshView} even twice (SF bug #1171).
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class EditorEnforcedSegmentTest extends TestCore {
+
+    private static final String SOURCE = "This is enforced.";
+    private static final String ENFORCED_TRANSLATION = "To jest wymuszone.";
+
+    private EditorController editorController;
+    private final List<String> warnings = new ArrayList<>();
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        assumeFalse("Skipping test: headless environment", GraphicsEnvironment.isHeadless());
+    }
+
+    @Before
+    public final void setUpProject() throws IOException {
+        TestCoreState.getInstance().setSegmenter(new Segmenter(SRX.getDefault()));
+        FilterMaster.setFilterClasses(Arrays.asList(TextFilter.class));
+        TestCoreState.getInstance().setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+
+        TestCoreInitializer.initNotes(new RecordingNotes());
+        File projectRootDir = Files.createTempDirectory("omegat-enforce").toFile();
+        EnforcedProjectProperties props = new EnforcedProjectProperties();
+        props.setProjectRoot(projectRootDir.getAbsolutePath());
+        props.setSourceTokenizer(LuceneEnglishTokenizer.class);
+        props.setTargetTokenizer(DefaultTokenizer.class);
+        EnforcedProject project = new EnforcedProject(props);
+        TestCoreState.getInstance().setProject(project);
+        project.seedEnforcedTranslation();
+        fireLoadProjectEvent();
+    }
+
+    @Test
+    public void viewRefreshOnEnforcedSegmentDoesNotWarn() throws Exception {
+        runOnEdt(() -> editorController.refreshView(true));
+        assertTrue("a plain view refresh of an enforced segment must not warn", warnings.isEmpty());
+    }
+
+    @Test
+    public void changingAnEnforcedSegmentStillWarnsExactlyOnce() throws Exception {
+        // Emptying the enforced translation is a genuine attempt to change it
+        // and must still raise the warning - exactly once.
+        runOnEdt(() -> editorController.registerEmptyTranslation());
+        assertEquals("changing an enforced translation must still warn", 1, warnings.size());
+        assertEquals("EC_WARNING_REVERT_ENFORCED_SEGMENT", warnings.get(0));
+    }
+
+    private void fireLoadProjectEvent() {
+        CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        long deadline = System.currentTimeMillis() + 5000;
+        while (editorController.editor.getOmDocument() == null
+                && System.currentTimeMillis() < deadline) {
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                });
+                Thread.sleep(20);
+            } catch (InterruptedException | InvocationTargetException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private void runOnEdt(Runnable r) throws Exception {
+        SwingUtilities.invokeAndWait(r);
+    }
+
+    @Override
+    protected void initEditor(IMainWindow mainWindow) {
+        editorController = new EditorController(mainWindow);
+        TestCoreInitializer.initEditor(editorController);
+    }
+
+    /**
+     * Main window mock that records the warning keys the editor raises.
+     */
+    @Override
+    protected IMainWindow getMainWindow() {
+        final IMainMenu mainMenu = getMainMenu();
+        return new ConsoleWindow() {
+            @Override
+            public void addDockable(Dockable pane) {
+            }
+
+            @Override
+            public void displayErrorRB(Throwable ex, String errorKey, Object... params) {
+            }
+
+            @Override
+            public void displayWarningRB(String warningKey, Object... params) {
+                warnings.add(warningKey);
+            }
+
+            @Override
+            public void displayWarningRB(String warningKey, String supercedesKey, Object... params) {
+                warnings.add(warningKey);
+            }
+
+            @Override
+            public Font getApplicationFont() {
+                return new Font("Dialog", Font.PLAIN, 12);
+            }
+
+            @Override
+            public JFrame getApplicationFrame() {
+                return new JFrame();
+            }
+
+            @Override
+            public void showLengthMessage(String messageText) {
+            }
+
+            @Override
+            public void showProgressMessage(String messageText) {
+            }
+
+            @Override
+            public IMainMenu getMainMenu() {
+                return mainMenu;
+            }
+        };
+    }
+
+    private static final class RecordingNotes implements org.omegat.gui.notes.INotes {
+        private String note;
+
+        @Override
+        public String getNoteText() {
+            return note;
+        }
+
+        @Override
+        public void setNoteText(String note) {
+            this.note = note;
+        }
+
+        @Override
+        public void clear() {
+            note = null;
+        }
+
+        @Override
+        public void undo() {
+        }
+
+        @Override
+        public void redo() {
+        }
+
+        @Override
+        public void requestFocus() {
+        }
+    }
+
+    private final class EnforcedProjectProperties extends ProjectProperties {
+        @Override
+        public void setProjectRoot(String projectRoot) {
+            super.setProjectRoot(projectRoot);
+        }
+
+        @Override
+        public Language getSourceLanguage() {
+            return new Language("en");
+        }
+
+        @Override
+        public Language getTargetLanguage() {
+            return new Language("pl");
+        }
+
+        @Override
+        public boolean isSentenceSegmentingEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isSupportDefaultTranslations() {
+            return true;
+        }
+    }
+
+    private static final class EnforcedProject extends RealProject {
+
+        private static final String SOURCE_FILE = "source.txt";
+        private final List<FileInfo> files = new ArrayList<>();
+        private final SourceTextEntry entry;
+
+        EnforcedProject(ProjectProperties props) {
+            super(props);
+            FileInfo file = new FileInfo(SOURCE_FILE);
+            entry = new SourceTextEntry(new EntryKey(SOURCE_FILE, SOURCE, null, "", "", null), 1, null,
+                    null, Collections.emptyList());
+            file.entries.add(entry);
+            files.add(file);
+        }
+
+        void seedEnforcedTranslation() {
+            PrepareTMXEntry prep = new PrepareTMXEntry();
+            prep.source = SOURCE;
+            prep.translation = ENFORCED_TRANSLATION;
+            setTranslation(entry, prep, true, TMXEntry.ExternalLinked.xENFORCED);
+        }
+
+        @Override
+        public List<FileInfo> getProjectFiles() {
+            return files;
+        }
+
+        @Override
+        public List<SourceTextEntry> getAllEntries() {
+            return Collections.singletonList(entry);
+        }
+
+        @Override
+        public ITokenizer getSourceTokenizer() {
+            return new LuceneEnglishTokenizer();
+        }
+
+        @Override
+        public ITokenizer getTargetTokenizer() {
+            return new DefaultTokenizer();
+        }
+
+        @Override
+        public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean isProjectLoaded() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
@@ -1,0 +1,316 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.TestCore;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.PrepareTMXEntry;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectTMX;
+import org.omegat.core.data.RealProject;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.core.events.IProjectEventListener;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
+import org.omegat.gui.main.ConsoleWindow;
+import org.omegat.gui.main.IMainMenu;
+import org.omegat.gui.main.IMainWindow;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.Language;
+
+import com.vlsolutions.swing.docking.Dockable;
+
+/**
+ * Leaving a segment whose translation is enforced from a tm/enforce/ memory
+ * must not raise the "reverting enforced segment" warning unless the user
+ * actually changed the translation. A mere deactivation - navigating away or
+ * the editor view refresh triggered by a preferences/colour change - used to
+ * raise the warning, and via {@code refreshView} even twice (SF bug #1171).
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class EditorEnforcedSegmentTest extends TestCore {
+
+    private static final String SOURCE = "This is enforced.";
+    private static final String ENFORCED_TRANSLATION = "To jest wymuszone.";
+
+    private EditorController editorController;
+    private final List<String> warnings = new ArrayList<>();
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        assumeFalse("Skipping test: headless environment", GraphicsEnvironment.isHeadless());
+    }
+
+    @Before
+    public final void setUpProject() throws IOException {
+        Core.setSegmenter(new Segmenter(SRX.getDefault()));
+        FilterMaster.setFilterClasses(Arrays.asList(TextFilter.class));
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+
+        TestCoreInitializer.initNotes(new RecordingNotes());
+        File projectRootDir = Files.createTempDirectory("omegat-enforce").toFile();
+        EnforcedProjectProperties props = new EnforcedProjectProperties();
+        props.setProjectRoot(projectRootDir.getAbsolutePath());
+        props.setSourceTokenizer(LuceneEnglishTokenizer.class);
+        props.setTargetTokenizer(DefaultTokenizer.class);
+        EnforcedProject project = new EnforcedProject(props);
+        Core.setProject(project);
+        project.seedEnforcedTranslation();
+        fireLoadProjectEvent();
+    }
+
+    @Test
+    public void viewRefreshOnEnforcedSegmentDoesNotWarn() throws Exception {
+        runOnEdt(() -> editorController.refreshView(true));
+        assertTrue("a plain view refresh of an enforced segment must not warn", warnings.isEmpty());
+    }
+
+    @Test
+    public void changingAnEnforcedSegmentStillWarnsExactlyOnce() throws Exception {
+        // Emptying the enforced translation is a genuine attempt to change it
+        // and must still raise the warning - exactly once.
+        runOnEdt(() -> editorController.registerEmptyTranslation());
+        assertEquals("changing an enforced translation must still warn", 1, warnings.size());
+        assertEquals("EC_WARNING_REVERT_ENFORCED_SEGMENT", warnings.get(0));
+    }
+
+    private void fireLoadProjectEvent() {
+        CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        long deadline = System.currentTimeMillis() + 5000;
+        while (editorController.editor.getOmDocument() == null
+                && System.currentTimeMillis() < deadline) {
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                });
+                Thread.sleep(20);
+            } catch (InterruptedException | InvocationTargetException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    private void runOnEdt(Runnable r) throws Exception {
+        SwingUtilities.invokeAndWait(r);
+    }
+
+    @Override
+    protected void initEditor(IMainWindow mainWindow) {
+        editorController = new EditorController(mainWindow);
+        TestCoreInitializer.initEditor(editorController);
+    }
+
+    /**
+     * Main window mock that records the warning keys the editor raises.
+     */
+    @Override
+    protected IMainWindow getMainWindow() {
+        final IMainMenu mainMenu = getMainMenu();
+        return new ConsoleWindow() {
+            @Override
+            public void addDockable(Dockable pane) {
+            }
+
+            @Override
+            public void displayErrorRB(Throwable ex, String errorKey, Object... params) {
+            }
+
+            @Override
+            public void displayWarningRB(String warningKey, Object... params) {
+                warnings.add(warningKey);
+            }
+
+            @Override
+            public void displayWarningRB(String warningKey, String supercedesKey, Object... params) {
+                warnings.add(warningKey);
+            }
+
+            @Override
+            public Font getApplicationFont() {
+                return new Font("Dialog", Font.PLAIN, 12);
+            }
+
+            @Override
+            public JFrame getApplicationFrame() {
+                return new JFrame();
+            }
+
+            @Override
+            public void showLengthMessage(String messageText) {
+            }
+
+            @Override
+            public void showProgressMessage(String messageText) {
+            }
+
+            @Override
+            public IMainMenu getMainMenu() {
+                return mainMenu;
+            }
+        };
+    }
+
+    private static final class RecordingNotes implements org.omegat.gui.notes.INotes {
+        private String note;
+
+        @Override
+        public String getNoteText() {
+            return note;
+        }
+
+        @Override
+        public void setNoteText(String note) {
+            this.note = note;
+        }
+
+        @Override
+        public void clear() {
+            note = null;
+        }
+
+        @Override
+        public void undo() {
+        }
+
+        @Override
+        public void redo() {
+        }
+
+        @Override
+        public void requestFocus() {
+        }
+    }
+
+    private final class EnforcedProjectProperties extends ProjectProperties {
+        @Override
+        public void setProjectRoot(String projectRoot) {
+            super.setProjectRoot(projectRoot);
+        }
+
+        @Override
+        public Language getSourceLanguage() {
+            return new Language("en");
+        }
+
+        @Override
+        public Language getTargetLanguage() {
+            return new Language("pl");
+        }
+
+        @Override
+        public boolean isSentenceSegmentingEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isSupportDefaultTranslations() {
+            return true;
+        }
+    }
+
+    private static final class EnforcedProject extends RealProject {
+
+        private static final String SOURCE_FILE = "source.txt";
+        private final List<FileInfo> files = new ArrayList<>();
+        private final SourceTextEntry entry;
+
+        EnforcedProject(ProjectProperties props) {
+            super(props);
+            FileInfo file = new FileInfo(SOURCE_FILE);
+            entry = new SourceTextEntry(new EntryKey(SOURCE_FILE, SOURCE, null, "", "", null), 1, null,
+                    null, Collections.emptyList());
+            file.entries.add(entry);
+            files.add(file);
+        }
+
+        void seedEnforcedTranslation() {
+            PrepareTMXEntry prep = new PrepareTMXEntry();
+            prep.source = SOURCE;
+            prep.translation = ENFORCED_TRANSLATION;
+            setTranslation(entry, prep, true, TMXEntry.ExternalLinked.xENFORCED);
+        }
+
+        @Override
+        public List<FileInfo> getProjectFiles() {
+            return files;
+        }
+
+        @Override
+        public List<SourceTextEntry> getAllEntries() {
+            return Collections.singletonList(entry);
+        }
+
+        @Override
+        public ITokenizer getSourceTokenizer() {
+            return new LuceneEnglishTokenizer();
+        }
+
+        @Override
+        public ITokenizer getTargetTokenizer() {
+            return new DefaultTokenizer();
+        }
+
+        @Override
+        public Map<Language, ProjectTMX> getOtherTargetLanguageTMs() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean isProjectLoaded() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

Enforced translations lose background color - https://sourceforge.net/p/omegat/bugs/1171/

## What does this PR change?

- Keeps the highlighting of enforced translations after a team-project save. The enforced status (`xENFORCED`) previously lived only in memory: the project TMX export never wrote it and `calcExternalLinkedMode` never read it back, so a team rebase - which replaces the project TMX content with the entries parsed from the merged file - silently downgraded enforced entries to plain ones and their colour disappeared until the next full project load. `RealProject` now re-applies the loaded `tm/enforce` memories directly after the TMX rebase.
- Persists the enforced status as an `x-enforced` TMX property when the user opted into saving auto states (preference `save_auto_status`), symmetrically to the existing `x-auto`/`x-ice`/`x-100pc` handling, so the status also round-trips through the saved file.
- Stops the spurious "reverting enforced segment" warning: deactivating an enforced default segment raised the warning unconditionally, so merely navigating away - or the editor view refresh triggered by a preferences/colour change (which commits via both `gotoFile` and `gotoEntry`) - popped it, and via the refresh even twice. The warning now only appears when the translation or note was actually changed.

## Other information

Tests: `AutoTmxTest` gains coverage for the save/reload round-trip of the enforced status (with and without the opt-in) and for the re-apply after a content replacement. A new `EditorEnforcedSegmentTest` verifies that a plain view refresh of an enforced segment stays silent while an actual change still warns exactly once (headless-skipped, like the sibling editor tests).

The spurious-warning fix is a closely related incidental finding: the two symptoms share the same enforced-segment code path and both surface when a colour change is applied while sitting on an enforced segment. The persistence half is only reachable in team projects (the content replacement happens during the rebase-on-save), so a full round-trip reproduction needs a git-backed team project; the unit tests exercise the underlying TMX and marker mechanics directly.
