### PR TITLE
fix(build): resolve language modules from the provided module libraries

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.java-conventions.gradle
@@ -23,6 +23,18 @@ ext {
     providedModuleLibsPath = 'lib/provided/module'
     providedCoreLibsDir = layout.settingsDirectory.dir(providedCoreLibsPath).asFile
     providedModuleLibsDir = layout.settingsDirectory.dir(providedModuleLibsPath).asFile
+    // Resolves jars that the source distribution provides in lib/provided/module.
+    // Fails instead of returning an empty tree so that an incomplete source
+    // distribution cannot silently produce modules without their content.
+    providedModuleLib = { String... artifacts ->
+        def patterns = artifacts.collect { "**/${it}-*.jar".toString() }
+        def tree = fileTree(dir: providedModuleLibsDir, includes: patterns)
+        if (tree.isEmpty()) {
+            throw new GradleException("No jar matches ${patterns} in ${providedModuleLibsDir}; "
+                    + "the provided module libraries are incomplete.")
+        }
+        return tree
+    }
 }
 
 repositories {

--- a/language-modules/ar/build.gradle
+++ b/language-modules/ar/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ar-*.jar'])
+        implementation providedModuleLib('language-ar')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ast/build.gradle
+++ b/language-modules/ast/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/morfologik-stemming-*.jar', '**/jspecify-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir, includes: ['**/language-ast-*.jar'])
+        implementation providedModuleLib('language-ast')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/be/build.gradle
+++ b/language-modules/be/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/jspecify-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-be-*.jar'])
+        implementation providedModuleLib('language-be')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/br/build.gradle
+++ b/language-modules/br/build.gradle
@@ -8,8 +8,7 @@ dependencies {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar',
                            '**/morfologik-stemming-*.jar', '**/jspecify-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-br-*.jar'])
