### PR TITLE
fix(gui): never surface a blank error message from an exception

### DIFF
--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemCommandEditorController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemCommandEditorController.java
@@ -37,6 +37,7 @@ import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.omegat.util.StringUtil;
 import org.omegat.externalfinder.item.ExternalFinderItem;
 import org.omegat.externalfinder.item.ExternalFinderItemCommand;
 import org.omegat.externalfinder.item.ExternalFinderValidationException;
@@ -156,7 +157,7 @@ public class ExternalFinderItemCommandEditorController {
             } catch (Exception ex) {
                 Logger.getLogger(ExternalFinderItemCommandEditorController.class.getName()).log(Level.SEVERE,
                         null, ex);
-                JOptionPane.showMessageDialog(dialog, ex.getLocalizedMessage(),
+                JOptionPane.showMessageDialog(dialog, StringUtil.describeException(ex),
                         OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
             }
         });

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
@@ -37,6 +37,7 @@ import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.omegat.util.StringUtil;
 import org.omegat.externalfinder.item.ExternalFinderItem;
 import org.omegat.externalfinder.item.ExternalFinderItemURL;
 import org.omegat.externalfinder.item.ExternalFinderValidationException;
@@ -134,7 +135,7 @@ public class ExternalFinderItemURLEditorController {
             } catch (Exception ex) {
                 Logger.getLogger(ExternalFinderItemURLEditorController.class.getName()).log(Level.SEVERE,
                         null, ex);
-                JOptionPane.showMessageDialog(dialog, ex.getLocalizedMessage(),
+                JOptionPane.showMessageDialog(dialog, StringUtil.describeException(ex),
                         OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
             }
         });

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
+import org.omegat.util.StringUtil;
 import org.omegat.core.Core;
 import org.omegat.externalfinder.ExternalFinder;
 import org.omegat.externalfinder.item.ExternalFinderItem.SCOPE;
@@ -123,7 +124,7 @@ public class ExternalFinderItemMenuGenerator implements IExternalFinderItemMenuG
                     } catch (Exception ex) {
                         Logger.getLogger(ExternalFinderItemMenuGenerator.class.getName()).log(Level.SEVERE,
                                 null, ex);
-                        JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), ex.getLocalizedMessage(),
+                        JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), StringUtil.describeException(ex),
                                 OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                     }
                 }
@@ -147,7 +148,7 @@ public class ExternalFinderItemMenuGenerator implements IExternalFinderItemMenuG
                     } catch (Exception ex) {
                         Logger.getLogger(ExternalFinderItemMenuGenerator.class.getName()).log(Level.SEVERE,
                                 null, ex);
-                        JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), ex.getLocalizedMessage(),
+                        JOptionPane.showMessageDialog(JOptionPane.getRootFrame(), StringUtil.describeException(ex),
                                 OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                     }
                 }

--- a/src/main/java/org/omegat/filters2/html2/EditOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/html2/EditOptionsDialog.java
@@ -38,6 +38,7 @@ import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
+import org.omegat.util.StringUtil;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.StaticUIUtils;
 
