### PR TITLE
feat(gui): export and import a colour scheme (RFE-1399)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ GEMINI.md
 .github/copilot-instructions.md
 .supermaven/
 .idx/
+
+# heap dumps from GUI/OOM test runs
+*.hprof

--- a/src/docs/manual/en/OmegaT_Preferences.xml
+++ b/src/docs/manual/en/OmegaT_Preferences.xml
@@ -399,10 +399,21 @@
             <link linkend="windows.source.files.list" endterm="windows.source.files.list.title"></link>
             window can also be changed here.</para>
          <para>Scripts can be used to set predefined themes. OmegaT is bundled with
-            a script called 
+            a script called
             <link linkend="windows.scripts.distribution.switch.colour.theme" endterm="windows.scripts.distribution.switch.colour.theme.title"></link> that
-            provides a default dark theme. See the 
+            provides a default dark theme. See the
             <link linkend="windows.scripts" endterm="windows.scripts.title"></link> window for details.</para>
+         <para><guibutton>Export Scheme...</guibutton> writes your current colours
+            to a plain, human-readable <literal>.properties</literal> file (one
+            colour per line), which you can keep, share or edit in any text
+            editor. <guibutton>Import Scheme...</guibutton> reads such a file
+            back: the imported colours appear in the table at once and are
+            applied when you confirm with <guibutton>Apply</guibutton> or
+            <guibutton>OK</guibutton>, so <guibutton>Cancel</guibutton> discards
+            them. Unknown entries in an imported file are ignored, so schemes
+            stay compatible across versions. This exchanges only the editor
+            colours listed here, not the overall look and feel, which is chosen
+            separately under <guilabel>Appearance</guilabel>.</para>
          <note>
             <para>Automatic dark theme detection is available on Linux systems
                		with the Gnome/GTK look and feel for users who run OmegaT on OpenJDK.

--- a/src/docs/tips/de/share_colour_scheme.html
+++ b/src/docs/tips/de/share_colour_scheme.html
@@ -1,0 +1,44 @@
+<html lang="de">
+<!--
+  ~  OmegaT - Computer Assisted Translation (CAT) tool
+  ~           with fuzzy matching, translation memory, keyword search,
+  ~           glossaries, and translation leveraging into updated projects.
+  ~
+  ~  Copyright (C) 2026 Stephan Pakebusch
+  ~                Home page: https://www.omegat.org/
+  ~                Support center: https://omegat.org/support
+  ~
+  ~  This file is part of OmegaT.
+  ~
+  ~  OmegaT is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  OmegaT is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<head>
+    <meta charset="UTF-8">
+    <title>Farbschema weitergeben</title>
+    <link rel="stylesheet" type="text/css" href="../tips.css">
+</head><body>
+<h3 class="title">Farbschema weitergeben</h3>
+<p>Wenn die Editor-Farben nach Eurem Geschmack eingestellt sind, könnt Ihr sie
+    behalten und weitergeben. Unter <b>Optionen &gt; Einstellungen &gt;
+    Farben</b> speichert <b>Farbschema exportieren…</b> alle Farben in eine
+    kleine, menschenlesbare <code>.properties</code>-Datei.</p>
+<p><b>Farbschema importieren…</b> liest so eine Datei in jedem OmegaT ab
+    Version 6.2 wieder ein. Die importierten Farben erscheinen sofort in der
+    Tabelle und werden mit <b>Anwenden</b> oder <b>OK</b> übernommen —
+    <b>Abbrechen</b> verwirft sie einfach.</p>
+<p>Die Datei ist reiner Text: in jedem Editor zu öffnen, ein Wert schnell
+    anpassbar, oder an Kolleginnen und Kollegen weiterzureichen, damit alle
+    dieselbe Ansicht haben.</p>
+</body></html>

--- a/src/docs/tips/de/tips.yaml
+++ b/src/docs/tips/de/tips.yaml
@@ -72,3 +72,5 @@ tips:
   name: "Tag-Probleme untersuchen"
 - file: "ignore_dictionary_word.html"
   name: "Wörter im Wörterbuch ignorieren"