+        implementation providedModuleLib('language-br')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ca/build.gradle
+++ b/language-modules/ca/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ca-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/catalan-pos-dict-*.jar')
+        implementation providedModuleLib('language-ca')
+        runtimeOnly providedModuleLib('catalan-pos-dict')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/da/build.gradle
+++ b/language-modules/da/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-da-*.jar'])
+        implementation providedModuleLib('language-da')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/de/build.gradle
+++ b/language-modules/de/build.gradle
@@ -7,10 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-de-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir,
-                includes: ['**/commons-lang3-*.jar', '**/jwordsplitter-*.jar', '**/german-*.jar', '**/openregex-*.jar'])
+        implementation providedModuleLib('language-de')
+        runtimeOnly providedModuleLib('commons-lang3', 'jwordsplitter', 'german', 'openregex')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/el/build.gradle
+++ b/language-modules/el/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-el-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/morphology-el-*.jar')
+        implementation providedModuleLib('language-el')
+        runtimeOnly providedModuleLib('morphology-el')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/en/build.gradle
+++ b/language-modules/en/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-en-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, includes: ['**/opennlp-*.jar'])
+        implementation providedModuleLib('language-en')
+        runtimeOnly providedModuleLib('opennlp')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/eo/build.gradle
+++ b/language-modules/eo/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-eo-*.jar'])
+        implementation providedModuleLib('language-eo')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/es/build.gradle
+++ b/language-modules/es/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-es-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/spanish-pos-dict-*.jar')
+        implementation providedModuleLib('language-es')
+        runtimeOnly providedModuleLib('spanish-pos-dict')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/fa/build.gradle
+++ b/language-modules/fa/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-fa-*.jar'])
+        implementation providedModuleLib('language-fa')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/fr/build.gradle
+++ b/language-modules/fr/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-fr-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/french-*.jar')
+        implementation providedModuleLib('language-fr')
+        runtimeOnly providedModuleLib('french')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ga/build.gradle
+++ b/language-modules/ga/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ga-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/languagetool-ga-dicts-*.jar')
+        implementation providedModuleLib('language-ga')
+        runtimeOnly providedModuleLib('languagetool-ga-dicts')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/gl/build.gradle
+++ b/language-modules/gl/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-gl-*.jar'])
+        implementation providedModuleLib('language-gl')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/it/build.gradle
+++ b/language-modules/it/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/morfologik-*.jar'])
-        implementation fileTree(dir: providedModuleLibsDir,
-                includes: ['**/language-it-*.jar'])
+        implementation providedModuleLib('language-it')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ja/build.gradle
+++ b/language-modules/ja/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/icu4j-*.jar'])
-        implementation fileTree(dir: providedModuleLibsDir,
-                includes: ['**/language-ja-*.jar'])
+        implementation providedModuleLib('language-ja')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/km/build.gradle
+++ b/language-modules/km/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/lucene-analyzers-common-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-km-*.jar'])
+        implementation providedModuleLib('language-km')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/nl/build.gradle
+++ b/language-modules/nl/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-nl-*.jar'])
+        implementation providedModuleLib('language-nl')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/pl/build.gradle
+++ b/language-modules/pl/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-pl-*.jar'])
+        implementation providedModuleLib('language-pl')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/pt/build.gradle
+++ b/language-modules/pt/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-pt-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/portuguese-pos-dict-*.jar')
+        implementation providedModuleLib('language-pt')
+        runtimeOnly providedModuleLib('portuguese-pos-dict')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ro/build.gradle
+++ b/language-modules/ro/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ro-*.jar'])
+        implementation providedModuleLib('language-ro')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ru/build.gradle
+++ b/language-modules/ru/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ru-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/openregex-*.jar')
+        implementation providedModuleLib('language-ru')
+        runtimeOnly providedModuleLib('openregex')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/sk/build.gradle
+++ b/language-modules/sk/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-sk-*.jar'])
+        implementation providedModuleLib('language-sk')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/sl/build.gradle
+++ b/language-modules/sl/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-nl-*.jar'])
+        implementation providedModuleLib('language-sl')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/sv/build.gradle
+++ b/language-modules/sv/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-nl-*.jar'])
+        implementation providedModuleLib('language-sv')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/ta/build.gradle
+++ b/language-modules/ta/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/morfologik-stemming-*.jar', '**/jspecify-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-ta-*.jar'])
+        implementation providedModuleLib('language-ta')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/tl/build.gradle
+++ b/language-modules/tl/build.gradle
@@ -7,8 +7,7 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/morfologik-stemming-*.jar', '**/jspecify-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-tl-*.jar'])
+        implementation providedModuleLib('language-tl')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/uk/build.gradle
+++ b/language-modules/uk/build.gradle
@@ -7,9 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar', '**/lucene-analyzers-common-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir,
-                includes: ['**/language-uk-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/morfologik-ukrainian-*.jar')
+        implementation providedModuleLib('language-uk')
+        runtimeOnly providedModuleLib('morfologik-ukrainian')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/language-modules/zh/build.gradle
+++ b/language-modules/zh/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     if (providedCoreLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir,
                 includes: ['**/languagetool-core-*.jar', '**/commons-io-*.jar'])
-        implementation fileTree(dir: providedCoreLibsDir, includes: ['**/language-zh-*.jar'])
-        runtimeOnly fileTree(dir: providedModuleLibsDir, include: '**/hanlp-portable-*.jar')
+        implementation providedModuleLib('language-zh')
+        runtimeOnly providedModuleLib('hanlp-portable')
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.languagetool.core)

