### PR TITLE
feat(dev): app title now shows commit sha + branch name for dev builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -499,10 +499,15 @@ tasks.withType(Zip).configureEach {
 
 def provided = findProperty('repoRevision') ?: ''
 def gitArchival = PropertiesUtil.loadProperties(file('.git-archival.properties')).getProperty('node')
-def git = file('.git').directory ? providers.exec {commandLine("git", "rev-parse", "--short", "HEAD")}.standardOutput.asText.get().trim() : ''
+// .git is a directory in a plain clone but a file in a linked git worktree
+def insideGitCheckout = file('.git').exists()
+def git = insideGitCheckout ? providers.exec {commandLine("git", "rev-parse", "--short", "HEAD")}.standardOutput.asText.get().trim() : ''
 def revision = [provided, gitArchival, omtVersion.revision, git, 'unknown'].find {
     !it.empty && it != '@dev@' && it != '$Format:%H$'
 }
+// The branch name is empty outside a git checkout and "HEAD" when detached
+// (e.g. a tag build); both cases mean "not a development build".
+def gitBranch = insideGitCheckout ? providers.exec {commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")}.standardOutput.asText.get().trim() : ''
 
 processResources {
     /*
@@ -515,9 +520,11 @@ processResources {
      3. If none of the above, the value "unknown"
      */
     inputs.property 'revision', revision
-    logger.lifecycle("Detected revision " + revision)
+    inputs.property 'branch', gitBranch
+    logger.lifecycle("Detected revision " + revision
+            + (gitBranch.empty ? "" : " on branch " + gitBranch))
     filesMatching('**/Version.properties') {
-        filter ReplaceTokens, tokens:["dev": revision]
+        filter ReplaceTokens, tokens:["dev": revision, "gitbranch": gitBranch]
     }
 }
 

--- a/src/main/java/org/omegat/gui/main/MainWindow.java
+++ b/src/main/java/org/omegat/gui/main/MainWindow.java
@@ -12,6 +12,7 @@
                2015 Yu Tang, Aaron Madlon-Kay
                2016 Didier Briel
                2023 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -291,6 +292,10 @@ public class MainWindow implements IMainWindow {
      */
     private void updateTitle() {
         String s = OStrings.getDisplayNameAndVersion();
+        String devBuildMarker = OStrings.getDevBuildMarker();
+        if (!devBuildMarker.isEmpty()) {
+            s += " " + devBuildMarker;
+        }
         if (Core.getProject().isProjectLoaded()) {
             s += " :: " + Core.getProject().getProjectProperties().getProjectName();
         }

--- a/src/main/java/org/omegat/util/OStrings.java
+++ b/src/main/java/org/omegat/util/OStrings.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2000-2006 Keith Godfrey and Maxym Mykhalchuk
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -33,6 +34,8 @@ import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.function.Function;
 
+import org.jetbrains.annotations.VisibleForTesting;
+
 /**
  * Localizable strings.
  * <p>
@@ -60,6 +63,9 @@ public final class OStrings {
     /** Repository revision number, e.g. r7500 */
     public static final String REVISION;
 
+    /** Git branch of a development checkout, empty for release builds. */
+    public static final String BRANCH;
+
     /** Indicates whether this is a "beta" (or "latest") version or a "standard" version. */
     public static final boolean IS_BETA;
 
@@ -69,6 +75,7 @@ public final class OStrings {
         VERSION = b.getString("version");
         UPDATE = b.getString("update");
         REVISION = b.getString("revision");
+        BRANCH = b.containsKey("branch") ? b.getString("branch") : "";
         IS_BETA = !b.getString("beta").isEmpty();
     }
 
@@ -167,6 +174,25 @@ public final class OStrings {
             return StringUtil.format(getString("app-version-template-pretty"),
                     getApplicationDisplayName(), VERSION);
         }
+    }
+
+    /**
+     * Returns a marker identifying a development build, made of the revision
+     * and branch of the checkout, e.g. "[6d79ee8db @ master]". Empty when
+     * this build was not made from a branch checkout (release and tag builds).
+     */
+    public static String getDevBuildMarker() {
+        return getDevBuildMarker(REVISION, BRANCH);
+    }
+
+    @VisibleForTesting
+    static String getDevBuildMarker(String revision, String branch) {
+        // "HEAD" means a detached checkout, e.g. a tag build; the raw token
+        // means the resource was not filtered (running from an IDE build).
+        if (branch.isEmpty() || "HEAD".equals(branch) || "@gitbranch@".equals(branch)) {
+            return "";
+        }
+        return "[" + revision + " @ " + branch + "]";
     }
 
     /**

--- a/src/main/resources/org/omegat/Version.properties
+++ b/src/main/resources/org/omegat/Version.properties
@@ -39,6 +39,8 @@ version=6.2.0
 update=0
 # Revision is managed by tooling; do not adjust manually
 revision=@dev@
+# Branch is managed by tooling; empty outside a development checkout
+branch=@gitbranch@
 # Use an empty string for non-beta versions (Standard flavor) and "_Beta" for
 # beta versions (Latest flavor)
 beta=_Beta

--- a/src/test/java/org/omegat/util/OStringsTest.java
+++ b/src/test/java/org/omegat/util/OStringsTest.java
@@ -1,0 +1,52 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**************************************************************************/
+
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for the development build marker.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class OStringsTest {
+
+    @Test
+    public void testDevBuildMarkerFromBranchCheckout() {
+        assertEquals("[6d79ee8db @ master]", OStrings.getDevBuildMarker("6d79ee8db", "master"));
+        assertEquals("[6d79ee8db @ topic/stpa/build/worktree-revision]",
+                OStrings.getDevBuildMarker("6d79ee8db", "topic/stpa/build/worktree-revision"));
+    }
+
+    @Test
+    public void testDevBuildMarkerHiddenOutsideBranchCheckouts() {
+        assertEquals("", OStrings.getDevBuildMarker("6d79ee8db", ""));
+        assertEquals("", OStrings.getDevBuildMarker("6d79ee8db", "HEAD"));
+        assertEquals("", OStrings.getDevBuildMarker("6d79ee8db", "@gitbranch@"));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Enhancement

## Which ticket is resolved?

No ticket.

## What does this PR change?

Development builds from a branch checkout show `[<sha> @ <branch>]` in the main window title, and the revision detection now also works in linked git worktrees (such builds were versioned `_unknown`). Release, tag and CI builds are unaffected: no git checkout, or a detached HEAD, yields no marker.

## Other information

makes it less easy to confuse during rapid prototyping what instance is supposed to have which fix or feature, and should only apply in non-release build configurations.

### screenshot

<img width="649" height="75" alt="Bildschirmfoto 2026-08-05 um 00 07 36" src="https://github.com/user-attachments/assets/9f8d841f-8cda-4d92-b4dd-009380868c2d" />