+- file: "share_colour_scheme.html"
+  name: "Farbschema weitergeben"

--- a/src/docs/tips/en/share_colour_scheme.html
+++ b/src/docs/tips/en/share_colour_scheme.html
@@ -1,0 +1,42 @@
+<html lang="en">
+<!--
+  ~  OmegaT - Computer Assisted Translation (CAT) tool
+  ~           with fuzzy matching, translation memory, keyword search,
+  ~           glossaries, and translation leveraging into updated projects.
+  ~
+  ~  Copyright (C) 2026 Stephan Pakebusch
+  ~                Home page: https://www.omegat.org/
+  ~                Support center: https://omegat.org/support
+  ~
+  ~  This file is part of OmegaT.
+  ~
+  ~  OmegaT is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  OmegaT is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<head>
+    <meta charset="UTF-8">
+    <title>Share your colour scheme</title>
+    <link rel="stylesheet" type="text/css" href="../tips.css">
+</head><body>
+<h3 class="title">Share your colour scheme</h3>
+<p>Once you have tuned the editor colours to your liking, you can keep and
+    share them. In <b>Options &gt; Preferences &gt; Colours</b>, use
+    <b>Export Scheme...</b> to save all your colours to a small, human-readable
+    <code>.properties</code> file.</p>
+<p><b>Import Scheme...</b> reads such a file back on any OmegaT 6.2 or later.
+    The imported colours show up in the table right away and take effect when
+    you click <b>Apply</b> or <b>OK</b> — so <b>Cancel</b> simply drops them.</p>
+<p>The file is plain text: you can open it in any editor, tweak a value, or
+    pass it to a colleague so everyone works with the same look.</p>
+</body></html>

--- a/src/docs/tips/en/tips.yaml
+++ b/src/docs/tips/en/tips.yaml
@@ -72,3 +72,5 @@ tips:
   name: Use Check Issues for tag problems
 - file: ignore_dictionary_word.html
   name: Ignore a word in the dictionary
+- file: share_colour_scheme.html
+  name: Share your colour scheme

--- a/src/main/java/org/omegat/gui/preferences/BasePreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/BasePreferencesController.java
@@ -69,6 +69,12 @@ public abstract class BasePreferencesController implements IPreferencesControlle
         }
     }
 
