### PR TITLE
fix(build): qualify loadProperties call in java-conventions plugin

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
@@ -1,3 +1,5 @@
+import org.omegat.gradle.PropertiesUtil
+
 plugins {
     id 'java-library'
     id 'checkstyle'
@@ -11,7 +13,7 @@ plugins {
 ext {
     localPropsFile = layout.settingsDirectory.file('local.properties').asFile
     if (localPropsFile.file) {
-        loadProperties(localPropsFile).each { k, v ->
+        PropertiesUtil.loadProperties(localPropsFile).each { k, v ->
             if (findProperty(k) == null) {
                 set(k, v)
             }


### PR DESCRIPTION
### What

One-word fix for a regression from #2209: `org.omegat.java-conventions.gradle` still calls the removed helper `loadProperties()` unqualified. The call only executes when a `local.properties` file exists in the repository root, so CI stays green while any checkout carrying one fails at configuration time with `Could not find method loadProperties() … on DefaultExtraPropertiesExtension`, regardless of the Java version. This adds the `PropertiesUtil` import (same style as document-conventions) and qualifies the call.

### Verification

Reproduced on current master by placing a `local.properties` in the repository root. With the fix the build configures again and the file's entries land in `ext` (verified via `gradle properties`); without the file behaviour is unchanged. Full test suite and checkstyle green.

### Note

#2209 left a few more unqualified helper calls on release/signing paths (`exePresent`/`injected` in mac-conventions, `injected` in verification-conventions, `condition` in main-utilities). They are latent for normal builds and signing environments are needed to test them, so they are not part of this minimal fix — happy to follow up separately.