--- a/src/test/java/org/omegat/LanguageModuleContentTest.java
+++ b/src/test/java/org/omegat/LanguageModuleContentTest.java
@@ -1,0 +1,119 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**************************************************************************/
+
+package org.omegat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+/**
+ * Audits the build scripts of the language modules.
+ * <p>
+ * Every language module bundles its LanguageTool language jar into the module
+ * jar. When OmegaT is built from the source distribution, that jar has to be
+ * taken from the provided module libraries via the providedModuleLib helper,
+ * which fails on an empty match; a plain fileTree over the provided core
+ * libraries matches nothing there and silently produces a module without its
+ * content (no grammar rules, no bundled spelling dictionaries). The same
+ * applies to the additional dictionary jars some modules pull in at runtime,
+ * so every provided jar has to go through the helper. This test also catches
+ * copy-paste mistakes where a module references the language jar or version
+ * catalog alias of another language.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class LanguageModuleContentTest {
+
+    private static final Pattern LANGUAGE_JAR_INCLUDE = Pattern.compile("language-([a-z]+)-\\*\\.jar");
+    private static final Pattern PROVIDED_MODULE_LIB = Pattern
+            .compile("providedModuleLib\\(['\"]language-([a-z]+)['\"]");
+    private static final Pattern CATALOG_ALIAS = Pattern.compile("libs\\.languagetool\\.([a-z]+)");
+    private static final List<String> NON_LANGUAGE_ALIASES = Arrays.asList("core", "server");
+
+    @Test
+    public void testLanguageModulesBundleTheirOwnLanguage() throws IOException {
+        File[] moduleDirs = new File("language-modules").listFiles(File::isDirectory);
+        assertNotNull("language-modules directory not found; the test must run in the project root",
+                moduleDirs);
+        Arrays.sort(moduleDirs);
+        List<String> violations = new ArrayList<>();
+        int checked = 0;
+        for (File moduleDir : moduleDirs) {
+            File buildFile = new File(moduleDir, "build.gradle");
+            if (!buildFile.isFile()) {
+                continue;
+            }
+            checked++;
+            String script = Files.readString(buildFile.toPath(), StandardCharsets.UTF_8);
+            String language = moduleDir.getName();
+            checkOwnLanguage(violations, language, LANGUAGE_JAR_INCLUDE.matcher(script));
+            checkOwnLanguage(violations, language, PROVIDED_MODULE_LIB.matcher(script));
+            checkCatalogAlias(violations, language, CATALOG_ALIAS.matcher(script));
+            if (!PROVIDED_MODULE_LIB.matcher(script).find()) {
+                violations.add(language + ": language jar is not resolved via providedModuleLib(...); "
+                        + "an incomplete source distribution would not be detected");
+            }
+            if (script.contains("implementation fileTree(dir: providedCoreLibsDir")) {
+                violations.add(language + ": bundles its content from the provided core libraries, "
+                        + "which do not contain the language jars");
+            }
+            if (script.contains("fileTree(dir: providedModuleLibsDir")) {
+                violations.add(language + ": resolves provided jars via a bare fileTree; "
+                        + "use providedModuleLib(...) so that empty matches fail the build");
+            }
+        }
+        assertTrue("Expected to audit at least 25 language modules, found " + checked, checked >= 25);
+        assertTrue(String.join("\n", violations), violations.isEmpty());
+    }
+
+    private static void checkOwnLanguage(List<String> violations, String language, Matcher matcher) {
+        while (matcher.find()) {
+            if (!matcher.group(1).equals(language)) {
+                violations.add(language + ": references the language jar of '" + matcher.group(1) + "'");
+            }
+        }
+    }
+
+    private static void checkCatalogAlias(List<String> violations, String language, Matcher matcher) {
+        while (matcher.find()) {
+            String alias = matcher.group(1);
+            if (!NON_LANGUAGE_ALIASES.contains(alias) && !alias.equals(language)) {
+                violations.add(language + ": depends on the version catalog alias of '" + alias + "'");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

No ticket.

## What does this PR change?

When OmegaT is built from the source distribution, 28 of 30 language modules looked for their LanguageTool jar in lib/provided/core, which only holds the core libraries. The empty match was not an error, so the module jars were silently built without their content - no grammar rules, no bundled spelling dictionaries. sl and sv also pointed at the Dutch jar (copy-paste). All provided jars are now resolved through a new providedModuleLib helper that aborts the build when nothing matches; the additional runtime dictionary jars of eleven modules use it as well. A new audit test keeps the module build scripts honest (own language only, no bare fileTrees over the provided libraries).

## Other information

End-to-end check via installSourceDist: omegat-language-sl.jar goes from 2.7 kB (empty) to 270 kB with the Slovenian resources, omegat-language-de.jar again contains its dictionaries, and a missing jar now stops the build with a clear message instead. The Source Distribution Test workflow covers this path on every PR. Full test suite and checkstyle pass.
