### PR TITLE
chore(ci): update JRE download to retry when error

### DIFF
--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -64,14 +64,17 @@ jobs:
           sudo apt-get install -y rpm
 
       - name: Download JRE (${{ matrix.arch }})
+        env:
+          JRE_URL: ${{ matrix.jre_url }}
         run: |
-          mkdir -p asset
-          cd asset
-          curl -L -O ${{ matrix.jre_url }}
+          mkdir -p "$RUNNER_TEMP/asset"
+          JRE_FILE="$RUNNER_TEMP/asset/$(basename "$JRE_URL")"
+          curl -fL "${{ env.JRE_URL }}" -o "$JRE_FILE"
+          tar tf "$JRE_FILE" | head -30
 
       - name: Build distributions
         run: |
-          ./gradlew ${{ matrix.gradle_tasks }} -PassetDir=asset --build-cache -PenvIsCi
+          ./gradlew ${{ matrix.gradle_tasks }} --build-cache -PenvIsCi "-PassetDir=$RUNNER_TEMP/asset"
 
       - name: Record project version into artifact
         run: |

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -33,14 +33,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-            jre_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_linux_hotspot_25.0.3_9.tar.gz
-            gradle_tasks: linuxDistDeb linuxDistRpm linuxArm64DistTarBz
-          - arch: amd64
-            runner: ubuntu-latest
-            jre_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_linux_hotspot_25.0.3_9.tar.gz
-            gradle_tasks: linuxDistDeb linuxDistRpm linux64DistTarBz
+        - arch: arm64
+          runner: ubuntu-24.04-arm
+          jre25_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_linux_hotspot_25.0.3_9.tar.gz
+          jre17_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.19_10.tar.gz
+          gradle_tasks: linuxDistDeb linuxDistRpm linuxArm64DistTarBz
+        - arch: amd64
+          runner: ubuntu-latest
+          jre25_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_linux_hotspot_25.0.3_9.tar.gz
+          jre17_url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_linux_hotspot_17.0.19_10.tar.gz
+          gradle_tasks: linuxDistDeb linuxDistRpm linux64DistTarBz
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
@@ -65,12 +67,21 @@ jobs:
 
       - name: Download JRE (${{ matrix.arch }})
         env:
-          JRE_URL: ${{ matrix.jre_url }}
+          TARGET_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+          JRE17_URL: ${{ matrix.jre17_url }}
+          JRE25_URL: ${{ matrix.jre25_url }}
         run: |
+          set -euo pipefail
           mkdir -p "$RUNNER_TEMP/asset"
-          JRE_FILE="$RUNNER_TEMP/asset/$(basename "$JRE_URL")"
-          curl -fL "${{ env.JRE_URL }}" -o "$JRE_FILE"
+          if [[ "$TARGET_BRANCH" == "releases/6.1" ]]; then
+            URL="$JRE17_URL"
+          else
+            URL="$JRE25_URL"
+          fi
+          JRE_FILE="$RUNNER_TEMP/asset/$(basename "$URL")"
+          curl -fL --retry 5 --retry-delay 5 --retry-all-errors "$URL" -o "$JRE_FILE"
           tar tf "$JRE_FILE" | head -30
+
 
       - name: Build distributions
         run: |


### PR DESCRIPTION
improve CI/CD publish linux script to retry when error.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none

## What does this PR change?

- Download JRE versions based on branch name
- Add --retry -f flag to curl
- Add check code for early stop on failure

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
