### PR TITLE
chore(gradle): exclude `lucene-analysis-kuromoji` in language-ja module dependencies

### DIFF
--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -8,12 +8,13 @@ dependencies {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/icu4j-*.jar'])
         implementation fileTree(dir: providedModuleLibsDir,
-                includes: ['**/language-ja-*.jar', '**/lucene-gosen-*.jar'])
+                includes: ['**/language-ja-*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)
         implementation(libs.languagetool.ja) {
             exclude module: 'languagetool-core'
+            exclude module: 'lucene-analysis-kuromoji'
         }
         compileOnly(libs.icu4j)
     }


### PR DESCRIPTION
Ref PR #2200

## Pull request type
- Other (describe below)
dependency duplication
## Which ticket is resolved?
None
## What does this PR change?

- PR#2200 point out kuromoji jar is duplicated in the distribution

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
