### PR TITLE
docs(devel/adr): add ADR for theme, color, and presentation architecture

### DIFF
--- a/src/docs/developer/84.ThemeColorAndPresentation.md
+++ b/src/docs/developer/84.ThemeColorAndPresentation.md
@@ -1,0 +1,142 @@
+# Theme, colour, and presentation architecture
+
+This page documents how OmegaT resolves colours and other presentation attributes for
+segment markers (active source, untranslated, fuzzy match highlights, and so on), and how
+Theme, `Styles`, and Preferences layer on top of each other. It exists to give contributors
+a map of the existing mechanism before proposing changes to it (for example, extending it
+to cover formatting, audio, or accessibility labels; see
+[ADR 2026003](adr/2026003.PresentationAndAccessibility.md)).
+
+There are three layers, resolved in order: Theme default, `Styles` registry, Preferences
+override.
+
+## 1. Theme: `UIDefaults` keys under the `OmegaT.*` namespace
+
+A Theme is a `LookAndFeel` implementation, installed via
+`UIDesignManager.setTheme(String lafClassName)`. In addition to the usual Swing LaF keys, an
+OmegaT theme also seeds a set of application-specific colours as `UIDefaults` entries under
+the `OmegaT.` prefix, for example `OmegaT.activeSource`, `OmegaT.untranslated`,
+`OmegaT.terminology`.
+
+Concretely, `DefaultFlatDarkTheme.getDefaults()` builds on `FlatDarkLaf`, then calls a
+private `setDarkDefaults(UIDefaults)` method that does, among other things:
+
+```java
+defaults.put("OmegaT.activeSource", new Color(0x287128));
+defaults.put("OmegaT.untranslated", new Color(0x4d4daa));
+defaults.put("OmegaT.terminology", new Color(0x8f5500));
+// ...
+```
+
+`DefaultFlatLightTheme` (light) does the equivalent for the light variant, in the `theme`
+Gradle module. `DefaultFlatTheme` (in `src/main/java`) is a shared base used by both — it
+supplies the `newUI.*` icon keys and the `adjustRGB` helper, not the marker colours
+themselves. Each installed theme is free to define its own values for every `OmegaT.*` key;
+nothing requires a theme to supply all of them.
+
+### Fallback: bundled colour scheme properties
+
+If, after a theme is installed, `UIManager.getColor("OmegaT.source")` is still `null` (the
+theme did not define the OmegaT-specific keys at all — relevant for third-party theme
+plugins), `UIDesignManager.initialize()` falls back to loading
+`src/main/resources/org/omegat/ColorScheme_dark.properties` or `ColorScheme_light.properties`
+via `ResourcesUtil.getBundleColorProperties(style)` and `UIDesignManager.loadDefaultColors`.
+This is a safety net for incomplete themes, not the primary path for the bundled themes.
+
+### Theme plugin constraint
+
+Theme plugins register their LaF class with the shared `UIManager`, which requires global
+visibility. This is why theme plugins share one ClassLoader rather than getting per-plugin
+isolation; see [ADR 2025012](adr/2025012.PluginSecurityArchitecture.md) for the full
+rationale.
+
+## 2. Registry: `org.omegat.util.gui.Styles` (`EditorColor` enum)
+
+Application code never reads `UIManager.getColor("OmegaT.xxx")` directly for marker colours.
+It goes through `Styles.EditorColor`, an enum where each constant corresponds to one marker
+and resolves its default from the active theme at construction time:
+
+```java
+COLOR_ACTIVE_SOURCE(OStrings.getString("COLOR_ACTIVE_SOURCE"),
+        UIManager.getColor("OmegaT.activeSource")),
+COLOR_UNTRANSLATED(OStrings.getString("COLOR_UNTRANSLATED"),
+        UIManager.getColor("OmegaT.untranslated")),
+```
+
+A few constants (for example `COLOR_PROJECT_FILES_PROGRESS_LOW`) use a three-argument
+constructor that supplies a hard-coded hex fallback if the `UIManager` key is absent, instead
+of depending on the theme having set it. A handful of constants (for example
+`COLOR_ACTIVE_SOURCE_FG`, `COLOR_GLOSSARY_SOURCE`) have no theme-backed default at all and
+rely entirely on a Preferences value or remain `null` until one is set.
+
+`EditorColor` is a registry, not just a lookup: at construction it also calls
+`setColorFromPreference()`, which is where layer 3 comes in.
+
+## 3. Preferences override
+
+Each `EditorColor` constant stores the user override under a Preferences key equal to its own
+enum name (`Preferences.getPreferenceDefault(name(), null)`, for example the preference key
+for `COLOR_ACTIVE_SOURCE` is literally `"COLOR_ACTIVE_SOURCE"`). If a preference value is
+present and is not the sentinel `"__DEFAULT__"`, it overrides the theme-derived colour.
+`setColor(Color)` is the write path used by the Colours preference panel
+(`org.omegat.gui.preferences.view.CustomColorSelectionController` /
+`AppearanceController`); passing the theme's own default writes back the `"__DEFAULT__"`
+sentinel rather than a literal colour, so switching themes later is not masked by a
+stale override.
+
+## Resolution order, summarized
+
+```
+Theme (UIDefaults "OmegaT.*")
+   -> fallback: ColorScheme_{dark,light}.properties  (only if theme omitted a key)
+-> Styles.EditorColor default (read once, at enum construction, from UIManager)
+-> Preferences override (checked at construction, and whenever setColor() is called)
+```
+
+Because `EditorColor` reads its default once per JVM at enum construction, changing the
+active theme at runtime does not retroactively change `EditorColor` defaults already
+resolved; theme switches are applied on restart (see `switch_colour_theme.js` script
+documentation for the user-facing workaround of a scripted theme swap).
+
+## Formatting attributes already exist, independent of colour
+
+`Styles.createAttributeSet(...)` already accepts bold, italic, strikethrough, and underline
+flags in addition to foreground/background colour, and returns a Swing `AttributeSet` used to
+render segment text:
+
+```java
+public static AttributeSet createAttributeSet(Color fg, Color bg,
+        Boolean bold, Boolean italic, Boolean strikethrough, Boolean underline)
+```
+
+This means the formatting channel is not new plumbing to invent; it is already wired at the
+`AttributeSet` level. What does not exist yet is a per-marker-category *configuration* for
+these flags (comparable to what `EditorColor` provides for colour) or a Theme/Preferences
+resolution chain for them. Any proposal to add formatting as a configurable channel should
+extend `EditorColor` (or a sibling registry following the same three-layer pattern) to also
+carry these flags, rather than adding a separate formatting mechanism.
+
+## What is not covered by this mechanism
+
+- **Audio/sound cues** and **accessibility labels/descriptions** have no equivalent registry
+  today; there is no `OmegaT.*` UIDefaults convention or `Styles` enum for either.
+- The chain above governs *colour and, at the `AttributeSet` level, text formatting*. It says
+  nothing about how a value is synchronised or persisted beyond the single
+  `Preferences.setPreference(name(), ...)` call — that is a separate, already-solved concern
+  (see [ADR 2026002](adr/2026002.PreferencesArchitecture.md) for the Preferences store's own
+  testability architecture, which this page does not depend on or duplicate).
+
+## Related documents
+
+- [ADR 2025012 — Plugin Security Architecture and ClassLoader Isolation](adr/2025012.PluginSecurityArchitecture.md)
+  (theme plugin ClassLoader sharing)
+- [ADR 2026003 — Unified Presentation and Accessibility](adr/2026003.PresentationAndAccessibility.md)
+  (proposal to extend this mechanism to formatting, audio, and accessibility channels)
+- [ADR 2026004 — EditorColor Registry Consistency](adr/2026004.EditorColorRegistryConsistency.md)
+  (the three default-resolution patterns described above for the two-, three-, and one-argument
+  `EditorColor` constructors are inconsistent; this ADR proposes unifying them before 2026003
+  extends the registry to further channels)
+- `org.omegat.util.gui.Styles`, `org.omegat.util.gui.UIDesignManager`,
+  `org.omegat.gui.theme.DefaultFlatTheme`, `org.omegat.gui.theme.DefaultFlatLightTheme`,
+  `org.omegat.gui.theme.DefaultFlatDarkTheme`
+- [Coding styles — Swing GUI design](30.CodingStyles.md)

