### PR TITLE
fix(cli): apply --config-dir again and restore legacy option handling

### DIFF
--- a/src/main/java/org/omegat/Main.java
+++ b/src/main/java/org/omegat/Main.java
@@ -10,6 +10,7 @@
                2014 Alex Buloichik
                2018 Enrique Estevez Fernandez
                2022-2025 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -42,10 +43,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
+import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
+
 import org.omegat.cli.LegacyParameters;
 import org.omegat.cli.SubCommands;
 import org.omegat.core.Core;
 import org.omegat.filters2.master.PluginUtils;
+import org.omegat.util.FileUtil;
 import org.omegat.util.RuntimePreferences;
 import org.omegat.util.Log;
 import org.omegat.util.StaticUtils;
@@ -74,6 +79,15 @@ public final class Main {
         // Workaround for Java 17 or later support of JAXB.
         // See https://sourceforge.net/p/omegat/feature-requests/1682/#12c5
         System.setProperty("com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize", "true");
+
+        // --config-dir must take effect before plugins are loaded (user
+        // plugins live below the configuration folder) and thus before the
+        // command line is parsed by picocli; pre-scan the arguments like
+        // extractPluginConfiguration() does.
+        String configDir = extractConfigDir(args);
+        if (configDir != null) {
+            RuntimePreferences.setConfigDir(FileUtil.expandTildeHomeDir(configDir));
+        }
 
         Map<String, String> pluginConfig = extractPluginConfiguration(args);
         PluginUtils.loadPlugins(pluginConfig);
@@ -169,8 +183,37 @@ public final class Main {
         return config;
     }
 
+    /**
+     * Pre-scan the command-line arguments for --config-dir before picocli
+     * parses them, so that user plugins below the configuration folder are
+     * already visible to loadPlugins().
+     */
+    @VisibleForTesting
+    @Nullable
+    static String extractConfigDir(String @Nullable [] args) {
+        if (args == null) {
+            return null;
+        }
+        for (int i = 0; i < args.length; i++) {
+            String value = null;
+            if (LegacyParameters.CONFIG_DIR.equals(args[i]) && i + 1 < args.length) {
+                value = args[i + 1];
+            } else if (args[i].startsWith(LegacyParameters.CONFIG_DIR + "=")) {
+                value = args[i].substring(LegacyParameters.CONFIG_DIR.length() + 1);
+            }
+            if (value != null && !value.isEmpty()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
     private static void constructCommandParams(List<String> command) {
         command.add("start");
+        if (RuntimePreferences.getConfigDir() != null) {
+            command.add(LegacyParameters.CONFIG_DIR);
+            command.add(RuntimePreferences.getConfigDir());
+        }
         if (RuntimePreferences.isNoTeam()) {
             command.add("--no-team");
         }

--- a/src/main/java/org/omegat/cli/LegacyParameters.java
+++ b/src/main/java/org/omegat/cli/LegacyParameters.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2025 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -27,6 +28,7 @@ package org.omegat.cli;
 import org.jspecify.annotations.Nullable;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
+import org.omegat.util.RuntimePreferences;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -132,6 +134,9 @@ public class LegacyParameters implements Callable<Integer> {
     @Nullable String project;
 
     public void initialize() {
+        if (configDir != null) {
+            RuntimePreferences.setConfigDir(FileUtil.expandTildeHomeDir(configDir));
+        }
         if (configFile != null) {
             applyConfigFile(configFile);
         }
@@ -142,6 +147,10 @@ public class LegacyParameters implements Callable<Integer> {
      */
     @Override
     public Integer call() {
+        // the sub-commands run this from their own call() methods; the
+        // legacy syntax reaches the run methods directly, so apply the
+        // configuration options here.
+        initialize();
         CommonParameters params = new CommonParameters();
         CommandCommon.logLevelInitialize(params);
         if (project != null) {
@@ -149,6 +158,7 @@ public class LegacyParameters implements Callable<Integer> {
         }
         if (consoleMode == null) {
             StartCommand command = new StartCommand();
+            command.legacyParams = this;
             command.params = params;
             return command.runGUI();
         } else {

--- a/src/test/java/org/omegat/MainTest.java
+++ b/src/test/java/org/omegat/MainTest.java
@@ -1,0 +1,60 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**************************************************************************/
+
+package org.omegat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * Tests for the command line pre-scan in Main.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MainTest {
+
+    @Test
+    public void testExtractConfigDirSeparateValue() {
+        assertEquals("/tmp/omegat-conf",
+                Main.extractConfigDir(new String[] { "--config-dir", "/tmp/omegat-conf", "start" }));
+    }
+
+    @Test
+    public void testExtractConfigDirEqualsForm() {
+        assertEquals("/tmp/omegat-conf",
+                Main.extractConfigDir(new String[] { "start", "--config-dir=/tmp/omegat-conf" }));
+    }
+
+    @Test
+    public void testExtractConfigDirAbsent() {
+        assertNull(Main.extractConfigDir(new String[] { "start", "project" }));
+        assertNull(Main.extractConfigDir(new String[] { "--config-dir" }));
+        assertNull(Main.extractConfigDir(new String[] { "--config-dir=" }));
+        assertNull(Main.extractConfigDir(new String[0]));
+        assertNull(Main.extractConfigDir(null));
+    }
+}

--- a/src/test/java/org/omegat/cli/LegacyParametersTest.java
+++ b/src/test/java/org/omegat/cli/LegacyParametersTest.java
@@ -1,0 +1,83 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**************************************************************************/
+
+package org.omegat.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.data.TestRuntimePreferenceStore;
+import org.omegat.util.RuntimePreferences;
+
+import picocli.CommandLine;
+
+/**
+ * Tests that the configuration options of the legacy command line syntax
+ * are applied.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class LegacyParametersTest {
+
+    @Before
+    public void setUp() {
+        TestRuntimePreferenceStore.reset();
+    }
+
+    @After
+    public void tearDown() {
+        TestRuntimePreferenceStore.reset();
+    }
+
+    @Test
+    public void testInitializeAppliesConfigDir() {
+        LegacyParameters params = new LegacyParameters();
+        new CommandLine(params).parseArgs(LegacyParameters.CONFIG_DIR, "/tmp/omegat-conf");
+        assertNull(RuntimePreferences.getConfigDir());
+        params.initialize();
+        assertEquals("/tmp/omegat-conf", RuntimePreferences.getConfigDir());
+    }
+
+    @Test
+    public void testInitializeExpandsTilde() {
+        LegacyParameters params = new LegacyParameters();
+        new CommandLine(params).parseArgs(LegacyParameters.CONFIG_DIR + "=~/omegat-conf");
+        params.initialize();
+        assertEquals(FileUtils.getUserDirectoryPath() + "/omegat-conf", RuntimePreferences.getConfigDir());
+    }
+
+    @Test
+    public void testInitializeWithoutConfigDir() {
+        LegacyParameters params = new LegacyParameters();
+        new CommandLine(params).parseArgs();
+        params.initialize();
+        assertNull(RuntimePreferences.getConfigDir());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

No ticket; regression from the command line parser rework (#1321).

## What does this PR change?

`--config-dir` was still declared but no longer applied anywhere. It is now applied in `Main` before the plugins load - user plugins live below the configuration folder, so it must take effect before picocli parsing (same pre-scan approach as `--dev-manifests`) - and in `LegacyParameters.initialize()` for the picocli routes.

Two more losses from the same rework are restored: the legacy syntax without a sub-command skipped `initialize()` entirely, so `--config-file` only worked with sub-commands, and `--no-team` was ignored because `legacyParams` was never handed to `StartCommand`. The GUI restart command line now forwards the configuration folder as well.

New tests cover the argument pre-scan and the option application including tilde expansion.

## Other information

Full test suite and checkstyle pass. Verified against the installed distribution: `OmegaT --config-dir <dir>` writes omegat.prefs, uiLayout.xml and logs below the given folder again.