@@ -251,7 +252,7 @@ public class EditOptionsDialog extends javax.swing.JDialog {
         } catch (PatternSyntaxException e) {
             textfield.setCaretPosition(e.getIndex());
             JOptionPane.showMessageDialog(this,
-                    e.getLocalizedMessage(), OStrings.getString("HTML_ERROR_CUSTOMREGEXP_TITLE"),
+                    StringUtil.describeException(e), OStrings.getString("HTML_ERROR_CUSTOMREGEXP_TITLE"),
                     JOptionPane.ERROR_MESSAGE);
             textfield.grabFocus();
             return false;

--- a/src/main/java/org/omegat/filters3/xml/xhtml/EditXOptionsDialog.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/EditXOptionsDialog.java
@@ -39,6 +39,7 @@ import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
+import org.omegat.util.StringUtil;
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.StaticUIUtils;
 
@@ -226,7 +227,7 @@ public class EditXOptionsDialog extends javax.swing.JDialog {
         } catch (PatternSyntaxException e) {
             textfield.setCaretPosition(e.getIndex());
             JOptionPane.showMessageDialog(this,
-                    e.getLocalizedMessage(), OStrings.getString("HTML_ERROR_CUSTOMREGEXP_TITLE"),
+                    StringUtil.describeException(e), OStrings.getString("HTML_ERROR_CUSTOMREGEXP_TITLE"),
                     JOptionPane.ERROR_MESSAGE);
             textfield.grabFocus();
             return false;

--- a/src/main/java/org/omegat/gui/dialogs/VersionCheckDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/VersionCheckDialog.java
@@ -33,6 +33,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
 import javax.swing.WindowConstants;
 
+import org.omegat.util.StringUtil;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -62,7 +63,7 @@ public class VersionCheckDialog {
                 } catch (Exception e) {
                     Log.logWarningRB("VERSION_CHECK_FAILED", e.getCause().getMessage());
                     JOptionPane.showMessageDialog(parent,
-                            OStrings.getString("VERSION_CHECK_FAILED", e.getCause().getMessage()),
+                            OStrings.getString("VERSION_CHECK_FAILED", StringUtil.describeException(e.getCause())),
                             OStrings.getString("ERROR_TITLE"),
                             JOptionPane.ERROR_MESSAGE);
                 }
@@ -95,7 +96,7 @@ public class VersionCheckDialog {
                 StaticUIUtils.closeWindowByEvent(dialog);
             } catch (Exception ex) {
                 Log.log(ex);
-                JOptionPane.showMessageDialog(parent, ex.getLocalizedMessage(), OStrings.getString("ERROR_TITLE"),
+                JOptionPane.showMessageDialog(parent, StringUtil.describeException(ex), OStrings.getString("ERROR_TITLE"),
                         JOptionPane.ERROR_MESSAGE);
             }
         });

--- a/src/main/java/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/main/java/org/omegat/gui/issues/IssuesPanelController.java
@@ -77,6 +77,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.omegat.util.StringUtil;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.DataUtils;
@@ -601,7 +602,7 @@ public class IssuesPanelController implements IIssues {
                 allIssues = get();
             } catch (InterruptedException | ExecutionException e) {
                 Log.log(e);
-                JOptionPane.showMessageDialog(parent, e.getMessage(), OStrings.getString("ERROR_TITLE"),
+                JOptionPane.showMessageDialog(parent, StringUtil.describeException(e), OStrings.getString("ERROR_TITLE"),
                         JOptionPane.ERROR_MESSAGE);
                 frame.setVisible(false);
                 return;

--- a/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -919,7 +919,7 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
             Help.showHelp();
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(Core.getMainWindow().getApplicationFrame(),
-                    ex.getLocalizedMessage(), OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
+                    StringUtil.describeException(ex), OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
             Log.log(ex);
         }
     }

--- a/src/main/java/org/omegat/gui/preferences/view/PluginDetailsPane.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginDetailsPane.java
@@ -30,6 +30,7 @@ import javax.swing.JOptionPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.text.html.HTMLDocument;
 
+import org.omegat.util.StringUtil;
 import org.omegat.core.data.PluginInformation;
 import org.omegat.gui.common.EntryInfoPane;
 import org.omegat.util.OStrings;
@@ -59,7 +60,7 @@ public class PluginDetailsPane extends EntryInfoPane<PluginInformation> {
                 try {
                     DesktopWrapper.browse(URI.create(e.getURL().toString()));
                 } catch (Exception ex) {
-                    JOptionPane.showConfirmDialog(this, ex.getLocalizedMessage(),
+                    JOptionPane.showConfirmDialog(this, StringUtil.describeException(ex),
                             OStrings.getString("ERROR_TITLE"), JOptionPane.DEFAULT_OPTION,
                             JOptionPane.ERROR_MESSAGE);
                 }

--- a/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -40,6 +40,7 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.table.TableRowSorter;
 
+import org.omegat.util.StringUtil;
 import org.omegat.core.Core;
 import org.omegat.core.data.PluginInformation;
 import org.omegat.gui.dialogs.ChoosePluginFile;
@@ -155,7 +156,7 @@ public class PluginsPreferencesController extends BasePreferencesController {
             try {
                 DesktopWrapper.browse(URI.create(PLUGINS_WIKI_URL));
             } catch (Exception ex) {
-                JOptionPane.showConfirmDialog(panel, ex.getLocalizedMessage(), OStrings.getString("ERROR_TITLE"),
+                JOptionPane.showConfirmDialog(panel, StringUtil.describeException(ex), OStrings.getString("ERROR_TITLE"),
                         JOptionPane.DEFAULT_OPTION, JOptionPane.ERROR_MESSAGE);
             }
         });

--- a/src/main/java/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptingWindow.java
@@ -987,7 +987,7 @@ public class ScriptingWindow {
             try {
                 Help.showJavadoc();
             } catch (Exception ex) {
-                JOptionPane.showMessageDialog(frame, ex.getLocalizedMessage(),
+                JOptionPane.showMessageDialog(frame, StringUtil.describeException(ex),
                         OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                 Log.log(ex);
             }

--- a/src/main/java/org/omegat/util/StringUtil.java
+++ b/src/main/java/org/omegat/util/StringUtil.java
@@ -76,6 +76,29 @@ public final class StringUtil {
     }
 
     /**
+     * Produce a non-empty, human-readable description of a throwable, suitable
+     * for a status line or error dialog. Prefers the localized message, then
+     * the plain message, and falls back to the class name so the text is never
+     * blank (which would otherwise surface as an empty or "null" dialog).
+     *
+     * @param t
+     *            the throwable to describe, may be null
+     * @return the description, or an empty string if {@code t} is null
+     */
+    public static String describeException(final @Nullable Throwable t) {
+        if (t == null) {
+            return "";
+        }
+        if (!isEmpty(t.getLocalizedMessage())) {
+            return t.getLocalizedMessage();
+        }
+        if (!isEmpty(t.getMessage())) {
+            return t.getMessage();
+        }
+        return t.getClass().getName();
+    }
+
+    /**
      * Returns true if the input has at least one letter and all letters are
      * lower case.
      */

--- a/src/main/java/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/main/java/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -50,6 +50,7 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.validator.routines.UrlValidator;
 
+import org.omegat.util.StringUtil;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 
@@ -270,7 +271,7 @@ public final class JTextPaneLinkifier {
                 try {
                     DesktopWrapper.browse(target);
                 } catch (Exception e) {
-                    JOptionPane.showConfirmDialog(null, e.getLocalizedMessage(),
+                    JOptionPane.showConfirmDialog(null, StringUtil.describeException(e),
                             OStrings.getString("ERROR_TITLE"), JOptionPane.ERROR_MESSAGE);
                     Log.log(e);
                 }

--- a/src/test/java/org/omegat/util/StringUtilTest.java
+++ b/src/test/java/org/omegat/util/StringUtilTest.java
@@ -633,4 +633,18 @@ public class StringUtilTest {
         // Test empty string
         assertEquals("", StringUtil.stripFromEnd("", "suffix"));
     }
+
+    @Test
+    public void testDescribeException() {
+        // Prefers the (localized) message when present.
+        assertEquals("boom", StringUtil.describeException(new RuntimeException("boom")));
+        // Falls back to the class name when the message is null or empty, so
+        // the result is never blank.
+        assertEquals("java.lang.RuntimeException",
+                StringUtil.describeException(new RuntimeException()));
+        assertEquals("java.lang.RuntimeException",
+                StringUtil.describeException(new RuntimeException("")));
+        // Null-safe.
+        assertEquals("", StringUtil.describeException(null));
+    }
 }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

No dedicated ticket. This is the broader counterpart to the "help wanted" PR
#2172, which fixes the same silent/blank error-message pattern in
`RealProject`. Here the fix is centralized and applied to the recurring UI
dialog and status-message sites.

## What does this PR change?

- Adds `StringUtil.describeException(Throwable)`: localized message → plain
  message → class name, null-safe, so an error description is never blank.
- Uses it at the dialog/status call sites that previously passed
  `getLocalizedMessage()` / `getMessage()` straight to the UI, where an empty
  message produced an empty or "null" dialog (external-finder menu and editors,
  plugin details and preferences, scripting window, issues panel, version
  check, the HTML filter option dialogs, the main menu handler and the
  link-ifier).
- Adds a unit test for the helper.

## Other information

`RealProject` is intentionally left to #2172. A shared `showError(parent,
throwable, ...)` dialog helper could deduplicate these call sites further as a
later cleanup.
