### PR TITLE
fix(core): create the user scripts folder under its documented name

### DIFF
--- a/src/main/java/org/omegat/util/StaticUtils.java
+++ b/src/main/java/org/omegat/util/StaticUtils.java
@@ -11,6 +11,7 @@
                2014 Aaron Madlon-Kay, Alex Buloichik
                2015 Aaron Madlon-Kay
                2023 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -42,10 +43,10 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +57,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * Static functions taken from CommandThread to reduce file size.
@@ -460,25 +462,35 @@ public final class StaticUtils {
         return userScriptsDir;
     }
 
-    private static Path determineUserScriptsPath() {
-        Path scriptsPath = Paths.get(getApplicationDataDir(), SCRIPT_DIR);
-        // ensure directory exists
+    @VisibleForTesting
+    static Path determineUserScriptsPath() {
+        Path scriptsPath = Paths.get(getApplicationDataDir(), SCRIPTS_DIR);
         if (Files.exists(scriptsPath)) {
             return scriptsPath;
         }
-        // it seems first run.
+        // Earlier 6.1 development builds created the folder under the
+        // segment-export folder name "script"; keep such user scripts by
+        // renaming the folder.
+        Path legacyPath = Paths.get(getApplicationDataDir(), SCRIPT_DIR);
+        if (Files.isDirectory(legacyPath)) {
+            try {
+                Files.move(legacyPath, scriptsPath);
+                return scriptsPath;
+            } catch (FileAlreadyExistsException e) {
+                // another instance won the rename race
+                return scriptsPath;
+            } catch (IOException e) {
+                Log.logErrorRB(e, "SU_SCRIPT_DIR_CREATE_ERROR");
+                return legacyPath;
+            }
+        }
+        // it seems first run; default scripts are installed afterwards by
+        // ensureUserScriptsDir().
         try {
             Files.createDirectories(scriptsPath);
         } catch (IOException e) {
             Log.logErrorRB(e, "SU_SCRIPT_DIR_CREATE_ERROR");
-            scriptsPath = Paths.get(getConfigDir() + SCRIPT_DIR);
-        }
-        try {
-            // ensure default script files installed
-            Path defaultScripts = Paths.get(installDir(), SCRIPT_DIR);
-            Files.copy(defaultScripts, scriptsPath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            Log.logErrorRB(e, "SU_SCRIPT_DIR_CREATE_ERROR");
+            scriptsPath = Paths.get(getConfigDir(), SCRIPTS_DIR);
         }
         return scriptsPath;
     }
@@ -495,7 +507,7 @@ public final class StaticUtils {
                 FileUtils.copyDirectory(defaultScripts, userScriptsPath.toFile());
             } catch (IOException e) {
                 // fallback to app install dir which contains default scripts
-                userScriptsDir = Paths.get(installDir() + SCRIPTS_DIR);
+                userScriptsDir = Paths.get(installDir(), SCRIPTS_DIR);
                 Preferences.setPreference(Preferences.SCRIPTS_DIRECTORY, userScriptsDir.toString());
             }
         }

--- a/src/test/java/org/omegat/util/StaticUtilsTest.java
+++ b/src/test/java/org/omegat/util/StaticUtilsTest.java
@@ -6,6 +6,7 @@
  Copyright (C) 2000-2006 Keith Godfrey and Maxym Mykhalchuk
                2013 Alex Buloichik
                2015 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -32,8 +33,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 /**
@@ -99,5 +106,73 @@ public class StaticUtilsTest {
         assertTrue(Pattern.matches(StaticUtils.globToRegex("a *", true), "a\u00A0b"));
         assertFalse(Pattern.matches(StaticUtils.globToRegex("a ?", false), "a\u00A0b"));
         assertTrue(Pattern.matches(StaticUtils.globToRegex("a ?", true), "a\u00A0b"));
+    }
+
+    @Test
+    public void testDetermineUserScriptsPathFirstRun() throws Exception {
+        withTempHome(dataDir -> {
+            Path scriptsPath = StaticUtils.determineUserScriptsPath();
+            assertEquals(dataDir.resolve("scripts"), scriptsPath);
+            assertTrue(Files.isDirectory(scriptsPath));
+        });
+    }
+
+    @Test
+    public void testDetermineUserScriptsPathMigratesLegacyFolder() throws Exception {
+        withTempHome(dataDir -> {
+            Path legacyPath = dataDir.resolve("script");
+            Files.createDirectories(legacyPath);
+            Files.write(legacyPath.resolve("my_script.groovy"), "// user content".getBytes(StandardCharsets.UTF_8));
+            Path scriptsPath = StaticUtils.determineUserScriptsPath();
+            assertEquals(dataDir.resolve("scripts"), scriptsPath);
+            assertTrue(Files.exists(scriptsPath.resolve("my_script.groovy")));
+            assertFalse(Files.exists(legacyPath));
+        });
+    }
+
+    @Test
+    public void testDetermineUserScriptsPathIgnoresLegacyFile() throws Exception {
+        withTempHome(dataDir -> {
+            Path legacyFile = dataDir.resolve("script");
+            Files.write(legacyFile, "not a folder".getBytes(StandardCharsets.UTF_8));
+            Path scriptsPath = StaticUtils.determineUserScriptsPath();
+            assertEquals(dataDir.resolve("scripts"), scriptsPath);
+            assertTrue(Files.isDirectory(scriptsPath));
+            assertTrue(Files.isRegularFile(legacyFile));
+        });
+    }
+
+    @Test
+    public void testDetermineUserScriptsPathKeepsExistingFolders() throws Exception {
+        withTempHome(dataDir -> {
+            Path legacyPath = dataDir.resolve("script");
+            Files.createDirectories(legacyPath);
+            Path existingPath = dataDir.resolve("scripts");
+            Files.createDirectories(existingPath);
+            Files.write(existingPath.resolve("current.groovy"), "// current".getBytes(StandardCharsets.UTF_8));
+            Path scriptsPath = StaticUtils.determineUserScriptsPath();
+            assertEquals(existingPath, scriptsPath);
+            assertTrue(Files.exists(scriptsPath.resolve("current.groovy")));
+            assertTrue(Files.isDirectory(legacyPath));
+        });
+    }
+
+    private interface DataDirConsumer {
+        void accept(Path dataDir) throws IOException;
+    }
+
+    private static void withTempHome(DataDirConsumer test) throws IOException {
+        Path tempHome = Files.createTempDirectory("omegat-home-");
+        String originalHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempHome.toString());
+        try {
+            // getApplicationDataDir on Windows requires this folder to exist
+            // to resolve under the home directory.
+            Files.createDirectories(tempHome.resolve("AppData").resolve("Local"));
+            test.accept(Paths.get(StaticUtils.getApplicationDataDir()));
+        } finally {
+            System.setProperty("user.home", originalHome);
+            FileUtils.deleteQuietly(tempHome.toFile());
+        }
     }
 }


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

No ticket; follow-up to the user scripts initialization introduced for RFE#1781 (#1869).

## What does this PR change?

`determineUserScriptsPath()` mixed up two folder names: it created the user scripts folder as `script` - the name of the unrelated segment-export folder - although its own javadoc, `ensureUserScriptsDir()` and the distribution all use `scripts`. It also tried to seed the default scripts from the non-existent install folder `script`, which logged "It was not possible to create the script folder" on every first start (`Files.copy` cannot copy a directory's contents anyway, and `ensureUserScriptsDir()` does the real seeding right afterwards). The fallback in `ensureUserScriptsDir()` additionally joined the install path without a separator.

The folder is now created under `scripts`, a `script` folder left behind by earlier builds is renamed to preserve user scripts, the broken seeding block is gone and the path join is fixed. Unit tests cover first start, migration, a legacy file of the same name and pre-existing folders.

## Other information

Full test suite and checkstyle pass. Verified against the installed distribution: a first start with a fresh home no longer logs the error and seeds the default scripts into `scripts`.
