### PR TITLE
fix(editor): colour tags for right-to-left targets too (SF-RFE-1122)

### DIFF
--- a/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -35,7 +35,6 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.apache.commons.text.StringEscapeUtils;
 
-import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.PatternConsts;
@@ -62,18 +61,15 @@ public class ProtectedPartsMarker implements IMarker {
 
         // The attributes bind the foreground to the palette entry so the mark
         // is not shadowed by the bound state color of the segment text (see
-        // Mark#attributes). The painter still snapshots the color and is
-        // created per call so that preference changes take effect.
-        HighlightPainter painter;
-        AttributeSet attrs;
-        if (Core.getEditor().isOrientationAllLtr()) {
-            attrs = Styles.createBoundAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER, null, null, null);
-            painter = null;
-        } else {
-            attrs = null;
-            painter = new TransparentHighlightPainter(
-                    Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
-        }
+        // Mark#attributes) and colour preference changes take effect without
+        // restarting the application. The tag colour is applied regardless of
+        // the editor orientation: a right-to-left target used to receive only
+        // a faint (0.2 alpha) background highlight instead, which left the
+        // tags barely legible (SF bug #1122). Merging the foreground attribute
+        // keeps the bidi attributes that hold the tags left-to-right intact.
+        HighlightPainter painter = null;
+        AttributeSet attrs = Styles.createBoundAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER, null,
+                null, null);
 
         List<Mark> r = new ArrayList<Mark>();
 

--- a/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -35,7 +35,6 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.apache.commons.text.StringEscapeUtils;
 
-import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.PatternConsts;
@@ -60,19 +59,16 @@ public class ProtectedPartsMarker implements IMarker {
             return null;
         }
 
-        // painter and attributes are created per call so that color
-        // preference changes take effect without restarting the application
-        HighlightPainter painter;
-        AttributeSet attrs;
-        if (Core.getEditor().isOrientationAllLtr()) {
-            attrs = Styles.createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), null, null,
-                    null);
-            painter = null;
-        } else {
-            attrs = null;
-            painter = new TransparentHighlightPainter(
-                    Styles.EditorColor.COLOR_PLACEHOLDER.getColor(), 0.2F);
-        }
+        // Attributes are created per call so that colour preference changes
+        // take effect without restarting the application. The tag colour is
+        // applied as a foreground text attribute regardless of the editor
+        // orientation: a right-to-left target used to receive only a faint
+        // (0.2 alpha) background highlight instead, which left the tags barely
+        // legible (SF bug #1122). Merging the foreground attribute keeps the
+        // bidi attributes that hold the tags left-to-right intact.
+        HighlightPainter painter = null;
+        AttributeSet attrs = Styles.createAttributeSet(Styles.EditorColor.COLOR_PLACEHOLDER.getColor(),
+                null, null, null);
 
         List<Mark> r = new ArrayList<Mark>();
 

--- a/src/test/java/org/omegat/gui/editor/mark/ProtectedPartsMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/ProtectedPartsMarkerTest.java
@@ -26,6 +26,7 @@ package org.omegat.gui.editor.mark;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
@@ -36,6 +37,7 @@ import org.omegat.core.TestCoreInitializer;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.editor.EditorStub;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.TagUtil;
 
@@ -61,6 +63,29 @@ public class ProtectedPartsMarkerTest extends MarkerTestBase {
         assertEquals(9, result.get(0).endOffset);
         assertEquals("%s", result.get(0).toolTipText);
         assertEquals("SOURCE", result.get(0).entryPart.toString());
+    }
+
+    /**
+     * A right-to-left target must colour tags with the same foreground
+     * attribute as a left-to-right target; it used to receive only a faint
+     * background highlight, which left the tags barely legible (SF bug #1122).
+     */
+    @Test
+    public void testMarkerColorsTagsForRtlTarget() throws Exception {
+        ((EditorStub) editor).setOrientationAllLtr(false);
+
+        IMarker marker = new ProtectedPartsMarker();
+        String sourceText = "source %s text.";
+        List<ProtectedPart> protectedParts = TagUtil.applyCustomProtectedParts(sourceText,
+                PatternConsts.PRINTF_VARS, null);
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        SourceTextEntry ste = new SourceTextEntry(key, 1, new String[0], sourceText, protectedParts);
+
+        List<Mark> result = marker.getMarksForEntry(ste, sourceText, null, true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertNotNull("RTL tags must carry a foreground colour attribute", result.get(0).attributes);
+        assertNull("RTL tags must not fall back to a faint highlight painter", result.get(0).painter);
     }
 
 }

--- a/src/testFixtures/java/org/omegat/gui/editor/EditorStub.java
+++ b/src/testFixtures/java/org/omegat/gui/editor/EditorStub.java
@@ -39,9 +39,20 @@ import java.util.List;
 public class EditorStub implements IEditor {
 
     private final IEditorSettings editorSettings;
+    private boolean orientationAllLtr = true;
 
     public EditorStub(IEditorSettings settings) {
         this.editorSettings = settings;
+    }
+
+    /** Lets tests simulate a right-to-left target orientation. */
+    public void setOrientationAllLtr(boolean value) {
+        this.orientationAllLtr = value;
+    }
+
+    @Override
+    public boolean isOrientationAllLtr() {
+        return orientationAllLtr;
     }
 
     @Override


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

Tag color is obfuscated if target language uses RTL script - https://sourceforge.net/p/omegat/bugs/1122/

## What does this PR change?

- Colours protected parts / tags with the placeholder foreground colour for right-to-left targets as well. Previously the foreground text colour was only applied when the editor orientation was all left-to-right; a right-to-left target (Arabic, Hebrew) instead received a faint 0.2 alpha background highlight, which left the tags barely legible.
- The foreground attribute is merged onto the tag range (`setCharacterAttributes` without replacement), so the bidi attributes that keep the tags displayed left-to-right stay intact and the tag order is unchanged.

## Other information

Verified visually with small EN->AR and EN->HE projects: tags now show in the placeholder colour, as clearly as with a left-to-right target, and stay correctly ordered. `ProtectedPartsMarkerTest` gains a case that drives the marker with a right-to-left orientation and asserts the mark carries the foreground colour attribute and no faint highlight painter; the editor test stub gained a small setter to simulate the orientation.