--- a/src/docs/developer/adr/2026004.EditorColorRegistryConsistency.md
+++ b/src/docs/developer/adr/2026004.EditorColorRegistryConsistency.md
@@ -56,17 +56,22 @@ cheaper to unify the registry first.
 
 ## Decision
 
-**Decision A.** Every `EditorColor` entry will have a real, theme-resolvable default. Concretely:
+**Decision A.** Every `EditorColor` entry will have a real, theme-resolvable default,
+reached via the standard two-argument, theme-backed constructor:
 
 - The three Source Files progress colours gain corresponding `OmegaT.*` keys in both
-  `DefaultFlatLightTheme` and `DefaultFlatDarkTheme` (using the current hardcoded values as
-  the starting colour choice, subject to normal visual/contrast review), and move from the
-  three-argument constructor to the standard two-argument, theme-backed constructor.
+  `DefaultFlatLightTheme` and `DefaultFlatDarkTheme`, and move off the three-argument
+  constructor.
 - The ~15 theme-less entries gain corresponding `OmegaT.*` keys in both bundled themes as
-  well, and move from the one-argument constructor to the two-argument constructor. Colour
-  choices for these are a design task (some are meant to equal or derive from an existing
-  paired colour, e.g. a foreground counterpart of an existing background marker), not a
-  mechanical copy of anything already in code, since no value currently exists to copy.
+  well, and move off the one-argument constructor.
+
+This is an architecture decision, not a design decision: it is about *where* each default
+lives (theme-backed key vs. hardcoded literal vs. absent), not about what the colour values
+should be. Selecting the actual colour values is an implementation detail left to the PR that
+carries out this change, not decided here. In particular, no visual change is intended as a
+result of this ADR: for the three progress-colour entries a value already exists (the current
+hardcoded literal) and the expectation is that it carries over unchanged; this ADR does not
+mandate that expectation, it simply is not proposing a redesign.
 
 **Decision B.** Once Decision A is complete, remove the one-argument and three-argument
 `EditorColor` constructors entirely, leaving a single canonical two-argument, theme-backed
