### PR TITLE
fix(build): restore imports dropped from mac-conventions by 6.1 merge

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.mac-conventions.gradle
@@ -1,5 +1,9 @@
 import java.util.zip.ZipFile
 
+import org.omegat.gradle.BuildConditions
+import org.omegat.gradle.DistPathUtil
+import org.omegat.gradle.InjectedOps
+
 configurations {
     genMac
 }


### PR DESCRIPTION

## Pull request type

regression fix

## Which ticket is resolved?

none

## What does this PR change?

The releases/6.1 merge (a197683ae) resolved the header of org.omegat.mac-conventions.gradle to the pre-refactoring state and lost the three org.omegat.gradle imports introduced by #2209. Since InjectedOps is instantiated while the plugin is applied, every Gradle invocation on master now fails at configuration time with MissingPropertyException, and every pull request check fails with it. Restoring the imports makes the file byte-identical to the last green master state.

## Other information

none