### PR TITLE
fix(cli): apply remaining runtime options and repair GUI restart command line

### DIFF
--- a/src/main/java/org/omegat/Main.java
+++ b/src/main/java/org/omegat/Main.java
@@ -46,6 +46,7 @@ import java.util.ResourceBundle;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.Nullable;
 
+import org.omegat.cli.CommonParameters;
 import org.omegat.cli.LegacyParameters;
 import org.omegat.cli.SubCommands;
 import org.omegat.core.Core;
@@ -208,22 +209,51 @@ public final class Main {
         return null;
     }
 
-    private static void constructCommandParams(List<String> command) {
-        command.add("start");
+    /**
+     * Reconstructs the command line arguments for a GUI restart from the
+     * runtime preferences. Options of the top-level command must precede the
+     * start sub-command; the options of its {@link CommonParameters} mixin
+     * must follow it.
+     */
+    @VisibleForTesting
+    static void constructCommandParams(List<String> command) {
         if (RuntimePreferences.getConfigDir() != null) {
             command.add(LegacyParameters.CONFIG_DIR);
             command.add(RuntimePreferences.getConfigDir());
         }
-        if (RuntimePreferences.isNoTeam()) {
-            command.add("--no-team");
+        if (RuntimePreferences.getConfigFile() != null) {
+            command.add(LegacyParameters.CONFIG_FILE);
+            command.add(RuntimePreferences.getConfigFile());
         }
+        if (RuntimePreferences.getResourceBundleFile() != null) {
+            command.add(LegacyParameters.RESOURCE_BUNDLE);
+            command.add(RuntimePreferences.getResourceBundleFile());
+        }
+        if (!RuntimePreferences.isProjectLockingEnabled()) {
+            command.add(LegacyParameters.DISABLE_PROJECT_LOCKING);
+        }
+        if (!RuntimePreferences.isLocationSaveEnabled()) {
+            command.add(LegacyParameters.DISABLE_LOCATION_SAVE);
+        }
+        if (RuntimePreferences.isNoTeam()) {
+            command.add(LegacyParameters.NO_TEAM);
+        }
+        command.add("start");
         if (RuntimePreferences.isQuietMode()) {
-            command.add("--quiet");
+            command.add(CommonParameters.QUIET);
+        }
+        if (RuntimePreferences.getTokenizerSource() != null) {
+            command.add(CommonParameters.TOKENIZER_SOURCE);
+            command.add(RuntimePreferences.getTokenizerSource());
+        }
+        if (RuntimePreferences.getTokenizerTarget() != null) {
+            command.add(CommonParameters.TOKENIZER_TARGET);
+            command.add(RuntimePreferences.getTokenizerTarget());
         }
         if (useAlternateFilename()) {
-            command.add("--alternate-filename-from");
+            command.add(CommonParameters.ALTERNATE_FILENAME_FROM);
             command.add(RuntimePreferences.getAlternateFilenameFrom());
-            command.add("--alternate-filenames-to");
+            command.add(CommonParameters.ALTERNATE_FILENAME_TO);
             command.add(RuntimePreferences.getAlternateFilenameTo());
         }
     }

--- a/src/main/java/org/omegat/cli/CommandCommon.java
+++ b/src/main/java/org/omegat/cli/CommandCommon.java
@@ -122,8 +122,13 @@ public final class CommandCommon {
         }
     }
 
+    /**
+     * Applies the options shared through {@link CommonParameters} to the
+     * runtime preferences. The options of the parent command are applied by
+     * {@link LegacyParameters#initialize()}.
+     */
     public static void parseCommonParams(CommonParameters params) {
-        if (!params.team) {
+        if (params.noTeam) {
             RuntimePreferences.setNoTeam();
         }
         if (params.disableProjectLocking) {
@@ -138,7 +143,6 @@ public final class CommandCommon {
         if (params.tokenizerTarget != null) {
             RuntimePreferences.setTokenizerTarget(params.tokenizerTarget);
         }
-        validateTagsConsoleMode(params);
     }
 
     /**

--- a/src/main/java/org/omegat/cli/CommonParameters.java
+++ b/src/main/java/org/omegat/cli/CommonParameters.java
@@ -32,11 +32,14 @@ import static picocli.CommandLine.Option;
 public class CommonParameters {
 
     /**
-     * CLI parameter to disable team functionality (treat as local project)
+     * CLI parameter to disable team functionality (treat as local project).
+     * Declared with the negative name because picocli sets a negatable option
+     * to the opposite of its default only when the declared form is matched;
+     * declaring positive "--team" with default true made "--no-team" a no-op.
      */
-    public static final String TEAM = "--team";
-    @Option(names = { TEAM }, negatable = true, descriptionKey = "params.TEAM")
-    boolean team = true;
+    public static final String NO_TEAM = "--no-team";
+    @Option(names = { NO_TEAM }, negatable = true, descriptionKey = "params.TEAM")
+    boolean noTeam = false;
 
     /**
      * CLI parameter to specify source tokenizer

--- a/src/main/java/org/omegat/cli/LegacyAlignCommand.java
+++ b/src/main/java/org/omegat/cli/LegacyAlignCommand.java
@@ -30,7 +30,6 @@ import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RealProject;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
-import org.omegat.util.RuntimePreferences;
 import org.omegat.util.TMXWriter2;
 
 import java.io.File;
@@ -51,16 +50,6 @@ public class LegacyAlignCommand {
 
         CommandCommon.initializeApp();
         Core.initializeConsole();
-
-        if (legacyParams.noTeam) {
-            RuntimePreferences.setNoTeam();
-        }
-        if (legacyParams.disableProjectLocking) {
-            RuntimePreferences.setProjectLockingEnabled(false);
-        }
-        if (legacyParams.disableLocationSave) {
-            RuntimePreferences.setLocationSaveEnabled(false);
-        }
 
         CommonParameters params = new CommonParameters();
         params.setProjectLocation(legacyParams.project);

--- a/src/main/java/org/omegat/cli/LegacyParameters.java
+++ b/src/main/java/org/omegat/cli/LegacyParameters.java
@@ -28,6 +28,7 @@ package org.omegat.cli;
 import org.jspecify.annotations.Nullable;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
+import org.omegat.util.OStrings;
 import org.omegat.util.RuntimePreferences;
 import picocli.CommandLine;
 
@@ -139,6 +140,21 @@ public class LegacyParameters implements Callable<Integer> {
         }
         if (configFile != null) {
             applyConfigFile(configFile);
+            RuntimePreferences.setConfigFile(FileUtil.expandTildeHomeDir(configFile));
+        }
+        if (resourceBundle != null) {
+            String bundleFile = FileUtil.expandTildeHomeDir(resourceBundle);
+            OStrings.loadBundle(bundleFile);
+            RuntimePreferences.setResourceBundleFile(bundleFile);
+        }
+        if (disableProjectLocking) {
+            RuntimePreferences.setProjectLockingEnabled(false);
+        }
+        if (disableLocationSave) {
+            RuntimePreferences.setLocationSaveEnabled(false);
+        }
+        if (noTeam) {
+            RuntimePreferences.setNoTeam();
         }
     }
 

--- a/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
+++ b/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
@@ -31,7 +31,6 @@ import org.omegat.core.data.RealProject;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.Log;
 import org.omegat.util.OConsts;
-import org.omegat.util.RuntimePreferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.TMXWriter2;
 import picocli.CommandLine;
@@ -86,19 +85,10 @@ public class PseudoTranslateCommand implements Callable<Integer> {
         CommandCommon.logLevelInitialize(params);
         Log.logInfoRB("CONSOLE_PSEUDO_TRANSLATION_MODE");
 
-        if (!params.team || legacyParameters.noTeam) {
-            RuntimePreferences.setNoTeam();
-        }
-
         CommandCommon.initializeApp();
         Core.initializeConsole();
 
-        if (legacyParameters.disableProjectLocking) {
-            RuntimePreferences.setProjectLockingEnabled(false);
-        }
-        if (legacyParameters.disableLocationSave) {
-            RuntimePreferences.setLocationSaveEnabled(false);
-        }
+        CommandCommon.parseCommonParams(params);
 
         if (filename == null && legacyParameters.pseudoTranslateTmxPath != null) {
             filename = legacyParameters.pseudoTranslateTmxPath;

--- a/src/main/java/org/omegat/cli/StartCommand.java
+++ b/src/main/java/org/omegat/cli/StartCommand.java
@@ -83,19 +83,10 @@ public class StartCommand implements Callable<Integer> {
         CommandCommon.showStartUpLogInfo();
         if (params != null) {
             CommandCommon.logLevelInitialize(params);
-            if (params.tokenizerSource != null) {
-                RuntimePreferences.setTokenizerSource(params.tokenizerSource);
-            }
-            if (params.tokenizerTarget != null) {
-                RuntimePreferences.setTokenizerTarget(params.tokenizerTarget);
-            }
+            CommandCommon.parseCommonParams(params);
         }
 
         CommandCommon.initializeApp();
-
-        if ((params != null && !params.team) || (legacyParams != null && legacyParams.noTeam)) {
-            RuntimePreferences.setNoTeam();
-        }
 
         UIManager.put("ClassLoader", PluginUtils.getClassLoader(PluginUtils.PluginType.THEME));
 

--- a/src/main/java/org/omegat/cli/StatsCommand.java
+++ b/src/main/java/org/omegat/cli/StatsCommand.java
@@ -34,7 +34,6 @@ import org.omegat.core.statistics.Statistics;
 import org.omegat.core.statistics.writer.StatisticsTextWriter;
 import org.omegat.util.FileUtil;
 import org.omegat.util.Log;
-import org.omegat.util.RuntimePreferences;
 import picocli.CommandLine;
 
 import java.io.File;
@@ -107,21 +106,7 @@ public class StatsCommand implements Callable<Integer> {
         CommandCommon.initializeApp();
         Core.initializeConsole();
 
-        if (!params.team || legacyParams.noTeam) {
-            RuntimePreferences.setNoTeam();
-        }
-        if (legacyParams.disableProjectLocking) {
-            RuntimePreferences.setProjectLockingEnabled(false);
-        }
-        if (legacyParams.disableLocationSave) {
-            RuntimePreferences.setLocationSaveEnabled(false);
-        }
-        if (params.tokenizerSource != null) {
-            RuntimePreferences.setTokenizerSource(params.tokenizerSource);
-        }
-        if (params.tokenizerTarget != null) {
-            RuntimePreferences.setTokenizerTarget(params.tokenizerTarget);
-        }
+        CommandCommon.parseCommonParams(params);
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
         if (p == null) {

--- a/src/main/java/org/omegat/cli/TranslateCommand.java
+++ b/src/main/java/org/omegat/cli/TranslateCommand.java
@@ -30,7 +30,6 @@ import org.omegat.core.Core;
 import org.omegat.core.data.RealProject;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.util.Log;
-import org.omegat.util.RuntimePreferences;
 import picocli.CommandLine;
 
 import java.util.Objects;
@@ -78,21 +77,7 @@ public class TranslateCommand implements Callable<Integer> {
         CommandCommon.initializeApp();
         Core.initializeConsole();
 
-        if (!params.team || legacyParams.noTeam) {
-            RuntimePreferences.setNoTeam();
-        }
-        if (legacyParams.disableProjectLocking) {
-            RuntimePreferences.setProjectLockingEnabled(false);
-        }
-        if (legacyParams.disableLocationSave) {
-            RuntimePreferences.setLocationSaveEnabled(false);
-        }
-        if (params.tokenizerSource != null) {
-            RuntimePreferences.setTokenizerSource(params.tokenizerSource);
-        }
-        if (params.tokenizerTarget != null) {
-            RuntimePreferences.setTokenizerTarget(params.tokenizerTarget);
-        }
+        CommandCommon.parseCommonParams(params);
 
         RealProject p = CommandCommon.selectProjectConsoleMode(true, params);
         if (p == null) {

--- a/src/main/java/org/omegat/core/data/RuntimePreferenceStore.java
+++ b/src/main/java/org/omegat/core/data/RuntimePreferenceStore.java
@@ -67,6 +67,12 @@ public class RuntimePreferenceStore {
     /** Force use specified config dir. */
     private String configDir;
 
+    /** Configuration properties file given on the command line. */
+    private String configFile;
+
+    /** Resource bundle file given on the command line. */
+    private String resourceBundleFile;
+
     /** Project locking is disabled. */
     private boolean projectLockingDisabled = false;
 
@@ -112,6 +118,42 @@ public class RuntimePreferenceStore {
      */
     public void setConfigDir(String v) {
         configDir = v;
+    }
+
+    /**
+     * Returns the configuration properties file given on the command line.
+     *
+     * @return the configuration file path, or {@code null} if not given
+     */
+    public String getConfigFile() {
+        return configFile;
+    }
+
+    /**
+     * Remembers the configuration properties file given on the command line.
+     *
+     * @param v the configuration file path to set
+     */
+    public void setConfigFile(String v) {
+        configFile = v;
+    }
+
+    /**
+     * Returns the resource bundle file given on the command line.
+     *
+     * @return the resource bundle file path, or {@code null} if not given
+     */
+    public String getResourceBundleFile() {
+        return resourceBundleFile;
+    }
+
+    /**
+     * Remembers the resource bundle file given on the command line.
+     *
+     * @param v the resource bundle file path to set
+     */
+    public void setResourceBundleFile(String v) {
+        resourceBundleFile = v;
     }
 
     public boolean isProjectLockingDisabled() {

--- a/src/main/java/org/omegat/util/RuntimePreferences.java
+++ b/src/main/java/org/omegat/util/RuntimePreferences.java
@@ -91,12 +91,36 @@ public final class RuntimePreferences {
         return RuntimePreferenceStore.getInstance().getAlternateFilenameTo();
     }
 
+    public static String getConfigFile() {
+        return RuntimePreferenceStore.getInstance().getConfigFile();
+    }
+
+    public static void setConfigFile(String v) {
+        RuntimePreferenceStore.getInstance().setConfigFile(v);
+    }
+
+    public static String getResourceBundleFile() {
+        return RuntimePreferenceStore.getInstance().getResourceBundleFile();
+    }
+
+    public static void setResourceBundleFile(String v) {
+        RuntimePreferenceStore.getInstance().setResourceBundleFile(v);
+    }
+
     public static void setTokenizerSource(@Nullable String tokenizerSource) {
         RuntimePreferenceStore.getInstance().setTokenizerSource(tokenizerSource);
     }
 
+    public static String getTokenizerSource() {
+        return RuntimePreferenceStore.getInstance().getTokenizerSource();
+    }
+
     public static void setTokenizerTarget(@Nullable String tokenizerTarget) {
         RuntimePreferenceStore.getInstance().setTokenizerTarget(tokenizerTarget);
+    }
+
+    public static String getTokenizerTarget() {
+        return RuntimePreferenceStore.getInstance().getTokenizerTarget();
     }
 
     public static void setNoTeam() {

--- a/src/test/java/org/omegat/MainTest.java
+++ b/src/test/java/org/omegat/MainTest.java
@@ -26,16 +26,40 @@
 package org.omegat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import org.omegat.cli.CommonParameters;
+import org.omegat.cli.LegacyParameters;
+import org.omegat.core.data.TestRuntimePreferenceStore;
+import org.omegat.util.RuntimePreferences;
+
+import picocli.CommandLine;
+
 /**
- * Tests for the command line pre-scan in Main.
+ * Tests for the command line pre-scan and the restart command line in Main.
  *
  * @author stephan.pakebusch at zollsoft.de
  */
 public class MainTest {
+
+    @Before
+    public void setUp() {
+        TestRuntimePreferenceStore.resetPristine();
+    }
+
+    @After
+    public void tearDown() {
+        TestRuntimePreferenceStore.reset();
+    }
 
     @Test
     public void testExtractConfigDirSeparateValue() {
@@ -56,5 +80,80 @@ public class MainTest {
         assertNull(Main.extractConfigDir(new String[] { "--config-dir=" }));
         assertNull(Main.extractConfigDir(new String[0]));
         assertNull(Main.extractConfigDir(null));
+    }
+
+    /**
+     * The reconstructed restart command line must parse with the real command
+     * definition, and the top-level options must reach the top-level command.
+     */
+    @Test
+    public void testConstructCommandParamsRoundTrip() {
+        RuntimePreferences.setConfigDir("/tmp/omegat-conf");
+        RuntimePreferences.setQuietMode(true);
+        RuntimePreferences.setNoTeam();
+        RuntimePreferences.setAlternateFilenames("draft-*.txt", "final-*.txt");
+
+        CommandLine.ParseResult result = parseReconstructedCommandLine();
+
+        assertEquals("/tmp/omegat-conf", result.matchedOptionValue(LegacyParameters.CONFIG_DIR, null));
+        assertTrue(result.hasMatchedOption(LegacyParameters.NO_TEAM));
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        assertTrue(start.hasMatchedOption(CommonParameters.QUIET));
+        assertEquals("draft-*.txt", start.matchedOptionValue(CommonParameters.ALTERNATE_FILENAME_FROM, null));
+        assertEquals("final-*.txt", start.matchedOptionValue(CommonParameters.ALTERNATE_FILENAME_TO, null));
+    }
+
+    /**
+     * A restart must keep the configuration file, the resource bundle, the
+     * lock and location-save switches and the tokenizer overrides.
+     */
+    @Test
+    public void testConstructCommandParamsKeepsRuntimeOptions() {
+        RuntimePreferences.setConfigFile("/tmp/omegat.properties");
+        RuntimePreferences.setResourceBundleFile("/tmp/Bundle_xx.properties");
+        RuntimePreferences.setProjectLockingEnabled(false);
+        RuntimePreferences.setLocationSaveEnabled(false);
+        RuntimePreferences.setTokenizerSource("org.omegat.tokenizer.LuceneEnglishTokenizer");
+        RuntimePreferences.setTokenizerTarget("org.omegat.tokenizer.LuceneGermanTokenizer");
+
+        CommandLine.ParseResult result = parseReconstructedCommandLine();
+
+        assertEquals("/tmp/omegat.properties", result.matchedOptionValue(LegacyParameters.CONFIG_FILE, null));
+        assertEquals("/tmp/Bundle_xx.properties",
+                result.matchedOptionValue(LegacyParameters.RESOURCE_BUNDLE, null));
+        assertTrue(result.hasMatchedOption(LegacyParameters.DISABLE_PROJECT_LOCKING));
+        assertTrue(result.hasMatchedOption(LegacyParameters.DISABLE_LOCATION_SAVE));
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        assertEquals("org.omegat.tokenizer.LuceneEnglishTokenizer",
+                start.matchedOptionValue(CommonParameters.TOKENIZER_SOURCE, null));
+        assertEquals("org.omegat.tokenizer.LuceneGermanTokenizer",
+                start.matchedOptionValue(CommonParameters.TOKENIZER_TARGET, null));
+    }
+
+    /**
+     * The project folder is appended after the reconstructed options and must
+     * arrive as the positional parameter of the start sub-command.
+     */
+    @Test
+    public void testConstructCommandParamsProjectAfterOptions() {
+        RuntimePreferences.setConfigDir("/tmp/omegat-conf");
+        List<String> command = new ArrayList<>();
+        Main.constructCommandParams(command);
+        command.add("/tmp/project");
+
+        CommandLine.ParseResult result = new CommandLine(new LegacyParameters())
+                .parseArgs(command.toArray(new String[0]));
+
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        assertEquals("/tmp/project", start.matchedPositionalValue(0, null));
+    }
+
+    private CommandLine.ParseResult parseReconstructedCommandLine() {
+        List<String> command = new ArrayList<>();
+        Main.constructCommandParams(command);
+        return new CommandLine(new LegacyParameters()).parseArgs(command.toArray(new String[0]));
     }
 }

--- a/src/test/java/org/omegat/cli/CommandCommonTest.java
+++ b/src/test/java/org/omegat/cli/CommandCommonTest.java
@@ -1,0 +1,110 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**************************************************************************/
+
+package org.omegat.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.data.TestRuntimePreferenceStore;
+import org.omegat.util.RuntimePreferences;
+
+import picocli.CommandLine;
+
+/**
+ * Tests that the options shared through the CommonParameters mixin reach the
+ * runtime preferences.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class CommandCommonTest {
+
+    @Before
+    public void setUp() {
+        TestRuntimePreferenceStore.resetPristine();
+    }
+
+    @After
+    public void tearDown() {
+        TestRuntimePreferenceStore.reset();
+    }
+
+    @Test
+    public void testParseCommonParamsAppliesSubCommandOptions() {
+        CommandLine.ParseResult result = new CommandLine(new LegacyParameters()).parseArgs("start",
+                "--no-project-locking", "--no-location-save", "--no-team", "--ITokenizer",
+                "org.omegat.tokenizer.LuceneEnglishTokenizer", "--ITokenizerTarget",
+                "org.omegat.tokenizer.LuceneGermanTokenizer");
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        StartCommand command = (StartCommand) start.commandSpec().userObject();
+
+        CommandCommon.parseCommonParams(command.params);
+
+        assertFalse(RuntimePreferences.isProjectLockingEnabled());
+        assertFalse(RuntimePreferences.isLocationSaveEnabled());
+        assertTrue(RuntimePreferences.isNoTeam());
+        assertEquals("org.omegat.tokenizer.LuceneEnglishTokenizer",
+                RuntimePreferences.getTokenizerSource());
+        assertEquals("org.omegat.tokenizer.LuceneGermanTokenizer",
+                RuntimePreferences.getTokenizerTarget());
+    }
+
+    /**
+     * The synthetic positive form of the negatable option must keep the
+     * default; the original declaration had this inverted.
+     */
+    @Test
+    public void testParseCommonParamsPositiveTeamKeepsDefault() {
+        CommandLine.ParseResult result = new CommandLine(new LegacyParameters()).parseArgs("start", "--team");
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        StartCommand command = (StartCommand) start.commandSpec().userObject();
+
+        CommandCommon.parseCommonParams(command.params);
+
+        assertFalse(RuntimePreferences.isNoTeam());
+    }
+
+    @Test
+    public void testParseCommonParamsDefaultsLeaveStoreUntouched() {
+        CommandLine.ParseResult result = new CommandLine(new LegacyParameters()).parseArgs("start");
+        CommandLine.ParseResult start = result.subcommand();
+        assertNotNull(start);
+        StartCommand command = (StartCommand) start.commandSpec().userObject();
+
+        CommandCommon.parseCommonParams(command.params);
+
+        assertTrue(RuntimePreferences.isProjectLockingEnabled());
+        assertTrue(RuntimePreferences.isLocationSaveEnabled());
+        assertFalse(RuntimePreferences.isNoTeam());
+    }
+}

--- a/src/test/java/org/omegat/cli/LegacyParametersTest.java
+++ b/src/test/java/org/omegat/cli/LegacyParametersTest.java
@@ -26,7 +26,17 @@
 package org.omegat.cli;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Locale;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -34,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.omegat.core.data.TestRuntimePreferenceStore;
+import org.omegat.util.OStrings;
 import org.omegat.util.RuntimePreferences;
 
 import picocli.CommandLine;
@@ -79,5 +90,49 @@ public class LegacyParametersTest {
         new CommandLine(params).parseArgs();
         params.initialize();
         assertNull(RuntimePreferences.getConfigDir());
+    }
+
+    /**
+     * The legacy runtime switches must reach the runtime preferences on every
+     * route through initialize(), including the plain GUI start.
+     */
+    @Test
+    public void testInitializeAppliesRuntimeFlags() {
+        TestRuntimePreferenceStore.resetPristine();
+        LegacyParameters params = new LegacyParameters();
+        new CommandLine(params).parseArgs(LegacyParameters.DISABLE_PROJECT_LOCKING,
+                LegacyParameters.DISABLE_LOCATION_SAVE, LegacyParameters.NO_TEAM);
+        assertTrue(RuntimePreferences.isProjectLockingEnabled());
+        assertTrue(RuntimePreferences.isLocationSaveEnabled());
+        assertFalse(RuntimePreferences.isNoTeam());
+        params.initialize();
+        assertFalse(RuntimePreferences.isProjectLockingEnabled());
+        assertFalse(RuntimePreferences.isLocationSaveEnabled());
+        assertTrue(RuntimePreferences.isNoTeam());
+    }
+
+    /**
+     * --resource-bundle must replace the strings that OStrings serves, like
+     * before the picocli migration.
+     */
+    @Test
+    public void testInitializeLoadsResourceBundle() throws Exception {
+        Path bundleFile = Files.createTempFile("omegat-bundle", ".properties");
+        try {
+            try (InputStream in = OStrings.class.getResourceAsStream("/org/omegat/Bundle.properties")) {
+                assertNotNull(in);
+                Files.copy(in, bundleFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            Files.writeString(bundleFile, "\nTF_MENU_FILE=Bundle from the command line\n",
+                    StandardOpenOption.APPEND);
+            LegacyParameters params = new LegacyParameters();
+            new CommandLine(params).parseArgs(LegacyParameters.RESOURCE_BUNDLE, bundleFile.toString());
+            params.initialize();
+            assertEquals("Bundle from the command line", OStrings.getString("TF_MENU_FILE"));
+            assertEquals(bundleFile.toString(), RuntimePreferences.getResourceBundleFile());
+        } finally {
+            OStrings.loadBundle(Locale.getDefault());
+            Files.deleteIfExists(bundleFile);
+        }
     }
 }

--- a/src/testFixtures/java/org/omegat/core/data/TestRuntimePreferenceStore.java
+++ b/src/testFixtures/java/org/omegat/core/data/TestRuntimePreferenceStore.java
@@ -32,4 +32,12 @@ public class TestRuntimePreferenceStore extends RuntimePreferenceStore {
         getInstance().setLocationSaveDisable();
         getInstance().setProjectLockingDisabled();
     }
+
+    /**
+     * Installs a fresh store without the test defaults, for tests that assert
+     * how command line options change the store.
+     */
+    public static void resetPristine() {
+        setInstance(new TestRuntimePreferenceStore());
+    }
 }


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

No ticket. Follow-up of #2219; stragglers of the picocli migration (#1321).

## What does this PR change?

Several declared options never took effect: --resource-bundle was completely dead, --disable-project-locking, --disable-location-save and --no-team were ignored on the GUI start path, and the sub-command form --no-team did nothing anywhere because a negatable option declared as --team with default true inverts the intent in picocli (--team even switched team support off). LegacyParameters.initialize() now applies all top-level options centrally, the previously uncalled parseCommonParams() replaces the duplicated blocks in the sub-commands, and the team option is declared through its negative form.

The GUI restart (language switcher) rebuilt a command line that picocli rejected once --config-dir or the alternate filenames were set: top-level options after the start token, plus a misspelled --alternate-filenames-to. The reconstruction now emits the options in parseable order and also forwards --config-file, --resource-bundle, the disable switches and the tokenizer overrides.

## Other information

Fourteen unit tests; the six behaviour tests fail on master and pass with the fix. Out of scope, unchanged: -D and --verbose are not forwarded on restart, and log messages keep the bundle captured during logger setup. Full test suite and checkstyle pass.