@@ -92,12 +97,15 @@ two bundled themes carrying inconsistent defaults internally.
   override short of also touching Preferences.
 
 ### Negative
-- Requires adding ~18 new keys to both `DefaultFlatLightTheme` and `DefaultFlatDarkTheme`,
-  which is a visual design task, not a mechanical refactor — reasonable default colours have
-  to be chosen for entries that have never had one.
+- Requires adding ~18 new keys to both `DefaultFlatLightTheme` and `DefaultFlatDarkTheme`.
+  Colour value selection for this is out of scope of this ADR and left to the implementation
+  PR; it is not a purely mechanical change for the ~15 entries that have never had a
+  theme-backed value before, since there is nothing existing to carry over for those.
 - Any third-party theme plugin, or a user relying on the current "null means inherit
   component default" behaviour for one of the fifteen theme-less markers, may see a visible
-  colour change once a real default is introduced.
+  colour change once a real default is introduced there. This risk does not apply to the
+  three progress-colour entries, where the existing hardcoded literal is expected to carry
+  over unchanged.
 - Removing the one- and three-argument constructors is a breaking change to `Styles.java`'s
   internal API surface (not a public/plugin API, but touches every affected enum literal in
   one changeset).

--- a/src/docs/developer/adr/2026004.EditorColorRegistryConsistency.md
+++ b/src/docs/developer/adr/2026004.EditorColorRegistryConsistency.md
@@ -1,0 +1,114 @@
+# ADR: EditorColor Registry Consistency
+
+## Status
+**Proposed** (Date: 2026-08-02)
+
+## Context
+
+`org.omegat.util.gui.Styles.EditorColor` is the registry that mediates between Theme,
+application code, and Preferences for every segment marker colour (see the mechanism
+reference in [84.ThemeColorAndPresentation.md](../84.ThemeColorAndPresentation.md)). An audit
+of the enum, done while reviewing [ADR 2026003](2026003.PresentationAndAccessibility.md),
+found that its ~50 entries are declared through three different constructors, each with a
+different default-resolution behaviour:
+
+1. **Two-argument, theme-backed** (the majority of entries): the default is
+   `UIManager.getColor("OmegaT.xxx")`, i.e. whatever the active theme defines.
+   Example: `COLOR_ACTIVE_SOURCE(displayName, UIManager.getColor("OmegaT.activeSource"))`.
+
+2. **Three-argument, hardcoded fallback** (3 entries — the Source Files progress colours):
+   the default is `UIManager.getColor(uiManagerKey)` if present, otherwise a literal hex
+   colour compiled into `Styles.java`:
+   ```java
+   COLOR_PROJECT_FILES_PROGRESS_LOW(displayName, "OmegaT.projectFilesProgressLow", "#f0b8b4"),
+   COLOR_PROJECT_FILES_PROGRESS_HIGH(displayName, "OmegaT.projectFilesProgressHigh", "#b7d7b7"),
+   COLOR_PROJECT_FILES_PROGRESS_COMPLETE(displayName, "OmegaT.projectFilesProgressComplete", "#b8ccf0"),
+   ```
+   Neither `DefaultFlatLightTheme` nor `DefaultFlatDarkTheme` defines these three
+   `OmegaT.*` keys, so the hardcoded literal is not a rare fallback — it is the value every
+   user of the two bundled themes actually gets today.
+
+3. **One-argument, no theme default** (roughly 15 entries): `defaultColor` is `null` at
+   construction, and the resolved colour stays `null` unless a Preferences value has been
+   set. No `OmegaT.*` UIDefaults key exists for these at all, in either bundled theme.
+   Example: `COLOR_ACTIVE_TARGET(displayName)`, and similarly
+   `COLOR_ACTIVE_SOURCE_FG`, `COLOR_ACTIVE_TARGET_FG`, `COLOR_SEGMENT_MARKER_FG`,
+   `COLOR_SEGMENT_MARKER_BG`, `COLOR_SOURCE_FG`, `COLOR_NOTED_FG`, `COLOR_UNTRANSLATED_FG`,
+   `COLOR_TRANSLATED_FG`, `COLOR_NON_UNIQUE_BG`, `COLOR_MOD_INFO`, `COLOR_MOD_INFO_FG`,
+   `COLOR_GLOSSARY_SOURCE`, `COLOR_GLOSSARY_TARGET`, `COLOR_GLOSSARY_NOTE`,
+   `COLOR_MATCHES_DEL_ACTIVE`, `COLOR_MATCHES_DEL_INACTIVE`. Consumers such as
+   `EditorSettings.getAttributeSet()` call `.getColor()` on these directly and pass the
+   (possibly null) result straight into `Styles.createAttributeSet()`; there is no
+   null-handling fallback at the call site either.
+
+Pattern (2) means a theme author has no reliable way to make the Source Files progress
+colours part of their palette without also relying on undocumented code-level defaults.
+Pattern (3) means a theme author — including a hypothetical high-contrast/accessibility
+theme, one of the options raised in the persona review behind 2026003 — cannot control
+those ~15 markers via the Theme layer at all; the only way to set them is per-user
+Preferences, which is not something a theme can ship.
+
+This is directly relevant to 2026003. That ADR's decision is to extend the theme-to-registry-
+to-preference chain to additional presentation channels (formatting, audio, accessibility
+labels) uniformly across markers. Doing that on top of the current registry means propagating
+three inconsistent default-resolution patterns across N new channels instead of one. It is
+cheaper to unify the registry first.
+
+## Decision
+
+**Decision A.** Every `EditorColor` entry will have a real, theme-resolvable default. Concretely:
+
+- The three Source Files progress colours gain corresponding `OmegaT.*` keys in both
+  `DefaultFlatLightTheme` and `DefaultFlatDarkTheme` (using the current hardcoded values as
+  the starting colour choice, subject to normal visual/contrast review), and move from the
+  three-argument constructor to the standard two-argument, theme-backed constructor.
+- The ~15 theme-less entries gain corresponding `OmegaT.*` keys in both bundled themes as
+  well, and move from the one-argument constructor to the two-argument constructor. Colour
+  choices for these are a design task (some are meant to equal or derive from an existing
+  paired colour, e.g. a foreground counterpart of an existing background marker), not a
+  mechanical copy of anything already in code, since no value currently exists to copy.
+
+**Decision B.** Once Decision A is complete, remove the one-argument and three-argument
+`EditorColor` constructors entirely, leaving a single canonical two-argument, theme-backed
+constructor. This is a deliberate constraint on the enum's API surface so that a future
+contributor — including whoever implements 2026003's additional channels — cannot
+reintroduce a theme-less or hardcoded-fallback entry.
+
+The existing `ColorScheme_{dark,light}.properties` fallback in `UIDesignManager` (used only
+when a *third-party* theme omits `OmegaT.*` keys entirely) is unaffected by this decision; it
+remains the safety net for incomplete external themes, which is a different concern from the
+two bundled themes carrying inconsistent defaults internally.
+
+## Consequences
+
+### Positive
+- Every marker becomes fully definable by a theme, which is required groundwork for a
+  high-contrast or otherwise accessibility-oriented theme, one of the resolutions proposed in
+  2026003 for the persona review's contrast-audit item.
+- 2026003's planned extension of the registry to formatting/audio/accessibility-label
+  channels can follow one constructor pattern instead of reconciling three.
+- Removes a currently silent behaviour (the hardcoded progress-colour fallback applies to the
+  bundled themes today, not just hypothetical incomplete ones) that no theme author can
+  override short of also touching Preferences.
+
+### Negative
+- Requires adding ~18 new keys to both `DefaultFlatLightTheme` and `DefaultFlatDarkTheme`,
+  which is a visual design task, not a mechanical refactor — reasonable default colours have
+  to be chosen for entries that have never had one.
+- Any third-party theme plugin, or a user relying on the current "null means inherit
+  component default" behaviour for one of the fifteen theme-less markers, may see a visible
+  colour change once a real default is introduced.
+- Removing the one- and three-argument constructors is a breaking change to `Styles.java`'s
+  internal API surface (not a public/plugin API, but touches every affected enum literal in
+  one changeset).
+
+## Related Documents
+
+- [84.ThemeColorAndPresentation.md](../84.ThemeColorAndPresentation.md) — mechanism reference
+  this ADR's Context is based on
+- [ADR 2026003 — Unified Presentation and Accessibility](2026003.PresentationAndAccessibility.md)
+  — depends on this ADR's registry being consistent before extending it to further channels
+- [ADR 2025012 — Plugin Security Architecture and ClassLoader Isolation](2025012.PluginSecurityArchitecture.md)
+  — theme plugin ClassLoader constraint, unaffected by this decision
+- `org.omegat.util.gui.Styles`, `org.omegat.gui.theme.DefaultFlatLightTheme`,
+  `org.omegat.gui.theme.DefaultFlatDarkTheme`, `org.omegat.util.gui.UIDesignManager`

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -12,6 +12,7 @@
 - 2025012 [Plugin Security Architecture and ClassLoader Isolation](2025012.PluginSecurityArchitecture.md)
 - 2025013 [Machine Translation SPI with multi-level context](2025013.MultiLevelContextSupportForMT.md)
 - 2026002 [Preferences Architecture and Testable Store Injection](2026002.PreferencesArchitecture.md)
+- 2026004 [EditorColor Registry Consistency](2026004.EditorColorRegistryConsistency.md)
 
 ## Core features
 

--- a/src/docs/developer/index.md
+++ b/src/docs/developer/index.md
@@ -74,7 +74,7 @@
 * [External Finder](81.ExternalFinder.md)
 * [How OmegaT create Backup files](82.BackupFiles.md)
 * [Team project](83.TeamProject.md)
-
+* [Theme, colour, and presentation architecture](84.ThemeColorAndPresentation.md)
 
 ## Architecture Designs/change log 
 


### PR DESCRIPTION
ADR#2026003 proposed an issue around UI/UX for accessibility in the PR #2204.
This is additional ADR that focus in the architecture in the OmegaT core how to handle colours of theme/markers/preferences.

Unfortunately, OmegaT core has an inconsistent in the architecture. This ADR propose a design and direction for the fix.

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?


## What does this PR change?

-
-
-

## Other information

Ref #2204