### PR TITLE
chore(gradle): fix macOS build tasks

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
@@ -14,8 +14,10 @@ dependencies {
     genMac(libs.evolvedbinary.appbundler)
 }
 
+def ops = project.objects.newInstance(InjectedOps)
 tasks.register('genMac') {
     def appbundlerClasspath = configurations.genMac.asPath
+    def iconFile = layout.settingsDirectory.file('images/OmegaT.icns').asFile.absolutePath
     def outDir = layout.buildDirectory.dir("appbundler")
     def appName = project.property('org.omegat.appName')
     def appClass = project.property('org.omegat.mainClassName')
@@ -24,7 +26,6 @@ tasks.register('genMac') {
     // $APP_ROOT is expanded at runtime by the launcher binary
     def configFile = '$APP_ROOT/Contents/Resources/Configuration.properties'
     def macSpecificDir = layout.projectDirectory.dir('release/mac-specific/OmegaT.app')
-    def fs = project.objects.newInstance(InjectedOps).fs
 
     description = 'Generates the macOS .app skeleton. Depends on AppBundler (https://github.com/TheInfiniteKind/appbundler).'
     inputs.files(configurations.genMac)
@@ -35,6 +36,7 @@ tasks.register('genMac') {
     inputs.property('ver', ver)
     inputs.property('jvmRequired', jvmRequired)
     inputs.property('configFile', configFile)
+    inputs.property('iconFile', iconFile)
     inputs.dir(macSpecificDir)
             .withPropertyName('macSpecificOverrides')
             .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -51,7 +53,7 @@ tasks.register('genMac') {
                 displayname: appName,
                 executablename: appName,
                 identifier: 'org.omegat.OmegaT',
-                icon: 'images/OmegaT.icns',
+                icon: iconFile,
                 version: ver,
                 jvmrequired: jvmRequired,
                 shortversion: ver,
@@ -63,13 +65,13 @@ tasks.register('genMac') {
             bundledocument(extensions: 'project',
                     name: "${appName} Project",
                     role: 'editor',
-                    icon: 'images/OmegaT.icns')
+                    icon: iconFile)
             bundledocument(extensions: '*',
                     name: 'All Files',
                     role: 'none')
             plistentry(key: 'JVMRuntime', value: 'jre.bundle')
         }
-        fs.copy {
+        ops.fs.copy {
             from(macSpecificDir) {
                 include '**/*.lproj/Localizable.strings'
             }
@@ -153,7 +155,17 @@ ext.makeMacTask = { args ->
     def parentTask = tasks.getByName(args.parentTaskName)
     def versionPart = project.ext.omtVersion.version + project.ext.omtVersion.beta
     def appName = project.property('org.omegat.appName')
-    def outDir = layout.buildDirectory.dir("install/${appName}-${versionPart}-${args.suffix}").get().asFile
+
+    def outDir = layout.buildDirectory.dir("install/${appName}-${versionPart}-${args.suffix}")
+    def entitlementsFile = project.layout.projectDirectory.file('release/mac-specific/java.entitlements')
+    def jreDir = outDir.map {it.dir("OmegaT.app/Contents/PlugIns/jre.bundle")}
+    def inputJar = layout.buildDirectory.file('libs/OmegaT.jar')
+    def bundledJar = outDir.map { it.file("OmegaT.app/Contents/Java/OmegaT.jar")}
+
+    def macSigned = project.hasProperty('macCodesignIdentity')
+    def macCodesignIdentity = macSigned ? project.property('macCodesignIdentity').toString() : null
+    def signedDistDir = layout.buildDirectory.file("install/${appName}-${versionPart}-${args.suffix}_Signed")
+    def appBundleDir = layout.buildDirectory.file("install/${appName}-${versionPart}-${args.suffix}_Signed/OmegaT.app")
 
     def installTask = tasks.register(installTaskName, Sync) {
         description = 'Builds the macOS distribution.'
@@ -177,24 +189,26 @@ ext.makeMacTask = { args ->
             }
         }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        destinationDir = outDir
+        destinationDir = outDir.get().asFile
         outputs.upToDateWhen {
             // detect up-to-date when OmegaT.jar exists and newer than libs/OmegaT.jar
-            def f1 = file("$destinationDir/OmegaT.app/Contents/Java/OmegaT.jar")
-            def f2 = base.libsDirectory.file('OmegaT.jar').get().asFile
+            def f1 = bundledJar.get().asFile
+            def f2 = inputJar.get().asFile
             f1.exists() && f2.exists() && f1.lastModified() > f2.lastModified()
         }
         doFirst {
-            delete "$destinationDir/OmegaT.app/Contents/PlugIns/jre.bundle"
+            ops.fs.delete {
+                delete(jreDir.get().asFile)
+            }
         }
         group = 'distribution'
     }
 
-    def signedInstallTask = tasks.register(signedInstallTaskName, Sync) {
+    tasks.register(signedInstallTaskName, Sync) {
         description = 'Builds the signed macOS distribution. Requires an Apple Developer Account.'
         onlyIf {
             // Set this in e.g. local.properties
-            conditions([project.hasProperty('macCodesignIdentity'), 'Code signing property not set'],
+            conditions([macSigned, 'Code signing property not set'],
                     [args.jrePath && !args.jrePath.empty, 'JRE not found'],
                     [exePresent('codesign'), 'codesign command is not present in system.'])
         }
@@ -207,19 +221,16 @@ ext.makeMacTask = { args ->
             from(files(signedNativeLibJarTasks))
         }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        destinationDir = file(layout.buildDirectory.file("install/${application.applicationName}-${versionPart}-${args.suffix}_Signed"))
-        doFirst {
-            delete "$destinationDir/OmegaT.app/Contents/PlugIns/jre.bundle"
-        }
-        def macCodesignIdentity = project.findProperty('macCodesignIdentity')
+        destinationDir = signedDistDir.get().asFile
         doLast {
+            def appBundle = appBundleDir.get().asFile
             injected.execOps.exec {
                 commandLine 'codesign', '--deep', '--force',
                         '--sign', macCodesignIdentity,
                         '--timestamp',
                         '--options', 'runtime',
-                        '--entitlements', file('release/mac-specific/java.entitlements'),
-                        file("${destinationDir}/OmegaT.app")
+                        '--entitlements', entitlementsFile,
+                        appBundle
             }
         }
         group = 'distribution'

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ org.omegat.firstStepLangs=ca,co,de,en,fr,ia,it,ja,nl,pt_BR,zh_CN
 org.omegat.mac.jvmRequired=21+
 
 # JVM settings for run and test tasks
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 runMaxHeapSize=1024M
 testMaxHeapSize=2048M
 


### PR DESCRIPTION
macOS build tasks does not work when configuration cache enalbed.
This fix the problems.

## Pull request type

- Build and release changes -> [build/release]


## Which ticket is resolved?
latest weekly build failed. 

## What does this PR change?

- use provider for destinationDir configuration
- remove $destinationDir from if block
- replace project.delete method to injectedOps

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