+    protected void fireTransientMessage(String message) {
+        for (FurtherActionListener listener : listeners) {
+            listener.showTransientMessage(message);
+        }
+    }
+
     public void setRestartRequired(boolean restartRequired) {
         this.restartRequired = restartRequired;
         fireRestartRequired();

--- a/src/main/java/org/omegat/gui/preferences/IPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/IPreferencesController.java
@@ -45,6 +45,13 @@ public interface IPreferencesController {
         void setReloadRequired(boolean reloadRequired);
 
         void setRestartRequired(boolean restartRequired);
+
+        /**
+         * Show a short-lived message in the preferences window, in the same
+         * place as the restart/reload notices. Default no-op.
+         */
+        default void showTransientMessage(String message) {
+        }
     }
 
     /**

--- a/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
@@ -800,6 +800,14 @@ public class PreferencesWindowController implements FurtherActionListener {
         }
     }
 
+    @Override
+    public void showTransientMessage(String message) {
+        outerPanel.messageTextArea.setText(message);
+        Timer timer = new Timer(APPLIED_MESSAGE_TIMEOUT_MS, e -> updateMessage());
+        timer.setRepeats(false);
+        timer.start();
+    }
+
     /**
      * Redisplay the current document so that saved preferences (e.g. colors)
      * take effect immediately. refreshView reloads the document the same way

--- a/src/main/java/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AppearanceController.java
@@ -136,9 +136,6 @@ public class AppearanceController extends BasePreferencesController {
                         .findFirst().orElse("");
             }
         });
-        panel.cbMenustyleSelect.addActionListener(e -> {
-            setRestartRequired(isModified());
-        });
 
         String[] lightLafs = lightThemeList.stream().map(LookAndFeelInfo::getClassName)
                 .toArray(String[]::new);
@@ -187,6 +184,10 @@ public class AppearanceController extends BasePreferencesController {
     private void initListeners() {
         panel.restoreWindowButton
                 .addActionListener(e -> Core.getMainWindow().resetDesktopLayout());
+        // Registered here, after initFromPrefs, so that populating the combo
+        // does not fire setRestartRequired before the theme radios are set,
+        // which made a fresh configuration wrongly demand a restart.
+        panel.cbMenustyleSelect.addActionListener(e -> setRestartRequired(isModified()));
         panel.cbLightThemeSelect.addActionListener(e -> setRestartRequired(isModified()));
         panel.cbDarkThemeSelect.addActionListener(e -> setRestartRequired(isModified()));
         panel.useDarkThemeRB.addActionListener(e -> setRestartRequired(isModified()));
@@ -223,7 +224,11 @@ public class AppearanceController extends BasePreferencesController {
             return true;
         }
         Object selected = panel.cbMenustyleSelect.getSelectedItem();
-        if (selected != null && !selected.toString().equals(Preferences.getPreference(Preferences.MENUUI_CLASS_NAME))) {
+        // Compare against the same effective default the combo was initialised
+        // with; comparing against the raw (empty) preference made a fresh
+        // configuration look modified and wrongly demanded a restart.
+        if (selected != null && !selected.toString().equals(Preferences.getPreferenceDefault(
+                Preferences.MENUUI_CLASS_NAME, MainMenuUI.class.getName()))) {
             return true;
         }
         if (themeMode.equals("sync")) {

--- a/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
@@ -29,26 +29,44 @@ package org.omegat.gui.preferences.view;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 
 import javax.swing.Icon;
+import javax.swing.JButton;
 import javax.swing.JColorChooser;
 import javax.swing.JComponent;
+import javax.swing.JFileChooser;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JSlider;
 import javax.swing.JSpinner;
 import javax.swing.colorchooser.AbstractColorChooserPanel;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.AbstractTableModel;
+
+import org.openide.awt.Mnemonics;
 
 import org.omegat.gui.preferences.BasePreferencesController;
 import org.omegat.gui.preferences.PreferencesWindowController;
+import org.omegat.util.Log;
 import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.util.gui.Styles.EditorColor;
 
 /**
@@ -58,6 +76,17 @@ import org.omegat.util.gui.Styles.EditorColor;
 public class CustomColorSelectionController extends BasePreferencesController {
 
     private static final int MAX_ROW_COUNT = 10;
+
+    // Heavily shortened project header, plus the note that colours without a
+    // fixed value follow the active look and feel and are therefore omitted.
+    private static final String[] EXPORT_HEADER = {
+        "# OmegaT colour scheme",
+        "# OmegaT is free/open-source software (GPLv3, https://omegat.org).",
+        "# This exported scheme is yours: use, share and modify it freely.",
+        "# Colours without a fixed value follow the active look and feel and",
+        "# are not listed. Each remaining line maps a colour to a #rrggbb value.",
+    };
+
     private final Map<EditorColor, Color> temporaryPreferences = new EnumMap<>(EditorColor.class);
     private ColorIcon icon;
     private CustomColorSelectionPanel panel;
@@ -96,6 +125,137 @@ public class CustomColorSelectionController extends BasePreferencesController {
         panel.colorStylesTable.setModel(new ColorTableModel());
         icon = new ColorIcon(panel.colorStylesTable.getRowHeight());
         panel.resetCurrentColorButton.addActionListener(e -> resetCurrentColor());
+        addImportExportButtons();
+    }
+
+    /**
+     * Add the theme import/export buttons to the same button column as the
+     * reset button, without touching the generated NetBeans form.
+     */
+    private void addImportExportButtons() {
+        Container buttonColumn = panel.resetCurrentColorButton.getParent();
+        JButton exportButton = new JButton();
+        Mnemonics.setLocalizedText(exportButton, OStrings.getString("GUI_COLORS_EXPORT"));
+        exportButton.addActionListener(e -> exportColors());
+        JButton importButton = new JButton();
+        Mnemonics.setLocalizedText(importButton, OStrings.getString("GUI_COLORS_IMPORT"));
+        importButton.addActionListener(e -> importColors());
+        buttonColumn.add(exportButton);
+        buttonColumn.add(importButton);
+    }
+
+    private JFileChooser colorSchemeChooser() {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setAcceptAllFileFilterUsed(true);
+        chooser.setFileFilter(new FileNameExtensionFilter(
+                OStrings.getString("GUI_COLORS_FILE_DESCRIPTION"), "properties"));
+        // Reopen in the folder used last time.
+        String lastDir = Preferences.getPreference(Preferences.COLOR_SCHEME_DIRECTORY);
+        if (!StringUtil.isEmpty(lastDir)) {
+            File dir = new File(lastDir);
+            if (dir.isDirectory()) {
+                chooser.setCurrentDirectory(dir);
+            }
+        }
+        return chooser;
+    }
+
+    private void rememberDirectory(File file) {
+        File dir = file.getParentFile();
+        if (dir != null) {
+            Preferences.setPreference(Preferences.COLOR_SCHEME_DIRECTORY, dir.getAbsolutePath());
+        }
+    }
+
+    private void exportColors() {
+        String title = Mnemonics.removeMnemonics(OStrings.getString("GUI_COLORS_EXPORT"));
+        JFileChooser chooser = colorSchemeChooser();
+        chooser.setDialogTitle(title);
+        chooser.setSelectedFile(new File(chooser.getCurrentDirectory(), "omegat-colours.properties"));
+        if (chooser.showSaveDialog(panel) != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+        File file = chooser.getSelectedFile();
+        if (file.exists() && JOptionPane.showConfirmDialog(panel,
+                OStrings.getString("GUI_COLORS_OVERWRITE_CONFIRM", file.getName()), title,
+                JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) {
+            return;
+        }
+        rememberDirectory(file);
+        // A plain, human-readable .properties file: one "EditorColor = #rrggbb"
+        // line per colour, in enum order. Same shape as the bundled
+        // ColorScheme_*.properties, and loadable with java.util.Properties.
+        int count = 0;
+        try (BufferedWriter w = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            for (String line : EXPORT_HEADER) {
+                w.write(line);
+                w.newLine();
+            }
+            for (EditorColor style : EditorColor.values()) {
+                Color color = temporaryPreferences.getOrDefault(style, style.getColor());
+                if (color != null) {
+                    w.write(style.name() + " = " + toHex(color));
+                    w.newLine();
+                    count++;
+                }
+            }
+            fireTransientMessage(OStrings.getString("GUI_COLORS_EXPORTED", count));
+        } catch (IOException ex) {
+            Log.log(ex);
+            JOptionPane.showMessageDialog(panel, ex.getLocalizedMessage(), title,
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void importColors() {
+        String title = Mnemonics.removeMnemonics(OStrings.getString("GUI_COLORS_IMPORT"));
+        JFileChooser chooser = colorSchemeChooser();
+        chooser.setDialogTitle(title);
+        if (chooser.showOpenDialog(panel) != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+        rememberDirectory(chooser.getSelectedFile());
+        Properties props = new Properties();
+        try (BufferedReader r = Files.newBufferedReader(chooser.getSelectedFile().toPath(),
+                StandardCharsets.UTF_8)) {
+            props.load(r);
+        } catch (IOException ex) {
+            Log.log(ex);
+            JOptionPane.showMessageDialog(panel, ex.getLocalizedMessage(), title,
+                    JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        int count = 0;
+        for (String key : props.stringPropertyNames()) {
+            EditorColor style = editorColorForName(key);
+            if (style == null) {
+                // Unknown key: ignore, so schemes stay forward-compatible.
+                continue;
+            }
+            try {
+                // Stage the colour only: it shows in the table at once but is
+                // applied by persist() on "Apply"/"OK", so "Cancel" discards it.
+                temporaryPreferences.put(style, Color.decode(props.getProperty(key).trim()));
+                count++;
+            } catch (NumberFormatException ex) {
+                Log.log(ex);
+            }
+        }
+        panel.colorStylesTable.repaint();
+        onSelectionChanged();
+        fireTransientMessage(OStrings.getString("GUI_COLORS_IMPORTED", count));
+    }
+
+    private static EditorColor editorColorForName(String name) {
+        try {
+            return EditorColor.valueOf(name);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private static String toHex(Color color) {
+        return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
     }
 
     private Optional<EditorColor> getSelection() {
@@ -195,6 +355,16 @@ public class CustomColorSelectionController extends BasePreferencesController {
 
     @Override
     public void restoreDefaults() {
+        // Nothing to reset if the colours already match their defaults; only
+        // ask for confirmation when there is something to lose.
+        if (!differsFromDefaults()) {
+            return;
+        }
+        if (JOptionPane.showConfirmDialog(panel, OStrings.getString("GUI_COLORS_RESTORE_CONFIRM"),
+                Mnemonics.removeMnemonics(OStrings.getString("PREFERENCES_BUTTON_RESET")),
+                JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) {
+            return;
+        }
         for (EditorColor style : EditorColor.values()) {
             temporaryPreferences.put(style, style.getDefault());
             // restoring the defaults is an explicit action and takes effect
@@ -205,6 +375,17 @@ public class CustomColorSelectionController extends BasePreferencesController {
         panel.colorStylesTable.clearSelection();
         onSelectionChanged();
         PreferencesWindowController.refreshEditorView();
+        fireTransientMessage(OStrings.getString("GUI_COLORS_RESTORED"));
+    }
+
+    private boolean differsFromDefaults() {
+        for (EditorColor style : EditorColor.values()) {
+            Color current = temporaryPreferences.getOrDefault(style, style.getColor());
+            if (!Objects.equals(current, style.getDefault())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -366,6 +366,11 @@ public final class Preferences {
     public static final String MARK_NON_UNIQUE_SEGMENTS = "mark_non_unique_segments";
 
     /**
+     * last folder used to import/export a colour scheme
+     */
+    public static final String COLOR_SCHEME_DIRECTORY = "color_scheme_directory";
+
+    /**
      * display modification info (author and modification date)
      */
     public static final String DISPLAY_MODIFICATION_INFO = "display_modification_info";

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2495,6 +2495,14 @@ COLOR_MACHINETRANSLATE_SELECTED_HIGHLIGHT=Machine translate highlight
 COLOR_MARK_ALT_TRANSLATION=Alternative translation highlight
 GUI_COLORS_COLOR=Item:
 GUI_COLORS_RESET_COLOR=&Reset Colour
+GUI_COLORS_EXPORT=E&xport Scheme...
+GUI_COLORS_IMPORT=&Import Scheme...
+GUI_COLORS_FILE_DESCRIPTION=OmegaT colour scheme (*.properties)
+GUI_COLORS_EXPORTED=Colour scheme exported: {0} entries.
+GUI_COLORS_IMPORTED=Colour scheme imported: {0} entries applied. Choose Apply or OK to keep them.
+GUI_COLORS_RESTORED=Colours reset to their default values.
+GUI_COLORS_OVERWRITE_CONFIRM=Overwrite the existing file "{0}"?
+GUI_COLORS_RESTORE_CONFIRM=Reset all colours to their default values?
 PREFS_TITLE_COLORS=Colours
 PREFS_COLOR_VALUE_PARSE_ERROR=Unable to set custom colour for {0}, defaulting to {1}.
 

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2359,6 +2359,14 @@ COLOR_MACHINETRANSLATE_SELECTED_HIGHLIGHT=Maschinelle-\u00DCbersetzung-Hervorheb
 COLOR_MARK_ALT_TRANSLATION=Alternative-\u00DCbersetzung-Hervorhebung
 GUI_COLORS_COLOR=Element:
 GUI_COLORS_RESET_COLOR=Fa&rbe zur\u00FCcksetzen
+GUI_COLORS_EXPORT=Farbschema e&xportieren...
+GUI_COLORS_IMPORT=Farbschema &importieren...
+GUI_COLORS_FILE_DESCRIPTION=OmegaT-Farbschema (*.properties)
+GUI_COLORS_EXPORTED=Farbschema exportiert: {0} Eintr\u00E4ge.
+GUI_COLORS_IMPORTED=Farbschema importiert: {0} Eintr\u00E4ge \u00FCbernommen; mit Anwenden oder OK behalten.
+GUI_COLORS_RESTORED=Farben auf Standardwerte zur\u00FCckgesetzt.
+GUI_COLORS_OVERWRITE_CONFIRM=Vorhandene Datei \u201E{0}\u201C \u00FCberschreiben?
+GUI_COLORS_RESTORE_CONFIRM=Alle Farben auf die Standardwerte zur\u00FCcksetzen?
 PREFS_TITLE_COLORS=Farben
 PREFS_COLOR_VALUE_PARSE_ERROR=Benutzerdefinierte Farbe f\u00FCr {0} kann nicht gesetzt werden, verwende standardm\u00E4\u00DFig {1}.
 


### PR DESCRIPTION
## Pull request type

- Feature -> [feature]

## Which ticket is resolved?

Importing/exporting custom colour themes - https://sourceforge.net/p/omegat/feature-requests/1399/

## What does this PR change?

- Adds **Export Scheme...** and **Import Scheme...** buttons to the Colours preferences panel. A colour scheme is a plain, human-readable Java `.properties` file with one `EditorColorName = #rrggbb` line per colour, in enum order — exactly the shape of the bundled `ColorScheme_light.properties` / `ColorScheme_dark.properties` and of the per-colour preference keys, so nothing new has to be learned or parsed.
- **Export** writes the currently effective colours, including edits that are still staged in the panel but not yet saved. It refuses to clobber an existing file without a yes/no confirmation, and remembers the folder for next time.
- **Import** reads such a file back, stages the colours into the table (they appear immediately) and applies them when you confirm with **Apply** or **OK**, so **Cancel** discards them. Keys that are not known editor colours are ignored, so schemes stay forward-compatible across versions; malformed values are skipped.
- **Restore defaults** in this panel now asks for confirmation, but only when the colours actually differ from their defaults.
- Export, import and reset each show a short confirmation with the number of colours involved, in the preferences window's message area — the same place the restart/reload notices appear. This goes through a new, small transient-message channel added to the preferences controller interface as a `default` method, so only the window implements it and no other controller has to change.
- Documentation: a paragraph in the Colours section of the manual and a "Share your colour scheme" tip of the day (en + de). A `*.hprof` rule was added to `.gitignore` (heap dumps from GUI runs must never be committed).
- The second commit is a small, related fix (see Other information): the Appearance panel no longer wrongly demands a restart after applying colours.

## Other information

**Scope / terminology.** This request is specifically about the *editor colours* — the marks and highlights configured under Preferences > Colours (the `Styles.EditorColor` values). It is deliberately **not** about the overall *look and feel* (the Swing Look-and-Feel / theme), which is chosen separately under Appearance and is provided by theme plugins. The two are easy to conflate, so the wording throughout (buttons, manual, tip) says "scheme" and keeps the look-and-feel out of it. The look-and-feel / theme side is already covered by earlier, closed tickets — e.g. SF-1567 (support theme plugins, choose theme in preferences), SF-1580 (theme plugin adjusts colour scheme/style), SF-1540 (add FlatLaf look and feel), SF-1513 (custom look and feel), SF-1653 (UI FlatLaf, wont-fix). SF-1514 (externalise default colour definitions) is what produced the `ColorScheme_*.properties` files this exchange format mirrors.

**Context — this is the logical continuation of recent colour work.** It builds directly on #2183 (apply colour changes without a restart, plus the Apply button this feature reuses), and follows #2182 (mark segments pre-translated in the source file), #2188 (keep enforced translations highlighted, SF-1171), #2190 (colour tags for right-to-left targets, SF-1122) and #2193 (mark segments where source = target, SF-1051). Import/export is the natural next step once colours are customisable and apply live: it lets users keep, share and version their colours.

**Only partly applied live so far — a dedicated follow-up PR is prepared.** #2183 made *marks* apply live, and this PR relies on that. However, several side panes (fuzzy matches, dictionary, machine translation, comments, notes, segment properties, the project files window, search results, glossary rendering, the issue providers) still read their colours once at construction, and `MatchesTextArea` caches some as static attribute sets. So a freshly imported colour that only those panes use will show fully only after a restart. Rather than sprinkle partial fixes here, the complete solution — a `CoreEvents.fireColorsChanged()` broadcast modelled on the existing `fireFontChanged()`, with every colour-consuming component re-applying on the event — is being done as its own focused PR that completes #2183 across the whole UI. Happy to reorder or fold that in if you prefer.

**The Appearance restart fix (second commit) — happy to split out.** While testing, applying a colour change raised "Restart OmegaT to apply these changes" on a fresh configuration, even though the change applies live. Root cause: the Colours panel is a child node of Appearance, and `AppearanceController` reported a spurious restart-required — its menu-style combo listener was registered before `initFromPrefs`, so populating the combo fired `setRestartRequired(isModified())` before the theme radios were initialised, and `isModified()` compared the menu style against the raw (empty) preference instead of its effective default. The fix registers the listener after initialisation (consistent with the theme listeners already there) and compares against the default the combo is filled with; a real theme/menu change still requests a restart. It is an independent, pre-existing bug and can move to its own PR if that is cleaner.

**How this was reviewed / the feedback rounds.** The feature went through several rounds of hands-on visual checks and adjustments before this PR:
1. Format decision: a plain `.properties` file was chosen over JSON/XML because it matches the existing colour-scheme files and the preference storage and needs almost no new code.
2. Naming: switched from "theme" to "scheme" (English) / "Farbschema" (German) to keep it distinct from the look-and-feel theme.
3. Export contents: it exports the 42 colours that have a concrete value; the 16 that have no fixed value follow the active look and feel and are intentionally omitted, with a short note in the file header (which also carries a shortened, GPL/free-and-open project header).
4. Import semantics: reworked from "apply immediately" to "stage in the table, apply only on Apply/OK, discard on Cancel", per request.
5. Usability: the buttons remember the last-used folder; a short confirmation is shown, and it was moved from an ad-hoc label into the window's message area to match the restart/reload notices; the confirmation now reports the number of colours; export asks before overwriting; reset asks for confirmation and also reports success.
6. A final, deliberately adversarial code review (fresh reviewer) flagged: exporting over an existing file without confirmation, the mnemonic `&` leaking into dialog titles, and the confirmation always claiming success — all fixed here. It also confirmed that Cancel truly discards (a fresh controller is created each time the dialog opens) and that the Appearance fix does not suppress any legitimate restart prompt. Lower-severity notes (OOM on a deliberately huge file, freezing a look-and-feel-derived colour via a hand-edited file, no auto-added extension, the programmatic button placement relying on the generated form's container) were considered and left as-is.

Tested manually with small EN->DE / EN->AR / EN->HE projects: export produces a readable file, import stages and applies as described, Cancel discards, overwrite and reset prompts behave, and the counts and confirmations appear in the right place. Full test suite and checkstyle are green.

### screenshots

export …
<img width="888" height="687" alt="Bildschirmfoto 2026-07-28 um 17 57 00" src="https://github.com/user-attachments/assets/50eb836c-633d-4e46-9ee3-a3d3af5ed8fe" />

edit ...
<img width="639" height="251" alt="Bildschirmfoto 2026-07-28 um 17 57 54" src="https://github.com/user-attachments/assets/36e730d1-458e-4366-93bc-d5e0e40c7684" />

import ...
<img width="897" height="49" alt="Bildschirmfoto 2026-07-28 um 17 58 20" src="https://github.com/user-attachments/assets/eadd389e-f5dc-492c-9480-089d085b797f" />



integrating my/your/our/these (take a pick) PR's locally …

<img width="1209" height="581" alt="Bildschirmfoto 2026-07-28 um 17 47 45" src="https://github.com/user-attachments/assets/e85e4f3d-7b10-4d55-9f87-fa177270de49" />

noticed merge conflict, amending cause, less conflict surface, blah blah i could produce walls of text faster than you could read and i am sorry for that and this will not go on forever for sure but right now i'm having a productive phase, so, here it is. next time less text, promised.