### PR TITLE
[6.1] chore(ci): update release paths to use "Standard" directory instead of "Latest"

### DIFF
--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -134,7 +134,7 @@ jobs:
               ;;
           esac
           if [[ "$MODE" == "release" ]]; then
-            echo "dest_dir=/home/frs/project/omegat/OmegaT - Latest/OmegaT ${VERSION}/" >> $GITHUB_OUTPUT
+            echo "dest_dir=/home/frs/project/omegat/OmegaT - Standard/OmegaT ${VERSION}/" >> $GITHUB_OUTPUT
           else
             echo "dest_dir=/home/frs/project/omegat/Weekly" >> $GITHUB_OUTPUT
           fi

--- a/ci/azure-pipelines/publish_release.yml
+++ b/ci/azure-pipelines/publish_release.yml
@@ -38,7 +38,7 @@ steps:
         dest=$(SOURCEFORGE_CI_USER)@$SF_HOST
         srcdir=$(Pipeline.Workspace)/build/distributions/
         ls -l $srcdir/*
-        destdir="/home/frs/project/omegat/OmegaT\\ -\\ Latest/OmegaT\\ ${OMEGAT_VERSION}/"
+        destdir="/home/frs/project/omegat/OmegaT - Standard/OmegaT ${OMEGAT_VERSION}/"
         cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd $srcdir; cd '$destdir'; mirror -R --verbose=3; bye"
         lftp --env-password -e "$cmd" $dest
         dest=sftp://$(SOURCEFORGE_CI_USER)@$SF_HOST


### PR DESCRIPTION

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?
None; found the issue when running publish CI/CD
## What does this PR change?

- publish to Standard sourceforge folder

## Other information
should be merged after built packages for macOS

ref #2229 #2230