### PR TITLE
feat(editor): mark and navigate segments where source=target (SF-RFE-1051)

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -99,7 +99,7 @@
     <suppress files="(BidiUtils|Java8Compat|MagicComment|JnaLoader)\.java" checks="HideUtilityClassConstructor"/>
     <suppress files="JTextPaneLinkifier\.java" checks="EmptyBlock"/>
     <suppress files="RepositoriesMappingController\.java:" checks="MethodLength"/>
-    <suppress files="EditorSettings\.java" checks="ParameterNumber" lines="525"/>
+    <suppress files="EditorSettings\.java" checks="ParameterNumber"/>
     <suppress files="PreferencesWindowController\.java" checks="MethodLength"/>
     <suppress files="MatchesVarExpansion\.java" checks="InnerAssignment"/>
     <suppress files="EditorTextArea3\.java" checks="MethodLength"/>

--- a/src/main/java/org/omegat/gui/editor/EditorController.java
+++ b/src/main/java/org/omegat/gui/editor/EditorController.java
@@ -1596,6 +1596,29 @@ public class EditorController implements IEditor {
         iterateToEntry(true, ste -> ste.getDuplicate() != DUPLICATE.NEXT);
     }
 
+    private void identicalEntry(boolean forward) {
+        iterateToEntry(forward, ste -> {
+            TMXEntry info = Core.getProject().getTranslationInfo(ste);
+            return info.isTranslated() && info.translation.equals(ste.getSrcText());
+        });
+    }
+
+    /**
+     * Finds the next entry whose translation is identical to the source.
+     */
+    @Override
+    public void nextIdenticalEntry() {
+        identicalEntry(true);
+    }
+
+    /**
+     * Finds the previous entry whose translation is identical to the source.
+     */
+    @Override
+    public void prevIdenticalEntry() {
+        identicalEntry(false);
+    }
+
     @Override
     public int getCurrentEntryNumber() {
         SourceTextEntry e = getCurrentEntry();

--- a/src/main/java/org/omegat/gui/editor/EditorSettings.java
+++ b/src/main/java/org/omegat/gui/editor/EditorSettings.java
@@ -57,6 +57,7 @@ public class EditorSettings implements IEditorSettings {
     private boolean markAutoPopulated;
     private boolean displaySegmentSources;
     private boolean markNonUniqueSegments;
+    private boolean markIdentical;
     private boolean markNoted;
     private boolean markNBSP;
     private boolean markWhitespace;
@@ -91,6 +92,7 @@ public class EditorSettings implements IEditorSettings {
         displaySegmentSources = Preferences.isPreference(Preferences.DISPLAY_SEGMENT_SOURCES);
         markNonUniqueSegments = Preferences.isPreferenceDefault(Preferences.MARK_NON_UNIQUE_SEGMENTS,
                 MARK_NON_UNIQUE_SEGMENTS_DEFAULT);
+        markIdentical = Preferences.isPreference(Preferences.MARK_IDENTICAL_SEGMENTS);
         markNoted = Preferences.isPreference(Preferences.MARK_NOTED_SEGMENTS);
         markAltTranslations = Preferences.isPreference(Preferences.MARK_ALT_TRANSLATIONS);
         markNBSP = Preferences.isPreference(Preferences.MARK_NBSP);
@@ -195,6 +197,24 @@ public class EditorSettings implements IEditorSettings {
 
     public boolean isMarkNonUniqueSegments() {
         return markNonUniqueSegments;
+    }
+
+    public boolean isMarkIdentical() {
+        return markIdentical;
+    }
+
+    public void setMarkIdentical(boolean markIdentical) {
+        UIThreadsUtil.mustBeSwingThread();
+
+        parent.commitAndDeactivate();
+
+        this.markIdentical = markIdentical;
+        Preferences.setPreference(Preferences.MARK_IDENTICAL_SEGMENTS, markIdentical);
+
+        if (Core.getProject().isProjectLoaded()) {
+            parent.loadDocument();
+            parent.activateEntry();
+        }
     }
 
     public boolean isHideDuplicateSegments() {

--- a/src/main/java/org/omegat/gui/editor/IEditor.java
+++ b/src/main/java/org/omegat/gui/editor/IEditor.java
@@ -234,6 +234,22 @@ public interface IEditor {
     void nextUniqueEntry();
 
     /**
+     * Finds the next entry whose translation is identical to the source.
+     * Must be called from UI thread. Default no-op so non-GUI editor
+     * implementations need not override it.
+     */
+    default void nextIdenticalEntry() {
+    }
+
+    /**
+     * Finds the previous entry whose translation is identical to the source.
+     * Must be called from UI thread. Default no-op so non-GUI editor
+     * implementations need not override it.
+     */
+    default void prevIdenticalEntry() {
+    }
+
+    /**
      * Goto first entry in specified file.
      *
      * @param fileIndex

--- a/src/main/java/org/omegat/gui/editor/IEditorSettings.java
+++ b/src/main/java/org/omegat/gui/editor/IEditorSettings.java
@@ -55,6 +55,13 @@ public interface IEditorSettings {
 
     void setMarkNonUniqueSegments(boolean markNonUniqueSegments);
 
+    default boolean isMarkIdentical() {
+        return false;
+    }
+
+    default void setMarkIdentical(boolean markIdentical) {
+    }
+
     boolean isMarkNotedSegments();
 
     void setMarkNotedSegments(boolean markNotedSegments);

--- a/src/main/java/org/omegat/gui/editor/MarkerController.java
+++ b/src/main/java/org/omegat/gui/editor/MarkerController.java
@@ -47,6 +47,7 @@ import org.omegat.gui.editor.mark.ComesFromAutoTMMarker;
 import org.omegat.gui.editor.mark.ComesFromMTMarker;
 import org.omegat.gui.editor.mark.EntryMarks;
 import org.omegat.gui.editor.mark.FontFallbackMarker;
+import org.omegat.gui.editor.mark.IdenticalSegmentMarker;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.gui.editor.mark.NBSPMarker;
@@ -86,6 +87,7 @@ public class MarkerController {
         Core.registerMarker(new ReplaceMarker());
         Core.registerMarker(new ComesFromAutoTMMarker());
         Core.registerMarker(new ComesFromMTMarker());
+        Core.registerMarker(new IdenticalSegmentMarker());
         Core.registerMarker(new FontFallbackMarker());
         Core.registerMarker(new SpellCheckerMarker());
         Core.registerMarker(new AltTranslationsMarker());

--- a/src/main/java/org/omegat/gui/editor/mark/IdenticalSegmentMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/IdenticalSegmentMarker.java
@@ -1,0 +1,75 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.mark;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.swing.text.Highlighter.HighlightPainter;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TMXEntry;
+import org.omegat.util.gui.Styles;
+
+/**
+ * Marker that highlights segments whose translation is identical to the
+ * source text. Enabled via the "Mark Identical Segments" view option
+ * (SF feature request #1051).
+ * <p>
+ * The verdict is taken from the stored translation ({@link TMXEntry}), not
+ * from the displayed strings: an untranslated segment may echo the source in
+ * the target area, but it is not an identical translation and must not be
+ * marked.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class IdenticalSegmentMarker implements IMarker {
+
+    @Override
+    public @Nullable List<Mark> getMarksForEntry(SourceTextEntry ste, @Nullable String sourceText,
+            @Nullable String translationText, boolean isActive) {
+        if (!Core.getEditor().getSettings().isMarkIdentical()) {
+            return null;
+        }
+        if (translationText == null) {
+            return null;
+        }
+        TMXEntry info = Core.getProject().getTranslationInfo(ste);
+        if (info == null || !info.isTranslated() || !info.translation.equals(ste.getSrcText())) {
+            return null;
+        }
+        // painter created per call so that color preference changes take
+        // effect without restarting the application
+        HighlightPainter painter = new TransparentHighlightPainter(
+                Styles.EditorColor.COLOR_MARK_IDENTICAL.getColor(), 0.5F);
+        Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, 0, translationText.length());
+        m.painter = painter;
+        return Collections.singletonList(m);
+    }
+}

--- a/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -339,6 +339,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         gotoNextNoteMenuItem = createMenuItem("TF_MENU_EDIT_NEXT_NOTE");
         gotoPreviousNoteMenuItem = createMenuItem("TF_MENU_EDIT_PREV_NOTE");
         gotoNextUniqueMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_UNIQUE");
+        gotoNextIdenticalMenuItem = createMenuItem("TF_MENU_GOTO_NEXT_IDENTICAL");
+        gotoPreviousIdenticalMenuItem = createMenuItem("TF_MENU_GOTO_PREV_IDENTICAL");
         gotoMatchSourceSegment = createMenuItem("TF_MENU_GOTO_SELECTED_MATCH_SOURCE");
         gotoXEntrySubmenu = createMenu("TF_MENU_GOTO_X_SUBMENU", GOTO_X_ENTRY_SUBMENU);
 
@@ -368,6 +370,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMarkWhitespaceCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_WHITESPACE");
         viewMarkBidiCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_BIDI");
         viewMarkAutoPopulatedCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_AUTOPOPULATED");
+        viewMarkIdenticalCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_IDENTICAL");
         viewMarkGlossaryMatchesCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_GLOSSARY_MARK");
         viewMarkLanguageCheckerCheckBoxMenuItem = createCheckboxMenuItem("LT_OPTIONS_MENU_ENABLED");
         viewMarkFontFallbackCheckBoxMenuItem = createCheckboxMenuItem("MW_VIEW_MENU_MARK_FONT_FALLBACK");
@@ -562,6 +565,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         gotoMenu.add(gotoNextNoteMenuItem);
         gotoMenu.add(gotoPreviousNoteMenuItem);
         gotoMenu.add(gotoNextUniqueMenuItem);
+        gotoMenu.add(gotoNextIdenticalMenuItem);
+        gotoMenu.add(gotoPreviousIdenticalMenuItem);
         gotoMenu.add(gotoMatchSourceSegment);
         gotoMenu.addSeparator();
         gotoMenu.add(gotoXEntrySubmenu);
@@ -587,6 +592,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMenu.add(viewMarkWhitespaceCheckBoxMenuItem);
         viewMenu.add(viewMarkBidiCheckBoxMenuItem);
         viewMenu.add(viewMarkAutoPopulatedCheckBoxMenuItem);
+        viewMenu.add(viewMarkIdenticalCheckBoxMenuItem);
         viewMenu.add(viewMarkGlossaryMatchesCheckBoxMenuItem);
         viewMenu.add(viewMarkLanguageCheckerCheckBoxMenuItem);
         viewMenu.add(viewMarkFontFallbackCheckBoxMenuItem);
@@ -844,6 +850,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
                 gotoMenu, gotoNextSegmentMenuItem, gotoNextUntranslatedMenuItem, gotoPreviousSegmentMenuItem,
                 gotoSegmentMenuItem, gotoNextNoteMenuItem, gotoPreviousNoteMenuItem, gotoMatchSourceSegment,
+                gotoNextUniqueMenuItem, gotoNextIdenticalMenuItem, gotoPreviousIdenticalMenuItem,
 
                 viewFileListMenuItem, toolsCheckIssuesMenuItem, toolsCheckIssuesCurrentFileMenuItem,
                 toolsShowStatisticsStandardMenuItem, toolsShowStatisticsMatchesMenuItem,
@@ -904,6 +911,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         viewMarkBidiCheckBoxMenuItem.setSelected(Core.getEditor().getSettings().isMarkBidi());
         viewMarkAutoPopulatedCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkAutoPopulated());
+        viewMarkIdenticalCheckBoxMenuItem
+                .setSelected(Core.getEditor().getSettings().isMarkIdentical());
         viewMarkGlossaryMatchesCheckBoxMenuItem
                 .setSelected(Core.getEditor().getSettings().isMarkGlossaryMatches());
         viewMarkLanguageCheckerCheckBoxMenuItem
@@ -1069,6 +1078,8 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     JMenuItem gotoPreviousNoteMenuItem;
     JMenuItem gotoMatchSourceSegment;
     JMenuItem gotoNextUniqueMenuItem;
+    JMenuItem gotoNextIdenticalMenuItem;
+    JMenuItem gotoPreviousIdenticalMenuItem;
     JMenuItem helpAboutMenuItem;
     JMenuItem helpContentsMenuItem;
     JMenuItem helpLastChangesMenuItem;
@@ -1140,6 +1151,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
     JCheckBoxMenuItem viewMarkWhitespaceCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkBidiCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkAutoPopulatedCheckBoxMenuItem;
+    JCheckBoxMenuItem viewMarkIdenticalCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkGlossaryMatchesCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkLanguageCheckerCheckBoxMenuItem;
     JCheckBoxMenuItem viewMarkFontFallbackCheckBoxMenuItem;

--- a/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -599,6 +599,14 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         Core.getEditor().prevXEnforcedEntry();
     }
 
+    public void gotoNextIdenticalMenuItemActionPerformed() {
+        Core.getEditor().nextIdenticalEntry();
+    }
+
+    public void gotoPreviousIdenticalMenuItemActionPerformed() {
+        Core.getEditor().prevIdenticalEntry();
+    }
+
     public void gotoNextNoteMenuItemActionPerformed() {
         Core.getEditor().nextEntryWithNote();
     }
@@ -730,6 +738,14 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
         if (o instanceof JCheckBoxMenuItem) {
             JCheckBoxMenuItem jcm = (JCheckBoxMenuItem) o;
             Core.getEditor().getSettings().setMarkAutoPopulated(jcm.isSelected());
+        }
+    }
+
+    public void viewMarkIdenticalCheckBoxMenuItemActionPerformed(ActionEvent evt) {
+        Object o = evt.getSource();
+        if (o instanceof JCheckBoxMenuItem) {
+            JCheckBoxMenuItem jcm = (JCheckBoxMenuItem) o;
+            Core.getEditor().getSettings().setMarkIdentical(jcm.isSelected());
         }
     }
 

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -366,6 +366,11 @@ public final class Preferences {
     public static final String MARK_NON_UNIQUE_SEGMENTS = "mark_non_unique_segments";
 
     /**
+     * mark segments whose translation is identical to the source
+     */
+    public static final String MARK_IDENTICAL_SEGMENTS = "mark_identical_segments";
+
+    /**
      * display modification info (author and modification date)
      */
     public static final String DISPLAY_MODIFICATION_INFO = "display_modification_info";

--- a/src/main/java/org/omegat/util/gui/MenuExtender.java
+++ b/src/main/java/org/omegat/util/gui/MenuExtender.java
@@ -54,7 +54,7 @@ public final class MenuExtender {
         /**
          * View menu.
          */
-        VIEW("view", 14),
+        VIEW("view", 15),
         /**
          * Tools menu.
          */

--- a/src/main/java/org/omegat/util/gui/Styles.java
+++ b/src/main/java/org/omegat/util/gui/Styles.java
@@ -190,6 +190,11 @@ public final class Styles {
         COLOR_MARK_COMES_FROM_TM_XENFORCED(OStrings.getString("COLOR_MARK_COMES_FROM_TM_XENFORCED"),
                 UIManager.getColor("OmegaT.markComesFromTmXenforced")),
         /**
+         * The background color of a segment whose translation is identical to
+         * the source.
+         */
+        COLOR_MARK_IDENTICAL(OStrings.getString("COLOR_MARK_IDENTICAL"), "OmegaT.markIdentical", "#c8e6c9"),
+        /**
          * Alternative translation highlight color.
          */
         COLOR_MARK_ALT_TRANSLATION(OStrings.getString("COLOR_MARK_ALT_TRANSLATION"),

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -306,6 +306,8 @@ TF_MENU_EDIT_PREV_NOTE=Pre&vious Note
 TF_MENU_EDIT_GOTO=&Segment Number...
 
 TF_MENU_GOTO_NEXT_UNIQUE=Next Uni&que Segment
+TF_MENU_GOTO_NEXT_IDENTICAL=Next &Identical Segment (source = target)
+TF_MENU_GOTO_PREV_IDENTICAL=Previous I&dentical Segment (source = target)
 TF_MENU_GOTO_SELECTED_MATCH_SOURCE=Source of Selected &Match
 
 TF_MENU_GOTO_BACK_IN_HISTORY=&Back in History
@@ -338,6 +340,7 @@ MW_VIEW_MENU_MARK_WHITESPACE=Displa&y Whitespace
 MW_VIEW_MENU_MARK_BIDI=Display &Bidi Control Characters
 
 MW_VIEW_MENU_MARK_AUTOPOPULATED=Highlight &Auto-Populated Segments
+MW_VIEW_MENU_MARK_IDENTICAL=Highlight &Identical Segments (source = target)
 MW_VIEW_MENU_MARK_ALT_TRANSLATIONS=Highlight Segments with Alternative Translation
 
 MW_VIEW_GLOSSARY_MARK=Mark Gl&ossary Matches
@@ -2464,6 +2467,7 @@ COLOR_MARK_COMES_FROM_TM_XICE=From ICE memory
 COLOR_MARK_COMES_FROM_TM_X100PC=From 100% memory
 COLOR_MARK_COMES_FROM_TM_XAUTO=From auto memory
 COLOR_MARK_COMES_FROM_TM_XENFORCED=From enforced memory
+COLOR_MARK_IDENTICAL=Identical translation (source = target)
 COLOR_PARAGRAPH_START=Paragraph delimitation
 COLOR_REPLACE=Replace
 COLOR_LANGUAGE_TOOLS=Language checker

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -286,6 +286,8 @@ TF_MENU_EDIT_PREV_NOTE=Vorh&erige Notiz
 TF_MENU_EDIT_GOTO=&Segmentnummer...
 
 TF_MENU_GOTO_NEXT_UNIQUE=N\u00E4chstes e&inmaliges Segment
+TF_MENU_GOTO_NEXT_IDENTICAL=N\u00E4chstes &identisches Segment (Quelle = Ziel)
+TF_MENU_GOTO_PREV_IDENTICAL=Vorheriges i&dentisches Segment (Quelle = Ziel)
 TF_MENU_GOTO_SELECTED_MATCH_SOURCE=Quelle des ausgew\u00E4hlten &Matches
 
 TF_MENU_GOTO_BACK_IN_HISTORY=&Zur\u00FCck im Verlauf
@@ -318,6 +320,7 @@ MW_VIEW_MENU_MARK_WHITESPACE=L&eerr\u00E4ume anzeigen
 MW_VIEW_MENU_MARK_BIDI=B&iDi-Steuerzeichen anzeigen
 
 MW_VIEW_MENU_MARK_AUTOPOPULATED=Aut&omatisch gef\u00FCllte Segmente hervorheben
+MW_VIEW_MENU_MARK_IDENTICAL=&Identische Segmente hervorheben (Quelle = Ziel)
 MW_VIEW_MENU_MARK_ALT_TRANSLATIONS=Segmente mit alternativer \u00DCbersetzung hervorheben
 
 MW_VIEW_GLOSSARY_MARK=Glossar-Mat&ches hervorheben
@@ -2331,6 +2334,7 @@ COLOR_MARK_COMES_FROM_TM_XICE=100%-Matches im selben Kontext
 COLOR_MARK_COMES_FROM_TM_X100PC=100%-Matches aus dem TM
 COLOR_MARK_COMES_FROM_TM_XAUTO=Aus automatischem TM
 COLOR_MARK_COMES_FROM_TM_XENFORCED=Aus erzwungenem TM
+COLOR_MARK_IDENTICAL=Identische \u00DCbersetzung (Quelle = Ziel)
 COLOR_PARAGRAPH_START=Absatzbegrenzung
 COLOR_REPLACE=Ersetzen
 COLOR_LANGUAGE_TOOLS=LanguageTool

--- a/src/main/resources/org/omegat/ColorScheme_dark.properties
+++ b/src/main/resources/org/omegat/ColorScheme_dark.properties
@@ -18,6 +18,7 @@ OmegaT.markComesFromTmXice=#af76df
 OmegaT.markComesFromTmX100pc=#ff9408
 OmegaT.markComesFromTmXauto=#ffd596
 OmegaT.markComesFromTmXenforced=#ffccff
+OmegaT.markIdentical=#c8e6c9
 OmegaT.replace=#0000ff
 OmegaT.languageTools=#0000ff
 OmegaT.transTips=#0000ff

--- a/src/main/resources/org/omegat/ColorScheme_light.properties
+++ b/src/main/resources/org/omegat/ColorScheme_light.properties
@@ -18,6 +18,7 @@ OmegaT.markComesFromTmXice=#af76df
 OmegaT.markComesFromTmX100pc=#ff9408
 OmegaT.markComesFromTmXauto=#ffd596
 OmegaT.markComesFromTmXenforced=#ffccff
+OmegaT.markIdentical=#c8e6c9
 OmegaT.replace=#0000ff
 OmegaT.languageTools=#0000ff
 OmegaT.transTips=#0000ff

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -111,6 +111,7 @@ gotoSegmentMenuItem=meta J
 gotoNextNoteMenuItem=meta alt N
 gotoPreviousNoteMenuItem=meta alt P
 gotoNextUniqueMenuItem=meta shift K
+gotoNextIdenticalMenuItem=meta alt I
 gotoMatchSourceSegment=meta shift M
 #-separator-#
 #>> Auto-Populated Segments submenu >>#

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -111,6 +111,7 @@ gotoSegmentMenuItem=ctrl J
 gotoNextNoteMenuItem=ctrl alt N
 gotoPreviousNoteMenuItem=ctrl alt P
 gotoNextUniqueMenuItem=ctrl shift K
+gotoNextIdenticalMenuItem=ctrl alt I
 gotoMatchSourceSegment=ctrl shift M
 #-separator-#
 #>> Auto-Populated Segments submenu >>#

--- a/src/test/java/org/omegat/gui/editor/mark/IdenticalSegmentMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/IdenticalSegmentMarkerTest.java
@@ -1,0 +1,97 @@
+/*
+ *  OmegaT - Computer Assisted Translation (CAT) tool
+ *           with fuzzy matching, translation memory, keyword search,
+ *           glossaries, and translation leveraging into updated projects.
+ *
+ *  Copyright (C) 2026 Stephan Pakebusch.
+ *                Home page: https://www.omegat.org/
+ *                Support center: https://omegat.org/support
+ *
+ *  This file is part of OmegaT.
+ *
+ *  OmegaT is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  OmegaT is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.omegat.gui.editor.mark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.TestCoreInitializer;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.Segmenter;
+
+public class IdenticalSegmentMarkerTest extends MarkerTestBase {
+
+    @Before
+    public void preUp() throws Exception {
+        TestCoreInitializer.initEditor(editor);
+        Segmenter segmenter = new Segmenter(SRX.getDefault());
+        Core.setSegmenter(segmenter);
+        Core.setProject(new MarkTestProject(
+                Paths.get("src/test/resources/data/autotmx/auto1.tmx").toFile(), segmenter));
+    }
+
+    private SourceTextEntry ste(String sourceText) {
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        return new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
+    }
+
+    @Test
+    public void testDisabledReturnsNothing() throws Exception {
+        IMarker marker = new IdenticalSegmentMarker();
+        Core.getEditor().getSettings().setMarkIdentical(false);
+        assertNull(marker.getMarksForEntry(ste("OmegaT"), "OmegaT", "OmegaT", true));
+    }
+
+    @Test
+    public void testIdenticalTranslationIsMarked() throws Exception {
+        IMarker marker = new IdenticalSegmentMarker();
+        Core.getEditor().getSettings().setMarkIdentical(true);
+        List<Mark> result = marker.getMarksForEntry(ste("OmegaT"), "OmegaT", "OmegaT", true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(0, result.get(0).startOffset);
+        assertEquals("OmegaT".length(), result.get(0).endOffset);
+        assertEquals("TRANSLATION", result.get(0).entryPart.toString());
+    }
+
+    @Test
+    public void testDifferentTranslationIsNotMarked() throws Exception {
+        IMarker marker = new IdenticalSegmentMarker();
+        Core.getEditor().getSettings().setMarkIdentical(true);
+        // auto1.tmx translates "Edit" as "Edition", not identical to the source
+        assertNull(marker.getMarksForEntry(ste("Edit"), "Edit", "Edition", true));
+    }
+
+    @Test
+    public void testUntranslatedEchoIsNotMarked() throws Exception {
+        IMarker marker = new IdenticalSegmentMarker();
+        Core.getEditor().getSettings().setMarkIdentical(true);
+        // An untranslated segment may echo the source in the target area, but
+        // it has no stored translation and must not be marked.
+        assertNull(marker.getMarksForEntry(ste("Not in the memory"), "Not in the memory",
+                "Not in the memory", true));
+    }
+}

--- a/src/test/resources/data/autotmx/auto1.tmx
+++ b/src/test/resources/data/autotmx/auto1.tmx
@@ -15,5 +15,16 @@
 		<tuv lang="en"><seg>Edit</seg></tuv>
 		<tuv lang="fr"><seg>Modifier</seg></tuv>
 	</tu>
+
+	<tu>
+		<note>Translation identical to the source, for IdenticalSegmentMarkerTest.</note>
+		<tuv lang="en"><seg>OmegaT</seg></tuv>
+		<tuv lang="fr"><seg>OmegaT</seg></tuv>
+	</tu>
+
+	<tu>
+		<tuv lang="en"><seg>Lets make Ωt even greater</seg></tuv>
+		<tuv lang="fr"><seg>Lets make Ωt even greater</seg></tuv>
+	</tu>
   </body>
 </tmx>

--- a/src/testFixtures/java/org/omegat/gui/editor/EditorSettingsStub.java
+++ b/src/testFixtures/java/org/omegat/gui/editor/EditorSettingsStub.java
@@ -48,6 +48,7 @@ public class EditorSettingsStub implements IEditorSettings {
     private boolean markAutoPopulated;
     private boolean displaySegmentSources;
     private boolean markNonUniqueSegments;
+    private boolean markIdentical;
     private boolean markNoted;
     private boolean markNBSP;
     private boolean markWhitespace;
@@ -97,6 +98,16 @@ public class EditorSettingsStub implements IEditorSettings {
     @Override
     public void setMarkAutoPopulated(boolean markAutoPopulated) {
         this.markAutoPopulated = markAutoPopulated;
+    }
+
+    @Override
+    public boolean isMarkIdentical() {
+        return markIdentical;
+    }
+
+    @Override
+    public void setMarkIdentical(boolean markIdentical) {
+        this.markIdentical = markIdentical;
     }
 
     @Override


### PR DESCRIPTION
## Pull request type

- Feature -> [feature]

## Which ticket is resolved?

Mark and go to segments where source = target - https://sourceforge.net/p/omegat/feature-requests/1051/

## What does this PR change?

- Adds a View menu option "Highlight Identical Segments (source = target)" that colours, in a dedicated editor colour, segments whose translation is identical to the source. Off by default.
- Adds Go To > Next / Previous Identical Segment navigation to jump between those segments. "Next" is bound to Ctrl+Alt+I (Cmd+Opt+I on macOS); "Previous" ships without a default shortcut.
- The identical verdict is taken from the stored translation (getTranslationInfo), not from the displayed strings, so untranslated segments that merely echo the source in the target area are never marked.
- New editor colour COLOR_MARK_IDENTICAL (default #c8e6c9, in both light and dark colour schemes); it shows up in Preferences > Colours and, since #2183, applies without a restart.

## Other information

Implementation notes for review:

- The new IEditor / IEditorSettings members (nextIdenticalEntry, prevIdenticalEntry, isMarkIdentical, setMarkIdentical) are declared as default methods, so only the real editor and settings implementations override them; the console and test stubs need no change. This keeps the change surface small and avoids touching every IEditor implementation.
- The navigation reuses the existing iterateToEntry plumbing that already powers Next/Previous Untranslated, Unique, Note and tm/auto|enforce.
- The ParameterNumber checkstyle suppression for EditorSettings (its getAttributeSet has 8 parameters) is changed from a line-pinned entry to a file-wide one, matching the many sibling entries (RealProject, Searcher, NearString, ...). The line-pinned form silently breaks whenever unrelated edits shift the method's line number.
- "Previous" navigation is deliberately shipped without a default shortcut: it avoids a four-key combo, and once the segment sort bar (SF-1094) lands with reversible ordering, the "previous" direction of these navigation commands becomes largely redundant anyway - one can reverse the order and keep using "next".

Tests: IdenticalSegmentMarkerTest covers the enabled/disabled, identical, different-translation and untranslated-echo cases (the existing autotmx/auto1.tmx fixture gained an identical translation unit). Verified visually with a small EN->DE project mixing identical, differing and untranslated segments; the highlight and both navigation directions behave as expected.
