### PR TITLE
[6.0] chore(ci): update release paths to use "Standard" directory instead of "Latest"

### DIFF
--- a/ci/azure-pipelines/publish_release.yml
+++ b/ci/azure-pipelines/publish_release.yml
@@ -38,8 +38,8 @@ steps:
         srcdir=$(Pipeline.Workspace)/build/distributions/
         ls -l $srcdir/*
         dest=$(SOURCEFORGE_CI_USER)@$SF_HOST
-        destdir="/home/frs/project/omegat/OmegaT\\ -\\ Latest/OmegaT\\ ${OMEGAT_VERSION}/"
-        cmd="mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -R --verbose=3 ; bye"
+        destdir="/home/frs/project/omegat/OmegaT - Standard/OmegaT ${OMEGAT_VERSION}/"
+        cmd="mkdir -p '$destdir' ; lcd '$srcdir' ; cd '$destdir' ; mirror -R --verbose=3 ; bye"
         lftp --env-password -e \"$cmd\" $dest"
         # Upload manuals
         echo "Push manuals to sourceforge project web"


### PR DESCRIPTION


## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
None; found issue on release 6.1 and backport from master
## What does this PR change?

- Publish to 'Standard' folder instead of Latest
- quote lftp command to support space character

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
