### PR TITLE
docs(manual): document TMX property display templates (SF documentation 451)

### DIFF
--- a/src/docs/manual/en/OmegaT_Preferences.xml
+++ b/src/docs/manual/en/OmegaT_Preferences.xml
@@ -1362,6 +1362,44 @@
                      </tbody>
                   </tgroup>
                </table>
+               <para>Values of TMX segment properties can additionally be inserted with the
+                  templates below. Unlike the variables above, these are <emphasis>not</emphasis>
+                  offered in the drop-down menu.</para>
+               <table xml:id="table.match.pane.setup.tmxprop" colsep="0" rowsep="0">
+                  <title xml:id="table.match.pane.setup.tmxprop.title">TMX property template variables</title>
+                  <tgroup cols="2" colsep="1" rowsep="1">
+                     <colspec align="left"></colspec>
+                     <colspec align="left"></colspec>
+                     <tbody>
+                        <row>
+                           <entry>
+                              <literal>@{propertyType}</literal>
+                           </entry>
+                           <entry>The value of the TMX property of the given
+                              <literal>propertyType</literal>.</entry>
+                        </row>
+                        <row>
+                           <entry>
+                              <literal>@[propertyType][keyValueSeparator][valueSeparator]</literal>
+                           </entry>
+                           <entry>All TMX properties whose type matches <literal>propertyType</literal>
+                              (where <literal>*</literal> and <literal>?</literal> act as wildcards),
+                              each rendered as the property type, the
+                              <literal>keyValueSeparator</literal> and the value, with the individual
+                              results joined by the <literal>valueSeparator</literal>.</entry>
+                        </row>
+                     </tbody>
+                  </tgroup>
+               </table>
+               <example xml:id="dialog.preferences.tm.matches.template.tmxprop.example">
+                  <title xml:id="dialog.preferences.tm.matches.template.tmxprop.example.title">Displaying a TMX property</title>
+                  <para>For a TMX entry property
+                     <literal>&lt;prop type="Att::Doc. Type"&gt;Regulation&lt;/prop&gt;</literal>, the
+                     template <literal>@{Att::Doc. Type}</literal> renders as
+                     <literal>Regulation</literal>, and the template
+                     <literal>@[Att::Doc. Type][=][,]</literal> renders as
+                     <literal>Att::Doc. Type=Regulation</literal>.</para>
+               </example>
             </listitem>
          </varlistentry>
          <varlistentry xml:id="dialog.preferences.tm.matches.paragraph.from.segmented.tmx">


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

- Title: Describe tmx prop display syntax in the manual
  * URL: https://sourceforge.net/p/omegat/documentation/451/

## What does this PR change?

- Documents the match-template property syntax in the manual: the single-value
  form `@{propertyType}` and the group form
  `@[propertyType][keyValueSeparator][valueSeparator]` (with `*` / `?`
  wildcards), as implemented in `org.omegat.gui.matches.MatchesVarExpansion`.
- Places them in a separate "TMX property template variables" table with an
  explicit note that, unlike the `${...}` variables, they are not offered in the
  template drop-down menu.
- Adds a worked example showing both forms and their rendered output.

## Other information

This picks up the stalled #1760 and addresses the review points raised there: a
separate table with the "not in the drop-down" note, a clear output example, and
a consistent `@`-prefixed syntax; the code reference is
`org.omegat.gui.matches.MatchesVarExpansion`. It is rebased onto the current
`src/docs/` layout, which the original predates.

Sincere apologies to @robinp for stepping in on your work — it looked stalled
and we did not want the effort to go to waste. The original documentation is
your contribution and the credit is yours; please chime in if you would rather
carry it forward. The hope is simply that, together, we can keep moving and get
these tickets and pull requests closed.
